### PR TITLE
Apply buckets optimization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
   fmt:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: rustup component add rustfmt
     - run: rustup update
     - run: cargo fmt --all --check
@@ -38,7 +38,7 @@ jobs:
     # Prevent sudden announcement of a new advisory from failing ci:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: EmbarkStudios/cargo-deny-action@b01e7a8cfb1f496c52d77361e84c1840d8246393
       with:
         command: check ${{ matrix.checks }}
@@ -49,7 +49,7 @@ jobs:
   rust-check-git-rev-deps:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: stellar/actions/rust-check-git-rev-deps@main
 
   build:
@@ -99,7 +99,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.toolchain }}-${{ matrix.protocol }}
 
-      - uses: actions/checkout@v3.5.2
+      - uses: actions/checkout@v4
         if: steps.cache.outputs.cache-hit != 'true'
         with:
            fetch-depth: 200

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -44,7 +44,7 @@ bucketlistDB-<X>.bulk.loads                 | meter     | number of entries Buck
 bucketlistDB-live.bulk.inflationWinners     | timer     | time to load inflation winners
 bucketlistDB-live.bulk.poolshareTrustlines  | timer     | time to load poolshare trustlines by accountID and assetID
 bucketlistDB-live.bulk.prefetch             | timer     | time to prefetch
-bucketlistDB-<X>.point.<y>                | timer     | time to load single entry of type <Y> on BucketList <X> (live/hotArchive)
+bucketlistDB-<X>.point.<Y>                | timer     | time to load single entry of type <Y> on BucketList <X> (live/hotArchive)
 bucketlistDB-cache.hit                    | meter     | number of cache hits on Live BucketList Disk random eviction cache
 bucketlistDB-cache.miss                   | meter     | number of cache misses on Live BucketList Disk random eviction cache
 crypto.verify.hit                         | meter     | number of signature cache hits

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -235,21 +235,21 @@ MAX_DEX_TX_OPERATIONS_IN_TX_SET = 0
 # 0, indiviudal index is always used. Default page size 16 kb.
 BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT = 14
 
-# BUCKETLIST_DB_CACHED_PERCENT (Integer) default 25
+# BUCKETLIST_DB_CACHED_PERCENT (Integer) default 10
 # Percentage of entries cached by BucketListDB when Bucket size is larger
 # than BUCKETLIST_DB_INDEX_CUTOFF. Note that this value does not impact
 # Buckets smaller than BUCKETLIST_DB_INDEX_CUTOFF, as they are always
 # completely held in memory. Roughly speaking, RAM usage for BucketList
 # cache == BucketListSize * (BUCKETLIST_DB_CACHED_PERCENT / 100).
-BUCKETLIST_DB_CACHED_PERCENT = 25
+BUCKETLIST_DB_CACHED_PERCENT = 10
 
-# BUCKETLIST_DB_INDEX_CUTOFF (Integer) default 250
+# BUCKETLIST_DB_INDEX_CUTOFF (Integer) default 100
 # Size, in MB, determining whether a bucket should have an individual
 # key index or a key range index. If bucket size is below this value, range
 # based index will be used. If set to 0, all buckets are range indexed. If
 # BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT == 0, value ignored and all
 # buckets have individual key index.
-BUCKETLIST_DB_INDEX_CUTOFF = 250
+BUCKETLIST_DB_INDEX_CUTOFF = 100
 
 # BUCKETLIST_DB_PERSIST_INDEX (bool) default true
 # Determines whether BucketListDB indexes are saved to disk for faster

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -247,7 +247,7 @@ BUCKETLIST_DB_CACHED_PERCENT = 25
 # Size, in MB, determining whether a bucket should have an individual
 # key index or a key range index. If bucket size is below this value, range
 # based index will be used. If set to 0, all buckets are range indexed. If
-# BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT == 0, value ingnored and all
+# BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT == 0, value ignored and all
 # buckets have individual key index.
 BUCKETLIST_DB_INDEX_CUTOFF = 250
 

