### PR TITLE
Rust quorum intersection checker integration

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -521,6 +521,7 @@ exit /b 0
     <ClCompile Include="..\..\src\herder\PendingEnvelopes.cpp" />
     <ClCompile Include="..\..\src\herder\QuorumIntersectionCheckerImpl.cpp" />
     <ClCompile Include="..\..\src\herder\QuorumTracker.cpp" />
+    <ClCompile Include="..\..\src\herder\RustQuorumCheckerAdaptor.cpp" />
     <ClCompile Include="..\..\src\herder\SurgePricingUtils.cpp" />
     <ClCompile Include="..\..\src\herder\test\HerderTests.cpp" />
     <ClCompile Include="..\..\src\herder\test\PendingEnvelopesTests.cpp" />
@@ -976,6 +977,7 @@ exit /b 0
     <ClInclude Include="..\..\src\herder\QuorumIntersectionChecker.h" />
     <ClInclude Include="..\..\src\herder\QuorumIntersectionCheckerImpl.h" />
     <ClInclude Include="..\..\src\herder\QuorumTracker.h" />
+    <ClInclude Include="..\..\src\herder\RustQuorumCheckerAdaptor.h" />
     <ClInclude Include="..\..\src\herder\SurgePricingUtils.h" />
     <ClInclude Include="..\..\src\herder\test\TestTxSetUtils.h" />
     <ClInclude Include="..\..\src\herder\TransactionQueue.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -696,6 +696,9 @@
     <ClCompile Include="..\..\src\herder\QuorumTracker.cpp">
       <Filter>herder</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\herder\RustQuorumCheckerAdaptor.cpp">
+      <Filter>herder</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\herder\SurgePricingUtils.cpp">
       <Filter>herder</Filter>
     </ClCompile>
@@ -1890,6 +1893,9 @@
       <Filter>herder</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\herder\QuorumTracker.h">
+      <Filter>herder</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\herder\RustQuorumCheckerAdaptor.h">
       <Filter>herder</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\herder\SurgePricingUtils.h">

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "batsat"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec82b6bbce8ea42f5003417b699267860a9f4dd869fc9ba8faceac761d5afed1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
+
+[[package]]
 name = "cc"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +139,12 @@ name = "ethnum"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "generator"
@@ -288,6 +309,16 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -533,7 +564,21 @@ dependencies = [
  "rustc-simple-version",
  "soroban-synth-wasm",
  "soroban-test-wasms",
+ "stellar-quorum-analyzer",
  "tracy-client",
+]
+
+[[package]]
+name = "stellar-quorum-analyzer"
+version = "0.1.0"
+source = "git+https://github.com/stellar/stellar-quorum-analyzer?rev=d23dd363cd2ae84fed346dc975bb8d56e2768002#d23dd363cd2ae84fed346dc975bb8d56e2768002"
+dependencies = [
+ "batsat",
+ "itertools",
+ "log",
+ "petgraph",
+ "stellar-strkey",
+ "stellar-xdr",
 ]
 
 [[package]]

--- a/docs/versioning-soroban.md
+++ b/docs/versioning-soroban.md
@@ -139,7 +139,7 @@ We are leveraging Rust's support for linking together multiple copies of "the
 same" library (soroban) with different versions, but we are doing so somewhat
 against the grain of how cargo normally wants to do it.
 
-Do do this "the normal way", we would just list the different versions of the
+To do this "the normal way", we would just list the different versions of the
 soroban crate in `Cargo.toml`, and then when we built it cargo would attempt to
 resolve all the dependencies and transitive-dependencies of all those soroban
 versions into a hopefully-minimal set of crates and download, compile and link
@@ -165,7 +165,7 @@ This has one minor and one major problem:
      p22 module on foo 0.1, cargo will bump _both_ to foo 0.2, which _changes_
      the semantics of the p22 module.
 
-       - We initially though a way out of this is to add redundant exact-version
+       - We initially thought a way out of this is to add redundant exact-version
          dependencies (like `foo = "=0.2"`) to `Cargo.toml` for
          `soroban-env-host` but there turn out to be both a minor and a major
          problem with that too.

--- a/src/herder/HerderUtils.h
+++ b/src/herder/HerderUtils.h
@@ -4,7 +4,10 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "herder/QuorumIntersectionChecker.h"
+#include "rust/RustBridge.h"
 #include "xdr/Stellar-types.h"
