### PR TITLE
Optimize the parallel tx set building implementation.

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -518,6 +518,7 @@ exit /b 0
     <ClCompile Include="..\..\src\herder\HerderSCPDriver.cpp" />
     <ClCompile Include="..\..\src\herder\HerderUtils.cpp" />
     <ClCompile Include="..\..\src\herder\LedgerCloseData.cpp" />
+    <ClCompile Include="..\..\src\herder\ParallelTxSetBuilder.cpp" />
     <ClCompile Include="..\..\src\herder\PendingEnvelopes.cpp" />
     <ClCompile Include="..\..\src\herder\QuorumIntersectionCheckerImpl.cpp" />
     <ClCompile Include="..\..\src\herder\QuorumTracker.cpp" />
@@ -972,6 +973,7 @@ exit /b 0
     <ClInclude Include="..\..\src\herder\HerderSCPDriver.h" />
     <ClInclude Include="..\..\src\herder\HerderUtils.h" />
     <ClInclude Include="..\..\src\herder\LedgerCloseData.h" />
+    <ClInclude Include="..\..\src\herder\ParallelTxSetBuilder.h" />
     <ClInclude Include="..\..\src\herder\PendingEnvelopes.h" />
     <ClInclude Include="..\..\src\herder\QuorumIntersectionChecker.h" />
     <ClInclude Include="..\..\src\herder\QuorumIntersectionCheckerImpl.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1365,6 +1365,15 @@
     <ClCompile Include="..\..\src\catchup\LedgerApplyManagerImpl.cpp">
       <Filter>catchup</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\herder\ParallelTxSetBuilder.cpp">
+      <Filter>herder</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\simulation\ApplyLoad.cpp">
+      <Filter>simulation</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\simulation\TxGenerator.cpp">
+      <Filter>simulation</Filter>
+    </ClCompile>    
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\util\cpptoml.h">
@@ -2359,6 +2368,15 @@
     </ClInclude>
     <ClInclude Include="..\..\src\main\QueryServer.h">
       <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\herder\ParallelTxSetBuilder.h">
+      <Filter>herder</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\simulation\ApplyLoad.h">
+      <Filter>simulation</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\simulation\TxGenerator.h">
+      <Filter>simulation</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\ledger\LedgerStateSnapshot.h">
       <Filter>ledger</Filter>

