### PR TITLE
Fix tests in `--disable-postgres` build

### DIFF
--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -163,7 +163,6 @@ class Config : public std::enable_shared_from_this<Config>
 #endif
         TESTDB_BUCKET_DB_VOLATILE,
         TESTDB_BUCKET_DB_PERSISTENT,
-        TESTDB_BUCKET_DB_PERSISTENT_POSTGRES,
         TESTDB_MODES
     };
 

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -291,10 +291,6 @@ getTestConfig(int instanceNumber, Config::TestDbMode mode)
             thisConfig.DISABLE_XDR_FSYNC = false;
             break;
 #ifdef USE_POSTGRES
-        case Config::TESTDB_BUCKET_DB_PERSISTENT_POSTGRES:
-            dbname << "postgresql://dbname=test" << instanceNumber;
-            thisConfig.DISABLE_XDR_FSYNC = false;
-            break;
         case Config::TESTDB_POSTGRESQL:
             dbname << "postgresql://dbname=test" << instanceNumber;
             thisConfig.DISABLE_XDR_FSYNC = false;


### PR DESCRIPTION
Resolves #4625 and #4614.

This change fixes the tests in the `--disable-postgres` build by disabling parallel ledger close tests when postgres is disabled. This is necessary because parallel ledger close requires postgres.

As part of this, I also removed the `TESTDB_BUCKET_DB_PERSISTENT_POSTGRES` test mode, as it's made redundant by the `TESTDB_POSTGRESQL` mode.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