+#include "xdrpp/marshal.h"
 #include <vector>
 
 namespace stellar
@@ -14,6 +17,25 @@ struct SCPEnvelope;
 struct SCPStatement;
 struct StellarValue;
 
+template <typename T>
+std::vector<uint8_t>
+toVec(T const& t)
+{
+    return std::vector<uint8_t>(xdr::xdr_to_opaque(t));
+}
+
+template <typename T>
+CxxBuf
+toCxxBuf(T const& t)
+{
+    return CxxBuf{std::make_unique<std::vector<uint8_t>>(toVec(t))};
+}
+
 std::vector<Hash> getTxSetHashes(SCPEnvelope const& envelope);
 std::vector<StellarValue> getStellarValues(SCPStatement const& envelope);
+std::string toShortString(std::optional<Config> const& cfg, NodeID const& id);
+QuorumIntersectionChecker::QuorumSetMap
+toQuorumIntersectionMap(QuorumTracker::QuorumMap const& qmap);
+std::pair<std::vector<PublicKey>, std::vector<PublicKey>>
+toQuorumSplitNodeIDs(QuorumSplit& split);
 }

--- a/src/herder/QuorumIntersectionChecker.h
+++ b/src/herder/QuorumIntersectionChecker.h
@@ -20,6 +20,9 @@ class QuorumIntersectionChecker
     using QuorumSetMap =
         stellar::UnorderedMap<stellar::NodeID, stellar::SCPQuorumSetPtr>;
 
+    using PotentialSplit =
+        std::pair<std::vector<PublicKey>, std::vector<PublicKey>>;
+    // for v1 qic
     static std::shared_ptr<QuorumIntersectionChecker>
     create(QuorumTracker::QuorumMap const& qmap,
            std::optional<stellar::Config> const& cfg,
@@ -32,15 +35,11 @@ class QuorumIntersectionChecker
            stellar_default_random_engine::result_type seed, bool quiet = false);
 
     static std::set<std::set<NodeID>> getIntersectionCriticalGroups(
-        QuorumTracker::QuorumMap const& qmap,
-        std::optional<stellar::Config> const& cfg,
-        std::atomic<bool>& interruptFlag,
-        stellar_default_random_engine::result_type seed);
-
-    static std::set<std::set<NodeID>> getIntersectionCriticalGroups(
-        QuorumSetMap const& qmap, std::optional<stellar::Config> const& cfg,
-        std::atomic<bool>& interruptFlag,
-        stellar_default_random_engine::result_type seed);
+        QuorumTracker::QuorumMap const& initQmap,
+        std::optional<Config> const& cfg,
+        std::function<bool(QuorumSetMap const&,
+                           std::optional<stellar::Config> const&)> const&
+            networkEnjoysQuorumIntersectionCB);
 
     virtual ~QuorumIntersectionChecker(){};
     virtual bool networkEnjoysQuorumIntersection() const = 0;

--- a/src/herder/QuorumIntersectionCheckerImpl.h
+++ b/src/herder/QuorumIntersectionCheckerImpl.h
@@ -543,4 +543,5 @@ class QuorumIntersectionCheckerImpl : public stellar::QuorumIntersectionChecker
     getPotentialSplit() const override;
     size_t getMaxQuorumsFound() const override;
 };
-}
+
+} // namespace {

