### PR TITLE
CAP-0065 - Reusable module cache

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -257,3 +257,7 @@ soroban.config.ledger-max-read-ledger-byte   | counter   | soroban config settin
 soroban.config.ledger-max-write-entry        | counter   | soroban config setting `ledger_max_write_ledger_entries`
 soroban.config.ledger-max-write-ledger-byte  | counter   | soroban config setting `ledger_max_write_bytes`
 soroban.config.bucket-list-target-size-byte  | counter   | soroban config setting `bucket_list_target_size_bytes`
+soroban.module-cache.num-entries             | counter   | current number of entries in module cache
+soroban.module-cache.compilation-time        | timer     | times each contract compilation when adding to module cache
+soroban.module-cache.rebuild-time            | timer     | times each rebuild of module cache (including all compilations)
+soroban.module-cache.rebuild-bytes           | counter   | bytes of WASM bytecode compiled in last rebuild of module cache

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -394,6 +394,12 @@ CATCHUP_RECENT=0
 # merging and vertification.
 WORKER_THREADS=11
 
+# COMPILATION_THREADS (integer) default 6
+# Number of threads launched temporarily when compiling contracts at
+# startup. These are short lived, CPU-bound threads that are not
+# in competition with the worker threads.
+COMPILATION_THREADS=6
+
 # QUORUM_INTERSECTION_CHECKER (boolean) default true
 # Enable/disable computation of quorum intersection monitoring
 QUORUM_INTERSECTION_CHECKER=true

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -188,6 +188,11 @@ $(RUST_DEP_TREE_STAMP): $(wildcard rust/soroban/*/Cargo.*) Makefile $(RUST_TOOLC
 	done
 	touch $@
 
+# Of course, RUST_PROFILE can't be used as an argument directly because cargo
+# doesn't let you pass --debug, that's the default! you can only pass --release.
+# So we have to derive a new variable here.
+RUST_PROFILE_ARG := $(if $(findstring release,$(RUST_PROFILE)),--release,)
+
 # This next build command looks a little weird but it's necessary. We have to
 # provide an auxiliary metadata string (using RUSTFLAGS=-Cmetadata=$*)
 # essentially manually marking-as-different the separate dependency trees
@@ -252,7 +257,7 @@ $(SOROBAN_LIBS_STAMP): $(wildcard rust/soroban/p*/Cargo.lock) Makefile $(RUST_DE
 		CARGO_NET_GIT_FETCH_WITH_CLI=true \
 		$(CARGO) build \
 			--package soroban-env-host \
-			--$(RUST_PROFILE) \
+			$(RUST_PROFILE_ARG) \
 			--locked \
 			$$FEATURE_FLAGS \
 		|| exit 1; \
@@ -279,7 +284,7 @@ $(LIBRUST_STELLAR_CORE): $(RUST_HOST_DEPFILES) $(SRC_RUST_FILES) Makefile $(SORO
 	CARGO_NET_GIT_FETCH_WITH_CLI=true \
 	$(CARGO) rustc \
 		--package stellar-core \
-		--$(RUST_PROFILE) \
+		$(RUST_PROFILE_ARG) \
 		--locked \
 		--target-dir $(abspath $(RUST_TARGET_DIR)) \
 		$(CARGO_FEATURE_TRACY) $(CARGO_FEATURE_NEXT) $(CARGO_FEATURE_TESTUTILS) \

--- a/src/bucket/BucketSnapshot.h
+++ b/src/bucket/BucketSnapshot.h
@@ -87,6 +87,10 @@ class LiveBucketSnapshot : public BucketSnapshotBase<LiveBucket>
                          std::list<EvictionResultEntry>& evictableKeys,
                          SearchableLiveBucketListSnapshot const& bl,
                          uint32_t ledgerVers) const;
+
+    // Scans contract code entries in the bucket.
+    Loop
+    scanForContractCode(std::function<Loop(BucketEntry const&)> callback) const;
 };
 
 class HotArchiveBucketSnapshot : public BucketSnapshotBase<HotArchiveBucket>

--- a/src/bucket/InMemoryIndex.h
+++ b/src/bucket/InMemoryIndex.h
@@ -190,6 +190,7 @@ class InMemoryIndex
     AssetPoolIDMap mAssetPoolIDMap;
     BucketEntryCounters mCounters{};
     std::optional<std::pair<std::streamoff, std::streamoff>> mOfferRange;
+    std::optional<std::pair<std::streamoff, std::streamoff>> mContractCodeRange;
 
   public:
     using IterT = InMemoryBucketState::IterT;
@@ -230,6 +231,12 @@ class InMemoryIndex
     getOfferRange() const
     {
         return mOfferRange;
+    }
+
+    std::optional<std::pair<std::streamoff, std::streamoff>>
+    getContractCodeRange() const
+    {
+        return mContractCodeRange;
     }
 
 #ifdef BUILD_TESTS

--- a/src/bucket/LiveBucket.cpp
+++ b/src/bucket/LiveBucket.cpp
@@ -327,6 +327,12 @@ LiveBucket::getOfferRange() const
     return getIndex().getOfferRange();
 }
 
+std::optional<std::pair<std::streamoff, std::streamoff>>
+LiveBucket::getContractCodeRange() const
+{
+    return getIndex().getContractCodeRange();
+}
+
 std::vector<BucketEntry>
 LiveBucket::convertToBucketEntry(bool useInit,
                                  std::vector<LedgerEntry> const& initEntries,

--- a/src/bucket/LiveBucket.h
+++ b/src/bucket/LiveBucket.h
@@ -91,6 +91,11 @@ class LiveBucket : public BucketBase<LiveBucket, LiveBucketIndex>,
     std::optional<std::pair<std::streamoff, std::streamoff>>
     getOfferRange() const;
 
+    // Returns [lowerBound, upperBound) of file offsets for all contract code
+    // entries in the bucket, or std::nullopt if no contract code exists
+    std::optional<std::pair<std::streamoff, std::streamoff>>
+    getContractCodeRange() const;
+
     // Create a fresh bucket from given vectors of init (created) and live
     // (updated) LedgerEntries, and dead LedgerEntryKeys. The bucket will
     // be sorted, hashed, and adopted in the provided BucketManager.

--- a/src/bucket/LiveBucketIndex.cpp
+++ b/src/bucket/LiveBucketIndex.cpp
@@ -295,6 +295,27 @@ LiveBucketIndex::getOfferRange() const
     return mInMemoryIndex->getOfferRange();
 }
 
+std::optional<std::pair<std::streamoff, std::streamoff>>
+LiveBucketIndex::getContractCodeRange() const
+{
+    if (mDiskIndex)
+    {
+        // Get the smallest and largest possible contract code keys
+        LedgerKey lowerBound(CONTRACT_CODE);
+        lowerBound.contractCode().hash.fill(
+            std::numeric_limits<uint8_t>::min());
+
+        LedgerKey upperBound(CONTRACT_CODE);
+        upperBound.contractCode().hash.fill(
+            std::numeric_limits<uint8_t>::max());
+
+        return mDiskIndex->getOffsetBounds(lowerBound, upperBound);
+    }
+
+    releaseAssertOrThrow(mInMemoryIndex);
+    return mInMemoryIndex->getContractCodeRange();
+}
+
 uint32_t
 LiveBucketIndex::getPageSize() const
 {

--- a/src/bucket/LiveBucketIndex.h
+++ b/src/bucket/LiveBucketIndex.h
@@ -138,6 +138,9 @@ class LiveBucketIndex : public NonMovableOrCopyable
 
     void maybeAddToCache(std::shared_ptr<BucketEntry const> const& entry) const;
 
+    std::optional<std::pair<std::streamoff, std::streamoff>>
+    getContractCodeRange() const;
+
     BucketEntryCounters const& getBucketEntryCounters() const;
     uint32_t getPageSize() const;
 

--- a/src/bucket/SearchableBucketList.cpp
+++ b/src/bucket/SearchableBucketList.cpp
@@ -64,6 +64,18 @@ SearchableLiveBucketListSnapshot::scanForEviction(
     return result;
 }
 
+void
+SearchableLiveBucketListSnapshot::scanForContractCode(
+    std::function<Loop(BucketEntry const&)> callback) const
+{
+    ZoneScoped;
+    releaseAssert(mSnapshot);
+    auto f = [&callback](auto const& b) {
+        return b.scanForContractCode(callback);
+    };
+    loopAllBuckets(f, *mSnapshot);
+}
+
 // This query has two steps:
 //  1. For each bucket, determine what PoolIDs contain the target asset via the
 //     assetToPoolID index

--- a/src/bucket/SearchableBucketList.h
+++ b/src/bucket/SearchableBucketList.h
@@ -35,6 +35,9 @@ class SearchableLiveBucketListSnapshot
         std::shared_ptr<EvictionStatistics> stats,
         StateArchivalSettings const& sas, uint32_t ledgerVers) const;
 
+    void
+    scanForContractCode(std::function<Loop(BucketEntry const&)> callback) const;
+
     friend SearchableSnapshotConstPtr
     BucketSnapshotManager::copySearchableLiveBucketListSnapshot() const;
 };

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -591,9 +591,9 @@ TEST_CASE_VERSIONS("bucket tombstones mutually-annihilate init entries",
                         FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY))
             {
                 // init/dead pairs should mutually-annihilate pretty readily as
-                // they go, empirically this test peaks at buckets around 400
+                // they go, empirically this test peaks at buckets around 500
                 // entries.
-                REQUIRE((currSz + snapSz) < 500);
+                REQUIRE((currSz + snapSz) < 600);
             }
             CLOG_INFO(Bucket, "Level {} size: {}", k, (currSz + snapSz));
         }

--- a/src/crypto/ByteSlice.h
+++ b/src/crypto/ByteSlice.h
@@ -4,6 +4,8 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "rust/RustBridge.h"
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <xdrpp/message.h>
@@ -69,6 +71,13 @@ class ByteSlice
     }
     ByteSlice(std::string const& bytes)
         : mData(bytes.data()), mSize(bytes.size())
+    {
+    }
+    ByteSlice(::rust::Vec<uint8_t> const& bytes)
+        : mData(bytes.data()), mSize(bytes.size())
+    {
+    }
+    ByteSlice(RustBuf const& bytes) : ByteSlice(bytes.data)
     {
     }
     ByteSlice(char const* str) : ByteSlice((void const*)str, strlen(str))

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -7,6 +7,7 @@
 #include "catchup/LedgerApplyManager.h"
 #include "history/HistoryManager.h"
 #include "ledger/NetworkConfig.h"
+#include "rust/RustBridge.h"
 #include <memory>
 
 namespace stellar
@@ -310,6 +311,7 @@ class LedgerManager
     virtual void manuallyAdvanceLedgerHeader(LedgerHeader const& header) = 0;
 
     virtual SorobanMetrics& getSorobanMetrics() = 0;