--- a/src/herder/ParallelTxSetBuilder.cpp
+++ b/src/herder/ParallelTxSetBuilder.cpp
@@ -1,0 +1,449 @@
+// Copyright 2025 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "herder/ParallelTxSetBuilder.h"
+#include "herder/SurgePricingUtils.h"
+#include "herder/TxSetFrame.h"
+#include "transactions/TransactionFrameBase.h"
+#include "util/BitSet.h"
+
+#include <unordered_set>
+
+namespace stellar
+{
+namespace
+{
+// Configuration for parallel partitioning of transactions.
+struct ParallelPartitionConfig
+{
+    ParallelPartitionConfig(Config const& cfg,
+                            SorobanNetworkConfig const& sorobanCfg)
+        : mStageCount(
+              std::max(cfg.SOROBAN_PHASE_STAGE_COUNT, static_cast<uint32_t>(1)))
+        , mClustersPerStage(sorobanCfg.ledgerMaxDependentTxClusters())
+        , mInstructionsPerCluster(sorobanCfg.ledgerMaxInstructions() /
+                                  mStageCount)
+    {
+    }
+
+    uint64_t
+    instructionsPerStage() const
+    {
+        return mInstructionsPerCluster * mClustersPerStage;
+    }
+
+    uint32_t mStageCount = 0;
+    uint32_t mClustersPerStage = 0;
+    uint64_t mInstructionsPerCluster = 0;
+};
+
+// Internal data structure that contains only relevant transaction information
+// necessary for building parallel processing stages.
+struct BuilderTx
+{
+    size_t mId = 0;
+    uint32_t mInstructions = 0;
+    BitSet mReadOnlyFootprint;
+    BitSet mReadWriteFootprint;
+
+    BuilderTx(size_t txId, TransactionFrameBase const& tx,
+              UnorderedMap<LedgerKey, size_t> const& entryIdMap)
+        : mId(txId), mInstructions(tx.sorobanResources().instructions)
+    {
+        auto const& footprint = tx.sorobanResources().footprint;
+        for (auto const& key : footprint.readOnly)
+        {
+            mReadOnlyFootprint.set(entryIdMap.at(key));
+        }
+        for (auto const& key : footprint.readWrite)
+        {
+            mReadWriteFootprint.set(entryIdMap.at(key));
+        }
+    }
+};
+
+// Cluster of (potentialy transitively) dependent transactions.
+// Transactions are considered to be dependent if the have the same key in
+// their footprints and for at least one of them this key belongs to read-write
+// footprint.
+struct Cluster
+{
+    // Total number of instructions in the cluster. Since transactions are
+    // dependenent, these are always 'sequential' instructions.
+    uint64_t mInstructions = 0;
+    // Union of read-only footprints of all transactions in the cluster.
+    BitSet mReadOnlyEntries;
+    // Union of read-write footprints of all transactions in the cluster.
+    BitSet mReadWriteEntries;
+    // Set of transaction ids in the cluster.
+    BitSet mTxIds;
+    // Id of the bin within a stage in which the cluster is packed.
+    size_t mBinId = 0;
+
+    explicit Cluster(BuilderTx const& tx) : mInstructions(tx.mInstructions)
+    {
+        mReadOnlyEntries.inplaceUnion(tx.mReadOnlyFootprint);
+        mReadWriteEntries.inplaceUnion(tx.mReadWriteFootprint);
+        mTxIds.set(tx.mId);
+    }
+
+    void
+    merge(Cluster const& other)
+    {
+        mInstructions += other.mInstructions;
+        mReadOnlyEntries.inplaceUnion(other.mReadOnlyEntries);
+        mReadWriteEntries.inplaceUnion(other.mReadWriteEntries);
+        mTxIds.inplaceUnion(other.mTxIds);
+    }
+};
+
+// The stage of parallel processing that consists of clusters of dependent
+// transactions that can be processed in parallel relative to each other
+// The stage contains an arbitrary number of clusters of actually dependent
+// transactions and the bin-packing of these clusters into at most
+// `mConfig.mClustersPerStage` bins, i.e. into as many clusters as the network
+// configuration allows.
+class Stage
+{
+  public:
+    Stage(ParallelPartitionConfig cfg) : mConfig(cfg)
+    {
+        mBinPacking.resize(mConfig.mClustersPerStage);
+        mBinInstructions.resize(mConfig.mClustersPerStage);
+    }
+
+    // Tries to add a transaction to the stage and returns true if the
+    // transaction has been added.
+    bool
+    tryAdd(BuilderTx const& tx)
+    {
+        ZoneScoped;
+        // A fast-fail condition to ensure that adding the transaction won't
+        // exceed the theorethical limit of instructions per stage.
+        if (mInstructions + tx.mInstructions > mConfig.instructionsPerStage())
+        {
+            return false;
+        }
+        // First, find all clusters that conflict with the new transaction.
+        auto conflictingClusters = getConflictingClusters(tx);
+
+        bool packed = false;
+        // Then, create new clusters by merging the conflicting clusters
+        // together and adding the new transaction to the resulting cluster.
+        auto newClusters = createNewClusters(tx, conflictingClusters, packed);
+        releaseAssert(!newClusters.empty());
+
+        // If the new cluster exceeds the limit of instructions per cluster,
+        // we can't add the transaction.
+        if (newClusters.back().mInstructions > mConfig.mInstructionsPerCluster)
+        {
+            return false;
+        }
+        // If the merge didn't cause a perturbation in bin-packing, we can just
+        // replace the old clusters with the new ones within one of the
+        // existing bins.
+        if (packed)
+        {
+            mClusters = newClusters;
+            mInstructions += tx.mInstructions;
+            return true;
+        }
+        // Otherwise, we need try to recompute the bin-packing from scratch.
+        std::vector<uint64_t> newBinInstructions;
+        auto newPacking = binPacking(newClusters, newBinInstructions);
+        // Even if the new cluster is below the limit, it may invalidate the
+        // stage as a whole in case if we can no longer pack the clusters into
+        // the required number of bins.
+        if (newPacking.empty())
+        {
+            return false;
+        }
+        mClusters = newClusters;
+        mBinPacking = newPacking;
+        mInstructions += tx.mInstructions;
+        mBinInstructions = newBinInstructions;
+        return true;
+    }
+
+    // Visit every transaction in the stage.
+    // The visitor arguments are the index of the bin the transaction is packed
+    // into and the index of the transaction itself.
+    void
+    visitAllTransactions(std::function<void(size_t, size_t)> visitor) const
+    {
+        for (auto const& cluster : mClusters)
+        {
+            size_t txId = 0;
+            while (cluster.mTxIds.nextSet(txId))
+            {
+                visitor(cluster.mBinId, txId);
+                ++txId;
+            }
+        }
+    }
+
+  private:
+    std::unordered_set<Cluster const*>
+    getConflictingClusters(BuilderTx const& tx) const
+    {
+        std::unordered_set<Cluster const*> conflictingClusters;
+        for (Cluster const& cluster : mClusters)
+        {
+            bool isConflicting = tx.mReadOnlyFootprint.intersectionCount(
+                                     cluster.mReadWriteEntries) > 0 ||
+                                 tx.mReadWriteFootprint.intersectionCount(
+                                     cluster.mReadOnlyEntries) > 0 ||
+                                 tx.mReadWriteFootprint.intersectionCount(
+                                     cluster.mReadWriteEntries) > 0;
+            if (isConflicting)
+            {
+                conflictingClusters.insert(&cluster);
+            }
+        }
+        return conflictingClusters;
+    }
+
+    std::vector<Cluster>
+    createNewClusters(BuilderTx const& tx,
+                      std::unordered_set<Cluster const*> const& txConflicts,
+                      bool& packed)
+    {
+        std::vector<Cluster> newClusters;
+        newClusters.reserve(mClusters.size());
+        for (auto const& cluster : mClusters)
+        {
+            if (txConflicts.find(&cluster) == txConflicts.end())
+            {
+                newClusters.push_back(cluster);
+            }
+        }
+
+        newClusters.emplace_back(tx);
+        for (auto const* cluster : txConflicts)
+        {
+            newClusters.back().merge(*cluster);
+        }
+        // Fast-fail condition to ensure that the new cluster doesn't exceed
+        // the instructions limit.
+        if (newClusters.back().mInstructions > mConfig.mInstructionsPerCluster)
+        {
+            return newClusters;
+        }
+
+        // Remove the clusters that were merged from their respective bins.
+        for (auto const& cluster : txConflicts)
+        {
+            mBinInstructions[cluster->mBinId] -= cluster->mInstructions;
+            mBinPacking[cluster->mBinId].inplaceDifference(cluster->mTxIds);
+        }
+
+        packed = false;
+        // Try to simply put the new cluster into any one of the existing bins.
+        // If we can do that, then we save quite a bit of time on not redoing
+        // the bin-packing from scratch.
+        for (size_t binId = 0; binId < mConfig.mClustersPerStage; ++binId)
+        {
+            if (mBinInstructions[binId] + newClusters.back().mInstructions <=
+                mConfig.mInstructionsPerCluster)
+            {
+                mBinInstructions[binId] += newClusters.back().mInstructions;
+                mBinPacking[binId].inplaceUnion(newClusters.back().mTxIds);
+                newClusters.back().mBinId = binId;
+                packed = true;
+                break;
+            }
+        }
+        // If we couldn't pack the new cluster without full bin-packing, we
+        // recover the state of the bins (so that the transaction is not
+        // considered to have been added yet).
+        if (!packed)
+        {
+            for (auto const& cluster : txConflicts)
+            {
+                mBinInstructions[cluster->mBinId] += cluster->mInstructions;
+                mBinPacking[cluster->mBinId].inplaceUnion(cluster->mTxIds);
+            }
+        }
+        return newClusters;
+    }
+
+    // Simple bin-packing first-fit-decreasing heuristic
+    // (https://en.wikipedia.org/wiki/First-fit-decreasing_bin_packing).
+    // This has around 11/9 maximum approximation ratio, which probably has
+    // the best complexity/performance tradeoff out of all the heuristics.
+    std::vector<BitSet>
+    binPacking(std::vector<Cluster>& clusters,
+               std::vector<uint64_t>& binInsns) const
+    {
+        // We could consider dropping the sort here in order to save some time
+        // and using just the first-fit heuristic, but that also raises the
+        // approximation ratio to 1.7.
+        std::sort(clusters.begin(), clusters.end(),
+                  [](auto const& a, auto const& b) {
+                      return a.mInstructions > b.mInstructions;
+                  });
+        size_t const binCount = mConfig.mClustersPerStage;
+        std::vector<BitSet> bins(binCount);
+        binInsns.resize(binCount);
+        // Just add every cluster into the first bin it fits into.
+        for (auto& cluster : clusters)
+        {
+            bool packed = false;
+            for (size_t i = 0; i < binCount; ++i)
+            {
+                if (binInsns[i] + cluster.mInstructions <=
+                    mConfig.mInstructionsPerCluster)
+                {
+                    binInsns[i] += cluster.mInstructions;
+                    bins[i].inplaceUnion(cluster.mTxIds);
+                    cluster.mBinId = i;
+                    packed = true;
+                    break;
+                }
+            }
+            if (!packed)
+            {
+                return std::vector<BitSet>();
+            }
+        }
+        return bins;
+    }
+
+    std::vector<Cluster> mClusters;
+    std::vector<BitSet> mBinPacking;
+    std::vector<uint64_t> mBinInstructions;
+    int64_t mInstructions = 0;
+    ParallelPartitionConfig mConfig;
+};
+
+} // namespace
+
+TxStageFrameList
+buildSurgePricedParallelSorobanPhase(
+    TxFrameList const& txFrames, Config const& cfg,
+    SorobanNetworkConfig const& sorobanCfg,
+    std::shared_ptr<SurgePricingLaneConfig> laneConfig,
+    std::vector<bool>& hadTxNotFittingLane)
+{
+    ZoneScoped;
+    // Map all the entries in the footprints to integers in order to be able to
+    // use the bitset operations.
+    UnorderedMap<LedgerKey, size_t> entryIdMap;
+    auto addToMap = [&entryIdMap](LedgerKey const& key) {
+        auto sz = entryIdMap.size();
+        entryIdMap.emplace(key, sz);
+    };
+    for (auto const& txFrame : txFrames)
+    {
+        auto const& footprint = txFrame->sorobanResources().footprint;
+        for (auto const& key : footprint.readOnly)
+        {
+            addToMap(key);
+        }
+        for (auto const& key : footprint.readWrite)
+        {
+            addToMap(key);
+        }
+    }
+
+    // Simplify the transactions to the minimum necessary amount of data.
+    std::unordered_map<TransactionFrameBaseConstPtr, BuilderTx> builderTxForTx;
+    for (size_t i = 0; i < txFrames.size(); ++i)
+    {
+        auto const& txFrame = txFrames[i];
+        builderTxForTx.emplace(txFrame, BuilderTx(i, *txFrame, entryIdMap));
+    }
+
+    // Process the transactions in the surge pricing (drecreasing fee) order.
+    // This also automatically ensures that the resource limits are respected
+    // for all the dimensions besides instructions.
+    SurgePricingPriorityQueue queue(
+        /* isHighestPriority */ true, laneConfig,
+        stellar::rand_uniform<size_t>(0, std::numeric_limits<size_t>::max()));
+    for (auto const& tx : txFrames)
+    {
+        queue.add(tx);
+    }
+
+    ParallelPartitionConfig partitionCfg(cfg, sorobanCfg);
+    std::vector<Stage> stages(partitionCfg.mStageCount, partitionCfg);
+
+    // Visit the transactions in the surge pricing queue and try to add them to
+    // at least one of the stages.
+    auto visitor = [&stages,
+                    &builderTxForTx](TransactionFrameBaseConstPtr const& tx) {
+        bool added = false;
+        auto builderTxIt = builderTxForTx.find(tx);
+        releaseAssert(builderTxIt != builderTxForTx.end());
+        for (auto& stage : stages)
+        {
+            if (stage.tryAdd(builderTxIt->second))
+            {
+                added = true;
+                break;
+            }
+        }
+        if (added)
+        {
+            return SurgePricingPriorityQueue::VisitTxResult::PROCESSED;
+        }
+        // If a transaction didn't fit into any of the stages, we consider it
+        // to have been excluded due to resource limits and thus notify the
+        // surge pricing queue that surge pricing should be triggered (
+        // REJECTED imitates the behavior for exceeding the resource limit
+        // within the queue itself).
+        return SurgePricingPriorityQueue::VisitTxResult::REJECTED;
+    };
+
+    std::vector<Resource> laneLeftUntilLimitUnused;
+    queue.popTopTxs(/* allowGaps */ true, visitor, laneLeftUntilLimitUnused,
+                    hadTxNotFittingLane);
+    releaseAssert(hadTxNotFittingLane.size() == 1);
+
+    // At this point the stages have been filled with transactions and we just
+    // need to place the full transactions into the respective stages/clusters.
+    TxStageFrameList resStages;
+    resStages.reserve(stages.size());
+    for (auto const& stage : stages)
+    {
+        auto& resStage = resStages.emplace_back();
+        resStage.reserve(partitionCfg.mClustersPerStage);
+
+        std::unordered_map<size_t, size_t> clusterIdToStageCluster;
+
+        stage.visitAllTransactions([&resStage, &txFrames,
+                                    &clusterIdToStageCluster](size_t clusterId,
+                                                              size_t txId) {
+            auto it = clusterIdToStageCluster.find(clusterId);
+            if (it == clusterIdToStageCluster.end())
+            {
+                it = clusterIdToStageCluster.emplace(clusterId, resStage.size())
+                         .first;
+                resStage.emplace_back();
+            }
+            resStage[it->second].push_back(txFrames[txId]);
+        });
+        // Algorithm ensures that clusters are populated from first to last and
+        // no empty clusters are generated.
+        for (auto const& cluster : resStage)
+        {
+            releaseAssert(!cluster.empty());
+        }
+    }
+    // Ensure we don't return any empty stages, which is prohibited by the
+    // protocol. The algorithm builds the stages such that the stages are
+    // populated from first to last.
+    while (!resStages.empty() && resStages.back().empty())
+    {
+        resStages.pop_back();
+    }
+    for (auto const& stage : resStages)
+    {
+        releaseAssert(!stage.empty());
+    }
+
+    return resStages;
+}
+
+} // namespace stellar