--- a/src/herder/RustQuorumCheckerAdaptor.cpp
+++ b/src/herder/RustQuorumCheckerAdaptor.cpp
@@ -1,0 +1,90 @@
+// Copyright 2025 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "herder/RustQuorumCheckerAdaptor.h"
+#include "crypto/KeyUtils.h"
+#include "herder/HerderUtils.h"
+#include "rust/RustBridge.h"
+#include "util/Logging.h"
+#include <chrono>
+
+namespace stellar
+{
+
+std::atomic<uint32_t> RustQuorumCheckerAdaptor::mSuccessfulCallCount{0};
+std::atomic<uint32_t> RustQuorumCheckerAdaptor::mFailedCallCount{0};
+std::atomic<uint32_t> RustQuorumCheckerAdaptor::mInterruptedCallCount{0};
+std::atomic<uint32_t> RustQuorumCheckerAdaptor::mPotentialSplitCount{0};
+
+bool
+RustQuorumCheckerAdaptor::networkEnjoysQuorumIntersection(
+    QuorumTracker::QuorumMap const& qmap,
+    std::optional<stellar::Config> const& cfg,
+    rust_bridge::quorum_checker::Interrupt const& interrupt,
+    QuorumIntersectionChecker::PotentialSplit& potentialSplit)
+{
+    return networkEnjoysQuorumIntersection(toQuorumIntersectionMap(qmap), cfg,
+                                           interrupt, potentialSplit);
+}
+
+bool
+RustQuorumCheckerAdaptor::networkEnjoysQuorumIntersection(
+    QuorumIntersectionChecker::QuorumSetMap const& qmap,
+    std::optional<stellar::Config> const& cfg,
+    rust_bridge::quorum_checker::Interrupt const& interrupt,
+    QuorumIntersectionChecker::PotentialSplit& potentialSplit)
+{
+    rust::Vec<CxxBuf> nodesBuf;
+    rust::Vec<CxxBuf> quorumSetsBuf;
+    nodesBuf.reserve(qmap.size());
+    quorumSetsBuf.reserve(qmap.size());
+    for (auto const& pair : qmap)
+    {
+        if (pair.second)
+        {
+            nodesBuf.push_back(toCxxBuf(pair.first));
+            quorumSetsBuf.push_back(toCxxBuf(*pair.second));
+        }
+        else
+        {
+            CLOG_DEBUG(SCP, "Node with missing QSet: {}",
+                       toShortString(cfg, pair.first));
+        }
+    }
+
+    QuorumSplit split;
+    QuorumCheckerStatus status;
+    try
+    {
+        auto start = std::chrono::steady_clock::now();
+        status =
+            rust_bridge::quorum_checker::network_enjoys_quorum_intersection(
+                nodesBuf, quorumSetsBuf, interrupt, split);
+        auto end = std::chrono::steady_clock::now();
+        auto duration =
+            std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+        CLOG_DEBUG(SCP, "Quorum intersection check took {} microseconds",
+                   duration.count());
+        ++mSuccessfulCallCount;
+    }
+    catch (const std::exception& e)
+    {
+        ++mFailedCallCount;
+        throw RustQuorumCheckerError(e.what());
+    }
+
+    if (status == QuorumCheckerStatus::UNKNOWN)
+    {
+        ++mInterruptedCallCount;
+        throw QuorumIntersectionChecker::InterruptedException();
+    }
+    else if (status == QuorumCheckerStatus::SAT)
+    {
+        ++mPotentialSplitCount;
+        potentialSplit = toQuorumSplitNodeIDs(split);
+    }
+    return status == QuorumCheckerStatus::UNSAT;
+}
+
+} // namespace stellar {

--- a/src/herder/RustQuorumCheckerAdaptor.h
+++ b/src/herder/RustQuorumCheckerAdaptor.h
@@ -1,0 +1,73 @@
+#pragma once
+
+// Copyright 2025 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "herder/QuorumIntersectionChecker.h"
+#include "herder/QuorumTracker.h"
+#include "main/Config.h"
+#include "rust/RustBridge.h"
+#include <optional>
+
+namespace stellar
+{
+
+// static adaptor class over rust QuorumChecker that exposes its functionalities
+class RustQuorumCheckerAdaptor
+{
+
+  public:
+    static bool networkEnjoysQuorumIntersection(
+        QuorumTracker::QuorumMap const& qmap,
+        std::optional<stellar::Config> const& cfg,
+        rust_bridge::quorum_checker::Interrupt const& interrupt,
+        QuorumIntersectionChecker::PotentialSplit& potentialSplit);
+
+    static bool networkEnjoysQuorumIntersection(
+        QuorumIntersectionChecker::QuorumSetMap const& qmap,
+        std::optional<stellar::Config> const& cfg,
+        rust_bridge::quorum_checker::Interrupt const& interrupt,
+        QuorumIntersectionChecker::PotentialSplit& potentialSplit);
+
+    static std::atomic<uint32_t>
+    getSuccessfulCallCount()
+    {
+        return mSuccessfulCallCount.load();
+    }
+
+    static std::atomic<uint32_t>
+    getFailedCallCount()
+    {
+        return mFailedCallCount.load();
+    }
+
+    static std::atomic<uint32_t>
+    getInterruptedCallCount()
+    {
+        return mInterruptedCallCount.load();
+    }
+
+    static std::atomic<uint32_t>
+    getPotentialSplitCount()
+    {
+        return mPotentialSplitCount.load();
+    }
+
+  private:
+    static std::atomic<uint32_t> mSuccessfulCallCount;
+    static std::atomic<uint32_t> mFailedCallCount;
+    static std::atomic<uint32_t> mInterruptedCallCount;
+    static std::atomic<uint32_t> mPotentialSplitCount;
+
+}; // class RustQuorumCheckerAdaptor {
+
+class RustQuorumCheckerError : public std::runtime_error
+{
+  public:
+    RustQuorumCheckerError(std::string const& msg) : std::runtime_error(msg)
+    {
+    }
+};
+
+} // namespace stellar {