--- a/src/bucket/BucketIndexUtils.cpp
+++ b/src/bucket/BucketIndexUtils.cpp
@@ -31,7 +31,7 @@ getPageSizeFromConfig(Config const& cfg)
 template <class BucketT>
 std::unique_ptr<typename BucketT::IndexT const>
 createIndex(BucketManager& bm, std::filesystem::path const& filename,
-            Hash const& hash, asio::io_context& ctx)
+            Hash const& hash, asio::io_context& ctx, SHA256* hasher)
 {
     BUCKET_TYPE_ASSERT(BucketT);
 
@@ -41,7 +41,7 @@ createIndex(BucketManager& bm, std::filesystem::path const& filename,
     try
     {
         return std::unique_ptr<typename BucketT::IndexT const>(
-            new typename BucketT::IndexT(bm, filename, hash, ctx));
+            new typename BucketT::IndexT(bm, filename, hash, ctx, hasher));
     }
     // BucketIndex throws if BucketManager shuts down before index finishes,
     // so return empty index instead of partial index
@@ -88,11 +88,12 @@ loadIndex(BucketManager const& bm, std::filesystem::path const& filename,
 template std::unique_ptr<typename LiveBucket::IndexT const>
 createIndex<LiveBucket>(BucketManager& bm,
                         std::filesystem::path const& filename, Hash const& hash,
-                        asio::io_context& ctx);
+                        asio::io_context& ctx, SHA256* hasher);
 template std::unique_ptr<typename HotArchiveBucket::IndexT const>
 createIndex<HotArchiveBucket>(BucketManager& bm,
                               std::filesystem::path const& filename,
-                              Hash const& hash, asio::io_context& ctx);
+                              Hash const& hash, asio::io_context& ctx,
+                              SHA256* hasher);
 
 template std::unique_ptr<typename LiveBucket::IndexT const>
 loadIndex<LiveBucket>(BucketManager const& bm,

--- a/src/bucket/BucketIndexUtils.h
+++ b/src/bucket/BucketIndexUtils.h
@@ -4,6 +4,7 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "crypto/SHA.h"
 #include "util/GlobalChecks.h"
 #include "util/XDROperators.h" // IWYU pragma: keep
 #include "xdr/Stellar-ledger-entries.h"
@@ -100,7 +101,7 @@ std::streamoff getPageSizeFromConfig(Config const& cfg);
 template <class BucketT>
 std::unique_ptr<typename BucketT::IndexT const>
 createIndex(BucketManager& bm, std::filesystem::path const& filename,
-            Hash const& hash, asio::io_context& ctx);
+            Hash const& hash, asio::io_context& ctx, SHA256* hasher);
 
 // Loads index from given file. If file does not exist or if saved
 // index does not have expected version or pageSize, return null

--- a/src/bucket/BucketOutputIterator.cpp
+++ b/src/bucket/BucketOutputIterator.cpp
@@ -198,7 +198,8 @@ BucketOutputIterator<BucketT>::getBucket(BucketManager& bucketManager,
     if (auto b = bucketManager.getBucketIfExists<BucketT>(hash);
         !b || !b->isIndexed())
     {
-        index = createIndex<BucketT>(bucketManager, mFilename, hash, mCtx);
+        index =
+            createIndex<BucketT>(bucketManager, mFilename, hash, mCtx, nullptr);
     }
 
     return bucketManager.adoptFileAsBucket<BucketT>(mFilename.string(), hash,

--- a/src/bucket/BucketUtils.h
+++ b/src/bucket/BucketUtils.h
@@ -171,6 +171,9 @@ class EvictionStatistics
                                       EvictionCounters& counters);
 };
 
+// Enum for more granular LedgerEntry types for Bucket metric reporting.
+// Specifically, this enum differentiates between TEMPORARY and PERSISTENT
+// CONTRACT_DATA types, which the regular LedgerEntryType enum does not.
 enum class LedgerEntryTypeAndDurability : uint32_t
 {
     ACCOUNT = 0,
@@ -187,6 +190,7 @@ enum class LedgerEntryTypeAndDurability : uint32_t
     NUM_TYPES = 11,
 };
 