--- a/src/herder/ParallelTxSetBuilder.h
+++ b/src/herder/ParallelTxSetBuilder.h
@@ -1,0 +1,29 @@
+#pragma once
+
+// Copyright 2025 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "herder/SurgePricingUtils.h"
+#include "herder/TxSetFrame.h"
+#include "ledger/NetworkConfig.h"
+#include "main/Config.h"
+
+namespace stellar
+{
+// Builds a sequence of parallel processing stages from the provided
+// transactions while respecting the limits defined by the network
+// configuration.
+// The number of stages and the number of clusters in each stage is determined
+// by the provided configurations (`cfg` and `sorobanCfg`).
+// The resource limits in transactions are determined based on the input
+// `laneConfig`.
+// This doesn't support multi-lane surge pricing and thus it's expected
+// `laneConfig` to only have a configuration for a single surge pricing lane.
+TxStageFrameList buildSurgePricedParallelSorobanPhase(
+    TxFrameList const& txFrames, Config const& cfg,
+    SorobanNetworkConfig const& sorobanCfg,
+    std::shared_ptr<SurgePricingLaneConfig> laneConfig,
+    std::vector<bool>& hadTxNotFittingLane);
+
+} // namespace stellar

--- a/src/herder/SurgePricingUtils.cpp
+++ b/src/herder/SurgePricingUtils.cpp
@@ -326,6 +326,13 @@ SurgePricingPriorityQueue::popTopTxs(
                 laneLeftUntilLimit[lane] -= res;
             }
         }