+    virtual ::rust::Box<rust_bridge::SorobanModuleCache> getModuleCache() = 0;
 
     virtual ~LedgerManager()
     {

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -2076,6 +2076,7 @@ void
 LedgerManagerImpl::ApplyState::evictFromModuleCache(
     uint32_t ledgerVersion, EvictedStateVectors const& evictedState)
 {
+    ZoneScoped;
     std::vector<Hash> keys;
     for (auto const& key : evictedState.deletedKeys)
     {
@@ -2110,6 +2111,7 @@ void
 LedgerManagerImpl::ApplyState::addAnyContractsToModuleCache(
     uint32_t ledgerVersion, std::vector<LedgerEntry> const& le)
 {
+    ZoneScoped;
     for (auto const& e : le)
     {
         if (e.data.type() == CONTRACT_CODE)

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -4,6 +4,7 @@
 
 #include "ledger/LedgerManagerImpl.h"
 #include "bucket/BucketManager.h"
+#include "bucket/BucketSnapshotManager.h"
 #include "bucket/HotArchiveBucketList.h"
 #include "bucket/LiveBucketList.h"
 #include "catchup/AssumeStateWork.h"
@@ -20,12 +21,15 @@
 #include "history/HistoryManager.h"
 #include "ledger/FlushAndRotateMetaDebugWork.h"
 #include "ledger/LedgerHeaderUtils.h"
+#include "ledger/LedgerManager.h"
 #include "ledger/LedgerTxn.h"
 #include "ledger/LedgerTxnEntry.h"
 #include "ledger/LedgerTxnHeader.h"
+#include "ledger/SharedModuleCacheCompiler.h"
 #include "main/Application.h"
 #include "main/Config.h"
 #include "main/ErrorMessages.h"
+#include "rust/RustBridge.h"
 #include "transactions/MutableTransactionResult.h"
 #include "transactions/OperationFrame.h"
 #include "transactions/TransactionFrameBase.h"
@@ -41,8 +45,10 @@
 #include "util/XDRCereal.h"
 #include "util/XDRStream.h"
 #include "work/WorkScheduler.h"
+#include "xdr/Stellar-ledger-entries.h"
 #include "xdrpp/printer.h"
 
+#include <cstdint>
 #include <fmt/format.h>
 
 #ifdef BUILD_TESTS
@@ -61,6 +67,8 @@
 #include <Tracy.hpp>
 
 #include <chrono>
+#include <memory>
+#include <mutex>
 #include <optional>
 #include <regex>
 #include <sstream>
@@ -130,7 +138,8 @@ LedgerManager::ledgerAbbrev(LedgerHeaderHistoryEntry const& he)
 
 LedgerManagerImpl::LedgerApplyMetrics::LedgerApplyMetrics(
     medida::MetricsRegistry& registry)
-    : mTransactionApply(registry.NewTimer({"ledger", "transaction", "apply"}))
+    : mSorobanMetrics(registry)
+    , mTransactionApply(registry.NewTimer({"ledger", "transaction", "apply"}))
     , mTransactionCount(
           registry.NewHistogram({"ledger", "transaction", "count"}))
     , mOperationCount(registry.NewHistogram({"ledger", "operation", "count"}))
@@ -154,10 +163,38 @@ LedgerManagerImpl::LedgerApplyMetrics::LedgerApplyMetrics(
 {
 }
 
+static std::vector<uint32_t>
+getModuleCacheProtocols()
+{
+    std::vector<uint32_t> ledgerVersions;
+    for (uint32_t i = (uint32_t)REUSABLE_SOROBAN_MODULE_CACHE_PROTOCOL_VERSION;
+         i <= Config::CURRENT_LEDGER_PROTOCOL_VERSION; i++)
+    {
+        ledgerVersions.push_back(i);
+    }
+    auto extra = getenv("SOROBAN_TEST_EXTRA_PROTOCOL");
+    if (extra)
+    {
+        uint32_t proto = static_cast<uint32_t>(atoi(extra));
+        if (proto > 0)
+        {
+            ledgerVersions.push_back(proto);
+        }
+    }
+    return ledgerVersions;
+}
+
+LedgerManagerImpl::ApplyState::ApplyState(Application& app)
+    : mMetrics(app.getMetrics())
+    , mModuleCache(::rust_bridge::new_module_cache())
+    , mModuleCacheProtocols(getModuleCacheProtocols())
+    , mNumCompilationThreads(app.getConfig().COMPILATION_THREADS)
+{
+}
+
 LedgerManagerImpl::LedgerManagerImpl(Application& app)
     : mApp(app)
-    , mLedgerApplyMetrics(app.getMetrics())
-    , mSorobanMetrics(app.getMetrics())
+    , mApplyState(app)
     , mLastClose(mApp.getClock().now())
     , mCatchupDuration(
           app.getMetrics().NewTimer({"ledger", "catchup", "duration"}))
@@ -248,7 +285,7 @@ LedgerManager::genesisLedger()
 void
 LedgerManagerImpl::startNewLedger(LedgerHeader const& genesisLedger)
 {
-    auto ledgerTime = mLedgerApplyMetrics.mLedgerClose.TimeScope();
+    auto ledgerTime = mApplyState.mMetrics.mLedgerClose.TimeScope();
     SecretKey skey = SecretKey::fromSeed(mApp.getNetworkID());
 
     LedgerTxn ltx(mApp.getLedgerTxnRoot(), false);
@@ -437,6 +474,12 @@ LedgerManagerImpl::loadLastKnownLedger(bool restoreBucketlist)
         updateSorobanNetworkConfigForApply(ltx);
         getLCLState().sorobanConfig = mApplyState.mSorobanNetworkConfig;
     }
+
+    // Prime module cache with LCL state, not apply-state. This is acceptable
+    // here because we just started and there is no apply-state yet and no apply
+    // thread to hold such state.
+    mApplyState.compileAllContractsInLedger(getLCLState().snapshot,
+                                            latestLedgerHeader->ledgerVersion);
 }
 
 Database&
@@ -590,50 +633,157 @@ LedgerManagerImpl::storeCurrentLedgerForTest(LedgerHeader const& header)
 SorobanMetrics&
 LedgerManagerImpl::getSorobanMetrics()
 {
-    return mSorobanMetrics;
+    return mApplyState.mMetrics.mSorobanMetrics;
+}
+
+::rust::Box<rust_bridge::SorobanModuleCache>
+LedgerManagerImpl::getModuleCache()
+{
+    // There should not be any compilation running when
+    // anyone calls this function. It is accessed from
+    // transactions during apply only.
+    releaseAssert(!mApplyState.mCompiler);
+    return mApplyState.mModuleCache->shallow_clone();
+}
+
+void
+LedgerManagerImpl::ApplyState::finishPendingCompilation()
+{
+    releaseAssert(mCompiler);
+    auto newCache = mCompiler->wait();
+    mMetrics.mSorobanMetrics.mModuleCacheRebuildBytes.set_count(
+        (int64)mCompiler->getBytesCompiled());
+    mMetrics.mSorobanMetrics.mModuleCacheNumEntries.set_count(
+        (int64)mCompiler->getContractsCompiled());
+    mMetrics.mSorobanMetrics.mModuleCacheRebuildTime.Update(
+        mCompiler->getCompileTime());
+    mModuleCache.swap(newCache);
+    mCompiler.reset();
+}
+
+void
+LedgerManagerImpl::ApplyState::compileAllContractsInLedger(
+    SearchableSnapshotConstPtr snap, uint32_t minLedgerVersion)
+{
+    startCompilingAllContracts(snap, minLedgerVersion);
+    finishPendingCompilation();
+}
+
+void
+LedgerManagerImpl::ApplyState::startCompilingAllContracts(
+    SearchableSnapshotConstPtr snap, uint32_t minLedgerVersion)
+{
+    // Always stop a previous compilation before starting a new one. Can only
+    // have one running at any time.
+    releaseAssert(!mCompiler);
+    std::vector<uint32_t> versions;
+    for (auto const& v : mModuleCacheProtocols)
+    {
+        if (v >= minLedgerVersion)
+        {
+            versions.push_back(v);
+        }
+    }
+    mCompiler = std::make_unique<SharedModuleCacheCompiler>(
+        snap, mNumCompilationThreads, versions);
+    mCompiler->start();
+}
+
+void
+LedgerManagerImpl::ApplyState::maybeRebuildModuleCache(
+    SearchableSnapshotConstPtr snap, uint32_t minLedgerVersion)
+{
+    // There is (currently) a grow-only arena underlying the module cache, so as
+    // entries are uploaded and evicted that arena will still grow. To cap this
+    // growth, we periodically rebuild the module cache from scratch.
+    //
+    // We could pick various size caps, but we want to avoid rebuilding
+    // spuriously when there just happens to be "a fairly large" cache due to
+    // having a fairly large live BL. I.e. we want to allow it to get as big as
+    // we can -- or as big as the "natural" BL-limits-dictated size -- while
+    // still rebuilding fairly often in DoS-attempt scenarios or just generally
+    // if there's regular upload/expiry churn that would otherwise cause
+    // unbounded growth.
+    //
+    // Unfortunately we do not know exactly how much memory is used by each byte
+    // of contract we compile, and the size estimates from the cost model have
+    // to assume a worst case which is almost a factor of _40_ larger than the
+    // byte-size of the contracts. So for example if we assume 100MB of
+    // contracts, the cost model says we ought to budget for 4GB of memory, just
+    // in case _all 100MB of contracts_ are "the worst case contract" that's
+    // just a continuous stream of function definitions.
+    //
+    // So: we take this multiplier, times the size of the contracts we _last_
+    // drew from the BL when doing a full recompile, times two, as a cap on the
+    // _current_ (post-rebuild, currently-growing) cache's budget-tracked
+    // memory. This should avoid rebuilding spuriously, while still treating
+    // events that double the size of the contract-set in the live BL as an
+    // event that warrants a rebuild.
+
+    // We try to fish the current cost multiplier out of the soroban network
+    // config's memory cost model, but fall back to a conservative default in
+    // case there is no mem cost param for VmInstantiation (This should never
+    // happen but just in case).
+    uint64_t linearTerm = 5000;
+
+    // linearTerm is in 1/128ths in the cost model, to reduce rounding error.
+    uint64_t scale = 128;
+
+    auto const& memParams = mSorobanNetworkConfig->memCostParams();
+    if (memParams.size() > (size_t)stellar::VmInstantiation)
+    {
+        auto const& param = memParams[(size_t)stellar::VmInstantiation];
+        linearTerm = param.linearTerm;
+    }
+    auto lastBytesCompiled =
+        mMetrics.mSorobanMetrics.mModuleCacheRebuildBytes.count();
+    uint64_t limit = 2 * lastBytesCompiled * linearTerm / scale;
+    if (mModuleCache->get_mem_bytes_consumed() > limit)
+    {
+        CLOG_DEBUG(Ledger,
+                   "Rebuilding module cache: worst-case estimate {} "
+                   "model-bytes consumed of {} limit",
+                   mModuleCache->get_mem_bytes_consumed(), limit);
+        startCompilingAllContracts(snap, minLedgerVersion);
+    }
 }
 
 void
 LedgerManagerImpl::publishSorobanMetrics()
 {
     auto const& conf = getSorobanNetworkConfigForApply();
+    auto& m = getSorobanMetrics();
     // first publish the network config limits
-    mSorobanMetrics.mConfigContractDataKeySizeBytes.set_count(
+    m.mConfigContractDataKeySizeBytes.set_count(
         conf.maxContractDataKeySizeBytes());
-    mSorobanMetrics.mConfigMaxContractDataEntrySizeBytes.set_count(
+    m.mConfigMaxContractDataEntrySizeBytes.set_count(
         conf.maxContractDataEntrySizeBytes());
-    mSorobanMetrics.mConfigMaxContractSizeBytes.set_count(
-        conf.maxContractSizeBytes());
-    mSorobanMetrics.mConfigTxMaxSizeByte.set_count(conf.txMaxSizeBytes());
-    mSorobanMetrics.mConfigTxMaxCpuInsn.set_count(conf.txMaxInstructions());
-    mSorobanMetrics.mConfigTxMemoryLimitBytes.set_count(conf.txMemoryLimit());
-    mSorobanMetrics.mConfigTxMaxReadLedgerEntries.set_count(
-        conf.txMaxReadLedgerEntries());
-    mSorobanMetrics.mConfigTxMaxReadBytes.set_count(conf.txMaxReadBytes());
-    mSorobanMetrics.mConfigTxMaxWriteLedgerEntries.set_count(
-        conf.txMaxWriteLedgerEntries());
-    mSorobanMetrics.mConfigTxMaxWriteBytes.set_count(conf.txMaxWriteBytes());
-    mSorobanMetrics.mConfigMaxContractEventsSizeBytes.set_count(
+    m.mConfigMaxContractSizeBytes.set_count(conf.maxContractSizeBytes());
+    m.mConfigTxMaxSizeByte.set_count(conf.txMaxSizeBytes());
+    m.mConfigTxMaxCpuInsn.set_count(conf.txMaxInstructions());
+    m.mConfigTxMemoryLimitBytes.set_count(conf.txMemoryLimit());
+    m.mConfigTxMaxReadLedgerEntries.set_count(conf.txMaxReadLedgerEntries());
+    m.mConfigTxMaxReadBytes.set_count(conf.txMaxReadBytes());
+    m.mConfigTxMaxWriteLedgerEntries.set_count(conf.txMaxWriteLedgerEntries());
+    m.mConfigTxMaxWriteBytes.set_count(conf.txMaxWriteBytes());
+    m.mConfigMaxContractEventsSizeBytes.set_count(
         conf.txMaxContractEventsSizeBytes());
-    mSorobanMetrics.mConfigLedgerMaxTxCount.set_count(conf.ledgerMaxTxCount());
-    mSorobanMetrics.mConfigLedgerMaxInstructions.set_count(
-        conf.ledgerMaxInstructions());
-    mSorobanMetrics.mConfigLedgerMaxTxsSizeByte.set_count(
+    m.mConfigLedgerMaxTxCount.set_count(conf.ledgerMaxTxCount());
+    m.mConfigLedgerMaxInstructions.set_count(conf.ledgerMaxInstructions());
+    m.mConfigLedgerMaxTxsSizeByte.set_count(
         conf.ledgerMaxTransactionSizesBytes());
-    mSorobanMetrics.mConfigLedgerMaxReadLedgerEntries.set_count(
+    m.mConfigLedgerMaxReadLedgerEntries.set_count(
         conf.ledgerMaxReadLedgerEntries());
-    mSorobanMetrics.mConfigLedgerMaxReadBytes.set_count(
-        conf.ledgerMaxReadBytes());
-    mSorobanMetrics.mConfigLedgerMaxWriteEntries.set_count(
+    m.mConfigLedgerMaxReadBytes.set_count(conf.ledgerMaxReadBytes());
+    m.mConfigLedgerMaxWriteEntries.set_count(
         conf.ledgerMaxWriteLedgerEntries());
-    mSorobanMetrics.mConfigLedgerMaxWriteBytes.set_count(
-        conf.ledgerMaxWriteBytes());
-    mSorobanMetrics.mConfigBucketListTargetSizeByte.set_count(
+    m.mConfigLedgerMaxWriteBytes.set_count(conf.ledgerMaxWriteBytes());
+    m.mConfigBucketListTargetSizeByte.set_count(
         conf.bucketListTargetSizeBytes());
-    mSorobanMetrics.mConfigFeeWrite1KB.set_count(conf.feeWrite1KB());
+    m.mConfigFeeWrite1KB.set_count(conf.feeWrite1KB());
 
     // then publish the actual ledger usage
-    mSorobanMetrics.publishAndResetLedgerWideMetrics();
+    m.publishAndResetLedgerWideMetrics();
 }
 
 // called by txherder
@@ -706,7 +856,7 @@ LedgerManagerImpl::secondsSinceLastLedgerClose() const
 void
 LedgerManagerImpl::syncMetrics()
 {
-    mLedgerApplyMetrics.mLedgerAge.set_count(secondsSinceLastLedgerClose());
+    mApplyState.mMetrics.mLedgerAge.set_count(secondsSinceLastLedgerClose());
     mApp.syncOwnMetrics();
 }
 
@@ -720,13 +870,13 @@ LedgerManagerImpl::emitNextMeta()
     auto timer = LogSlowExecution("MetaStream write",
                                   LogSlowExecution::Mode::AUTOMATIC_RAII,
                                   "took", std::chrono::milliseconds(100));
-    auto streamWrite = mLedgerApplyMetrics.mMetaStreamWriteTime.TimeScope();
+    auto streamWrite = mApplyState.mMetrics.mMetaStreamWriteTime.TimeScope();
     if (mMetaStream)
     {
         size_t written = 0;
         mMetaStream->writeOne(mNextMetaToEmit->getXDR(), nullptr, &written);
         mMetaStream->flush();
-        mLedgerApplyMetrics.mMetaStreamBytes.Mark(written);
+        mApplyState.mMetrics.mMetaStreamBytes.Mark(written);
     }
     if (mMetaDebugStream)
     {
@@ -834,11 +984,19 @@ LedgerManagerImpl::applyLedger(LedgerCloseData const& ledgerData,
         return;
     }
 
+    // Complete any pending wasm-module-compilation before closing the ledger.
+    // This might or might-not exist, depending on whether we triggered a
+    // compilation in the previous ledger-apply.
+    if (mApplyState.mCompiler)
+    {
+        mApplyState.finishPendingCompilation();
+    }
+
 #ifdef BUILD_TESTS
     mLastLedgerTxMeta.clear();
 #endif
     ZoneScoped;
-    auto ledgerTime = mLedgerApplyMetrics.mLedgerClose.TimeScope();
+    auto ledgerTime = mApplyState.mMetrics.mLedgerClose.TimeScope();
     LogSlowExecution applyLedgerTime{"applyLedger",
                                      LogSlowExecution::Mode::MANUAL, "",
                                      std::chrono::milliseconds::max()};
@@ -867,11 +1025,11 @@ LedgerManagerImpl::applyLedger(LedgerCloseData const& ledgerData,
     ZoneValue(static_cast<int64_t>(header.current().ledgerSeq));
 
     auto now = mApp.getClock().now();
-    mLedgerApplyMetrics.mLedgerAgeClosed.Update(now - mLastClose);
+    mApplyState.mMetrics.mLedgerAgeClosed.Update(now - mLastClose);
     // mLastClose is only accessed by a single thread, so no synchronization
     // needed
     mLastClose = now;
-    mLedgerApplyMetrics.mLedgerAge.set_count(0);
+    mApplyState.mMetrics.mLedgerAge.set_count(0);
 
     TxSetXDRFrameConstPtr txSet = ledgerData.getTxSet();
 
@@ -1152,6 +1310,10 @@ void
 LedgerManagerImpl::setLastClosedLedger(
     LedgerHeaderHistoryEntry const& lastClosed)
 {
+    // NB: this method is a sort of half-apply that runs on main thread and
+    // updates LCL without apply having happened any txs. It's only relevant
+    // when finishing the _bucket-apply_ phase of catchup (which is not
+    // transaction-apply, it's like "load any bucket state into the DB").
     ZoneScoped;
     releaseAssert(threadIsMain());
     LedgerTxn ltx(mApp.getLedgerTxnRoot());
@@ -1165,11 +1327,19 @@ LedgerManagerImpl::setLastClosedLedger(
         advanceBucketListSnapshotAndMakeLedgerState(lastClosed.header, has));
 
     LedgerTxn ltx2(mApp.getLedgerTxnRoot());
-    if (protocolVersionStartsFrom(ltx2.loadHeader().current().ledgerVersion,
-                                  SOROBAN_PROTOCOL_VERSION))
+    auto lv = ltx2.loadHeader().current().ledgerVersion;
+    if (protocolVersionStartsFrom(lv, SOROBAN_PROTOCOL_VERSION))
     {
         mApp.getLedgerManager().updateSorobanNetworkConfigForApply(ltx2);
     }
+    // This should not be additionally conditionalized on lv >= anything,
+    // since we want to support SOROBAN_TEST_EXTRA_PROTOCOL > lv.
+    //
+    // Again, since we are only called during catchup and just got a full
+    // bucket state, there's no tx-apply state to snapshot, in this one
+    // case we will prime the tx-apply-state's soroban module cache using
+    // a snapshot _from_ the LCL state.
+    mApplyState.compileAllContractsInLedger(getLCLState().snapshot, lv);
 }
 
 void
@@ -1601,11 +1771,11 @@ LedgerManagerImpl::applyTransactions(
     // Record counts
     if (numTxs > 0)
     {
-        mLedgerApplyMetrics.mTransactionCount.Update(
+        mApplyState.mMetrics.mTransactionCount.Update(
             static_cast<int64_t>(numTxs));
         TracyPlot("ledger.transaction.count", static_cast<int64_t>(numTxs));
 
-        mLedgerApplyMetrics.mOperationCount.Update(
+        mApplyState.mMetrics.mOperationCount.Update(
             static_cast<int64_t>(numOps));
         TracyPlot("ledger.operation.count", static_cast<int64_t>(numOps));
         CLOG_INFO(Tx, "applying ledger {} ({})",
@@ -1631,7 +1801,7 @@ LedgerManagerImpl::applyTransactions(
             ZoneNamedN(txZone, "applyTransaction", true);
             auto mutableTxResult = mutableTxResults.at(resultIndex++);
 
-            auto txTime = mLedgerApplyMetrics.mTransactionApply.TimeScope();
+            auto txTime = mApplyState.mMetrics.mTransactionApply.TimeScope();
             TransactionMetaFrame tm(ltx.loadHeader().current().ledgerVersion,
                                     mApp.getConfig());
 
@@ -1701,11 +1871,11 @@ LedgerManagerImpl::applyTransactions(
         }
     }
 
-    mLedgerApplyMetrics.mTransactionApplySucceeded.inc(txSucceeded);
-    mLedgerApplyMetrics.mTransactionApplyFailed.inc(txFailed);
-    mLedgerApplyMetrics.mSorobanTransactionApplySucceeded.inc(
+    mApplyState.mMetrics.mTransactionApplySucceeded.inc(txSucceeded);
+    mApplyState.mMetrics.mTransactionApplyFailed.inc(txFailed);
+    mApplyState.mMetrics.mSorobanTransactionApplySucceeded.inc(
         sorobanTxSucceeded);
-    mLedgerApplyMetrics.mSorobanTransactionApplyFailed.inc(sorobanTxFailed);
+    mApplyState.mMetrics.mSorobanTransactionApplyFailed.inc(sorobanTxFailed);
     logTxApplyMetrics(ltx, numTxs, numOps);
     return txResultSet;
 }
@@ -1721,7 +1891,7 @@ LedgerManagerImpl::logTxApplyMetrics(AbstractLedgerTxn& ltx, size_t numTxs,
                ledgerSeq, numTxs, numOps, hitRate);
 
     // We lose a bit of precision here, as medida only accepts int64_t
-    mLedgerApplyMetrics.mPrefetchHitRate.Update(std::llround(hitRate));
+    mApplyState.mMetrics.mPrefetchHitRate.Update(std::llround(hitRate));
     TracyPlot("ledger.prefetch.hit-rate", hitRate);
 }
 
@@ -1820,6 +1990,8 @@ LedgerManagerImpl::sealLedgerTxnAndTransferEntriesToBucketList(
                 ledgerCloseMeta->populateEvictedEntries(evictedState);
             }
 
+            mApplyState.evictFromModuleCache(lh.ledgerVersion, evictedState);
+
             ltxEvictions.commit();
         }
 
@@ -1831,6 +2003,8 @@ LedgerManagerImpl::sealLedgerTxnAndTransferEntriesToBucketList(
     ltx.getAllEntries(initEntries, liveEntries, deadEntries);
     if (blEnabled)
     {
+        mApplyState.addAnyContractsToModuleCache(lh.ledgerVersion, initEntries);
+        mApplyState.addAnyContractsToModuleCache(lh.ledgerVersion, liveEntries);
         mApp.getBucketManager().addLiveBatch(mApp, lh, initEntries, liveEntries,
                                              deadEntries);
     }
@@ -1889,6 +2063,75 @@ LedgerManagerImpl::sealLedgerTxnAndStoreInBucketsAndDB(
         res = advanceBucketListSnapshotAndMakeLedgerState(lh, has);
     });
 
+    if (protocolVersionStartsFrom(
+            initialLedgerVers, REUSABLE_SOROBAN_MODULE_CACHE_PROTOCOL_VERSION))
+    {
+        mApplyState.maybeRebuildModuleCache(res.snapshot, initialLedgerVers);
+    }
+
     return res;
 }
+
+void
+LedgerManagerImpl::ApplyState::evictFromModuleCache(
+    uint32_t ledgerVersion, EvictedStateVectors const& evictedState)
+{
+    std::vector<Hash> keys;
+    for (auto const& key : evictedState.deletedKeys)
+    {
+        if (key.type() == CONTRACT_CODE)
+        {
+            keys.emplace_back(key.contractCode().hash);
+        }
+    }
+    for (auto const& entry : evictedState.archivedEntries)
+    {
+        if (entry.data.type() == CONTRACT_CODE)
+        {
+            Hash const& hash = entry.data.contractCode().hash;
+            keys.emplace_back(hash);
+        }
+    }
+    if (keys.size() > 0)
+    {
+        CLOG_DEBUG(Ledger, "evicting {} modules from module cache",
+                   keys.size());
+        for (auto const& hash : keys)
+        {
+            CLOG_DEBUG(Ledger, "evicting {} from module cache", binToHex(hash));
+            ::rust::Slice<uint8_t const> slice{hash.data(), hash.size()};
+            mModuleCache->evict_contract_code(slice);
+            mMetrics.mSorobanMetrics.mModuleCacheNumEntries.dec();
+        }
+    }
+}
+
+void
+LedgerManagerImpl::ApplyState::addAnyContractsToModuleCache(
+    uint32_t ledgerVersion, std::vector<LedgerEntry> const& le)
+{
+    for (auto const& e : le)
+    {
+        if (e.data.type() == CONTRACT_CODE)
+        {
+            for (auto const& v : mModuleCacheProtocols)
+            {
+                if (v >= ledgerVersion)
+                {
+                    auto const& wasm = e.data.contractCode().code;
+                    CLOG_DEBUG(Ledger,
+                               "compiling wasm {} for protocol {} module cache",
+                               binToHex(sha256(wasm)), v);
+                    auto slice =
+                        rust::Slice<const uint8_t>(wasm.data(), wasm.size());
+                    mMetrics.mSorobanMetrics.mModuleCacheNumEntries.inc();
+                    auto timer = mMetrics.mSorobanMetrics.mModuleCompilationTime
+                                     .TimeScope();
+                    mModuleCache->compile(v, slice);
+                }
+            }
+        }
+    }
+}
+
 }

--- a/src/ledger/SharedModuleCacheCompiler.cpp
+++ b/src/ledger/SharedModuleCacheCompiler.cpp
@@ -1,0 +1,222 @@
+// Copyright 2025 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "ledger/SharedModuleCacheCompiler.h"
+#include "bucket/SearchableBucketList.h"
+#include "crypto/Hex.h"
+#include "crypto/SHA.h"
+#include "rust/RustBridge.h"
+#include "util/Logging.h"
+#include "xdr/Stellar-ledger-entries.h"
+#include <chrono>
+#include <cstddef>
+
+namespace stellar
+{
+
+size_t const SharedModuleCacheCompiler::BUFFERED_WASM_CAPACITY =
+    100 * 1024 * 1024;
+
+SharedModuleCacheCompiler::SharedModuleCacheCompiler(
+    SearchableSnapshotConstPtr snap, size_t numThreads,
+    std::vector<uint32_t> const& ledgerVersions)
+    : mModuleCache(rust_bridge::new_module_cache())
+    , mSnap(snap)
+    , mNumThreads(numThreads)
+    , mLedgerVersions(ledgerVersions)
+    , mStarted(std::chrono::steady_clock::now())
+{
+}
+
+SharedModuleCacheCompiler::~SharedModuleCacheCompiler()
+{
+    for (auto& t : mThreads)
+    {
+        t.join();
+    }
+}
+
+void
+SharedModuleCacheCompiler::pushWasm(xdr::xvector<uint8_t> const& vec)
+{
+    std::unique_lock<std::mutex> lock(mMutex);
+    mHaveSpace.wait(lock, [&] {
+        return mBytesLoaded - mBytesCompiled < BUFFERED_WASM_CAPACITY;
+    });
+    xdr::xvector<uint8_t> buf(vec);
+    auto size = buf.size();
+    mWasms.emplace_back(std::move(buf));
+    mBytesLoaded += size;
+    lock.unlock();
+    mHaveContracts.notify_all();
+    LOG_DEBUG(DEFAULT_LOG, "Loaded contract with {} bytes of wasm code", size);
+}
+
+bool
+SharedModuleCacheCompiler::isFinishedCompiling(
+    std::unique_lock<std::mutex>& lock)
+{
+    releaseAssert(lock.owns_lock());
+    return mLoadedAll && mBytesCompiled == mBytesLoaded;
+}
+
+void
+SharedModuleCacheCompiler::setFinishedLoading(size_t nContracts)
+{
+    std::unique_lock lock(mMutex);
+    mLoadedAll = true;
+    mContractsCompiled = nContracts;
+    lock.unlock();
+    mHaveContracts.notify_all();
+}
+
+bool
+SharedModuleCacheCompiler::popAndCompileWasm(size_t thread,
+                                             std::unique_lock<std::mutex>& lock)
+{
+
+    releaseAssert(lock.owns_lock());
+
+    // Wait for a new contract to compile (or being done).
+    mHaveContracts.wait(
+        lock, [&] { return !mWasms.empty() || isFinishedCompiling(lock); });
+
+    // Check to see if we were woken up due to end-of-compilation.
+    if (isFinishedCompiling(lock))
+    {
+        return false;
+    }
+
+    xdr::xvector<uint8_t> wasm = std::move(mWasms.front());
+    mWasms.pop_front();
+    lock.unlock();
+
+    auto start = std::chrono::steady_clock::now();
+    auto slice = rust::Slice<const uint8_t>(wasm.data(), wasm.size());
+    auto hash = binToHex(sha256(wasm));
+    for (auto ledgerVersion : mLedgerVersions)
+    {
+        try
+        {
+            mModuleCache->compile(ledgerVersion, slice);
+        }
+        catch (std::exception const& e)
+        {
+            LOG_FATAL(DEFAULT_LOG,
+                      "Thread {} failed to compile {} byte wasm {} for "
+                      "protocol {}: {}",
+                      thread, wasm.size(), hash, ledgerVersion, e.what());
+            throw;
+        }
+    }
+    auto end = std::chrono::steady_clock::now();
+    auto dur_us =
+        std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+    LOG_DEBUG(DEFAULT_LOG,
+              "Thread {} compiled {} byte wasm contract {} in {}us", thread,
+              wasm.size(), hash, dur_us.count());
+    lock.lock();
+    mTotalCompileTime += dur_us;
+    mBytesCompiled += wasm.size();
+    wasm.clear();
+    mHaveSpace.notify_all();
+    mHaveContracts.notify_all();
+    return true;
+}
+
+void
+SharedModuleCacheCompiler::start()
+{
+    mStarted = std::chrono::steady_clock::now();
+
+    LOG_INFO(DEFAULT_LOG,
+             "Launching 1 loading and {} compiling background threads",
+             mNumThreads - 1);
+
+    mThreads.emplace_back(std::thread([this]() {
+        std::set<Hash> seenContracts;
+        this->mSnap->scanForContractCode([&](BucketEntry const& entry) {
+            Hash h;
+            switch (entry.type())
+            {
+            case INITENTRY:
+            case LIVEENTRY:
+                h = entry.liveEntry().data.contractCode().hash;
+                if (seenContracts.find(h) == seenContracts.end())
+                {
+                    this->pushWasm(entry.liveEntry().data.contractCode().code);
+                }
+                break;
+            case DEADENTRY:
+                h = entry.deadEntry().contractCode().hash;
+                break;
+            default:
+                break;
+            }
+            seenContracts.insert(h);
+            return Loop::INCOMPLETE;
+        });
+        this->setFinishedLoading(seenContracts.size());
+    }));
+
+    for (auto thread = 1; thread < this->mNumThreads; ++thread)
+    {
+        mThreads.emplace_back(std::thread([this, thread]() {
+            size_t nContractsCompiled = 0;
+            std::unique_lock<std::mutex> lock(this->mMutex);
+            while (!this->isFinishedCompiling(lock))
+            {
+                if (this->popAndCompileWasm(thread, lock))
+                {
+                    ++nContractsCompiled;
+                }
+            }
+            LOG_DEBUG(DEFAULT_LOG, "Thread {} compiled {} contracts", thread,
+                      nContractsCompiled);
+        }));
+    }
+}
+
+::rust::Box<stellar::rust_bridge::SorobanModuleCache>
+SharedModuleCacheCompiler::wait()
+{
+    std::unique_lock lock(mMutex);
+    mHaveContracts.wait(
+        lock, [this, &lock] { return this->isFinishedCompiling(lock); });
+
+    auto end = std::chrono::steady_clock::now();
+    LOG_INFO(
+        DEFAULT_LOG,
+        "Compiled {} contracts ({} bytes of Wasm) in {}ms real time, {}ms "
+        "CPU time",
+        mContractsCompiled, mBytesCompiled,
+        std::chrono::duration_cast<std::chrono::milliseconds>(end - mStarted)
+            .count(),
+        std::chrono::duration_cast<std::chrono::milliseconds>(mTotalCompileTime)
+            .count());
+    return mModuleCache->shallow_clone();
+}
+
+size_t
+SharedModuleCacheCompiler::getBytesCompiled()
+{
+    std::unique_lock lock(mMutex);
+    return mBytesCompiled;
+}
+
+std::chrono::nanoseconds
+SharedModuleCacheCompiler::getCompileTime()
+{
+    std::unique_lock lock(mMutex);
+    return mTotalCompileTime;
+}
+
+size_t
+SharedModuleCacheCompiler::getContractsCompiled()
+{
+    std::unique_lock lock(mMutex);
+    return mContractsCompiled;
+}
+
+}

--- a/src/ledger/SharedModuleCacheCompiler.cpp
+++ b/src/ledger/SharedModuleCacheCompiler.cpp
@@ -75,6 +75,7 @@ bool
 SharedModuleCacheCompiler::popAndCompileWasm(size_t thread,
                                              std::unique_lock<std::mutex>& lock)
 {
+    ZoneScoped;
 
     releaseAssert(lock.owns_lock());
 
@@ -135,6 +136,7 @@ SharedModuleCacheCompiler::start()
              mNumThreads - 1);
 
     mThreads.emplace_back(std::thread([this]() {
+        ZoneScopedN("load wasm contracts");
         std::set<Hash> seenContracts;
         this->mSnap->scanForContractCode([&](BucketEntry const& entry) {
             Hash h;
@@ -163,6 +165,7 @@ SharedModuleCacheCompiler::start()
     for (auto thread = 1; thread < this->mNumThreads; ++thread)
     {
         mThreads.emplace_back(std::thread([this, thread]() {
+            ZoneScopedN("compile wasm contracts");
             size_t nContractsCompiled = 0;
             std::unique_lock<std::mutex> lock(this->mMutex);
             while (!this->isFinishedCompiling(lock))

--- a/src/ledger/SharedModuleCacheCompiler.h
+++ b/src/ledger/SharedModuleCacheCompiler.h
@@ -1,0 +1,68 @@
+#pragma once
+// Copyright 2025 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "bucket/BucketSnapshotManager.h"
+#include "rust/RustBridge.h"
+#include "util/NonCopyable.h"
+#include "xdrpp/types.h"
+
+#include <chrono>
+#include <cstdint>
+#include <deque>
+
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+namespace stellar
+{
+class Application;
+
+// This class encapsulates a multithreaded strategy for loading contracts
+// out of the database (on one thread) and compiling them (on N-1 others).
+class SharedModuleCacheCompiler : NonMovableOrCopyable
+{
+    ::rust::Box<stellar::rust_bridge::SorobanModuleCache> mModuleCache;
+    stellar::SearchableSnapshotConstPtr mSnap;
+    std::deque<xdr::xvector<uint8_t>> mWasms;
+
+    size_t const mNumThreads;
+    std::vector<std::thread> mThreads;
+    // The loading thread will pause and wait for the compiling threads to catch
+    // up when it's more than BUFFERED_WASM_CAPACITY bytes ahead of them.
+    static size_t const BUFFERED_WASM_CAPACITY;
+    bool mLoadedAll{false};
+    size_t mBytesLoaded{0};
+    size_t mBytesCompiled{0};
+    size_t mContractsCompiled{0};
+    std::vector<uint32_t> mLedgerVersions;
+
+    std::mutex mMutex;
+    std::condition_variable mHaveSpace;
+    std::condition_variable mHaveContracts;
+
+    std::chrono::steady_clock::time_point mStarted;
+    std::chrono::nanoseconds mTotalCompileTime{0};
+
+    void setFinishedLoading(size_t nContracts);
+    bool isFinishedCompiling(std::unique_lock<std::mutex>& lock);
+    // This gets called in a loop on the loader/producer thread.
+    void pushWasm(xdr::xvector<uint8_t> const& vec);
+    // This gets called in a loop on the compiler/consumer threads. It returns
+    // true if anything was actually compiled.
+    bool popAndCompileWasm(size_t thread, std::unique_lock<std::mutex>& lock);
+
+  public:
+    SharedModuleCacheCompiler(SearchableSnapshotConstPtr snap,
+                              size_t numThreads,
+                              std::vector<uint32_t> const& ledgerVersions);
+    ~SharedModuleCacheCompiler();
+    void start();
+    ::rust::Box<stellar::rust_bridge::SorobanModuleCache> wait();
+    size_t getBytesCompiled();
+    std::chrono::nanoseconds getCompileTime();
+    size_t getContractsCompiled();
+};
+}

--- a/src/ledger/SorobanMetrics.cpp
+++ b/src/ledger/SorobanMetrics.cpp
@@ -20,6 +20,11 @@ SorobanMetrics::SorobanMetrics(medida::MetricsRegistry& metrics)
           metrics.NewHistogram({"soroban", "ledger", "write-entry"}))
     , mLedgerWriteLedgerByte(
           metrics.NewHistogram({"soroban", "ledger", "write-ledger-byte"}))
+    , mLedgerHostFnCpuInsnsRatio(metrics.NewHistogram(
+          {"soroban", "host-fn-op", "ledger-cpu-insns-ratio"}))
+    , mLedgerHostFnCpuInsnsRatioExclVm(metrics.NewHistogram(
+          {"soroban", "host-fn-op", "ledger-cpu-insns-ratio-excl-vm"}))
+
     /* tx-wide metrics */
     , mTxSizeByte(metrics.NewHistogram({"soroban", "tx", "size-byte"}))
     /* InvokeHostFunctionOp metrics */
@@ -62,6 +67,8 @@ SorobanMetrics::SorobanMetrics(medida::MetricsRegistry& metrics)
     , mHostFnOpInvokeTimeFsecsCpuInsnRatioExclVm(
           metrics.NewHistogram({"soroban", "host-fn-op",
                                 "invoke-time-fsecs-cpu-insn-ratio-excl-vm"}))
+    , mHostFnOpDeclaredInsnsUsageRatio(metrics.NewHistogram(
+          {"soroban", "host-fn-op", "declared-cpu-insns-usage-ratio"}))
     , mHostFnOpMaxRwKeyByte(metrics.NewMeter(
           {"soroban", "host-fn-op", "max-rw-key-byte"}, "byte"))
     , mHostFnOpMaxRwDataByte(metrics.NewMeter(
@@ -128,12 +135,17 @@ SorobanMetrics::SorobanMetrics(medida::MetricsRegistry& metrics)
           {"soroban", "config", "bucket-list-target-size-byte"}))
     , mConfigFeeWrite1KB(
           metrics.NewCounter({"soroban", "config", "fee-write-1kb"}))
-    , mLedgerHostFnCpuInsnsRatio(metrics.NewHistogram(
-          {"soroban", "host-fn-op", "ledger-cpu-insns-ratio"}))
-    , mLedgerHostFnCpuInsnsRatioExclVm(metrics.NewHistogram(
-          {"soroban", "host-fn-op", "ledger-cpu-insns-ratio-excl-vm"}))
-    , mHostFnOpDeclaredInsnsUsageRatio(metrics.NewHistogram(
-          {"soroban", "host-fn-op", "declared-cpu-insns-usage-ratio"}))
+
+    /* Module cache related metrics */
+    , mModuleCacheNumEntries(
+          metrics.NewCounter({"soroban", "module-cache", "num-entries"}))
+    , mModuleCompilationTime(
+          metrics.NewTimer({"soroban", "module-cache", "compilation-time"}))
+    , mModuleCacheRebuildTime(
+          metrics.NewTimer({"soroban", "module-cache", "rebuild-time"}))
+    , mModuleCacheRebuildBytes(
+          metrics.NewCounter({"soroban", "module-cache", "rebuild-bytes"}))
+
 {
 }
 

--- a/src/ledger/SorobanMetrics.h
+++ b/src/ledger/SorobanMetrics.h
@@ -111,6 +111,12 @@ class SorobanMetrics
     medida::Counter& mConfigBucketListTargetSizeByte;
     medida::Counter& mConfigFeeWrite1KB;
 
+    // Module cache related metrics
+    medida::Counter& mModuleCacheNumEntries;
+    medida::Timer& mModuleCompilationTime;
+    medida::Timer& mModuleCacheRebuildTime;
+    medida::Counter& mModuleCacheRebuildBytes;
+
     SorobanMetrics(medida::MetricsRegistry& metrics);
 
     void accumulateModelledCpuInsns(uint64_t insnsCount,

--- a/src/ledger/test/LedgerTestUtils.cpp
+++ b/src/ledger/test/LedgerTestUtils.cpp
@@ -380,6 +380,12 @@ makeValid(ContractDataEntry& cde)
 void
 makeValid(ContractCodeEntry& cce)
 {
+    auto seed = rand_uniform<uint64_t>(0, UINT64_MAX);
+    auto size = rand_uniform<size_t>(64, 150);
+    auto wasmBuf = rust_bridge::get_random_wasm(size, seed);
+    cce.code.assign(wasmBuf.data.data(),
+                    wasmBuf.data.data() + wasmBuf.data.size());
+    cce.hash = sha256(cce.code);
 }
 
 void

--- a/src/main/AppConnector.cpp
+++ b/src/main/AppConnector.cpp
@@ -9,12 +9,16 @@
 #include "overlay/OverlayMetrics.h"
 #include "overlay/Peer.h"
 #include "util/Timer.h"
+#include <mutex>
+#include <shared_mutex>
 
 namespace stellar
 {
 
 AppConnector::AppConnector(Application& app)
-    : mApp(app), mConfig(app.getConfig())
+    : mApp(app)
+    , mConfig(app.getConfig())
+    , mModuleCache(rust_bridge::new_module_cache())
 {
 }
 
@@ -106,6 +110,12 @@ Config const&
 AppConnector::getConfig() const
 {
     return mConfig;
+}
+
+rust::Box<rust_bridge::SorobanModuleCache>
+AppConnector::getModuleCache()
+{
+    return mApp.getLedgerManager().getModuleCache();
 }
 
 bool

--- a/src/main/AppConnector.cpp
+++ b/src/main/AppConnector.cpp
@@ -9,16 +9,12 @@
 #include "overlay/OverlayMetrics.h"
 #include "overlay/Peer.h"
 #include "util/Timer.h"
-#include <mutex>
-#include <shared_mutex>
 
 namespace stellar
 {
 
 AppConnector::AppConnector(Application& app)
-    : mApp(app)
-    , mConfig(app.getConfig())
-    , mModuleCache(rust_bridge::new_module_cache())
+    : mApp(app), mConfig(app.getConfig())
 {
 }
 

--- a/src/main/AppConnector.h
+++ b/src/main/AppConnector.h
@@ -28,12 +28,6 @@ class AppConnector
     // Copy config for threads to use, and avoid warnings from thread sanitizer
     // about accessing mApp
     Config const mConfig;
-    // Copy of module cache handle, for threads to use. All copies of the module
-    // cache handle point to the same, shared, threadsafe module cache. It may
-    // periodically be replaced by a delete/rebuild cycle in the LedgerManager.
-    // This is always done under a mutex.
-    rust::Box<rust_bridge::SorobanModuleCache> mModuleCache;
-    std::shared_mutex mModuleCacheMutex;
 
   public:
     AppConnector(Application& app);

--- a/src/main/AppConnector.h
+++ b/src/main/AppConnector.h
@@ -4,6 +4,8 @@
 #include "main/Application.h"
 #include "main/Config.h"
 #include "medida/metrics_registry.h"
+#include "rust/RustBridge.h"
+#include <shared_mutex>
 
 namespace stellar
 {
@@ -26,6 +28,12 @@ class AppConnector
     // Copy config for threads to use, and avoid warnings from thread sanitizer
     // about accessing mApp
     Config const mConfig;
+    // Copy of module cache handle, for threads to use. All copies of the module
+    // cache handle point to the same, shared, threadsafe module cache. It may
+    // periodically be replaced by a delete/rebuild cycle in the LedgerManager.
+    // This is always done under a mutex.
+    rust::Box<rust_bridge::SorobanModuleCache> mModuleCache;
+    std::shared_mutex mModuleCacheMutex;
 
   public:
     AppConnector(Application& app);
@@ -51,6 +59,7 @@ class AppConnector
                              std::string const& message);
     VirtualClock::time_point now() const;
     Config const& getConfig() const;
+    rust::Box<rust_bridge::SorobanModuleCache> getModuleCache();
     bool overlayShuttingDown() const;
     OverlayMetrics& getOverlayMetrics();
     // This method is always exclusively called from one thread

--- a/src/main/AppConnector.h
+++ b/src/main/AppConnector.h
@@ -5,7 +5,6 @@
 #include "main/Config.h"
 #include "medida/metrics_registry.h"
 #include "rust/RustBridge.h"
-#include <shared_mutex>
 
 namespace stellar
 {

--- a/src/main/ApplicationUtils.h
+++ b/src/main/ApplicationUtils.h
@@ -4,6 +4,7 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "database/Database.h"
 #include "history/HistoryArchive.h"
 #include "ledger/LedgerRange.h"
 #include "main/Application.h"
@@ -33,6 +34,7 @@ int dumpLedger(Config cfg, std::string const& outputFile,
                std::optional<uint64_t> limit,
                std::optional<std::string> groupBy,
                std::optional<std::string> aggregate, bool includeAllStates);
+void dumpWasmBlob(Config cfg, std::string const& hash, std::string const& dir);
 void showOfflineInfo(Config cfg, bool verbose);
 int reportLastHistoryCheckpoint(Config cfg, std::string const& outputFile);
 

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -363,6 +363,13 @@ ledgerHashParser(std::string& ledgerHash)
 }
 
 clara::Opt
+wasmHashParser(std::string& wasmHash)
+{
+    return clara::Opt{wasmHash, "HASH"}["--wasm-hash"](
+        "Hash of the a specific Wasm blob to dump, or 'ALL' to dump all");
+}
+
+clara::Opt
 forceUntrustedCatchup(bool& force)
 {
     return clara::Opt{force}["--force-untrusted-catchup"](
@@ -1024,6 +1031,22 @@ runDumpXDR(CommandLineArgs const& args)
     return runWithHelp(args, {compactParser(compact), fileNameParser(xdr)},
                        [&] {
                            dumpXdrStream(xdr, compact);
+                           return 0;
+                       });
+}
+
+int
+runDumpWasm(CommandLineArgs const& args)
+{
+    CommandLine::ConfigOption configOption;
+    std::string hash;
+    std::string dir;
+
+    return runWithHelp(args,
+                       {configurationParser(configOption), wasmHashParser(hash),
+                        outputDirParser(dir)},
+                       [&] {
+                           dumpWasmBlob(configOption.getConfig(), hash, dir);
                            return 0;
                        });
 }
@@ -1942,6 +1965,8 @@ handleCommandLine(int argc, char* const* argv)
          {"dump-ledger", "dumps the current ledger state as JSON for debugging",
           runDumpLedger},
          {"dump-xdr", "dump an XDR file, for debugging", runDumpXDR},
+         {"dump-wasm", "dump WASM blobs from ledger, for debugging",
+          runDumpWasm},
          {"encode-asset", "Print an encoded asset in base 64 for debugging",
           runEncodeAsset},
          {"force-scp", "deprecated, use --wait-for-consensus option instead",

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -279,6 +279,13 @@ Config::Config() : NODE_SEED(SecretKey::random())
     //
     // Worst case = 10 concurrent merges + 1 quorum intersection calculation.
     WORKER_THREADS = 11;
+
+    // Compilation is a short process that runs at startup and is CPU limited.
+    // Empirically it tends to peak and start getting slower around 6 threads
+    // due to coordination overhead between the producer and consumer threads.
+    // This could probably be improved with some work but it's ok for now.
+    COMPILATION_THREADS = 6;
+
     MAX_CONCURRENT_SUBPROCESSES = 16;
     NODE_IS_VALIDATOR = false;
     QUORUM_INTERSECTION_CHECKER = true;
@@ -1361,6 +1368,8 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                  [&]() {
                      QUERY_THREAD_POOL_SIZE = readInt<int>(item, 1, 1000);
                  }},
+                {"COMPILATION_THREADS",
+                 [&]() { COMPILATION_THREADS = readInt<int>(item, 2, 1000); }},
                 {"QUERY_SNAPSHOT_LEDGERS",
                  [&]() {
                      QUERY_SNAPSHOT_LEDGERS = readInt<uint32_t>(item, 0, 10);

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -672,6 +672,10 @@ class Config : public std::enable_shared_from_this<Config>
     // Number of threads to serve query commands
     int QUERY_THREAD_POOL_SIZE;
 
+    // Number of threads to use when compiling contracts
+    // at startup.
+    int COMPILATION_THREADS;
+
     // Number of ledger snapshots to maintain for querying
     uint32_t QUERY_SNAPSHOT_LEDGERS;
 

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -198,6 +198,7 @@ mod rust_bridge {
             ttl_entries: &Vec<CxxBuf>,
             base_prng_seed: &CxxBuf,
             rent_fee_configuration: CxxRentFeeConfiguration,
+            module_cache: &SorobanModuleCache,
         ) -> Result<InvokeHostFunctionOutput>;
 
         fn init_logging(maxLevel: LogLevel) -> Result<()>;
@@ -279,6 +280,20 @@ mod rust_bridge {
         fn i128_sub_will_underflow(lhs: &CxxI128, rhs: &CxxI128) -> Result<bool>;
 
         fn i128_from_i64(val: i64) -> Result<CxxI128>;
+
+        type SorobanModuleCache;
+
+        fn new_module_cache() -> Result<Box<SorobanModuleCache>>;
+        fn compile(
+            self: &mut SorobanModuleCache,
+            ledger_protocol: u32,
+            source: &[u8],
+        ) -> Result<()>;
+        fn shallow_clone(self: &SorobanModuleCache) -> Result<Box<SorobanModuleCache>>;
+        fn evict_contract_code(self: &mut SorobanModuleCache, key: &[u8]) -> Result<()>;
+        fn clear(self: &mut SorobanModuleCache) -> Result<()>;
+        fn contains_module(self: &SorobanModuleCache, protocol: u32, key: &[u8]) -> Result<bool>;
+        fn get_mem_bytes_consumed(self: &SorobanModuleCache) -> Result<u64>;
     }
 
     // And the extern "C++" block declares C++ stuff we're going to import to
@@ -538,19 +553,66 @@ use log::partition::TX;
 #[path = "."]
 mod p23 {
     pub(crate) extern crate soroban_env_host_p23;
+    use super::SorobanModuleCache;
+    use soroban_env_host::{
+        budget::Budget,
+        e2e_invoke::{self, InvokeHostFunctionResult},
+        xdr::DiagnosticEvent,
+        HostError, LedgerInfo, TraceHook,
+    };
     pub(crate) use soroban_env_host_p23 as soroban_env_host;
 
     pub(crate) mod contract;
+
+    // We do some more local re-exports here of things used in contract.rs that
+    // don't exist in older hosts (eg. the p21 & 22 hosts, where we define stubs for
+    // these imports).
+    pub(crate) use soroban_env_host::{CompilationContext, ErrorHandler, ModuleCache};
 
     // An adapter for some API breakage between p21 and p22.
     pub(crate) const fn get_version_pre_release(v: &soroban_env_host::Version) -> u32 {
         v.interface.pre_release
     }
 
-    pub(crate) const fn get_version_protocol(v: &soroban_env_host::Version) -> u32 {
+    pub(crate) const fn get_version_protocol(_v: &soroban_env_host::Version) -> u32 {
         // Temporarily hardcode the protocol version until we actually bump it
         // in the host library.
         23
+    }
+
+    pub fn invoke_host_function_with_trace_hook_and_module_cache<
+        T: AsRef<[u8]>,
+        I: ExactSizeIterator<Item = T>,
+    >(
+        budget: &Budget,
+        enable_diagnostics: bool,
+        encoded_host_fn: T,
+        encoded_resources: T,
+        encoded_source_account: T,
+        encoded_auth_entries: I,
+        ledger_info: LedgerInfo,
+        encoded_ledger_entries: I,
+        encoded_ttl_entries: I,
+        base_prng_seed: T,
+        diagnostic_events: &mut Vec<DiagnosticEvent>,
+        trace_hook: Option<TraceHook>,
+        module_cache: &SorobanModuleCache,
+    ) -> Result<InvokeHostFunctionResult, HostError> {
+        e2e_invoke::invoke_host_function_with_trace_hook_and_module_cache(
+            &budget,
+            enable_diagnostics,
+            encoded_host_fn,
+            encoded_resources,
+            encoded_source_account,
+            encoded_auth_entries,
+            ledger_info,
+            encoded_ledger_entries,
+            encoded_ttl_entries,
+            base_prng_seed,
+            diagnostic_events,
+            trace_hook,
+            Some(module_cache.p23_cache.module_cache.clone()),
+        )
     }
 }
 
@@ -558,8 +620,60 @@ mod p23 {
 mod p22 {
     pub(crate) extern crate soroban_env_host_p22;
     pub(crate) use soroban_env_host_p22 as soroban_env_host;
-
     pub(crate) mod contract;
+    use super::SorobanModuleCache;
+    use soroban_env_host::{
+        budget::{AsBudget, Budget},
+        e2e_invoke::{self, InvokeHostFunctionResult},
+        xdr::{DiagnosticEvent, Hash},
+        Error, HostError, LedgerInfo, TraceHook, Val,
+    };
+
+    // Some stub definitions to handle API additions for the
+    // reusable module cache.
+
+    #[allow(dead_code)]
+    const INTERNAL_ERROR: Error = Error::from_type_and_code(
+        soroban_env_host::xdr::ScErrorType::Context,
+        soroban_env_host::xdr::ScErrorCode::InternalError,
+    );
+
+    #[allow(dead_code)]
+    #[derive(Clone)]
+    pub(crate) struct ModuleCache;
+    #[allow(dead_code)]
+    pub(crate) trait ErrorHandler {
+        fn map_err<T, E>(&self, res: Result<T, E>) -> Result<T, HostError>
+        where
+            Error: From<E>,
+            E: core::fmt::Debug;
+        fn error(&self, error: Error, msg: &str, args: &[Val]) -> HostError;
+    }
+    #[allow(dead_code)]
+    impl ModuleCache {
+        pub(crate) fn new<T>(_handler: T) -> Result<Self, HostError> {
+            Err(INTERNAL_ERROR.into())
+        }
+        pub(crate) fn parse_and_cache_module_simple<T>(
+            &self,
+            _handler: &T,
+            _protocol: u32,
+            _wasm: &[u8],
+        ) -> Result<(), HostError> {
+            Err(INTERNAL_ERROR.into())
+        }
+        pub(crate) fn remove_module(&self, _key: &Hash) -> Result<(), HostError> {
+            Err(INTERNAL_ERROR.into())
+        }
+        pub(crate) fn clear(&self) -> Result<(), HostError> {
+            Err(INTERNAL_ERROR.into())
+        }
+        pub(crate) fn contains_module(&self, _key: &Hash) -> Result<bool, HostError> {
+            Err(INTERNAL_ERROR.into())
+        }
+    }
+    #[allow(dead_code)]
+    pub(crate) trait CompilationContext: ErrorHandler + AsBudget {}
 
     // An adapter for some API breakage between p21 and p22.
     pub(crate) const fn get_version_pre_release(v: &soroban_env_host::Version) -> u32 {
@@ -569,14 +683,100 @@ mod p22 {
     pub(crate) const fn get_version_protocol(v: &soroban_env_host::Version) -> u32 {
         v.interface.protocol
     }
+
+    pub fn invoke_host_function_with_trace_hook_and_module_cache<
+        T: AsRef<[u8]>,
+        I: ExactSizeIterator<Item = T>,
+    >(
+        budget: &Budget,
+        enable_diagnostics: bool,
+        encoded_host_fn: T,
+        encoded_resources: T,
+        encoded_source_account: T,
+        encoded_auth_entries: I,
+        ledger_info: LedgerInfo,
+        encoded_ledger_entries: I,
+        encoded_ttl_entries: I,
+        base_prng_seed: T,
+        diagnostic_events: &mut Vec<DiagnosticEvent>,
+        trace_hook: Option<TraceHook>,
+        _module_cache: &SorobanModuleCache,
+    ) -> Result<InvokeHostFunctionResult, HostError> {
+        e2e_invoke::invoke_host_function_with_trace_hook(
+            &budget,
+            enable_diagnostics,
+            encoded_host_fn,
+            encoded_resources,
+            encoded_source_account,
+            encoded_auth_entries,
+            ledger_info,
+            encoded_ledger_entries,
+            encoded_ttl_entries,
+            base_prng_seed,
+            diagnostic_events,
+            trace_hook,
+        )
+    }
 }
 
 #[path = "."]
 mod p21 {
     pub(crate) extern crate soroban_env_host_p21;
     pub(crate) use soroban_env_host_p21 as soroban_env_host;
-
     pub(crate) mod contract;
+    use super::SorobanModuleCache;
+    use soroban_env_host::{
+        budget::{AsBudget, Budget},
+        e2e_invoke::{self, InvokeHostFunctionResult},
+        xdr::{DiagnosticEvent, Hash},
+        Error, HostError, LedgerInfo, TraceHook, Val,
+    };
+
+    // Some stub definitions to handle API additions for the
+    // reusable module cache.
+
+    #[allow(dead_code)]
+    const INTERNAL_ERROR: Error = Error::from_type_and_code(
+        soroban_env_host::xdr::ScErrorType::Context,
+        soroban_env_host::xdr::ScErrorCode::InternalError,
+    );
+
+    #[allow(dead_code)]
+    #[derive(Clone)]
+    pub(crate) struct ModuleCache;
+    #[allow(dead_code)]
+    pub(crate) trait ErrorHandler {
+        fn map_err<T, E>(&self, res: Result<T, E>) -> Result<T, HostError>
+        where
+            Error: From<E>,
+            E: core::fmt::Debug;
+        fn error(&self, error: Error, msg: &str, args: &[Val]) -> HostError;
+    }
+    #[allow(dead_code)]
+    impl ModuleCache {
+        pub(crate) fn new<T>(_handler: T) -> Result<Self, HostError> {
+            Err(INTERNAL_ERROR.into())
+        }
+        pub(crate) fn parse_and_cache_module_simple<T>(
+            &self,
+            _handler: &T,
+            _protocol: u32,
+            _wasm: &[u8],
+        ) -> Result<(), HostError> {
+            Err(INTERNAL_ERROR.into())
+        }
+        pub(crate) fn remove_module(&self, _key: &Hash) -> Result<(), HostError> {
+            Err(INTERNAL_ERROR.into())
+        }
+        pub(crate) fn clear(&self) -> Result<(), HostError> {
+            Err(INTERNAL_ERROR.into())
+        }
+        pub(crate) fn contains_module(&self, _key: &Hash) -> Result<bool, HostError> {
+            Err(INTERNAL_ERROR.into())
+        }
+    }
+    #[allow(dead_code)]
+    pub(crate) trait CompilationContext: ErrorHandler + AsBudget {}
 
     // An adapter for some API breakage between p21 and p22.
     pub(crate) const fn get_version_pre_release(v: &soroban_env_host::Version) -> u32 {
@@ -585,6 +785,40 @@ mod p21 {
 
     pub(crate) const fn get_version_protocol(v: &soroban_env_host::Version) -> u32 {
         soroban_env_host::meta::get_ledger_protocol_version(v.interface)
+    }
+
+    pub fn invoke_host_function_with_trace_hook_and_module_cache<
+        T: AsRef<[u8]>,
+        I: ExactSizeIterator<Item = T>,
+    >(
+        budget: &Budget,
+        enable_diagnostics: bool,
+        encoded_host_fn: T,
+        encoded_resources: T,
+        encoded_source_account: T,
+        encoded_auth_entries: I,
+        ledger_info: LedgerInfo,
+        encoded_ledger_entries: I,
+        encoded_ttl_entries: I,
+        base_prng_seed: T,
+        diagnostic_events: &mut Vec<DiagnosticEvent>,
+        trace_hook: Option<TraceHook>,
+        _module_cache: &SorobanModuleCache,
+    ) -> Result<InvokeHostFunctionResult, HostError> {
+        e2e_invoke::invoke_host_function_with_trace_hook(
+            &budget,
+            enable_diagnostics,
+            encoded_host_fn,
+            encoded_resources,
+            encoded_source_account,
+            encoded_auth_entries,
+            ledger_info,
+            encoded_ledger_entries,
+            encoded_ttl_entries,
+            base_prng_seed,
+            diagnostic_events,
+            trace_hook,
+        )
     }
 }
 
@@ -667,6 +901,7 @@ struct HostModule {
         ttl_entries: &Vec<CxxBuf>,
         base_prng_seed: &CxxBuf,
         rent_fee_configuration: &CxxRentFeeConfiguration,
+        module_cache: &SorobanModuleCache,
     ) -> Result<InvokeHostFunctionOutput, Box<dyn std::error::Error>>,
     compute_transaction_resource_fee:
         fn(tx_resources: CxxTransactionResources, fee_config: CxxFeeConfiguration) -> FeePair,
@@ -764,6 +999,7 @@ pub(crate) fn invoke_host_function(
     ttl_entries: &Vec<CxxBuf>,
     base_prng_seed: &CxxBuf,
     rent_fee_configuration: CxxRentFeeConfiguration,
+    module_cache: &SorobanModuleCache,
 ) -> Result<InvokeHostFunctionOutput, Box<dyn std::error::Error>> {
     let hm = get_host_module_for_protocol(config_max_protocol, ledger_info.protocol_version)?;
     let res = (hm.invoke_host_function)(
@@ -778,6 +1014,7 @@ pub(crate) fn invoke_host_function(
         ttl_entries,
         base_prng_seed,
         &rent_fee_configuration,
+        module_cache,
     );
 
     #[cfg(feature = "testutils")]
@@ -796,6 +1033,7 @@ pub(crate) fn invoke_host_function(
         ttl_entries,
         base_prng_seed,
         rent_fee_configuration,
+        module_cache,
     );
 
     res
@@ -827,6 +1065,7 @@ mod test_extra_protocol {
         ttl_entries: &Vec<CxxBuf>,
         base_prng_seed: &CxxBuf,
         rent_fee_configuration: CxxRentFeeConfiguration,
+        module_cache: &SorobanModuleCache,
     ) {
         if let Ok(extra) = std::env::var("SOROBAN_TEST_EXTRA_PROTOCOL") {
             if let Ok(proto) = u32::from_str(&extra) {
@@ -858,6 +1097,7 @@ mod test_extra_protocol {
                         ttl_entries,
                         base_prng_seed,
                         &rent_fee_configuration,
+                        module_cache,
                     );
                     if mostly_the_same_host_function_output(&res1, &res2) {
                         info!(target: TX, "{}", summarize_host_function_output(hm1, &res1));
@@ -1100,4 +1340,84 @@ pub(crate) fn i128_from_i64(val: i64) -> Result<CxxI128, Box<dyn std::error::Err
         hi: i128_hi(res),
         lo: i128_lo(res),
     })
+}
+
+// The SorobanModuleCache needs to hold a different protocol-specific cache for
+// each supported protocol version it's going to be used with. It has to hold
+// all these caches _simultaneously_ because it might perform an upgrade from
+// protocol N to protocol N+1 in a single transaction, and needs to be ready for
+// that before it happens.
+//
+// Most of these caches can be empty at any given time, because we're not
+// expecting core to need to replay old protocols, and/or if it does it's during
+// replay and there's no problem stalling while filling a cache with new entries
+// on a per-ledger basis as they are replayed.
+//
+// But for the current protocol version we need to have a cache ready to execute
+// anything thrown at it once it's in sync, so we should prime the
+// current-protocol cache as soon as we start, as well as the next-protocol
+// cache (if it exists) so that we can upgrade without stalling.
+struct SorobanModuleCache {
+    p23_cache: p23::contract::ProtocolSpecificModuleCache,
+}
+
+impl SorobanModuleCache {
+    fn new() -> Result<Self, Box<dyn std::error::Error>> {
+        Ok(Self {
+            p23_cache: p23::contract::ProtocolSpecificModuleCache::new()?,
+        })
+    }
+    pub fn compile(
+        &mut self,
+        ledger_protocol: u32,
+        wasm: &[u8],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        match ledger_protocol {
+            23 => self.p23_cache.compile(wasm),
+            // Add other protocols here as needed.
+            _ => Err(Box::new(soroban_curr::contract::CoreHostError::General(
+                "unsupported protocol",
+            ))),
+        }
+    }
+    pub fn shallow_clone(&self) -> Result<Box<Self>, Box<dyn std::error::Error>> {
+        Ok(Box::new(Self {
+            p23_cache: self.p23_cache.shallow_clone()?,
+        }))
+    }
+
+    pub fn evict_contract_code(&mut self, key: &[u8]) -> Result<(), Box<dyn std::error::Error>> {
+        let hash: [u8; 32] = key
+            .as_ref()
+            .try_into()
+            .map_err(|_| "Invalid contract-code key length")?;
+        self.p23_cache.evict(&hash)
+    }
+    pub fn clear(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        self.p23_cache.clear()
+    }
+
+    pub fn contains_module(
+        &self,
+        protocol: u32,
+        key: &[u8],
+    ) -> Result<bool, Box<dyn std::error::Error>> {
+        let hash: [u8; 32] = key
+            .as_ref()
+            .try_into()
+            .map_err(|_| "Invalid contract-code key length")?;
+        match protocol {
+            23 => self.p23_cache.contains_module(&hash),
+            _ => Err(Box::new(soroban_curr::contract::CoreHostError::General(
+                "unsupported protocol",
+            ))),
+        }
+    }
+    pub fn get_mem_bytes_consumed(&self) -> Result<u64, Box<dyn std::error::Error>> {
+        self.p23_cache.get_mem_bytes_consumed()
+    }
+}
+
+fn new_module_cache() -> Result<Box<SorobanModuleCache>, Box<dyn std::error::Error>> {
+    Ok(Box::new(SorobanModuleCache::new()?))
 }

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -293,11 +293,11 @@ class LoadGenerator
 
     // Internal loadgen state gets reset after each run, but it is impossible to
     // regenerate contract instance keys for DB lookup. Due to this we maintain
-    // a static list of instances and the wasm entry which we use to rebuild
+    // a list of instances and the wasm entry which we use to rebuild
     // mContractInstances at the start of each SOROBAN_INVOKE run
-    inline static UnorderedSet<LedgerKey> mContractInstanceKeys = {};
-    inline static std::optional<LedgerKey> mCodeKey = std::nullopt;
-    inline static uint64_t mContactOverheadBytes = 0;
+    UnorderedSet<LedgerKey> mContractInstanceKeys = {};
+    std::optional<LedgerKey> mCodeKey = std::nullopt;
+    uint64_t mContactOverheadBytes = 0;
 
     // Maps account ID to it's contract instance, where each account has a
     // unique instance

--- a/src/test/SimpleTestReporter.h
+++ b/src/test/SimpleTestReporter.h
@@ -57,7 +57,10 @@ struct SimpleTestReporter : public ConsoleReporter
         bool res = _assertionStats.assertionResult.isOk();
         if (!res)
         {
-            ConsoleReporter::assertionStarting(*mLastAssertInfo);
+            if (mLastAssertInfo)
+            {
+                ConsoleReporter::assertionStarting(*mLastAssertInfo);
+            }
             res = ConsoleReporter::assertionEnded(_assertionStats);
         }
         mLastAssertInfo.reset();

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -524,7 +524,7 @@ InvokeHostFunctionOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
         basePrngSeedBuf.data = std::make_unique<std::vector<uint8_t>>();
         basePrngSeedBuf.data->assign(sorobanBasePrngSeed.begin(),
                                      sorobanBasePrngSeed.end());
-
+        auto moduleCache = app.getModuleCache();
         out = rust_bridge::invoke_host_function(
             appConfig.CURRENT_LEDGER_PROTOCOL_VERSION,
             appConfig.ENABLE_SOROBAN_DIAGNOSTIC_EVENTS, resources.instructions,
@@ -532,7 +532,7 @@ InvokeHostFunctionOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
             toCxxBuf(getSourceID()), authEntryCxxBufs,
             getLedgerInfo(ltx, app, sorobanConfig), ledgerEntryCxxBufs,
             ttlEntryCxxBufs, basePrngSeedBuf,
-            sorobanConfig.rustBridgeRentFeeConfiguration());
+            sorobanConfig.rustBridgeRentFeeConfiguration(), *moduleCache);
         metrics.mCpuInsn = out.cpu_insns;
         metrics.mMemByte = out.mem_bytes;
         metrics.mInvokeTimeNsecs = out.time_nsecs;

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -3,6 +3,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "test/test.h"
+#include "transactions/TransactionFrameBase.h"
 #include "util/Logging.h"
 #include "util/ProtocolVersion.h"
 #include "util/UnorderedSet.h"
@@ -4912,3 +4913,343 @@ TEST_CASE("contract constructor support", "[tx][soroban]")
         REQUIRE(invocation.getReturnValue().u32() == 303);
     }
 }
+
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+
+static TransactionFrameBasePtr
+makeAddTx(TestContract const& contract, int64_t instructions,
+          TestAccount& source)
+{
+    auto fnName = "add";
+    auto sc7 = makeI32(7);
+    auto sc16 = makeI32(16);
+    auto spec = SorobanInvocationSpec()
+                    .setInstructions(instructions)
+                    .setReadBytes(2'000)
+                    .setInclusionFee(12345)
+                    .setNonRefundableResourceFee(33'000)
+                    .setRefundableResourceFee(100'000);
+    auto invocation = contract.prepareInvocation(fnName, {sc7, sc16}, spec);
+    return invocation.createTx(&source);
+}
+
+static bool
+wasms_are_cached(Application& app, std::vector<Hash> const& wasms)
+{
+    auto moduleCache = app.getLedgerManager().getModuleCache();
+    for (auto const& wasm : wasms)
+    {
+        if (!moduleCache->contains_module(
+                app.getLedgerManager()
+                    .getLastClosedLedgerHeader()
+                    .header.ledgerVersion,
+                ::rust::Slice{wasm.data(), wasm.size()}))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+static const int64_t INVOKE_ADD_UNCACHED_COST_PASS = 500'000;
+static const int64_t INVOKE_ADD_UNCACHED_COST_FAIL = 400'000;
+
+static const int64_t INVOKE_ADD_CACHED_COST_PASS = 300'000;
+static const int64_t INVOKE_ADD_CACHED_COST_FAIL = 200'000;
+
+TEST_CASE("reusable module cache", "[soroban][modulecache]")
+{
+    VirtualClock clock;
+    Config cfg = getTestConfig(0, Config::TESTDB_BUCKET_DB_PERSISTENT);
+
+    cfg.OVERRIDE_EVICTION_PARAMS_FOR_TESTING = true;
+    cfg.TESTING_STARTING_EVICTION_SCAN_LEVEL = 1;
+
+    // This test uses/tests/requires the reusable module cache.
+    if (!protocolVersionStartsFrom(
+            cfg.LEDGER_PROTOCOL_VERSION,
+            REUSABLE_SOROBAN_MODULE_CACHE_PROTOCOL_VERSION))
+        return;
+
+    // First upload some wasms
+    std::vector<RustBuf> testWasms = {rust_bridge::get_test_wasm_add_i32(),
+                                      rust_bridge::get_test_wasm_err(),
+                                      rust_bridge::get_test_wasm_complex()};
+
+    std::vector<Hash> contractHashes;
+    uint32_t ttl{0};
+    {
+        txtest::SorobanTest stest(cfg);
+        ttl = stest.getNetworkCfg().stateArchivalSettings().minPersistentTTL;
+        for (auto const& wasm : testWasms)
+        {
+
+            stest.deployWasmContract(wasm);
+            contractHashes.push_back(sha256(wasm));
+        }
+        // Check the module cache got populated by the uploads.
+        REQUIRE(wasms_are_cached(stest.getApp(), contractHashes));
+    }
+
+    // Restart the application and check module cache gets populated in the new
+    // app.
+    auto app = createTestApplication(clock, cfg, false, true);
+    REQUIRE(wasms_are_cached(*app, contractHashes));
+
+    // Crank the app forward a while until the wasms are evicted.
+    CLOG_INFO(Ledger, "advancing for {} ledgers to evict wasms", ttl);
+    for (int i = 0; i < ttl; ++i)
+    {
+        txtest::closeLedger(*app);
+    }
+    // Check the modules got evicted.
+    REQUIRE(!wasms_are_cached(*app, contractHashes));
+}
+
+TEST_CASE("Module cache across protocol versions", "[tx][soroban][modulecache]")
+{
+    VirtualClock clock;
+    auto cfg = getTestConfig(0);
+    // Start in p22
+    cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION =
+        static_cast<int>(REUSABLE_SOROBAN_MODULE_CACHE_PROTOCOL_VERSION) - 1;
+    auto app = createTestApplication(clock, cfg);
+
+    // Deploy and invoke contract in protocol 22
+    SorobanTest test(app);
+
+    size_t baseContractCount = app->getLedgerManager()
+                                   .getSorobanMetrics()
+                                   .mModuleCacheNumEntries.count();
+
+    auto const& addContract =
+        test.deployWasmContract(rust_bridge::get_test_wasm_add_i32());
+
+    auto invoke = [&](int64_t instructions) -> bool {
+        auto tx = makeAddTx(addContract, instructions, test.getRoot());
+        auto res = test.invokeTx(tx);
+        return isSuccessResult(res);
+    };
+
+    REQUIRE(!invoke(INVOKE_ADD_UNCACHED_COST_FAIL));
+    REQUIRE(invoke(INVOKE_ADD_UNCACHED_COST_PASS));
+
+    // The upload should have triggered a single compilation for the p23 module
+    // cache, which _exists_ in this version of stellar-core, and needs to be
+    // populated on each upload, is just not yet active.
+    REQUIRE(app->getLedgerManager()
+                .getSorobanMetrics()
+                .mModuleCacheNumEntries.count() == baseContractCount + 1);
+
+    // Upgrade to protocol 23 (with the reusable module cache)
+    auto upgradeTo23 = LedgerUpgrade{LEDGER_UPGRADE_VERSION};
+    upgradeTo23.newLedgerVersion() =
+        static_cast<int>(REUSABLE_SOROBAN_MODULE_CACHE_PROTOCOL_VERSION);
+    executeUpgrade(*app, upgradeTo23);
+
+    // We can now run the same contract with fewer instructions
+    REQUIRE(!invoke(INVOKE_ADD_CACHED_COST_FAIL));
+    REQUIRE(invoke(INVOKE_ADD_CACHED_COST_PASS));
+}
+
+TEST_CASE("Module cache miss on immediate execution",
+          "[tx][soroban][modulecache]")
+{
+    VirtualClock clock;
+    auto cfg = getTestConfig(0);
+
+    // This test uses/tests/requires the reusable module cache.
+    if (!protocolVersionStartsFrom(
+            cfg.LEDGER_PROTOCOL_VERSION,
+            REUSABLE_SOROBAN_MODULE_CACHE_PROTOCOL_VERSION))
+        return;
+
+    auto app = createTestApplication(clock, cfg);
+
+    SorobanTest test(app);
+
+    size_t baseContractCount = app->getLedgerManager()
+                                   .getSorobanMetrics()
+                                   .mModuleCacheNumEntries.count();
+
+    auto wasm = rust_bridge::get_test_wasm_add_i32();
+
+    SECTION("separate ledger upload and execution")
+    {
+        // First upload the contract
+        auto const& contract = test.deployWasmContract(wasm);
+
+        // Confirm upload succeeded and triggered compilation
+        REQUIRE(app->getLedgerManager()
+                    .getSorobanMetrics()
+                    .mModuleCacheNumEntries.count() == baseContractCount + 1);
+
+        // Try to execute with low instructions since we can use cached module.
+        auto txFail =
+            makeAddTx(contract, INVOKE_ADD_CACHED_COST_FAIL, test.getRoot());
+        REQUIRE(!isSuccessResult(test.invokeTx(txFail)));
+
+        auto txPass =
+            makeAddTx(contract, INVOKE_ADD_CACHED_COST_PASS, test.getRoot());
+        REQUIRE(isSuccessResult(test.invokeTx(txPass)));
+    }
+
+    SECTION("same ledger upload and execution")
+    {
+
+        // Here we're going to create 4 txs in the same ledger (so they have to
+        // come from 4 separate accounts). The 1st uploads a contract wasm, the
+        // 2nd creates a contract, and the 3rd and 4th run it.
+        //
+        // Because all 4 happen in the same ledger, there is no opportunity for
+        // the module cache to be populated between the upload and the
+        // execution. This should result in a cache miss and higher cost: the
+        // 3rd (invoking) tx fails and the 4th passes, but at the higher cost.
+        //
+        // Finally to confirm that the cache is populated, we run the same
+        // invocations in the next ledger and it should succeed at a lower cost.
+
+        auto minbal = test.getApp().getLedgerManager().getLastMinBalance(1);
+        TestAccount A(test.getRoot().create("A", minbal * 1000));
+        TestAccount B(test.getRoot().create("B", minbal * 1000));
+        TestAccount C(test.getRoot().create("C", minbal * 1000));
+        TestAccount D(test.getRoot().create("D", minbal * 1000));
+
+        // Transaction 1: the upload
+        auto uploadResources = defaultUploadWasmResourcesWithoutFootprint(
+            wasm, getLclProtocolVersion(test.getApp()));
+        auto uploadTx = makeSorobanWasmUploadTx(test.getApp(), A, wasm,
+                                                uploadResources, 1000);
+
+        // Transaction 2: create contract
+        Hash contractHash = sha256(wasm);
+        ContractExecutable executable = makeWasmExecutable(contractHash);
+        Hash salt = sha256("salt");
+        ContractIDPreimage contractPreimage = makeContractIDPreimage(B, salt);
+        HashIDPreimage hashPreimage = makeFullContractIdPreimage(
+            test.getApp().getNetworkID(), contractPreimage);
+        SCAddress contractId = makeContractAddress(xdrSha256(hashPreimage));
+        auto createResources = SorobanResources();
+        createResources.instructions = 5'000'000;
+        createResources.readBytes =
+            static_cast<uint32_t>(wasm.data.size() + 1000);
+        createResources.writeBytes = 1000;
+        auto createContractTx =
+            makeSorobanCreateContractTx(test.getApp(), B, contractPreimage,
+                                        executable, createResources, 1000);
+
+        // Transaction 3: invocation (with inadequate instructions to succeed)
+        TestContract contract(test, contractId,
+                              {contractCodeKey(contractHash),
+                               makeContractInstanceKey(contractId)});
+        auto invokeFailTx =
+            makeAddTx(contract, INVOKE_ADD_UNCACHED_COST_FAIL, C);
+
+        // Transaction 4: invocation (with inadequate instructions to succeed)
+        auto invokePassTx =
+            makeAddTx(contract, INVOKE_ADD_UNCACHED_COST_PASS, C);
+
+        // Run single ledger with all 4 txs. First 2 should pass, 3rd should
+        // fail, 4th should pass.
+        auto txResults = closeLedger(
+            *app, {uploadTx, createContractTx, invokeFailTx, invokePassTx},
+            /*strictOrder=*/true);
+
+        REQUIRE(txResults.results.size() == 4);
+        REQUIRE(
+            isSuccessResult(txResults.results[0].result)); // Upload succeeds
+        REQUIRE(
+            isSuccessResult(txResults.results[1].result)); // Create succeeds
+        REQUIRE(!isSuccessResult(
+            txResults.results[2].result)); // Invoke fails at 400k
+        REQUIRE(isSuccessResult(
+            txResults.results[3].result)); // Invoke passes at 500k
+
+        // But if we try again in next ledger, the cost threshold should be
+        // lower.
+        auto invokeTxFail2 =
+            makeAddTx(contract, INVOKE_ADD_CACHED_COST_FAIL, C);
+        auto invokeTxPass2 =
+            makeAddTx(contract, INVOKE_ADD_CACHED_COST_PASS, D);
+        txResults = closeLedger(*app, {invokeTxFail2, invokeTxPass2},
+                                /*strictOrder=*/true);
+        REQUIRE(txResults.results.size() == 2);
+        REQUIRE(!isSuccessResult(txResults.results[0].result));
+        REQUIRE(isSuccessResult(txResults.results[1].result));
+    }
+}
+
+TEST_CASE("Module cache cost with restore gaps", "[tx][soroban][modulecache]")
+{
+    VirtualClock clock;
+    auto cfg = getTestConfig(0);
+
+    cfg.OVERRIDE_EVICTION_PARAMS_FOR_TESTING = true;
+    cfg.TESTING_STARTING_EVICTION_SCAN_LEVEL = 1;
+
+    auto app = createTestApplication(clock, cfg);
+    auto& lm = app->getLedgerManager();
+    SorobanTest test(app);
+    auto wasm = rust_bridge::get_test_wasm_add_i32();
+
+    auto minbal = lm.getLastMinBalance(1);
+    TestAccount A(test.getRoot().create("A", minbal * 1000));
+    TestAccount B(test.getRoot().create("B", minbal * 1000));
+
+    auto contract = test.deployWasmContract(wasm);
+    auto contractKeys = contract.getKeys();
+
+    // Let contract expire
+    auto ttl = test.getNetworkCfg().stateArchivalSettings().minPersistentTTL;
+    auto proto = lm.getLastClosedLedgerHeader().header.ledgerVersion;
+    for (auto i = 0; i < ttl; ++i)
+    {
+        closeLedger(test.getApp());
+    }
+    auto moduleCache = lm.getModuleCache();
+    auto const wasmHash = sha256(wasm);
+    REQUIRE(!moduleCache->contains_module(
+        proto, ::rust::Slice{wasmHash.data(), wasmHash.size()}));
+
+    SECTION("scenario A: restore in one ledger, invoke in next")
+    {
+        // Restore contract in ledger N+1
+        test.invokeRestoreOp(contractKeys, 40096);
+
+        // Invoke in ledger N+2
+        // Because we have a gap between restore and invoke, the module cache
+        // will be populated and we need fewer instructions
+        auto tx1 = makeAddTx(contract, INVOKE_ADD_CACHED_COST_FAIL, A);
+        auto tx2 = makeAddTx(contract, INVOKE_ADD_CACHED_COST_PASS, B);
+        auto txResults = closeLedger(*app, {tx1, tx2}, /*strictOrder=*/true);
+        REQUIRE(txResults.results.size() == 2);
+        REQUIRE(!isSuccessResult(txResults.results[0].result));
+        REQUIRE(isSuccessResult(txResults.results[1].result));
+    }
+
+    SECTION("scenario B: restore and invoke in same ledger")
+    {
+        // Combine restore and invoke in ledger N+1
+        // First restore
+        SorobanResources resources;
+        resources.footprint.readWrite = contractKeys;
+        resources.instructions = 0;
+        resources.readBytes = 10'000;
+        resources.writeBytes = 10'000;
+        auto resourceFee = 300'000 + 40'000 * contractKeys.size();
+        auto tx1 = test.createRestoreTx(resources, 1'000, resourceFee);
+
+        // Then try to invoke immediately
+        // Because there is no gap between restore and invoke, the module cache
+        // won't be populated and we need more instructions.
+        auto tx2 = makeAddTx(contract, INVOKE_ADD_UNCACHED_COST_FAIL, A);
+        auto tx3 = makeAddTx(contract, INVOKE_ADD_UNCACHED_COST_PASS, B);
+        auto txResults =
+            closeLedger(*app, {tx1, tx2, tx3}, /*strictOrder=*/true);
+        REQUIRE(txResults.results.size() == 3);
+        REQUIRE(isSuccessResult(txResults.results[0].result));
+        REQUIRE(!isSuccessResult(txResults.results[1].result));
+        REQUIRE(isSuccessResult(txResults.results[2].result));
+    }
+}
+#endif

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -4934,7 +4934,7 @@ makeAddTx(TestContract const& contract, int64_t instructions,
 }
 
 static bool
-wasms_are_cached(Application& app, std::vector<Hash> const& wasms)
+wasmsAreCached(Application& app, std::vector<Hash> const& wasms)
 {
     auto moduleCache = app.getLedgerManager().getModuleCache();
     for (auto const& wasm : wasms)
@@ -4988,13 +4988,13 @@ TEST_CASE("reusable module cache", "[soroban][modulecache]")
             contractHashes.push_back(sha256(wasm));
         }
         // Check the module cache got populated by the uploads.
-        REQUIRE(wasms_are_cached(stest.getApp(), contractHashes));
+        REQUIRE(wasmsAreCached(stest.getApp(), contractHashes));
     }
 
     // Restart the application and check module cache gets populated in the new
     // app.
     auto app = createTestApplication(clock, cfg, false, true);
-    REQUIRE(wasms_are_cached(*app, contractHashes));
+    REQUIRE(wasmsAreCached(*app, contractHashes));
 
     // Crank the app forward a while until the wasms are evicted.
     CLOG_INFO(Ledger, "advancing for {} ledgers to evict wasms", ttl);
@@ -5003,7 +5003,7 @@ TEST_CASE("reusable module cache", "[soroban][modulecache]")
         txtest::closeLedger(*app);
     }
     // Check the modules got evicted.
-    REQUIRE(!wasms_are_cached(*app, contractHashes));
+    REQUIRE(!wasmsAreCached(*app, contractHashes));
 }
 
 TEST_CASE("Module cache across protocol versions", "[tx][soroban][modulecache]")

--- a/src/util/ProtocolVersion.h
+++ b/src/util/ProtocolVersion.h
@@ -53,4 +53,6 @@ bool protocolVersionEquals(uint32_t protocolVersion,
 constexpr ProtocolVersion SOROBAN_PROTOCOL_VERSION = ProtocolVersion::V_20;
 constexpr ProtocolVersion PARALLEL_SOROBAN_PHASE_PROTOCOL_VERSION =
     ProtocolVersion::V_23;
+constexpr ProtocolVersion REUSABLE_SOROBAN_MODULE_CACHE_PROTOCOL_VERSION =
+    ProtocolVersion::V_23;
 }

--- a/test-tx-meta-baseline-next/InvokeHostFunctionTests.json
+++ b/test-tx-meta-baseline-next/InvokeHostFunctionTests.json
@@ -31,6 +31,18 @@
 		23
 	],
 	"Module cache" : [ "MR6BJ3xmn2c=" ],
+	"Module cache across protocol versions" : [ "bKDF6V5IzTo=" ],
+	"Module cache cost with restore gaps" : 
+	[
+		"+cR3oq2qY0I=",
+		"UD0Xgb4n2Vw=",
+		"WPvgcDNwIAw=",
+		"+cR3oq2qY0I=",
+		"UD0Xgb4n2Vw=",
+		"WPvgcDNwIAw="
+	],
+	"Module cache miss on immediate execution" : [ "+cR3oq2qY0I=", "+cR3oq2qY0I=" ],
+	"Module cache miss on immediate execution|same ledger upload and execution" : [ "UD0Xgb4n2Vw=", "WPvgcDNwIAw=", "nRewjxlY5K4=", "4cnLIfJKMcE=" ],
 	"Native stellar asset contract" : [ "+cR3oq2qY0I=", "Km/vSoEZ5bA=" ],
 	"Soroban authorization" : 
 	[


### PR DESCRIPTION
This is the stellar-core side of a [soroban change to surface the module cache for reuse](https://github.com/stellar/rs-soroban-env/pull/1506).

On the core side we:
  1. Add a new mechanism to scan the live BL snapshot for contracts alone (which is a small part of the BL)
  2. Add a new wrapper type `SorobanModuleCache` to the core-side Rust code, which holds a `soroban_env_host::ModuleCache` for each host protocol version we support caching modules for (there is currently only one but there will be more in the future)
  3. Also add a `CoreCompilationContext` type to `contract.rs` which carries a `Budget` and logs errors to the core console logging system. This is sufficient to allow operating the `soroban_env_host::ModuleCache` from outside the `Host`.
  4. Pass a `SorobanModuleCache` into the host function invocation path that core calls during transactions.
  5. Store a `SorobanModuleCache` in the `LedgerManagerImpl` that is long-lived, spans ledgers.
  6. Add a utility class `SharedModuleCacheCompiler` that does a multithreaded load-all-contracts / populate-the-module-cache, and call this on startup when the `LedgerManagerImpl` restores its LCL.
  7. Add a couple command-line helpers that list and forcibly compile all contracts (we might choose to remove these, they were helpful during debugging but at this point perhaps redundant)

The main things left to do here are:

 - [x] Maybe move all this to the soon-to-be-added `p23` soroban submodule
 - [x] Decide how we're going to handle growing the cache with new uploads and wire that up
 - [x] Similarly decide how we're going to handle expiry and restoration events [as discussed in CAP0062](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0062.md) and wire that up too
 - [x] Write some tests if I can think of any more specific than just "everything existing still works"
 - [x] Write a CAP describing this

I think that's .. kinda it? The reusable module cache is just "not passed in" on p22 and "passed in" on p23, so it should just start working at the p23 boundary. 