### PR TITLE
remove import of  <asm-generic/errno.h> in src/bucket/InMemoryIndex.cpp

### DIFF
--- a/src/bucket/InMemoryIndex.cpp
+++ b/src/bucket/InMemoryIndex.cpp
@@ -10,7 +10,6 @@
 #include "util/types.h"
 #include "xdr/Stellar-ledger-entries.h"
 #include <algorithm>
-#include <asm-generic/errno.h>
 
 namespace stellar
 {


### PR DESCRIPTION
# Description

This import breaks builds on mac. I don't think the constants defined in it are used? 

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