+// Metrics for BucketEntry state by LedgerEntryTypeAndDurability
 struct BucketEntryCounters
 {
     std::map<LedgerEntryTypeAndDurability, size_t> entryTypeCounts;

--- a/src/bucket/DiskIndex.h
+++ b/src/bucket/DiskIndex.h
@@ -31,6 +31,7 @@ class io_context;
 namespace stellar
 {
 class BucketManager;
+class SHA256;
 
 // maps smallest and largest LedgerKey on a given page inclusively
 // [lowerBound, upperbound]
@@ -118,7 +119,8 @@ template <class BucketT> class DiskIndex : public NonMovableOrCopyable
 
     // Constructor for creating a fresh index.
     DiskIndex(BucketManager& bm, std::filesystem::path const& filename,
-              std::streamoff pageSize, Hash const& hash, asio::io_context& ctx);
+              std::streamoff pageSize, Hash const& hash, asio::io_context& ctx,
+              SHA256* hasher);
 
     // Constructor for loading pre-existing index from disk. Must call preLoad
     // before calling this constructor to properly deserialize index.

--- a/src/bucket/HotArchiveBucketIndex.cpp
+++ b/src/bucket/HotArchiveBucketIndex.cpp
@@ -15,8 +15,9 @@ namespace stellar
 
 HotArchiveBucketIndex::HotArchiveBucketIndex(
     BucketManager& bm, std::filesystem::path const& filename, Hash const& hash,
-    asio::io_context& ctx)
-    : mDiskIndex(bm, filename, getPageSize(bm.getConfig(), 0), hash, ctx)
+    asio::io_context& ctx, SHA256* hasher)
+    : mDiskIndex(bm, filename, getPageSize(bm.getConfig(), 0), hash, ctx,
+                 hasher)
 {
     ZoneScoped;
     releaseAssert(!filename.empty());

--- a/src/bucket/HotArchiveBucketIndex.h
+++ b/src/bucket/HotArchiveBucketIndex.h
@@ -57,7 +57,8 @@ class HotArchiveBucketIndex : public NonMovableOrCopyable
 
     HotArchiveBucketIndex(BucketManager& bm,
                           std::filesystem::path const& filename,
-                          Hash const& hash, asio::io_context& ctx);
+                          Hash const& hash, asio::io_context& ctx,
+                          SHA256* hasher);
 
     template <class Archive>
     HotArchiveBucketIndex(BucketManager const& bm, Archive& ar,

--- a/src/bucket/InMemoryIndex.cpp
+++ b/src/bucket/InMemoryIndex.cpp
@@ -50,7 +50,8 @@ InMemoryBucketState::scan(IterT start, LedgerKey const& searchKey) const
 }
 
 InMemoryIndex::InMemoryIndex(BucketManager const& bm,
-                             std::filesystem::path const& filename)
+                             std::filesystem::path const& filename,
+                             SHA256* hasher)
 {
     XDRInputFileStream in;
     in.open(filename.string());
@@ -60,7 +61,7 @@ InMemoryIndex::InMemoryIndex(BucketManager const& bm,
     std::optional<std::streamoff> firstOffer;
     std::optional<std::streamoff> lastOffer;
 
-    while (in && in.readOne(be))
+    while (in && in.readOne(be, hasher))
     {
         if (++iter >= 1000)
         {

--- a/src/bucket/InMemoryIndex.h
+++ b/src/bucket/InMemoryIndex.h
@@ -14,6 +14,8 @@
 namespace stellar
 {
 
+class SHA256;
+
 // For small Buckets, we can cache all contents in memory. Because we cache all
 // entries, the index is just as large as the Bucket itself, so we never persist
 // this index type. It is always recreated on startup.
@@ -66,7 +68,7 @@ class InMemoryIndex
     using IterT = InMemoryBucketState::IterT;
 
     InMemoryIndex(BucketManager const& bm,
-                  std::filesystem::path const& filename);
+                  std::filesystem::path const& filename, SHA256* hasher);
 
     IterT
     begin() const

--- a/src/bucket/LiveBucketIndex.cpp
+++ b/src/bucket/LiveBucketIndex.cpp
@@ -39,7 +39,8 @@ LiveBucketIndex::getPageSize(Config const& cfg, size_t bucketSize)
 
 LiveBucketIndex::LiveBucketIndex(BucketManager& bm,
                                  std::filesystem::path const& filename,
-                                 Hash const& hash, asio::io_context& ctx)
+                                 Hash const& hash, asio::io_context& ctx,
+                                 SHA256* hasher)
     : mCacheHitMeter(bm.getCacheHitMeter())
     , mCacheMissMeter(bm.getCacheMissMeter())
 {
@@ -54,7 +55,7 @@ LiveBucketIndex::LiveBucketIndex(BucketManager& bm,
                    "LiveBucketIndex::createIndex() using in-memory index for "
                    "bucket {}",
                    filename);
-        mInMemoryIndex = std::make_unique<InMemoryIndex>(bm, filename);
+        mInMemoryIndex = std::make_unique<InMemoryIndex>(bm, filename, hasher);
     }
     else
     {
@@ -63,7 +64,7 @@ LiveBucketIndex::LiveBucketIndex(BucketManager& bm,
                    "page size {} in bucket {}",
                    pageSize, filename);
         mDiskIndex = std::make_unique<DiskIndex<LiveBucket>>(
-            bm, filename, pageSize, hash, ctx);
+            bm, filename, pageSize, hash, ctx, hasher);
 
         auto percentCached = bm.getConfig().BUCKETLIST_DB_CACHED_PERCENT;
         if (percentCached > 0)

--- a/src/bucket/LiveBucketIndex.h
+++ b/src/bucket/LiveBucketIndex.h
@@ -48,7 +48,7 @@ namespace stellar
  */
 
 class BucketManager;
-
+class SHA256;
 class LiveBucketIndex : public NonMovableOrCopyable
 {
   public:
@@ -98,7 +98,7 @@ class LiveBucketIndex : public NonMovableOrCopyable
 
     // Constructor for creating new index from Bucketfile
     LiveBucketIndex(BucketManager& bm, std::filesystem::path const& filename,
-                    Hash const& hash, asio::io_context& ctx);
+                    Hash const& hash, asio::io_context& ctx, SHA256* hasher);
 
     // Constructor for loading pre-existing index from disk
     template <class Archive>

--- a/src/bucket/readme.md
+++ b/src/bucket/readme.md
@@ -89,7 +89,7 @@ lookup speed and memory overhead. The following configuration flags control thes
     Larger values slow down lookup speed but
     decrease memory usage.
 - `BUCKETLIST_DB_INDEX_CUTOFF`
-  - Bucket file size, in MB, that determines wether the Bucket is cached in memory or not.
+  - Bucket file size, in MB, that determines whether Bucket is cached in memory or not.
     Default value is 250 MB, which indexes the first ~5 levels with the `IndividualIndex`.
     Larger values speed up lookups but increase memory usage.
 - `BUCKETLIST_DB_PERSIST_INDEX`

--- a/src/catchup/IndexBucketsWork.cpp
+++ b/src/catchup/IndexBucketsWork.cpp
@@ -6,6 +6,7 @@
 #include "bucket/BucketManager.h"
 #include "bucket/DiskIndex.h"
 #include "bucket/LiveBucket.h"
+#include "crypto/SHA.h"
 #include "util/Fs.h"
 #include "util/Logging.h"
 #include "util/UnorderedSet.h"
@@ -86,9 +87,9 @@ IndexBucketsWork::IndexWork::postWork()
             if (!self->mIndex)
             {
                 // TODO: Fix this when archive BucketLists assume state
-                self->mIndex =
-                    createIndex<LiveBucket>(bm, self->mBucket->getFilename(),
-                                            self->mBucket->getHash(), ctx);
+                self->mIndex = createIndex<LiveBucket>(
+                    bm, self->mBucket->getFilename(), self->mBucket->getHash(),
+                    ctx, nullptr);
             }
 
             app.postOnMainThread(

--- a/src/history/HistoryArchive.h
+++ b/src/history/HistoryArchive.h
@@ -62,6 +62,19 @@ struct HistoryStateBucket
  */
 struct HistoryArchiveState
 {
+    // Maximum supported size of a bucket in the history archive. This is used
+    // as a very basic DOS protection against downloading very large malicious
+    // buckets. If a downloaded bucket is above this size, we automatically fail
+    // it as invalid. Note that we will still publish Buckets over this size so
+    // the network doesn't halt, but we will warn significantly, as at that
+    // point no new nodes could assume state from lcl. This value is _very_
+    // large given ledger state size as of Feb 2025, but we may want to revisit
+    // in the future. Worst case if we forget about this, new nodes could still
+    // assume state from an earlier ledger where Bucket sizes were not above
+    // the limit and replay ledgers to join the network.
+    static constexpr size_t MAX_HISTORY_ARCHIVE_BUCKET_SIZE =
+        1024ull * 1024ull * 1024ull * 100ull; // 100 GB
+
     static unsigned const HISTORY_ARCHIVE_STATE_VERSION;
 
     unsigned version{HISTORY_ARCHIVE_STATE_VERSION};

--- a/src/historywork/DownloadBucketsWork.h
+++ b/src/historywork/DownloadBucketsWork.h
@@ -23,6 +23,10 @@ class DownloadBucketsWork : public BatchWork
     TmpDir const& mDownloadDir;
     std::shared_ptr<HistoryArchive> mArchive;
 
+    // Store indexes of downloaded buckets
+    std::map<int, std::unique_ptr<LiveBucketIndex const>> mIndexMap;
+    int mIndexId{0};
+
   public:
     DownloadBucketsWork(
         Application& app,

--- a/src/historywork/GetRemoteFileWork.cpp
+++ b/src/historywork/GetRemoteFileWork.cpp
@@ -38,6 +38,9 @@ GetRemoteFileWork::getCommand()
     {
         mCurrentArchive = mApp.getHistoryArchiveManager()
                               .selectRandomReadableHistoryArchive();
+        CLOG_INFO(History, "Selected archive {} to download {}",
+                  mCurrentArchive->getName(),
+                  std::filesystem::path(mRemote).filename().string());
     }
     releaseAssert(mCurrentArchive);
     releaseAssert(mCurrentArchive->hasGetCmd());

--- a/src/historywork/VerifyBucketWork.h
+++ b/src/historywork/VerifyBucketWork.h
@@ -15,6 +15,8 @@ class Meter;
 namespace stellar
 {
 
+class LiveBucketIndex;
+
 class Bucket;
 
 class VerifyBucketWork : public BasicWork
@@ -23,14 +25,16 @@ class VerifyBucketWork : public BasicWork
     uint256 mHash;
     bool mDone{false};
     std::error_code mEc;
-
+    std::unique_ptr<LiveBucketIndex const>& mIndex;
     void spawnVerifier();
 
     OnFailureCallback mOnFailure;
 
   public:
     VerifyBucketWork(Application& app, std::string const& bucketFile,
-                     uint256 const& hash, OnFailureCallback failureCb);
+                     uint256 const& hash,
+                     std::unique_ptr<LiveBucketIndex const>& index,
+                     OnFailureCallback failureCb);
     ~VerifyBucketWork() = default;
 
   protected:

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -162,7 +162,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     EXPERIMENTAL_PARALLEL_LEDGER_CLOSE = false;
     BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT = 14; // 2^14 == 16 kb
     BUCKETLIST_DB_INDEX_CUTOFF = 250;            // 250 mb
-    BUCKETLIST_DB_CACHED_PERCENT = 25;
+    BUCKETLIST_DB_CACHED_PERCENT = 10;
     BUCKETLIST_DB_PERSIST_INDEX = true;
     PUBLISH_TO_ARCHIVE_DELAY = std::chrono::seconds{0};
     // automatic maintenance settings:

--- a/src/util/XDRStream.h
+++ b/src/util/XDRStream.h
@@ -114,9 +114,11 @@ class XDRInputFileStream
         return sz;
     }
 
+    // If a hasher is provided, it will be updated with the raw XDR bytes
+    // read from the stream.
     template <typename T>
     bool
-    readOne(T& out)
+    readOne(T& out, SHA256* hasher = nullptr)
     {
         ZoneScoped;
         char szBuf[4];
@@ -147,6 +149,12 @@ class XDRInputFileStream
         {
             throw xdr::xdr_runtime_error(
                 "malformed XDR file or IO failure in readOne");
+        }
+
+        if (hasher)
+        {
+            hasher->add(ByteSlice(szBuf, sizeof(szBuf)));
+            hasher->add(ByteSlice(mBuf.data(), sz));
         }
 
         xdr::xdr_get g(mBuf.data(), mBuf.data() + sz);


### PR DESCRIPTION
# Description

Resolves #4633

This PR indexes bucket files during `VerifyBucketsWork`. Previously we would download Buckets, iterate all the buckets to check their hash, then iterate through all the buckets again to index them. Since startup is primarily disk bound, iterating through the entire BucketList twice is expensive. This change does the hash verification and indexing step in the same pass so we only have to read the BucketList once.

This introduces no new DOS vectors. Indexing unverified buckets could lead to an OOM based DOS attack, where a malicious History Archive provider hosts malicious buckets that are very large. However, such OOM attacks are already possible via a zip bomb, and History Archive providers are fairly trusted, so this is not a significant concern. To mitigate this I've added an INFO level log message saying what history archive a given file is being downloaded from. In the event of a DOS attack, these logs would give us enough info to quickly assign blame to the attacker and remove them from quorum sets.

On my laptop, this decreases startup time from `new-db` by about 16%.

Rebased on top of https://github.com/stellar/stellar-core/pull/4630.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
