### PR TITLE
BucketListDB Random Eviction Cache

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -45,6 +45,8 @@ bucketlistDB-live.bulk.inflationWinners     | timer     | time to load inflation
 bucketlistDB-live.bulk.poolshareTrustlines  | timer     | time to load poolshare trustlines by accountID and assetID
 bucketlistDB-live.bulk.prefetch             | timer     | time to prefetch
 bucketlistDB-<X>.point.<y>                | timer     | time to load single entry of type <Y> on BucketList <X> (live/hotArchive)
+bucketlistDB-cache.hit                    | meter     | number of cache hits on Live BucketList Disk random eviction cache
+bucketlistDB-cache.miss                   | meter     | number of cache misses on Live BucketList Disk random eviction cache
 crypto.verify.hit                         | meter     | number of signature cache hits
 crypto.verify.miss                        | meter     | number of signature cache misses
 crypto.verify.total                       | meter     | sum of both hits and misses

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -239,7 +239,8 @@ BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT = 14
 # Percentage of entries cached by BucketListDB when Bucket size is larger
 # than BUCKETLIST_DB_INDEX_CUTOFF. Note that this value does not impact
 # Buckets smaller than BUCKETLIST_DB_INDEX_CUTOFF, as they are always
-# completely held in memory.
+# completely held in memory. Roughly speaking, RAM usage for BucketList
+# cache == BucketListSize * (BUCKETLIST_DB_CACHED_PERCENT / 100).
 BUCKETLIST_DB_CACHED_PERCENT = 25
 
 # BUCKETLIST_DB_INDEX_CUTOFF (Integer) default 250

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -235,6 +235,13 @@ MAX_DEX_TX_OPERATIONS_IN_TX_SET = 0
 # 0, indiviudal index is always used. Default page size 16 kb.
 BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT = 14
 
+# BUCKETLIST_DB_CACHED_PERCENT (Integer) default 25
+# Percentage of entries cached by BucketListDB when Bucket size is larger
+# than BUCKETLIST_DB_INDEX_CUTOFF. Note that this value does not impact
+# Buckets smaller than BUCKETLIST_DB_INDEX_CUTOFF, as they are always
+# completely held in memory.
+BUCKETLIST_DB_CACHED_PERCENT = 25
+
 # BUCKETLIST_DB_INDEX_CUTOFF (Integer) default 250
 # Size, in MB, determining whether a bucket should have an individual
 # key index or a key range index. If bucket size is below this value, range

--- a/src/bucket/BucketIndexUtils.cpp
+++ b/src/bucket/BucketIndexUtils.cpp
@@ -19,7 +19,8 @@ namespace stellar
 std::streamoff
 getPageSizeFromConfig(Config const& cfg)
 {
-    if (cfg.BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT == 0)
+    if (cfg.BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT == 0 ||
+        cfg.BUCKETLIST_DB_CACHED_PERCENT == 100)
     {
         return 0;
     }

--- a/src/bucket/BucketManager.cpp
+++ b/src/bucket/BucketManager.cpp
@@ -157,6 +157,10 @@ BucketManager::BucketManager(Application& app)
           app.getMetrics().NewCounter({"bucketlist", "size", "bytes"}))
     , mArchiveBucketListSizeCounter(
           app.getMetrics().NewCounter({"bucketlist-archive", "size", "bytes"}))
+    , mCacheHitMeter(app.getMetrics().NewMeter({"bucketlistDB", "cache", "hit"},
+                                               "bucketlistDB"))
+    , mCacheMissMeter(app.getMetrics().NewMeter(
+          {"bucketlistDB", "cache", "miss"}, "bucketlistDB"))
     , mBucketListEvictionCounters(app)
     , mEvictionStatistics(std::make_shared<EvictionStatistics>())
     , mConfig(app.getConfig())
@@ -349,6 +353,18 @@ BucketManager::readMergeCounters()
 {
     std::lock_guard<std::recursive_mutex> lock(mBucketMutex);
     return mMergeCounters;
+}
+
+medida::Meter&
+BucketManager::getCacheHitMeter() const
+{
+    return mCacheHitMeter;
+}
+
+medida::Meter&
+BucketManager::getCacheMissMeter() const
+{
+    return mCacheMissMeter;
 }
 
 void

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -100,6 +100,8 @@ class BucketManager : NonMovableOrCopyable
     medida::Counter& mSharedBucketsSize;
     medida::Counter& mLiveBucketListSizeCounter;
     medida::Counter& mArchiveBucketListSizeCounter;
+    medida::Meter& mCacheHitMeter;
+    medida::Meter& mCacheMissMeter;
     EvictionCounters mBucketListEvictionCounters;
     MergeCounters mMergeCounters;
     std::shared_ptr<EvictionStatistics> mEvictionStatistics{};
