### PR TITLE
WIP Add LedgerStateCache

### DIFF
--- a/src/bucket/InMemoryIndex.h
+++ b/src/bucket/InMemoryIndex.h
@@ -61,6 +61,8 @@ class InMemoryIndex
     AssetPoolIDMap mAssetPoolIDMap;
     BucketEntryCounters mCounters{};
     std::optional<std::pair<std::streamoff, std::streamoff>> mOfferRange;
+    std::optional<std::pair<std::streamoff, std::streamoff>>
+        mContractEntryRange;
 
   public:
     using IterT = InMemoryBucketState::IterT;
@@ -101,6 +103,12 @@ class InMemoryIndex
     getOfferRange() const
     {
         return mOfferRange;
+    }
+
+    std::optional<std::pair<std::streamoff, std::streamoff>>
+    getContractEntryRange() const
+    {
+        return mContractEntryRange;
     }
 
 #ifdef BUILD_TESTS

--- a/src/bucket/LiveBucket.cpp
+++ b/src/bucket/LiveBucket.cpp
@@ -316,6 +316,16 @@ LiveBucket::getOfferRange() const
     return getIndex().getOfferRange();
 }
 
+std::optional<std::pair<std::streamoff, std::streamoff>>
+LiveBucket::getContractEntryRange() const
+{
+    if (!getIndex().getContractEntryRange())
+    {
+        CLOG_DEBUG(Bucket, "LiveBucket::getContractEntryRange() = nullopt");
+    }
+    return getIndex().getContractEntryRange();
+}
+
 std::vector<BucketEntry>
 LiveBucket::convertToBucketEntry(bool useInit,
                                  std::vector<LedgerEntry> const& initEntries,

--- a/src/bucket/LiveBucket.h
+++ b/src/bucket/LiveBucket.h
@@ -90,6 +90,11 @@ class LiveBucket : public BucketBase<LiveBucket, LiveBucketIndex>,
     std::optional<std::pair<std::streamoff, std::streamoff>>
     getOfferRange() const;
 
+    // Returns [lowerBound, upperBound) of file offsets for all contract entries
+    // in the bucket, or std::nullopt if no contract entries exist
+    std::optional<std::pair<std::streamoff, std::streamoff>>
+    getContractEntryRange() const;
+
     // Create a fresh bucket from given vectors of init (created) and live
     // (updated) LedgerEntries, and dead LedgerEntryKeys. The bucket will
     // be sorted, hashed, and adopted in the provided BucketManager.

--- a/src/bucket/LiveBucketIndex.h
+++ b/src/bucket/LiveBucketIndex.h
@@ -97,6 +97,9 @@ class LiveBucketIndex : public NonMovableOrCopyable
     std::optional<std::pair<std::streamoff, std::streamoff>>
     getOfferRange() const;
 
+    std::optional<std::pair<std::streamoff, std::streamoff>>
+    getContractEntryRange() const;
+
     BucketEntryCounters const& getBucketEntryCounters() const;
     uint32_t getPageSize() const;
 

--- a/src/catchup/AssumeStateWork.cpp
+++ b/src/catchup/AssumeStateWork.cpp
@@ -9,8 +9,10 @@
 #include "crypto/Hex.h"
 #include "history/HistoryArchive.h"
 #include "invariant/InvariantManager.h"
+#include "util/Logging.h"
 #include "work/WorkSequence.h"
 #include "work/WorkWithCallback.h"
+#include "xdrpp/printer.h"
 
 namespace stellar
 {
@@ -26,6 +28,7 @@ AssumeStateWork::AssumeStateWork(Application& app,
     // Maintain reference to all Buckets in HAS to avoid garbage collection,
     // including future buckets that have already finished merging
     auto& bm = mApp.getBucketManager();
+    int counter = 0;
     for (uint32_t i = 0; i < LiveBucketList::kNumLevels; ++i)
     {
         auto curr = bm.getBucketByHash<LiveBucket>(
@@ -39,7 +42,13 @@ AssumeStateWork::AssumeStateWork(Application& app,
         }
 
         mBuckets.emplace_back(curr);
+        CLOG_DEBUG(Ledger, "AssumeStateWork: Adding bucket {} to mBuckets[{}]",
+                   xdr::xdr_to_string(curr->getHash()), counter);
+        counter++;
         mBuckets.emplace_back(snap);
+        CLOG_DEBUG(Ledger, "AssumeStateWork: Adding bucket {} to mBuckets[{}]",
+                   xdr::xdr_to_string(snap->getHash()), counter);
+        counter++;
         auto& nextFuture = mHas.currentBuckets.at(i).next;
         if (nextFuture.hasOutputHash())
         {
@@ -52,6 +61,10 @@ AssumeStateWork::AssumeStateWork(Application& app,
             }
 
             mBuckets.emplace_back(nextBucket);
+            CLOG_DEBUG(Ledger,
+                       "AssumeStateWork: Adding bucket {} to mBuckets[{}]",
+                       xdr::xdr_to_string(nextBucket->getHash()), counter);
+            counter++;
         }
     }
 }

--- a/src/catchup/PopulateLedgerCacheWork.cpp
+++ b/src/catchup/PopulateLedgerCacheWork.cpp
@@ -1,0 +1,115 @@
+// Copyright 2025 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "catchup/PopulateLedgerCacheWork.h"
+#include "bucket/BucketInputIterator.h"
+#include "bucket/BucketManager.h"
+#include "bucket/LiveBucket.h"
+#include "bucket/LiveBucketIndex.h"
+#include "bucket/LiveBucketList.h"
+#include "ledger/LedgerManager.h"
+#include "ledger/LedgerStateCache.h"
+#include "xdrpp/printer.h"
+
+namespace stellar
+{
+PopulateLedgerCacheWork::PopulateLedgerCacheWork(Application& app)
+    : Work(app, "populate-ledger-cache", BasicWork::RETRY_NEVER)
+    , mBucketsToProcess{}
+    , mBucketToProcessIndex(0)
+    , mDeadKeys{}
+{
+    auto& bm = mApp.getBucketManager();
+    auto& bl = bm.getLiveBucketList();
+    int counter = 0;
+    for (uint32_t i = 0; i < LiveBucketList::kNumLevels; ++i)
+    {
+        auto const& level = bl.getLevel(i);
+        for (auto const& bucket : {level.getCurr(), level.getSnap()})
+        {
+            mBucketsToProcess.push_back(bucket);
+            CLOG_DEBUG(Ledger, "Adding bucket {} to mBucketsToProcess[{}]",
+                       xdr::xdr_to_string(bucket->getHash()), counter);
+            counter++;
+        }
+    }
+}
+// TODO possibly refactor BucketApplicator to have modular
+// application logic for:
+// - selecting entries to apply (e.g. offers, contract entries)
+// - applying the entry (e.g. add to ltx or ledgerStateCache)
+// It seems the main motivation for BucketApplicator is to limit
+// applications to batches of LEDGER_ENTRY_BATCH_COMMIT_SIZE entries.
+// No such limit is necessary here, but it would deduplicate
+// some shared logic.
+BasicWork::State
+PopulateLedgerCacheWork::advance()
+{
+    CLOG_INFO(Ledger, "Added bucket {}/{} to LedgerStateCache",
+              mBucketToProcessIndex, mBucketsToProcess.size());
+    mBucketToProcessIndex++;
+    if (mBucketToProcessIndex >= mBucketsToProcess.size())
+    {
+        mBucketsToProcess.clear();
+        return State::WORK_SUCCESS;
+    }
+    return State::WORK_RUNNING;
+}
+
+BasicWork::State
+PopulateLedgerCacheWork::doWork()
+{
+    auto const& bucket = mBucketsToProcess.at(mBucketToProcessIndex);
+    // Hacky way to skip empty buckets
+    if (!bucket || bucket->getFilename().empty())
+    {
+        CLOG_DEBUG(Ledger,
+                   "PopulateLedgerCacheWork: Advancing past empty bucket {}",
+                   mBucketToProcessIndex);
+        return advance();
+    }
+
+    auto contractEntryRange = bucket->getContractEntryRange();
+    auto ledgerStateCache = mApp.getLedgerManager().getLedgerStateCache();
+    if (ledgerStateCache && contractEntryRange)
+    {
+        auto cache = ledgerStateCache.value();
+        auto [lowerBound, upperBound] = *contractEntryRange;
+        for (LiveBucketInputIterator iter(bucket);
+             iter && iter.pos() < upperBound; ++iter)
+        {
+            if (iter.pos() < lowerBound)
+            {
+                iter.seek(lowerBound);
+            }
+            BucketEntry const& entry = *iter;
+            if (entry.type() == LIVEENTRY || entry.type() == INITENTRY)
+            {
+                auto const& e = entry.liveEntry();
+                auto const& k = LedgerEntryKey(e);
+                // If the key is not in the dead keys set and not already in the
+                // cache, add it.
+                if (mDeadKeys.find(k) == mDeadKeys.end() && !cache->getEntry(k))
+                {
+                    cache->addEntry(e);
+                }
+            }
+            else if (entry.type() == DEADENTRY)
+            {
+                if (!cache->getEntry(entry.deadEntry()))
+                {
+                    mDeadKeys.insert(entry.deadEntry());
+                }
+            }
+            else
+            {
+                releaseAssert(false);
+                continue;
+            }
+        }
+    }
+    return advance();
+}
+
+}

--- a/src/catchup/PopulateLedgerCacheWork.h
+++ b/src/catchup/PopulateLedgerCacheWork.h
@@ -1,0 +1,29 @@
+// Copyright 2025 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#pragma once
+
+#include "util/types.h"
+#include "work/Work.h"
+
+namespace stellar
+{
+
+class LiveBucket;
+
+class PopulateLedgerCacheWork : public Work
+{
+    std::vector<std::shared_ptr<LiveBucket>> mBucketsToProcess;
+    uint32_t mBucketToProcessIndex;
+    LedgerKeySet mDeadKeys;
+    State advance();
+
+  public:
+    PopulateLedgerCacheWork(Application& app);
+
+  protected:
+    State doWork() override;
+};
+
+}

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -8,12 +8,14 @@
 #include "history/HistoryManager.h"
 #include "ledger/NetworkConfig.h"
 #include <memory>
+#include <optional>
 
 namespace stellar
 {
 
-class LedgerCloseData;
 class Database;
+class LedgerCloseData;
+class LedgerStateCache;
 class SorobanMetrics;
 
 /**
@@ -206,5 +208,8 @@ class LedgerManager
     }
 
     virtual bool isApplying() const = 0;
+
+    virtual std::optional<std::shared_ptr<LedgerStateCache>>
+    getLedgerStateCache() const = 0;
 };
 }

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -15,6 +15,7 @@
 #include "util/XDRStream.h"
 #include "xdr/Stellar-ledger.h"
 #include <filesystem>
+#include <optional>
 #include <string>
 
 /*
@@ -37,6 +38,7 @@ class AbstractLedgerTxn;
 class Application;
 class Database;
 class LedgerTxnHeader;
+class LedgerStateCache;
 class BasicWork;
 
 class LedgerManagerImpl : public LedgerManager
@@ -99,6 +101,9 @@ class LedgerManagerImpl : public LedgerManager
     mutable std::recursive_mutex mLedgerStateMutex;
 
     medida::Timer& mCatchupDuration;
+
+    std::optional<std::shared_ptr<LedgerStateCache>> mLedgerStateCache =
+        std::nullopt;
 
     std::unique_ptr<LedgerCloseMetaFrame> mNextMetaToEmit;
 
@@ -251,5 +256,8 @@ class LedgerManagerImpl : public LedgerManager
     {
         return mCurrentlyApplyingLedger;
     }
+
+    std::optional<std::shared_ptr<LedgerStateCache>>
+    getLedgerStateCache() const override;
 };
 }

--- a/src/ledger/LedgerStateCache.cpp
+++ b/src/ledger/LedgerStateCache.cpp
@@ -1,0 +1,115 @@
+// Copyright 2025 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "ledger/LedgerStateCache.h"
+#include "ledger/LedgerHashUtils.h"
+#include "util/GlobalChecks.h"
+#include "util/Logging.h"
+#include "util/types.h"
+#include "xdrpp/printer.h"
+
+namespace stellar
+{
+size_t
+LedgerEntryHash::operator()(LedgerEntry const& entry) const
+{
+    // Extract the key from the entry and return the key's hash.
+    const LedgerKey& key = LedgerEntryKey(entry);
+    return std::hash<stellar::LedgerKey>()(key);
+}
+
+std::optional<LedgerEntry>
+LedgerStateCache::getEntry(LedgerKey const& key) const
+{
+    // TODO support other types, for test mode.
+    if (!supportedKeyType(key.type()))
+    {
+        return std::nullopt;
+    }
+
+    std::shared_lock lock(mMutex);
+    if (mState.empty())
+    {
+        CLOG_DEBUG(Ledger, "LedgerStateCache has not yet been populated.");
+        return std::nullopt;
+    }
+
+    auto it = mState.find(KeyToDummyLedgerEntry(key));
+    if (it != mState.end())
+    {
+        return std::optional<LedgerEntry>(*it);
+    }
+    else
+    {
+        // TODO potentially return an optional if we cannot find the entry, but
+        // the cache should contain all entries that are in the ledger so
+        // perhaps a runtime error is appropriate. For now we will just return
+        // nullopt.
+        CLOG_ERROR(Ledger, "LedgerStateCache does not contain entry for key {}",
+                   xdr::xdr_to_string(key));
+        return std::nullopt;
+    }
+}
+
+void
+LedgerStateCache::addEntries(std::vector<LedgerEntry> const& initEntries,
+                             std::vector<LedgerEntry> const& liveEntries,
+                             std::vector<LedgerKey> const& deadEntries)
+{
+    std::unique_lock lock(mMutex);
+    // Remove dead entries
+    for (auto const& key : deadEntries)
+    {
+        if (!supportedKeyType(key.type()))
+        {
+            CLOG_DEBUG(Ledger, "Skipping unsupported key type {}", key.type());
+            continue;
+        }
+        mState.erase(KeyToDummyLedgerEntry(key));
+    }
+
+    // Add/update live entries
+    for (auto const& entry : liveEntries)
+    {
+        if (!supportedKeyType(entry.data.type()))
+        {
+            CLOG_DEBUG(Ledger, "Skipping unsupported key type {}",
+                       entry.data.type());
+            continue;
+        }
+        mState.erase(entry); // Remove old version if it exists
+        mState.emplace(entry);
+    }
+}
+
+void
+LedgerStateCache::addEntry(LedgerEntry const& entry)
+{
+    std::unique_lock lock(mMutex);
+    if (!supportedKeyType(entry.data.type()))
+    {
+        CLOG_DEBUG(Ledger, "Skipping unsupported key type {}",
+                   entry.data.type());
+        return;
+    }
+    mState.erase(entry);
+    mState.emplace(entry);
+}
+
+size_t
+LedgerStateCache::size() const
+{
+    std::shared_lock lock(mMutex);
+    return mState.size();
+}
+
+bool
+LedgerStateCache::supportedKeyType(LedgerEntryType type)
+{
+    // TODO support other types
+    // possibly do something more sophisticated here
+    return type == CONTRACT_DATA || type == CONTRACT_CODE || type == TTL;
+}
+
+}

--- a/src/ledger/LedgerStateCache.h
+++ b/src/ledger/LedgerStateCache.h
@@ -1,0 +1,73 @@
+#pragma once
+
+// Copyright 2025 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "ledger/LedgerTxn.h"
+#include "xdr/Stellar-ledger-entries.h"
+#include <optional>
+#include <shared_mutex>
+#include <unordered_set>
+
+namespace stellar
+{
+// TODO Add ifdef
+struct LedgerEntryHash
+{
+    size_t operator()(LedgerEntry const& entry) const;
+};
+
+struct LedgerEntryEqual
+{
+    bool
+    operator()(LedgerEntry const& a, LedgerEntry const& b) const
+    {
+        return LedgerEntryKey(a) == LedgerEntryKey(b);
+    }
+};
+
+class LedgerManagerImpl;
+class PopulateLedgerCacheWork;
+
+class LedgerStateCache
+{
+  private:
+    std::unordered_set<LedgerEntry, LedgerEntryHash, LedgerEntryEqual> mState;
+    mutable std::shared_mutex mMutex;
+
+    // Add entries to the cache
+    // Acquires a unique lock on the cache. Should be called
+    // once per ledger, when transfering entries to the bucket list.
+    // LedgerEntry in initEntries and liveEntries are added to the cache,
+    // while LedgerEntry in deadEntries are removed from the cache.
+    void addEntries(std::vector<LedgerEntry> const& initEntries,
+                    std::vector<LedgerEntry> const& liveEntries,
+                    std::vector<LedgerKey> const& deadEntries);
+
+    // Add a single entry to the cache
+    // Acquires a unique lock on the cache. Called
+    // when populating the cache.
+    void addEntry(LedgerEntry const& entry);
+
+  public:
+    LedgerStateCache() = default;
+
+    // Read an entry from the cache
+    // Acquires a shared lock on the cache.
+    std::optional<LedgerEntry> getEntry(LedgerKey const& key) const;
+
+    size_t size() const;
+    // TODO support other types
+    static bool supportedKeyType(LedgerEntryType type);
+
+    // TODO Find a way to limit access to just the methods we need
+    // PopulateLedgerCacheWork::doWork() / addEntry() and
+    // LedgerManagerImpl::transferLedgerEntriesToBucketList() / addEntries() I
+    // don't think that is possible as they are private/protected themselves,
+    // maybe another layer of indirection?
+    friend class PopulateLedgerCacheWork;
+    friend class LedgerManagerImpl;
+};
+
+}

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -15,6 +15,7 @@
 #include <ledger/LedgerHashUtils.h>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <soci.h>
 
@@ -277,6 +278,7 @@ struct InflationVotes;
 struct LedgerEntry;
 struct LedgerKey;
 struct LedgerRange;
+class LedgerStateCache;
 class SessionWrapper;
 
 struct OfferDescriptor
@@ -854,11 +856,12 @@ class LedgerTxnRoot : public AbstractLedgerTxnParent
     std::unique_ptr<Impl> const mImpl;
 
   public:
-    explicit LedgerTxnRoot(Application& app, size_t entryCacheSize,
-                           size_t prefetchBatchSize
+    explicit LedgerTxnRoot(
+        Application& app, size_t entryCacheSize, size_t prefetchBatchSize,
+        std::optional<std::shared_ptr<LedgerStateCache>> ledgerStateCache
 #ifdef BEST_OFFER_DEBUGGING
-                           ,
-                           bool bestOfferDebuggingEnabled
+        ,
+        bool bestOfferDebuggingEnabled
 #endif
     );
 

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -21,6 +21,7 @@
 namespace stellar
 {
 
+class LedgerStateCache;
 class SearchableLiveBucketListSnapshot;
 
 class EntryIterator::AbstractImpl
@@ -647,6 +648,8 @@ class LedgerTxnRoot::Impl
     std::unique_ptr<soci::transaction> mTransaction;
     AbstractLedgerTxn* mChild;
 
+    std::optional<std::shared_ptr<LedgerStateCache>> mLedgerStateCache;
+
 #ifdef BEST_OFFER_DEBUGGING
     bool const mBestOfferDebuggingEnabled;
 #endif
@@ -716,7 +719,8 @@ class LedgerTxnRoot::Impl
 
   public:
     // Constructor has the strong exception safety guarantee
-    Impl(Application& app, size_t entryCacheSize, size_t prefetchBatchSize
+    Impl(Application& app, size_t entryCacheSize, size_t prefetchBatchSize,
+         std::optional<std::shared_ptr<LedgerStateCache>> ledgerStateCache
 #ifdef BEST_OFFER_DEBUGGING
          ,
          bool bestOfferDebuggingEnabled

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -261,9 +261,10 @@ ApplicationImpl::initialize(bool createNewDB, bool forceRebuild)
                     mConfig.ENTRY_CACHE_SIZE);
     }
     mLedgerTxnRoot = std::make_unique<LedgerTxnRoot>(
-        *this, mConfig.ENTRY_CACHE_SIZE, mConfig.PREFETCH_BATCH_SIZE
+        *this, mConfig.ENTRY_CACHE_SIZE, mConfig.PREFETCH_BATCH_SIZE,
+        mLedgerManager->getLedgerStateCache()
 #ifdef BEST_OFFER_DEBUGGING
-        ,
+            ,
         mConfig.BEST_OFFER_DEBUGGING_ENABLED
 #endif
     );

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -65,7 +65,8 @@ static const std::unordered_set<std::string> TESTING_ONLY_OPTIONS = {
     "ARTIFICIALLY_DELAY_BUCKET_APPLICATION_FOR_TESTING",
     "ARTIFICIALLY_SLEEP_MAIN_THREAD_FOR_TESTING",
     "ARTIFICIALLY_SKIP_CONNECTION_ADJUSTMENT_FOR_TESTING",
-    "ARTIFICIALLY_DELAY_LEDGER_CLOSE_FOR_TESTING"};
+    "ARTIFICIALLY_DELAY_LEDGER_CLOSE_FOR_TESTING",
+    "IN_MEMORY_SOROBAN_STATE_FOR_TESTING"};
 
 // Options that should only be used for testing
 static const std::unordered_set<std::string> TESTING_SUGGESTED_OPTIONS = {
@@ -281,6 +282,9 @@ Config::Config() : NODE_SEED(SecretKey::random())
 
     ENTRY_CACHE_SIZE = 100000;
     PREFETCH_BATCH_SIZE = 1000;
+#ifdef BUILD_TESTS
+    IN_MEMORY_SOROBAN_STATE_FOR_TESTING = true;
+#endif
 
     HISTOGRAM_WINDOW_SIZE = std::chrono::seconds(30);
 

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -201,6 +201,9 @@ class Config : public std::enable_shared_from_this<Config>
     // application of failed transactions and will not verify signatures of
     // successful transactions.
     bool CATCHUP_SKIP_KNOWN_RESULTS_FOR_TESTING;
+
+    // Whether to use an in-memory ledger state cache for Soroban state.
+    bool IN_MEMORY_SOROBAN_STATE_FOR_TESTING;
 #endif // BUILD_TESTS
 
     // Interval between automatic maintenance executions

--- a/src/util/types.cpp
+++ b/src/util/types.cpp
@@ -71,6 +71,31 @@ LedgerEntryKey(LedgerEntry const& e)
     return k;
 }
 
+LedgerEntry
+KeyToDummyLedgerEntry(LedgerKey const& k)
+{
+    LedgerEntry e;
+    e.data.type(k.type());
+    // TODO support other types
+    switch (k.type())
+    {
+    case CONTRACT_DATA:
+        e.data.contractData().contract = k.contractData().contract;
+        e.data.contractData().key = k.contractData().key;
+        e.data.contractData().durability = k.contractData().durability;
+        break;
+    case CONTRACT_CODE:
+        e.data.contractCode().hash = k.contractCode().hash;
+        break;
+    case TTL:
+        e.data.ttl().keyHash = k.ttl().keyHash;
+        break;
+    default:
+        abort();
+    }
+    return e;
+}
+
 bool
 isZero(uint256 const& b)
 {

--- a/src/util/types.h
+++ b/src/util/types.h
@@ -19,6 +19,9 @@ typedef std::set<LedgerKey, LedgerEntryIdCmp> LedgerKeySet;
 
 LedgerKey LedgerEntryKey(LedgerEntry const& e);
 
+// Returns a dummy LedgerEntry with the same key as the given LedgerKey.
+LedgerEntry KeyToDummyLedgerEntry(LedgerKey const& k);
+
 bool isZero(uint256 const& b);
 
 Hash& operator^=(Hash& l, Hash const& r);


### PR DESCRIPTION
Adds LedgerStateCache to store all **Soroban** entries:
* Populates (`LedgerEntryCache::addEntry`) the cache in `PopulateLedgerCacheWork` (executed in `LedgerManagerImpl::loadLastKnownLedger`). 
* Updates the cache (`LedgerEntryCache:::addEntries`) each ledger from `LedgerManagerImpl::transferLedgerEntriesToBucketList`. 
* Reads the cache (`LedgerEntryCache::readEntry`) in LedgerTxnRoot::Impl:::getNewestVersion.

Notes:
* `addEntry` and `addEntries` are private and only accessible from `friend` classes `LedgerManagerImpl` and `PopulateLedgerCacheWork`
* `addEntry` and `addEntries` acquire a unique lock on the cache
* Currently, the `LeddgerStateCache` only supports contract entries. To access them in the index, I've added `Bucket / Index::getContractEntryRange`.
* The `LedgerStateCache` is enabled via `Config::IN_MEMORY_SOROBAN_STATE_FOR_TESTING` (default `true`)

# Description

Resolves #X

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