+        else if (visitRes == VisitTxResult::REJECTED)
+        {
+            // If a transaction hasn't been processed, then it is considered to
+            // be not fitting the lane.
+            hadTxNotFittingLane[GENERIC_LANE] = true;
+            hadTxNotFittingLane[lane] = true;
+        }
         erase(currIt);
     }
 }

--- a/src/herder/test/TxSetTests.cpp
+++ b/src/herder/test/TxSetTests.cpp
@@ -1299,8 +1299,11 @@ TEST_CASE("applicable txset validation - Soroban resources", "[txset][soroban]")
                             std::numeric_limits<uint32_t>::max();
                         sorobanCfg.mLedgerMaxTransactionsSizeBytes =
                             std::numeric_limits<uint32_t>::max();
-                        sorobanCfg.mLedgerMaxDependentTxClusters =
-                            std::numeric_limits<uint32_t>::max();
+                        // sorobanCfg.mLedgerMaxDependentTxClusters =
+                        //     std::numeric_limits<uint32_t>::max();
+                        //  TODO: need a reasonable lower bound for validating
+                        //  this?
+                        sorobanCfg.mLedgerMaxDependentTxClusters = 100;
                     });
                 TxStageFrameList nonConflictingTxsPerStage = {
                     {
@@ -2037,5 +2040,524 @@ TEST_CASE("txset nomination", "[txset]")
 #endif
 }
 
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+TEST_CASE("parallel tx set building", "[txset][soroban]")
+{
+    int const STAGE_COUNT = 4;
+    int const CLUSTER_COUNT = 8;
+
+    VirtualClock clock;
+    auto cfg = getTestConfig();
+    cfg.LEDGER_PROTOCOL_VERSION =
+        static_cast<uint32_t>(PARALLEL_SOROBAN_PHASE_PROTOCOL_VERSION);
+    cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION =
+        static_cast<uint32_t>(PARALLEL_SOROBAN_PHASE_PROTOCOL_VERSION);
+    cfg.SOROBAN_PHASE_STAGE_COUNT = STAGE_COUNT;
+    Application::pointer app = createTestApplication(clock, cfg);
+    overrideSorobanNetworkConfigForTest(*app);
+    modifySorobanNetworkConfig(*app, [&](SorobanNetworkConfig& sorobanCfg) {
+        sorobanCfg.mLedgerMaxInstructions = 400'000'000;
+        sorobanCfg.mLedgerMaxReadLedgerEntries = 3000;
+        sorobanCfg.mLedgerMaxWriteLedgerEntries = 2000;
+        sorobanCfg.mLedgerMaxReadBytes = 1'000'000;
+        sorobanCfg.mLedgerMaxWriteBytes = 100'000;
+        sorobanCfg.mLedgerMaxTxCount = 1000;
+        sorobanCfg.mLedgerMaxDependentTxClusters = CLUSTER_COUNT;
+    });
+    auto root = TestAccount::createRoot(*app);
+    std::map<int, TestAccount> accounts;
+    int accountId = 1;
+    SCAddress contract(SC_ADDRESS_TYPE_CONTRACT);
+
+    auto generateKey = [&contract](int i) {
+        return stellar::contractDataKey(
+            contract, txtest::makeU32(i),
+            i % 2 == 0 ? ContractDataDurability::PERSISTENT
+                       : ContractDataDurability::TEMPORARY);
+    };
+
+    auto createTx = [&](int instructions, std::vector<int> const& roKeys,
+                        std::vector<int> rwKeys, int64_t inclusionFee = 1000,
+                        int readBytes = 1000, int writeBytes = 100) {
+        auto it = accounts.find(accountId);
+        if (it == accounts.end())
+        {
+            it = accounts
+                     .emplace(accountId, root.create(std::to_string(accountId),
+                                                     1'000'000'000))
+                     .first;
+        }
+        ++accountId;
+        auto source = it->second;
+        SorobanResources resources;
+        resources.instructions = instructions;
+        resources.readBytes = readBytes;
+        resources.writeBytes = writeBytes;
+        for (auto roKeyId : roKeys)
+        {
+            resources.footprint.readOnly.push_back(generateKey(roKeyId));
+        }
+        for (auto rwKeyId : rwKeys)
+        {
+            resources.footprint.readWrite.push_back(generateKey(rwKeyId));
+        }
+        auto resourceFee = sorobanResourceFee(*app, resources, 10'000, 40);
+        // It doesn't really matter what tx does as we're only interested in
+        // its resources.
+        auto tx = createUploadWasmTx(*app, source, inclusionFee, resourceFee,
+                                     resources);
+        LedgerSnapshot ls(*app);
+        REQUIRE(
+            tx->checkValid(app->getAppConnector(), ls, 0, 0, 0)->isSuccess());
+
+        return tx;
+    };
+
+    auto validateShape = [&](ApplicableTxSetFrame const& txSet,
+                             size_t stageCount, size_t clustersPerStage,
+                             size_t txsPerCluster) {
+        auto const& phase =
+            txSet.getPhase(TxSetPhase::SOROBAN).getParallelStages();
+
+        REQUIRE(phase.size() == stageCount);
+        for (auto const& stage : phase)
+        {
+            REQUIRE(stage.size() == clustersPerStage);
+            for (auto const& cluster : stage)
+            {
+                REQUIRE(cluster.size() == txsPerCluster);
+            }
+        }
+    };
+
+    auto validateBaseFee = [&](ApplicableTxSetFrame const& txSet,
+                               int64_t baseFee) {
+        for (auto const& tx : txSet.getPhase(TxSetPhase::SOROBAN))
+        {
+            REQUIRE(*txSet.getTxBaseFee(tx) == baseFee);
+        }
+    };
+
+    SECTION("no conflicts")
+    {
+        SECTION("single stage")
+        {
+            std::vector<TransactionFrameBaseConstPtr> sorobanTxs;
+            for (int i = 0; i < CLUSTER_COUNT; ++i)
+            {
+                sorobanTxs.push_back(createTx(100'000'000, {4 * i, 4 * i + 1},
+                                              {4 * i + 2, 4 * i + 3}));
+            }
+            PerPhaseTransactionList phases = {{}, sorobanTxs};
+            auto [_, txSet] = makeTxSetFromTransactions(phases, *app, 0, 0);
+            validateShape(*txSet, 1, CLUSTER_COUNT, 1);
+            validateBaseFee(*txSet, 100);
+        }
+        SECTION("all stages")
+        {
+            std::vector<TransactionFrameBaseConstPtr> sorobanTxs;
+            for (int i = 0; i < STAGE_COUNT * CLUSTER_COUNT; ++i)
+            {
+                sorobanTxs.push_back(createTx(100'000'000, {4 * i, 4 * i + 1},
+                                              {4 * i + 2, 4 * i + 3}));
+            }
+            PerPhaseTransactionList phases = {{}, sorobanTxs};
+            auto [_, txSet] = makeTxSetFromTransactions(phases, *app, 0, 0);
+
+            validateShape(*txSet, STAGE_COUNT, CLUSTER_COUNT, 1);
+            validateBaseFee(*txSet, 100);
+        }
+        SECTION("all stages, smaller txs")
+        {
+            std::vector<TransactionFrameBaseConstPtr> sorobanTxs;
+            for (int i = 0; i < STAGE_COUNT * CLUSTER_COUNT * 5; ++i)
+            {
+                sorobanTxs.push_back(createTx(20'000'000, {4 * i, 4 * i + 1},
+                                              {4 * i + 2, 4 * i + 3}));
+            }
+            PerPhaseTransactionList phases = {{}, sorobanTxs};
+            auto [_, txSet] = makeTxSetFromTransactions(phases, *app, 0, 0);
+
+            validateShape(*txSet, STAGE_COUNT, CLUSTER_COUNT, 5);
+            validateBaseFee(*txSet, 100);
+        }
+
+        SECTION("all stages, smaller txs with prioritization")
+        {
+            std::vector<TransactionFrameBaseConstPtr> sorobanTxs;
+            for (int i = 0; i < STAGE_COUNT * CLUSTER_COUNT * 10; ++i)
+            {
+                sorobanTxs.push_back(createTx(
+                    20'000'000, {4 * i, 4 * i + 1}, {4 * i + 2, 4 * i + 3},
+                    /* inclusionFee*/ (i + 1) * 1000LL));
+            }
+            PerPhaseTransactionList phases = {{}, sorobanTxs};
+            auto [_, txSet] = makeTxSetFromTransactions(phases, *app, 0, 0);
+
+            validateShape(*txSet, STAGE_COUNT, CLUSTER_COUNT, 5);
+            validateBaseFee(
+                *txSet, 10LL * STAGE_COUNT * CLUSTER_COUNT * 1000 / 2 + 1000);
+        }
+
+        SECTION("instruction limit reached")
+        {
+            modifySorobanNetworkConfig(
+                *app, [&](SorobanNetworkConfig& sorobanCfg) {
+                    sorobanCfg.mLedgerMaxInstructions = 1'000'000;
+                });
+            std::vector<TransactionFrameBaseConstPtr> sorobanTxs;
+            for (int i = 0; i < STAGE_COUNT * CLUSTER_COUNT * 4; ++i)
+            {
+                sorobanTxs.push_back(createTx(250'000, {4 * i, 4 * i + 1},
+                                              {4 * i + 2, 4 * i + 3},
+                                              /* inclusionFee */ 100 + i));
+            }
+            PerPhaseTransactionList phases = {{}, sorobanTxs};
+            auto [_, txSet] = makeTxSetFromTransactions(phases, *app, 0, 0);
+
+            validateShape(*txSet, STAGE_COUNT, CLUSTER_COUNT, 1);
+            validateBaseFee(*txSet, 100 + STAGE_COUNT * CLUSTER_COUNT * 4 -
+                                        STAGE_COUNT * CLUSTER_COUNT);
+        }
+        SECTION("read bytes limit reached")
+        {
+            std::vector<TransactionFrameBaseConstPtr> sorobanTxs;
+            for (int i = 0; i < STAGE_COUNT * CLUSTER_COUNT; ++i)
+            {
+                sorobanTxs.push_back(createTx(1'000'000, {4 * i, 4 * i + 1},
+                                              {4 * i + 2, 4 * i + 3},
+                                              /* inclusionFee */ 100 + i,
+                                              /* readBytes */ 100'000));
+            }
+            PerPhaseTransactionList phases = {{}, sorobanTxs};
+            auto [_, txSet] = makeTxSetFromTransactions(phases, *app, 0, 0);
+
+            validateShape(*txSet, 1, 1, 10);
+            validateBaseFee(*txSet, 100 + STAGE_COUNT * CLUSTER_COUNT - 10);
+        }
+        SECTION("read entries limit reached")
+        {
+            modifySorobanNetworkConfig(
+                *app, [&](SorobanNetworkConfig& sorobanCfg) {
+                    sorobanCfg.mLedgerMaxReadLedgerEntries = 4 * 10 + 3;
+                });
+            std::vector<TransactionFrameBaseConstPtr> sorobanTxs;
+            for (int i = 0; i < STAGE_COUNT * CLUSTER_COUNT; ++i)
+            {
+                sorobanTxs.push_back(createTx(1'000'000, {4 * i, 4 * i + 1},
+                                              {4 * i + 2, 4 * i + 3},
+                                              /* inclusionFee */ 100 + i,
+                                              /* readBytes */ 100'000));
+            }
+            PerPhaseTransactionList phases = {{}, sorobanTxs};
+            auto [_, txSet] = makeTxSetFromTransactions(phases, *app, 0, 0);
+
+            validateShape(*txSet, 1, 1, 10);
+            validateBaseFee(*txSet, 100 + STAGE_COUNT * CLUSTER_COUNT - 10);
+        }
+        SECTION("write bytes limit reached")
+        {
+            std::vector<TransactionFrameBaseConstPtr> sorobanTxs;
+            for (int i = 0; i < STAGE_COUNT * CLUSTER_COUNT; ++i)
+            {
+                sorobanTxs.push_back(createTx(1'000'000, {4 * i, 4 * i + 1},
+                                              {4 * i + 2, 4 * i + 3},
+                                              /* inclusionFee */ 100 + i,
+                                              /* readBytes */ 100,
+                                              /* writeBytes */ 10'000));
+            }
+            PerPhaseTransactionList phases = {{}, sorobanTxs};
+            auto [_, txSet] = makeTxSetFromTransactions(phases, *app, 0, 0);
+
+            validateShape(*txSet, 1, 1, 10);
+            validateBaseFee(*txSet, 100 + STAGE_COUNT * CLUSTER_COUNT - 10);
+        }
+        SECTION("write entries limit reached")
+        {
+            modifySorobanNetworkConfig(
+                *app, [&](SorobanNetworkConfig& sorobanCfg) {
+                    sorobanCfg.mLedgerMaxWriteLedgerEntries = 2 * 10 + 1;
+                });
+            std::vector<TransactionFrameBaseConstPtr> sorobanTxs;
+            for (int i = 0; i < STAGE_COUNT * CLUSTER_COUNT; ++i)
+            {
+                sorobanTxs.push_back(createTx(1'000'000, {4 * i, 4 * i + 1},
+                                              {4 * i + 2, 4 * i + 3},
+                                              /* inclusionFee */ 100 + i));
+            }
+            PerPhaseTransactionList phases = {{}, sorobanTxs};
+            auto [_, txSet] = makeTxSetFromTransactions(phases, *app, 0, 0);
+
+            validateShape(*txSet, 1, 1, 10);
+            validateBaseFee(*txSet, 100 + STAGE_COUNT * CLUSTER_COUNT - 10);
+        }
+        SECTION("tx size limit reached")
+        {
+            std::vector<TransactionFrameBaseConstPtr> sorobanTxs;
+            for (int i = 0; i < STAGE_COUNT * CLUSTER_COUNT; ++i)
+            {
+                sorobanTxs.push_back(createTx(1'000'000, {4 * i, 4 * i + 1},
+                                              {4 * i + 2, 4 * i + 3},
+                                              /* inclusionFee */ 100 + i));
+            }
+            modifySorobanNetworkConfig(
+                *app, [&](SorobanNetworkConfig& sorobanCfg) {
+                    sorobanCfg.mLedgerMaxTransactionsSizeBytes =
+                        xdr::xdr_size(sorobanTxs[0]->getEnvelope()) * 11 - 1;
+                });
+            PerPhaseTransactionList phases = {{}, sorobanTxs};
+            auto [_, txSet] = makeTxSetFromTransactions(phases, *app, 0, 0);
+
+            validateShape(*txSet, 1, 1, 10);
+            validateBaseFee(*txSet, 100 + STAGE_COUNT * CLUSTER_COUNT - 10);
+        }
+        SECTION("tx count limit reached")
+        {
+            modifySorobanNetworkConfig(*app,
+                                       [&](SorobanNetworkConfig& sorobanCfg) {
+                                           sorobanCfg.mLedgerMaxTxCount = 5;
+                                       });
+            std::vector<TransactionFrameBaseConstPtr> sorobanTxs;
+            for (int i = 0; i < STAGE_COUNT * CLUSTER_COUNT; ++i)
+            {
+                sorobanTxs.push_back(createTx(1'000'000, {4 * i, 4 * i + 1},
+                                              {4 * i + 2, 4 * i + 3},
+                                              /* inclusionFee */ 100 + i));
+            }
+
+            PerPhaseTransactionList phases = {{}, sorobanTxs};
+            auto [_, txSet] = makeTxSetFromTransactions(phases, *app, 0, 0);
+
+            validateShape(*txSet, 1, 1, 5);
+            validateBaseFee(*txSet, 100 + STAGE_COUNT * CLUSTER_COUNT - 5);
+        }
+    }
+
+    SECTION("with conflicts")
+    {
+        SECTION("all RW conflicting")
+        {
+            std::vector<TransactionFrameBaseConstPtr> sorobanTxs;
+            for (int i = 0; i < CLUSTER_COUNT * STAGE_COUNT; ++i)
+            {
+                sorobanTxs.push_back(createTx(100'000'000,
+                                              {4 * i + 1, 4 * i + 2},
+                                              {4 * i + 3, 0, 4 * i + 4},
+                                              /* inclusionFee */ 100 + i));
+            }
+            PerPhaseTransactionList phases = {{}, sorobanTxs};
+            auto [_, txSet] = makeTxSetFromTransactions(phases, *app, 0, 0);
+            validateShape(*txSet, STAGE_COUNT, 1, 1);
+            validateBaseFee(*txSet,
+                            100 + CLUSTER_COUNT * STAGE_COUNT - STAGE_COUNT);
+        }
+        SECTION("chain of conflicts")
+        {
+            std::vector<TransactionFrameBaseConstPtr> sorobanTxs;
+            for (int i = 0; i < CLUSTER_COUNT * STAGE_COUNT; ++i)
+            {
+                sorobanTxs.push_back(createTx(100'000'000, {i}, {i + 1},
+                                              /* inclusionFee */ 100 + i));
+            }
+            PerPhaseTransactionList phases = {{}, sorobanTxs};
+            auto [_, txSet] = makeTxSetFromTransactions(phases, *app, 0, 0);
+            // It's easy to 'break' the chain by allocating transactions to
+            // different stages (technically, 2 stages would be sufficient).
+            validateShape(*txSet, STAGE_COUNT, CLUSTER_COUNT, 1);
+            validateBaseFee(*txSet, 100);
+        }
+        SECTION("small conflict clusters")
+        {
+            std::vector<TransactionFrameBaseConstPtr> sorobanTxs;
+            for (int i = 0; i < CLUSTER_COUNT; ++i)
+            {
+                for (int j = 0; j < STAGE_COUNT; ++j)
+                {
+                    sorobanTxs.push_back(
+                        createTx(100'000'000, {i * STAGE_COUNT + j + 1000},
+                                 {i, i * STAGE_COUNT + j + 10000},
+                                 /* inclusionFee */ 100 + i));
+                }
+            }
+            PerPhaseTransactionList phases = {{}, sorobanTxs};
+            auto [_, txSet] = makeTxSetFromTransactions(phases, *app, 0, 0);
+            // Conflicting transactions can be distributed into separate stages.
+            validateShape(*txSet, STAGE_COUNT, CLUSTER_COUNT, 1);
+            validateBaseFee(*txSet, 100);
+        }
+        SECTION("small conflict clusters with excluded txs")
+        {
+            std::vector<TransactionFrameBaseConstPtr> sorobanTxs;
+            for (int i = 0; i < CLUSTER_COUNT; ++i)
+            {
+                for (int j = 0; j < STAGE_COUNT + 1; ++j)
+                {
+                    sorobanTxs.push_back(createTx(
+                        100'000'000, {}, {i},
+                        /* inclusionFee */ 100 + i * (STAGE_COUNT + 1) + j));
+                }
+            }
+            PerPhaseTransactionList phases = {{}, sorobanTxs};
+            auto [_, txSet] = makeTxSetFromTransactions(phases, *app, 0, 0);
+            // Conflicting transactions can be distributed into separate stages
+            // and lower fee txs in every cluster will be excluded.
+            validateShape(*txSet, STAGE_COUNT, CLUSTER_COUNT, 1);
+            // 1 cluster worth of txs will be excluded, however, the lowest fee
+            // transaction in the set has a fee of 101 (generated in cluster 0,
+            // stage 1).
+            validateBaseFee(*txSet, 101);
+        }
+        SECTION("one sparse conflict cluster")
+        {
+            std::vector<TransactionFrameBaseConstPtr> sorobanTxs;
+            // A small dense cluster of RW conflicts on entry 1000.
+            for (int i = 0; i < STAGE_COUNT; ++i)
+            {
+                sorobanTxs.push_back(createTx(100'000'000, {}, {i, 1000},
+                                              /* inclusionFee */ 1'000'000));
+            }
+            for (int i = 0; i < CLUSTER_COUNT; ++i)
+            {
+                // Create a tx with RO-RW conflict with one of the transactions
+                // in the small dense cluster.
+                for (int j = 0; j < STAGE_COUNT; ++j)
+                {
+                    sorobanTxs.push_back(createTx(
+                        100'000'000, {j}, {i * STAGE_COUNT + j + 10'000},
+                        /* inclusionFee */ 100 + i * STAGE_COUNT + j));
+                }
+            }
+            PerPhaseTransactionList phases = {{}, sorobanTxs};
+            auto [_, txSet] = makeTxSetFromTransactions(phases, *app, 0, 0);
+            // All transactions can be distributed across stages, but 4
+            // transactions simply don't fit into instruction limits (hence 103
+            // base fee).
+            validateShape(*txSet, STAGE_COUNT, CLUSTER_COUNT, 1);
+            validateBaseFee(*txSet, 103);
+        }
+        SECTION("many clusters with small transactions")
+        {
+            std::vector<TransactionFrameBaseConstPtr> sorobanTxs;
+            for (int i = 0; i < CLUSTER_COUNT; ++i)
+            {
+                for (int j = 0; j < 10 * STAGE_COUNT; ++j)
+                {
+                    sorobanTxs.push_back(createTx(
+                        10'000'000, {1000 + i * 10 + j},
+                        {i, 10'000 + i * 10 + j},
+                        /* inclusionFee */ 100 + i * (STAGE_COUNT + 1) + j));
+                }
+            }
+            PerPhaseTransactionList phases = {{}, sorobanTxs};
+            auto [_, txSet] = makeTxSetFromTransactions(phases, *app, 0, 0);
+
+            validateShape(*txSet, STAGE_COUNT, CLUSTER_COUNT, 10);
+            validateBaseFee(*txSet, 100);
+        }
+        SECTION("all RO conflict with one RW")
+        {
+            std::vector<TransactionFrameBaseConstPtr> sorobanTxs;
+            sorobanTxs.push_back(createTx(100'000'000, {1, 2}, {0, 3, 4},
+                                          /* inclusionFee */ 1'000'000));
+            for (int i = 1; i < CLUSTER_COUNT * STAGE_COUNT * 5; ++i)
+            {
+                sorobanTxs.push_back(createTx(20'000'000,
+                                              {0, 4 * i + 1, 4 * i + 2},
+                                              {4 * i + 3, 4 * i + 4},
+                                              /* inclusionFee */ 100 + i));
+            }
+
+            PerPhaseTransactionList phases = {{}, sorobanTxs};
+            auto [_, txSet] = makeTxSetFromTransactions(phases, *app, 0, 0);
+            auto const& phase =
+                txSet->getPhase(TxSetPhase::SOROBAN).getParallelStages();
+
+            bool wasSingleThreadStage = false;
+
+            for (auto const& stage : phase)
+            {
+                if (stage.size() == 1)
+                {
+                    REQUIRE(!wasSingleThreadStage);
+                    wasSingleThreadStage = true;
+                    REQUIRE(stage[0].size() == 1);
+                    REQUIRE(stage[0][0]->getEnvelope() ==
+                            sorobanTxs[0]->getEnvelope());
+                    continue;
+                }
+                REQUIRE(stage.size() == CLUSTER_COUNT);
+                for (auto const& thread : stage)
+                {
+                    REQUIRE(thread.size() == 5);
+                }
+            }
+            // We can't include any of the small txs into stage 0, as it's
+            // occupied by high fee tx that writes entry 0.
+            validateBaseFee(*txSet, 100 + CLUSTER_COUNT * 5);
+        }
+    }
+    SECTION("smoke test")
+    {
+        auto runTest = [&]() {
+            stellar::uniform_int_distribution<> maxInsnsDistr(20'000'000,
+                                                              100'000'000);
+            stellar::uniform_int_distribution<> keyRangeDistr(50, 1000);
+            stellar::uniform_int_distribution<> insnsDistr(
+                1'000'000, maxInsnsDistr(Catch::rng()));
+            stellar::uniform_int_distribution<> keyCountDistr(1, 10);
+            stellar::uniform_int_distribution<> keyDistr(
+                1, keyRangeDistr(Catch::rng()));
+            stellar::uniform_int_distribution<> feeDistr(100, 100'000);
+            stellar::uniform_int_distribution<> readBytesDistr(100, 10'000);
+            stellar::uniform_int_distribution<> writeBytesDistr(10, 1000);
+            std::vector<TransactionFrameBaseConstPtr> sorobanTxs;
+            accountId = 1;
+            for (int iter = 0; iter < 500; ++iter)
+            {
+                int roKeyCount = keyCountDistr(Catch::rng());
+                int rwKeyCount = keyCountDistr(Catch::rng());
+                std::unordered_set<int> usedKeys;
+                std::vector<int> roKeys;
+                std::vector<int> rwKeys;
+                for (int i = 0; i < roKeyCount + rwKeyCount; ++i)
+                {
+                    int key = keyDistr(Catch::rng());
+                    while (usedKeys.find(key) != usedKeys.end())
+                    {
+                        key = keyDistr(Catch::rng());
+                    }
+                    if (i < roKeyCount)
+                    {
+                        roKeys.push_back(key);
+                    }
+                    else
+                    {
+                        rwKeys.push_back(key);
+                    }
+                    usedKeys.insert(key);
+                }
+                sorobanTxs.push_back(createTx(insnsDistr(Catch::rng()), roKeys,
+                                              rwKeys, feeDistr(Catch::rng()),
+                                              readBytesDistr(Catch::rng()),
+                                              writeBytesDistr(Catch::rng())));
+            }
+            PerPhaseTransactionList phases = {{}, sorobanTxs};
+            // NB: `makeTxSetFromTransactions` does an XDR roundtrip and
+            // validation, so just calling it does a good amount of smoke
+            // testing.
+            auto [_, txSet] = makeTxSetFromTransactions(phases, *app, 0, 0);
+            auto const& phase =
+                txSet->getPhase(TxSetPhase::SOROBAN).getParallelStages();
+            // The only thing we can really be sure about is that all the
+            // stages are utilized, as we have enough transactions.
+            REQUIRE(phase.size() == STAGE_COUNT);
+        };
+        for (int iter = 0; iter < 10; ++iter)
+        {
+            runTest();
+        }
+    }
+}
+#endif
 } // namespace
 } // namespace stellar

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -304,6 +304,10 @@ Config::Config() : NODE_SEED(SecretKey::random())
     EMIT_LEDGER_CLOSE_META_EXT_V1 = false;
 
     FORCE_OLD_STYLE_LEADER_ELECTION = false;
+    // This is not configurable for now. It doesn't need to be a network-wide
+    // setting, but on the other hand there aren't many good values for it and
+    // it's not clear what the right way to configure it would be, if at all.
+    SOROBAN_PHASE_STAGE_COUNT = 1;
 
 #ifdef BUILD_TESTS
     TEST_CASES_ENABLED = false;

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -752,6 +752,8 @@ class Config : public std::enable_shared_from_this<Config>
     bool EMIT_SOROBAN_TRANSACTION_META_EXT_V1;
     bool EMIT_LEDGER_CLOSE_META_EXT_V1;
 
+    uint32_t SOROBAN_PHASE_STAGE_COUNT;
+
 #ifdef BUILD_TESTS
     // If set to true, the application will be aware this run is for a test
     // case.  This is used right now in the signal handler to exit() instead of


### PR DESCRIPTION
# Description

Also add a simple benchmark in case further improvements are necessary. The changes resulted in up to 20x speedup for some scenarios on my laptop

- Avoid unnecessary copies of clusters (use shared ptr instead)
- Precompute conflicting transactions, which speeds up low-conflict scenarios very significantly (and this is what we expect to see the most)
- Some minor optimizations to avoid doing work when possible

Also updated a flaky test scenario.

This is rebased on https://github.com/stellar/stellar-core/pull/4486

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