@@ -197,6 +199,8 @@ class BucketManager : NonMovableOrCopyable
 
     template <class BucketT> medida::Meter& getBloomMissMeter() const;
     template <class BucketT> medida::Meter& getBloomLookupMeter() const;
+    medida::Meter& getCacheHitMeter() const;
+    medida::Meter& getCacheMissMeter() const;
 
     // Reading and writing the merge counters is done in bulk, and takes a lock
     // briefly; this can be done from any thread.

--- a/src/bucket/BucketSnapshot.cpp
+++ b/src/bucket/BucketSnapshot.cpp
@@ -39,7 +39,7 @@ BucketSnapshotBase<BucketT>::isEmpty() const
 }
 
 template <class BucketT>
-std::pair<std::shared_ptr<typename BucketT::EntryT>, bool>
+std::pair<std::shared_ptr<typename BucketT::EntryT const>, bool>
 BucketSnapshotBase<BucketT>::getEntryAtOffset(LedgerKey const& k,
                                               std::streamoff pos,
                                               size_t pageSize) const
@@ -58,12 +58,16 @@ BucketSnapshotBase<BucketT>::getEntryAtOffset(LedgerKey const& k,
     {
         if (stream.readOne(be))
         {
-            return {std::make_shared<typename BucketT::EntryT>(be), false};
+            auto entry = std::make_shared<typename BucketT::EntryT const>(be);
+            mBucket->getIndex().maybeAddToCache(entry);
+            return {entry, false};
         }
     }
     else if (stream.readPage(be, k, pageSize))
     {
-        return {std::make_shared<typename BucketT::EntryT>(be), false};
+        auto entry = std::make_shared<typename BucketT::EntryT const>(be);
+        mBucket->getIndex().maybeAddToCache(entry);
+        return {entry, false};
     }
 
     mBucket->getIndex().markBloomMiss();

--- a/src/bucket/BucketSnapshot.h
+++ b/src/bucket/BucketSnapshot.h
@@ -41,7 +41,7 @@ template <class BucketT> class BucketSnapshotBase : public NonMovable
     // reads until key is found or the end of the page. Returns <BucketEntry,
     // bloomMiss>, where bloomMiss is true if a bloomMiss occurred during the
     // load.
-    std::pair<std::shared_ptr<typename BucketT::EntryT>, bool>
+    std::pair<std::shared_ptr<typename BucketT::EntryT const>, bool>
     getEntryAtOffset(LedgerKey const& k, std::streamoff pos,
                      size_t pageSize) const;
 

--- a/src/bucket/BucketUtils.cpp
+++ b/src/bucket/BucketUtils.cpp
@@ -337,6 +337,17 @@ BucketEntryCounters::operator!=(BucketEntryCounters const& other) const
     return !(*this == other);
 }
 
+size_t
+BucketEntryCounters::numEntries() const
+{
+    size_t num = 0;
+    for (auto const& [_, count] : entryTypeCounts)
+    {
+        num += count;
+    }
+    return num;
+}
+
 template void
 BucketEntryCounters::count<LiveBucket>(LiveBucket::EntryT const& be);
 template void BucketEntryCounters::count<HotArchiveBucket>(

--- a/src/bucket/BucketUtils.h
+++ b/src/bucket/BucketUtils.h
@@ -196,6 +196,7 @@ struct BucketEntryCounters
     BucketEntryCounters& operator+=(BucketEntryCounters const& other);
     bool operator==(BucketEntryCounters const& other) const;
     bool operator!=(BucketEntryCounters const& other) const;
+    size_t numEntries() const;
 
     template <class Archive>
     void

--- a/src/bucket/HotArchiveBucketIndex.h
+++ b/src/bucket/HotArchiveBucketIndex.h
@@ -77,7 +77,8 @@ class HotArchiveBucketIndex : public NonMovableOrCopyable
     // Hot Archive does not support the cache, so define empty function for
     // consistency with LiveBucketIndex
     void
-    maybeAddToCache(std::shared_ptr<HotArchiveBucketEntry const> entry) const
+    maybeAddToCache(
+        std::shared_ptr<HotArchiveBucketEntry const> const& entry) const
     {
     }
 

--- a/src/bucket/HotArchiveBucketIndex.h
+++ b/src/bucket/HotArchiveBucketIndex.h
@@ -74,6 +74,13 @@ class HotArchiveBucketIndex : public NonMovableOrCopyable
         return mDiskIndex.scan(mDiskIndex.begin(), k).first;
     }
 
+    // Hot Archive does not support the cache, so define empty function for
+    // consistency with LiveBucketIndex
+    void
+    maybeAddToCache(std::shared_ptr<HotArchiveBucketEntry const> entry) const
+    {
+    }
+
     std::pair<IndexReturnT, IterT> scan(IterT start, LedgerKey const& k) const;
 
     BucketEntryCounters const&