--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -753,8 +753,12 @@ checkQuorumIntersectionFromJson(std::string const& jsonPath,
     }
 
     std::atomic<bool> interrupt(false);
+    // TODO: toggle between v1 and v2 via cfg option
     auto qicPtr =
         QuorumIntersectionChecker::create(qmap, cfg, interrupt, false);
+    // auto qicPtr =
+    //     QuorumIntersectionChecker::create(qmap, cfg,
+    //     rust_bridge::create_quorum_checker_interrupt().into_raw(), false);
 
     return qicPtr->networkEnjoysQuorumIntersection();
 }

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -277,6 +277,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     MAX_CONCURRENT_SUBPROCESSES = 16;
     NODE_IS_VALIDATOR = false;
     QUORUM_INTERSECTION_CHECKER = true;
+    USE_QUORUM_INTERSECTION_CHECKER_V2 = true;
     DATABASE = SecretValue{"sqlite3://:memory:"};
 
     ENTRY_CACHE_SIZE = 100000;
@@ -1355,6 +1356,10 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                  }},
                 {"QUORUM_INTERSECTION_CHECKER",
                  [&]() { QUORUM_INTERSECTION_CHECKER = readBool(item); }},
+                {"USE_QUORUM_INTERSECTION_CHECKER_V2",
+                 [&]() {
+                     USE_QUORUM_INTERSECTION_CHECKER_V2 = readBool(item);
+                 }},
                 {"HISTORY",
                  [&]() {
                      auto hist = item.second->as_table();

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -677,6 +677,9 @@ class Config : public std::enable_shared_from_this<Config>
     // Whether to run online quorum intersection checks.
     bool QUORUM_INTERSECTION_CHECKER;
 
+    // Whether to use the new Rust SAT-solving based quorum intersection
+    // checker.
+    bool USE_QUORUM_INTERSECTION_CHECKER_V2;
     // Invariants
     std::vector<std::string> INVARIANT_CHECKS;
 

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -103,6 +103,12 @@ version = "=22.0.0"
 git = "https://github.com/stellar/rs-soroban-env"
 rev = "a3f7fca9c2ad89796c7525a648da086543502dd5"
 
+[dependencies.stellar-quorum-analyzer]
+version = "0.1.0"
+git = "https://github.com/stellar/stellar-quorum-analyzer"
+rev = "d23dd363cd2ae84fed346dc975bb8d56e2768002"
+# path = "../../../stellar-quorum-analyzer"
+
 [features]
 
 tracy = ["dep:tracy-client"]

--- a/src/rust/src/contract.rs
+++ b/src/rust/src/contract.rs
@@ -17,6 +17,7 @@ use std::{fmt::Display, io::Cursor, panic, rc::Rc, time::Instant};
 // tree: crate::lo::contract and crate::hi::contract, each of which has a (lo or
 // hi) version-specific definition of stellar_env_host. We therefore
 // import it from our _parent_ module rather than from the crate root.
+// TODO: update
 pub(crate) use super::soroban_env_host::{
     budget::Budget,
     e2e_invoke::{self, extract_rent_changes, LedgerEntryChange},

--- a/src/rust/src/quorum_checker.rs
+++ b/src/rust/src/quorum_checker.rs
@@ -1,0 +1,94 @@
+use super::{
+    rust_bridge::{CxxBuf, QuorumSplit},
+    QuorumCheckerStatus,
+};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use stellar_quorum_analyzer::{Callbacks, FbasAnalyzer, FbasError, SolveStatus};
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub(crate) enum QuorumCheckerError {
+    Fbas(FbasError),
+    General(&'static str),
+}
+
+impl std::fmt::Display for QuorumCheckerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl From<FbasError> for QuorumCheckerError {
+    fn from(h: FbasError) -> Self {
+        QuorumCheckerError::Fbas(h)
+    }
+}
+
+impl std::error::Error for QuorumCheckerError {}
+
+impl From<SolveStatus> for QuorumCheckerStatus {
+    fn from(ss: SolveStatus) -> Self {
+        match ss {
+            stellar_quorum_analyzer::SolveStatus::SAT(_) => QuorumCheckerStatus::SAT,
+            stellar_quorum_analyzer::SolveStatus::UNSAT => QuorumCheckerStatus::UNSAT,
+            stellar_quorum_analyzer::SolveStatus::UNKNOWN => QuorumCheckerStatus::UNKNOWN,
+        }
+    }
+}
+
+/// [`Callbacks`] that allow the solver to be asynchronously interrupted
+#[derive(Clone)]
+pub struct Interrupt(Arc<AtomicBool>);
+
+impl Callbacks for Interrupt {
+    fn stop(&self) -> bool {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+impl Default for Interrupt {
+    fn default() -> Self {
+        Interrupt(Arc::new(AtomicBool::new(false)))
+    }
+}
+
+impl Interrupt {
+    pub fn fire(&self) {
+        self.0.store(true, Ordering::SeqCst)
+    }
+
+    pub fn reset(&self) {
+        self.0.store(false, Ordering::SeqCst)
+    }
+}
+
+pub(crate) fn new_interrupt() -> Box<Interrupt> {
+    Box::new(Interrupt::default())
+}
+
+pub(crate) fn network_enjoys_quorum_intersection(
+    nodes: &Vec<CxxBuf>,
+    quorum_set: &Vec<CxxBuf>,
+    interrupt: &Interrupt,
+    potential_split: &mut QuorumSplit,
+) -> Result<QuorumCheckerStatus, Box<dyn std::error::Error>> {
+    let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let mut solver = FbasAnalyzer::from_quorum_set_map_buf(
+            nodes.iter(),
+            quorum_set.iter(),
+            interrupt.clone(),
+        )?;
+        let status = solver.solve();
+        let (left, right) = solver.get_potential_split()?;
+        potential_split.left = left;
+        potential_split.right = right;
+        Ok(status.into())
+    }));
+    match res {
+        Err(_) => Err(QuorumCheckerError::General("solver panicked").into()),
+        Ok(r) => r,
+    }
+}


### PR DESCRIPTION
# Description

This is the implementation of a new quorum intersection checker that leverages a SAT-solver. It contains

- The bridge implementation for `stellar/stellar-quorum-analyzer`, the underneath Rust library.  
- A new adaptor class `RustQuorumCheckerAdaptor` that wraps the Rust calls in C++ that provides some basic metrics. 
- Async interruption handling
- A new config flag `USE_QUORUM_INTERSECTION_CHECKER_V2` to toggle between old and new solver.
- Update all existing test cases to pass with the new solver. 

Rust side: https://github.com/stellar/stellar-quorum-analyzer/pull/1

Preliminary benchmark results look very good. This is run with the stellar-core `check-quorum-intersection` command line locally, sample test cases can be found [here](https://github.com/jayz22/stellar-quorum-analyzer-fork/tree/quorum-checker/tests/test_data/random). A 16-org configuration which previously won't finish, now takes only fraction of a second. 

| no. of orgs / nodes  | old solve time(s) | new solve time(s) |
| ------------------- | ----------------- | ------------------ |
| 10 (30)                    | 1.59                      | 0.05                        |
| 12  (36)                   | 40.09                   | 0.01                       |
| 13  (39)                   | 5166.47               | 0.03                       |
| 14  (42)                   | 6469.11               | 0.03                       |
| 16  (48)                   | n/a                       | 0.12                        | 


Marking draft for now since it needs to be merged after the Rust side PR (and update the commit hash in cargo.toml). However, this it is now ready for review. 

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