--- a/src/bucket/LiveBucketIndex.h
+++ b/src/bucket/LiveBucketIndex.h
@@ -68,6 +68,9 @@ class LiveBucketIndex : public NonMovableOrCopyable
     // mutex.
     mutable std::shared_mutex mCacheMutex;
 
+    medida::Meter& mCacheHitMeter;
+    medida::Meter& mCacheMissMeter;
+
     static inline DiskIndex<LiveBucket>::IterT
     getDiskIter(IterT const& iter)
     {
@@ -118,7 +121,7 @@ class LiveBucketIndex : public NonMovableOrCopyable
     std::optional<std::pair<std::streamoff, std::streamoff>>
     getOfferRange() const;
 
-    void maybeAddToCache(std::shared_ptr<BucketEntry const> entry) const;
+    void maybeAddToCache(std::shared_ptr<BucketEntry const> const& entry) const;
 
     BucketEntryCounters const& getBucketEntryCounters() const;
     uint32_t getPageSize() const;
@@ -128,6 +131,8 @@ class LiveBucketIndex : public NonMovableOrCopyable
     void markBloomMiss() const;
 #ifdef BUILD_TESTS
     bool operator==(LiveBucketIndex const& in) const;
+
+    void clearCache() const;
 #endif
 };
 }

--- a/src/bucket/readme.md
+++ b/src/bucket/readme.md
@@ -97,3 +97,8 @@ lookup speed and memory overhead. The following configuration flags control thes
     on startup. Defaults to true, should only be set to false for testing purposes.
     Validators do not currently support persisted indexes. If NODE_IS_VALIDATOR=true,
     this value is ignored and indexes are never persisted.
+- `BUCKETLIST_DB_CACHED_PERCENT`
+  - Percentage of entries cached by BucketListDB when Bucket size is larger
+    than `BUCKETLIST_DB_INDEX_CUTOFF`. Note that this value does not impact
+    Buckets smaller than `BUCKETLIST_DB_INDEX_CUTOFF`, as they are always
+    completely held in memory.

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -162,6 +162,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     EXPERIMENTAL_PARALLEL_LEDGER_CLOSE = false;
     BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT = 14; // 2^14 == 16 kb
     BUCKETLIST_DB_INDEX_CUTOFF = 250;            // 250 mb
+    BUCKETLIST_DB_CACHED_PERCENT = 25;
     BUCKETLIST_DB_PERSIST_INDEX = true;
     PUBLISH_TO_ARCHIVE_DELAY = std::chrono::seconds{0};
     // automatic maintenance settings:
@@ -1140,6 +1141,11 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                  [&]() {
                      BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT =
                          readInt<size_t>(item);
+                 }},
+                {"BUCKETLIST_DB_CACHED_PERCENT",
+                 [&]() {
+                     BUCKETLIST_DB_CACHED_PERCENT =
+                         readInt<size_t>(item, 0, 100);
                  }},
                 {"BUCKETLIST_DB_INDEX_CUTOFF",
                  [&]() { BUCKETLIST_DB_INDEX_CUTOFF = readInt<size_t>(item); }},

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -461,6 +461,12 @@ class Config : public std::enable_shared_from_this<Config>
     // 2^BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT.
     size_t BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT;
 
+    // Percentage of entries cached by BucketListDB when Bucket size is larger
+    // than BUCKETLIST_DB_INDEX_CUTOFF. Note that this value does not impact
+    // Buckets smaller than BUCKETLIST_DB_INDEX_CUTOFF, as they are always
+    // completely held in memory.
+    size_t BUCKETLIST_DB_CACHED_PERCENT;
+
     // Size, in MB, determining whether a bucket should have an individual
     // key index or a key range index. If bucket size is below this value, range
     // based index will be used. If set to 0, all buckets are range indexed. If

--- a/src/util/RandomEvictionCache.h
+++ b/src/util/RandomEvictionCache.h
@@ -95,11 +95,14 @@ class RandomEvictionCache : public NonMovableOrCopyable
         mValuePtrs.reserve(maxSize + 1);
     }
 
-    RandomEvictionCache(size_t maxSize, bool separatePRNG)
+    RandomEvictionCache(size_t maxSize, bool separatePRNG, bool reserve = true)
         : mMaxSize(maxSize), mSeparatePRNG(separatePRNG)
     {
-        mValueMap.reserve(maxSize + 1);
-        mValuePtrs.reserve(maxSize + 1);
+        if (reserve)
+        {
+            mValueMap.reserve(maxSize + 1);
+            mValuePtrs.reserve(maxSize + 1);
+        }
     }
 
     void


### PR DESCRIPTION
# Description

Resolves #3696

Adds a random eviction cache to `LiveBucket` using `DiskIndex`. Currently, I've set the default to cache up to 25% of Bucket entries, which puts total stellar-core memory usage at about 5-6 GB by default.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
