### PR TITLE
Path Payment Memoization POC

### DIFF
--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -17,8 +17,11 @@ class Database;
 class SorobanMetrics;
 
 using PathPaymentStrictSendMap =
-    std::map<Hash, std::map<int64_t, std::set<int64_t>>>;
-using AssetToPathsMap = std::map<Hash, std::vector<std::pair<Asset, Asset>>>;
+    UnorderedMap<Hash, std::map<int64_t, std::set<int64_t>>>;
+
+// Change map definition to use unordered_map with asset pair as key
+using AssetToPathsMap =
+    UnorderedMap<AssetPair, std::vector<Hash>, AssetPairHash>;
 
 /**
  * LedgerManager maintains, in memory, a logical pair of ledgers:
@@ -229,7 +232,6 @@ class LedgerManager
 
     // Invalidate paths containing the given asset pair (in that order)
     virtual void
-    invalidatePathPaymentCachesForAssetPair(Asset const& selling,
-                                            Asset const& buying) = 0;
+    invalidatePathPaymentCachesForAssetPair(AssetPair const& pair) = 0;
 };
 }

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -16,8 +16,11 @@ class LedgerCloseData;
 class Database;
 class SorobanMetrics;
 
-using PathPaymentStrictSendMap =
-    UnorderedMap<Hash, std::map<int64_t, std::set<int64_t>>>;
+// Maps the entire path hash to a map of {sendValue, minimumFailedRecvValue}
+// Essentially, for the given path hash, we check all memos from TXs that have
+// an equal or greater sendValue. If one of these asked to receive less than the
+// current op and failed, we can guarantee the op will also fail.
+using PathPaymentStrictSendMap = UnorderedMap<Hash, std::map<int64_t, int64_t>>;
 
 // Change map definition to use unordered_map with asset pair as key
 using AssetToPathsMap =

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -215,10 +215,9 @@ class LedgerManager
     virtual void clearPathPaymentStrictSendCache() = 0;
 
     // Cache a failed path payment strict send attempt
-    virtual void
-    cachePathPaymentStrictSendFailure(Hash const& pathHash, int64_t sendAmount,
-                                      int64_t receiveAmount,
-                                      std::vector<Asset> const& assets) = 0;
+    virtual void cachePathPaymentStrictSendFailure(
+        Hash const& pathHash, int64_t sendAmount, int64_t receiveAmount,
+        Asset const& source, std::vector<Asset> const& assets) = 0;
 
     // Get cached failures for a path, or end iterator if not found
     virtual PathPaymentStrictSendMap::const_iterator

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -16,6 +16,10 @@ class LedgerCloseData;
 class Database;
 class SorobanMetrics;
 
+using PathPaymentStrictSendMap =
+    std::map<Hash, std::map<int64_t, std::set<int64_t>>>;
+using AssetToPathsMap = std::map<Hash, std::vector<std::pair<Asset, Asset>>>;
+
 /**
  * LedgerManager maintains, in memory, a logical pair of ledgers:
  *
@@ -206,5 +210,27 @@ class LedgerManager
     }
 
     virtual bool isApplying() const = 0;
+
+    // Clear the path payment strict send failure cache
+    virtual void clearPathPaymentStrictSendCache() = 0;
+
+    // Cache a failed path payment strict send attempt
+    virtual void
+    cachePathPaymentStrictSendFailure(Hash const& pathHash, int64_t sendAmount,
+                                      int64_t receiveAmount,
+                                      std::vector<Asset> const& assets) = 0;
+
+    // Get cached failures for a path, or end iterator if not found
+    virtual PathPaymentStrictSendMap::const_iterator
+    getPathPaymentStrictSendCache(Hash const& pathHash) const = 0;
+
+    // Get the end iterator for the path payment cache
+    virtual PathPaymentStrictSendMap::const_iterator
+    getPathPaymentStrictSendCacheEnd() const = 0;
+
+    // Invalidate paths containing the given asset pair (in that order)
+    virtual void
+    invalidatePathPaymentCachesForAssetPair(Asset const& selling,
+                                            Asset const& buying) = 0;
 };
 }

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1017,6 +1017,8 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData,
         emitNextMeta();
     }
 
+    releaseAssertOrThrow(ledgerSeq != 53514768);
+
     // The next 7 steps happen in a relatively non-obvious, subtle order.
     // This is unfortunate and it would be nice if we could make it not
     // be so subtle, but for the time being this is where we are.

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1890,13 +1890,15 @@ LedgerManagerImpl::clearPathPaymentStrictSendCache()
 void
 LedgerManagerImpl::cachePathPaymentStrictSendFailure(
     Hash const& pathHash, int64_t sendAmount, int64_t receiveAmount,
-    std::vector<Asset> const& assets)
+    Asset const& source, std::vector<Asset> const& assets)
 {
+    ZoneScoped;
     mPathPaymentStrictSendFailureCache[pathHash][sendAmount].insert(
         receiveAmount);
 
     // Convert path into buy-sell pairs
     std::vector<std::pair<Asset, Asset>> pairs;
+    pairs.emplace_back(source, assets[0]);
     for (size_t i = 0; i < assets.size() - 1; i++)
     {
         pairs.emplace_back(assets[i], assets[i + 1]);
@@ -1921,6 +1923,7 @@ void
 LedgerManagerImpl::invalidatePathPaymentCachesForAssetPair(Asset const& selling,
                                                            Asset const& buying)
 {
+    ZoneScoped;
     // For each path in the cache
     for (auto const& [pathHash, pairs] : mAssetToPaths)
     {

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1939,10 +1939,10 @@ LedgerManagerImpl::cachePathPaymentStrictSendFailure(
     };
 
     // Convert path into buy-sell pairs
-    insert(AssetPair{source, assets[0]});
+    insert(AssetPair{assets[0], source});
     for (size_t i = 0; i < assets.size() - 1; i++)
     {
-        insert(AssetPair{assets[i], assets[i + 1]});
+        insert(AssetPair{assets[i + 1], assets[i]});
     }
 }
 

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -106,6 +106,13 @@ class LedgerManagerImpl : public LedgerManager
     // is currently closing a ledger or has ledgers queued to apply.
     bool mCurrentlyApplyingLedger{false};
 
+    // Cache for path payment strict send operations
+    // Hash(subPath) -> (sendAmount -> set of receiveAmounts)
+    PathPaymentStrictSendMap mPathPaymentStrictSendFailureCache;
+
+    // Maps assets to the paths that contain them
+    AssetToPathsMap mAssetToPaths;
+
     static std::vector<MutableTxResultPtr> processFeesSeqNums(
         ApplicableTxSetFrame const& txSet, AbstractLedgerTxn& ltxOuter,
         std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta,
@@ -251,5 +258,18 @@ class LedgerManagerImpl : public LedgerManager
     {
         return mCurrentlyApplyingLedger;
     }
+
+    void clearPathPaymentStrictSendCache() override;
+    void cachePathPaymentStrictSendFailure(
+        Hash const& pathHash, int64_t sendAmount, int64_t receiveAmount,
+        std::vector<Asset> const& assets) override;
+    PathPaymentStrictSendMap::const_iterator
+    getPathPaymentStrictSendCache(Hash const& pathHash) const override;
+
+    PathPaymentStrictSendMap::const_iterator
+    getPathPaymentStrictSendCacheEnd() const override;
+
+    void invalidatePathPaymentCachesForAssetPair(Asset const& selling,
+                                                 Asset const& buying) override;
 };
 }

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -262,7 +262,7 @@ class LedgerManagerImpl : public LedgerManager
     void clearPathPaymentStrictSendCache() override;
     void cachePathPaymentStrictSendFailure(
         Hash const& pathHash, int64_t sendAmount, int64_t receiveAmount,
-        std::vector<Asset> const& assets) override;
+        Asset const& source, std::vector<Asset> const& assets) override;
     PathPaymentStrictSendMap::const_iterator
     getPathPaymentStrictSendCache(Hash const& pathHash) const override;
 

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -269,7 +269,7 @@ class LedgerManagerImpl : public LedgerManager
     PathPaymentStrictSendMap::const_iterator
     getPathPaymentStrictSendCacheEnd() const override;
 
-    void invalidatePathPaymentCachesForAssetPair(Asset const& selling,
-                                                 Asset const& buying) override;
+    void
+    invalidatePathPaymentCachesForAssetPair(AssetPair const& pair) override;
 };
 }

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -500,6 +500,7 @@ LedgerTxn::commit() noexcept
 void
 LedgerTxn::Impl::commit() noexcept
 {
+    ZoneNamedN(commitZone, "child_commit", true);
     maybeUpdateLastModifiedThenInvokeThenSeal([&](EntryMap const& entries) {
         // getEntryIterator has the strong exception safety guarantee
         // commitChild has the strong exception safety guarantee

--- a/src/transactions/LiquidityPoolDepositOpFrame.cpp
+++ b/src/transactions/LiquidityPoolDepositOpFrame.cpp
@@ -313,6 +313,10 @@ LiquidityPoolDepositOpFrame::doApply(
         throw std::runtime_error("insufficient liquidity pool limit");
     }
 
+    app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
+        cpp().assetA, cpp().assetB);
+    app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
+        cpp().assetB, cpp().assetA);
     innerResult(res).code(LIQUIDITY_POOL_DEPOSIT_SUCCESS);
     return true;
 }

--- a/src/transactions/LiquidityPoolDepositOpFrame.cpp
+++ b/src/transactions/LiquidityPoolDepositOpFrame.cpp
@@ -314,9 +314,9 @@ LiquidityPoolDepositOpFrame::doApply(
     }
 
     app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
-        cpp().assetA, cpp().assetB);
+        AssetPair{cpp().assetA, cpp().assetB});
     app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
-        cpp().assetB, cpp().assetA);
+        AssetPair{cpp().assetB, cpp().assetA});
     innerResult(res).code(LIQUIDITY_POOL_DEPOSIT_SUCCESS);
     return true;
 }

--- a/src/transactions/LiquidityPoolWithdrawOpFrame.cpp
+++ b/src/transactions/LiquidityPoolWithdrawOpFrame.cpp
@@ -100,10 +100,10 @@ LiquidityPoolWithdrawOpFrame::doApply(
         throw std::runtime_error("insufficient reserveB");
     }
 
-    app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
-        constantProduct().params.assetA, constantProduct().params.assetB);
-    app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
-        constantProduct().params.assetB, constantProduct().params.assetA);
+    app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(AssetPair{
+        constantProduct().params.assetA, constantProduct().params.assetB});
+    app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(AssetPair{
+        constantProduct().params.assetB, constantProduct().params.assetA});
 
     innerResult(res).code(LIQUIDITY_POOL_WITHDRAW_SUCCESS);
     return true;

--- a/src/transactions/LiquidityPoolWithdrawOpFrame.cpp
+++ b/src/transactions/LiquidityPoolWithdrawOpFrame.cpp
@@ -100,6 +100,11 @@ LiquidityPoolWithdrawOpFrame::doApply(
         throw std::runtime_error("insufficient reserveB");
     }
 
+    app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
+        constantProduct().params.assetA, constantProduct().params.assetB);
+    app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
+        constantProduct().params.assetB, constantProduct().params.assetA);
+
     innerResult(res).code(LIQUIDITY_POOL_WITHDRAW_SUCCESS);
     return true;
 }

--- a/src/transactions/ManageOfferOpFrameBase.cpp
+++ b/src/transactions/ManageOfferOpFrameBase.cpp
@@ -551,10 +551,10 @@ ManageOfferOpFrameBase::doApply(
     {
         // Since the offer is new, we don't know which side of the trade has
         // improved, so invalidate both
-        app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(mSheep,
-                                                                       mWheat);
-        app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(mWheat,
-                                                                       mSheep);
+        app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
+            AssetPair{mSheep, mWheat});
+        app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
+            AssetPair{mWheat, mSheep});
     }
     // Deleting an offer does not invalidate any cached fails
     else if (!isDeleteOffer())
@@ -572,10 +572,10 @@ ManageOfferOpFrameBase::doApply(
         // }
 
         // TODO: Tighten this
-        app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(mSheep,
-                                                                       mWheat);
-        app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(mWheat,
-                                                                       mSheep);
+        app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
+            AssetPair{mSheep, mWheat});
+        app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
+            AssetPair{mWheat, mSheep});
     }
 
     return true;

--- a/src/transactions/ManageOfferOpFrameBase.cpp
+++ b/src/transactions/ManageOfferOpFrameBase.cpp
@@ -546,32 +546,13 @@ ManageOfferOpFrameBase::doApply(
 
     ltx.commit();
 
-    // Invalidate paths containing either asset in this offer
-    if (creatingNewOffer)
-    {
-        // Since the offer is new, we don't know which side of the trade has
-        // improved, so invalidate both
-        app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
-            AssetPair{mSheep, mWheat});
-        app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
-            AssetPair{mWheat, mSheep});
-    }
     // Deleting an offer does not invalidate any cached fails
-    else if (!isDeleteOffer())
+    if (!isDeleteOffer())
     {
-        // // Invalidate paths containing the asset pair if the offer is better
-        // if (mPrice < oldSellSheepOfferPrice ||
-        //     (mPrice == oldSellSheepOfferPrice && amount > oldSheepAmount))
-        // {
-        //     //
-        //     app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
-        //     //     mSheep, mWheat);
-        //     //
-        //     app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
-        //     //     mWheat, mSheep);
-        // }
-
-        // TODO: Tighten this
+        // Unfortunately, due to rounding errors we need to invalidate both side
+        // of the offer. Sometimes, even if an offer gets "worse", (like if the
+        // amount offer decreases), different rounding behavior can actually
+        // cause the "worse" offer to now favor the taker.
         app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
             AssetPair{mSheep, mWheat});
         app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(

--- a/src/transactions/ManageOfferOpFrameBase.cpp
+++ b/src/transactions/ManageOfferOpFrameBase.cpp
@@ -549,19 +549,33 @@ ManageOfferOpFrameBase::doApply(
     // Invalidate paths containing either asset in this offer
     if (creatingNewOffer)
     {
+        // Since the offer is new, we don't know which side of the trade has
+        // improved, so invalidate both
         app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(mSheep,
                                                                        mWheat);
+        app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(mWheat,
+                                                                       mSheep);
     }
     // Deleting an offer does not invalidate any cached fails
     else if (!isDeleteOffer())
     {
-        // Invalidate paths containing the asset pair if the offer is better
-        if (mPrice < oldSellSheepOfferPrice ||
-            (mPrice == oldSellSheepOfferPrice && amount > oldSheepAmount))
-        {
-            app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
-                mSheep, mWheat);
-        }
+        // // Invalidate paths containing the asset pair if the offer is better
+        // if (mPrice < oldSellSheepOfferPrice ||
+        //     (mPrice == oldSellSheepOfferPrice && amount > oldSheepAmount))
+        // {
+        //     //
+        //     app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
+        //     //     mSheep, mWheat);
+        //     //
+        //     app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
+        //     //     mWheat, mSheep);
+        // }
+
+        // TODO: Tighten this
+        app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(mSheep,
+                                                                       mWheat);
+        app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(mWheat,
+                                                                       mSheep);
     }
 
     return true;

--- a/src/transactions/PathPaymentStrictReceiveOpFrame.cpp
+++ b/src/transactions/PathPaymentStrictReceiveOpFrame.cpp
@@ -135,12 +135,12 @@ PathPaymentStrictReceiveOpFrame::doApply(
     // Invalidate paths containing any asset pairs in the path, but reversed
     // since the counter party is getting better
     app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
-        AssetPair{getDestAsset(), fullPath.front()});
+        AssetPair{fullPath.front(), getDestAsset()});
 
     for (size_t i = 0; i < fullPath.size() - 1; i++)
     {
         app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
-            AssetPair{fullPath[i], fullPath[i + 1]});
+            AssetPair{fullPath[i + 1], fullPath[i]});
     }
 
     return true;

--- a/src/transactions/PathPaymentStrictReceiveOpFrame.cpp
+++ b/src/transactions/PathPaymentStrictReceiveOpFrame.cpp
@@ -135,12 +135,12 @@ PathPaymentStrictReceiveOpFrame::doApply(
     // Invalidate paths containing any asset pairs in the path, but reversed
     // since the counter party is getting better
     app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
-        getDestAsset(), fullPath.front());
+        AssetPair{getDestAsset(), fullPath.front()});
 
     for (size_t i = 0; i < fullPath.size() - 1; i++)
     {
         app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
-            fullPath[i], fullPath[i + 1]);
+            AssetPair{fullPath[i], fullPath[i + 1]});
     }
 
     return true;

--- a/src/transactions/PathPaymentStrictReceiveOpFrame.cpp
+++ b/src/transactions/PathPaymentStrictReceiveOpFrame.cpp
@@ -72,6 +72,56 @@ PathPaymentStrictReceiveOpFrame::doApply(
                     mPathPayment.path.rend());
     fullPath.emplace_back(getSourceAsset());
 
+    SHA256 pathHasher;
+    for (auto iter = fullPath.rbegin(); iter != fullPath.rend(); iter++)
+    {
+        auto hash = getAssetHash(*iter);
+        pathHasher.add(
+            ByteSlice(reinterpret_cast<unsigned char*>(&hash), sizeof(hash)));
+    }
+
+    auto destHash = getAssetHash(getDestAsset());
+    pathHasher.add(ByteSlice(reinterpret_cast<unsigned char*>(&destHash),
+                             sizeof(destHash)));
+
+    auto pathHash = pathHasher.finish();
+
+    // TODO: Optimize better by keeping max as well
+    auto iter = app.getLedgerManager().getPathPaymentStrictSendCache(pathHash);
+    if (iter != app.getLedgerManager().getPathPaymentStrictSendCacheEnd())
+    {
+        auto const& sendAmountToMinReceiveAmount = iter->second;
+
+        // Get set of receive amounts for which sendAmount is greater than or
+        // equal to our send amount
+        auto sendToReceiveAmountsIter = std::lower_bound(
+            sendAmountToMinReceiveAmount.begin(),
+            sendAmountToMinReceiveAmount.end(), mPathPayment.sendMax,
+            [](const auto& pair, uint64_t value) {
+                // Pair == {sendAmount, minReceiveAmount}
+                return pair.first < value;
+            });
+
+        // For each op that has sent the same or more than this op
+        for (; sendToReceiveAmountsIter != sendAmountToMinReceiveAmount.end();
+             ++sendToReceiveAmountsIter)
+        {
+            releaseAssert(sendToReceiveAmountsIter->first >=
+                          mPathPayment.sendMax);
+
+            // If minimum received amount is less than or equal to destAmount,
+            // we know the trade will fail since a previous trade sent more and
+            // received less than this op but still failed
+            if (sendToReceiveAmountsIter->second <= mPathPayment.destAmount)
+            {
+                setResultConstraintNotMet(res);
+                pathStr += "-> hit";
+                ZoneTextV(applyZone, pathStr.c_str(), pathStr.size());
+                return false;
+            }
+        }
+    }
+
     // Walk the path
     Asset recvAsset = getDestAsset();
     int64_t maxAmountRecv = mPathPayment.destAmount;
@@ -122,6 +172,16 @@ PathPaymentStrictReceiveOpFrame::doApply(
 
     if (maxAmountRecv > mPathPayment.sendMax)
     { // make sure not over the max
+
+        // Convert to strict send format for cache purposes
+        std::vector<Asset> path;
+        path.insert(path.end(), mPathPayment.path.begin(),
+                    mPathPayment.path.end());
+        path.emplace_back(getDestAsset());
+        app.getLedgerManager().cachePathPaymentStrictSendFailure(
+            pathHash, mPathPayment.sendMax, mPathPayment.destAmount,
+            getSourceAsset(), path);
+
         setResultConstraintNotMet(res);
         return false;
     }

--- a/src/transactions/PathPaymentStrictReceiveOpFrame.cpp
+++ b/src/transactions/PathPaymentStrictReceiveOpFrame.cpp
@@ -131,6 +131,14 @@ PathPaymentStrictReceiveOpFrame::doApply(
     {
         return false;
     }
+
+    // Invalidate paths containing any asset pairs in the path
+    for (size_t i = 0; i < fullPath.size() - 1; i++)
+    {
+        app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
+            fullPath[i], fullPath[i + 1]);
+    }
+
     return true;
 }
 

--- a/src/transactions/PathPaymentStrictReceiveOpFrame.cpp
+++ b/src/transactions/PathPaymentStrictReceiveOpFrame.cpp
@@ -132,7 +132,11 @@ PathPaymentStrictReceiveOpFrame::doApply(
         return false;
     }
 
-    // Invalidate paths containing any asset pairs in the path
+    // Invalidate paths containing any asset pairs in the path, but reversed
+    // since the counter party is getting better
+    app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
+        getDestAsset(), fullPath.front());
+
     for (size_t i = 0; i < fullPath.size() - 1; i++)
     {
         app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(

--- a/src/transactions/PathPaymentStrictSendOpFrame.cpp
+++ b/src/transactions/PathPaymentStrictSendOpFrame.cpp
@@ -186,13 +186,15 @@ PathPaymentStrictSendOpFrame::doApply(
     }
 
     // Invalidate caches for filled offers, but in reverse because counter party
+    // is getting better. We don't need to invalidate paths we filled, as
+    // filling them made the path strictly worse
     app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
-        AssetPair{fullPath.front(), getSourceAsset()});
+        AssetPair{getSourceAsset(), fullPath.front()});
 
     for (size_t i = 0; i < fullPath.size() - 1; i++)
     {
         app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
-            AssetPair{fullPath[i + 1], fullPath[i]});
+            AssetPair{fullPath[i], fullPath[i + 1]});
     }
 
     pathStr += "-> miss";

--- a/src/transactions/PathPaymentStrictSendOpFrame.cpp
+++ b/src/transactions/PathPaymentStrictSendOpFrame.cpp
@@ -194,12 +194,12 @@ PathPaymentStrictSendOpFrame::doApply(
 
     // Invalidate caches for filled offers, but in reverse because counter party
     app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
-        fullPath.front(), getSourceAsset());
+        AssetPair{fullPath.front(), getSourceAsset()});
 
     for (size_t i = 0; i < fullPath.size() - 1; i++)
     {
         app.getLedgerManager().invalidatePathPaymentCachesForAssetPair(
-            fullPath[i + 1], fullPath[i]);
+            AssetPair{fullPath[i + 1], fullPath[i]});
     }
 
     pathStr += "-> miss";

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -1721,6 +1721,16 @@ TransactionFrame::applyOperations(SignatureChecker& signatureChecker,
                     CLOG_FATAL(Tx, "Skipping failed TX {}", num_tx_skipped++);
                     break;
                 }
+
+                if (opRes.code() == opINNER &&
+                    opRes.tr().type() == PATH_PAYMENT_STRICT_RECEIVE &&
+                    opRes.tr().pathPaymentStrictReceiveResult().code() !=
+                        PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX)
+                {
+                    skipTx = true;
+                    CLOG_FATAL(Tx, "Skipping failed TX {}", num_tx_skipped++);
+                    break;
+                }
             }
         }
     }

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -556,6 +556,7 @@ addBalanceSkipAuthorization(LedgerTxnHeader const& header,
 bool
 addBalance(LedgerTxnHeader const& header, LedgerTxnEntry& entry, int64_t delta)
 {
+    ZoneScoped;
     if (entry.current().data.type() == ACCOUNT)
     {
         if (delta == 0)
@@ -1142,6 +1143,7 @@ void
 releaseLiabilities(AbstractLedgerTxn& ltx, LedgerTxnHeader const& header,
                    LedgerTxnEntry const& offer)
 {
+    ZoneScoped;
     acquireOrReleaseLiabilities(ltx, header, offer, false);
 }
 


### PR DESCRIPTION
# Description

This PR is a proof of concept optimization for path payments that significantly decreases the duration of exceptional "slow ledger" and modestly improves average ledger close times.

# Observation

Sometimes, stellar-core takes a very long time to apply transactions, on the scale of 5-10 seconds. Initially, I analyzed 2 such slow ledgers, 53514768 and 53514801. These ledgers take 3.01 seconds and 2.05 seconds to apply on my laptop, and even longer on validator hardware.

Like most transactions sets, these ledgers contained a large amount of arbitrage path payments, most of which were very similar or identical and most of which failed. I thought we might have an improper offer cache and doing extra disk IO, but  offer table caches work as expected. Upon profiling, I found that these ledgers took over 1 second just constructing and committing non-root LedgerTxn objects. Despite not going to disk, the churn on constantly creating, commiting, and eventually rolling back ledgerTxn objects for repetitive path payments was very expensive.

# Solution

The issue had to do with our current "exit early" strategy.  In order to prevent recomputing the same failed offer pairs, we use the `worstBestOfferCache`. The issue with this cache is that it reasons on individual asset pairs instead of the payment path as a whole. For path payments, often many asset pairs along the path would succeed and an asset pair very deep in the order book would eventually fail. `worstBestOfferCache` is useless in preventing us from traversing this failed path, since we will not hit the cached asset pair until we have done most of the work.

The solution to this is to use dynamic programming memoization at the asset path level. To do this, for each failed path payment, I cache the path hash to the src sell amount and destination amount that failed. Before walking the path of another payment op, we check the path hash against the hash. The cache is conservative such that we fail early iff:

1. The cache contains a src amount equal or larger than the current op source amount
2. The corresponding destination amount for that src amount is lower or equal to current op destination amount

Intuitively, the reasoning is "If a previous failed transaction gave away more and received less than me, I must also fail."

These conditions assume that no offers along the path have been modified since the last failed path payment has been cached. To achieve this, we invalidate the cache as follows:

1. Whenever an offer is updated or created, we invalidate all cached paths that contain the pair {sheep, wheat} and {wheat, sheep}. We must invalidate both sides of the trade due to rounding conditions.
2. Whenever a liquidity bool is deposited to or withdrawn from, we invalidate all paths that contain the pair {assetA, assetB} and {assetB, assetA}. Note this constraint can probably be tightened, but I didn't bother because it happens so rarely.
3. Whenever a path payment succeeds, invalidate the counter party to each asset trade pair.

Reasoning for point 3. Consider we have two path payments with the same path. The first path payment fails, so we cache it. The 2nd path payment succeeds.  Because the two payments target the same path, the success of op 2 has made the market strictly more competitive for path payments of the same path. More formally, for some path N, if a path payment of path N is executed, no op with path N that previously failed could now succeed, so we do not need to invalidate the cache. However, we do need to invalidate the counter party. I.e. if the path assetA -> assetB -> assetC executes, we must invalidate the cache for the counter party pairs {assetC -> B} and {assetB -> assetA}.

# Results

Disclosure: I performed all these tests on my laptop. Due to the memory consumption of tracy, I could only record in 500 ledger chunks. These are rough, preliminary estimates. I need to follow up with more ranges and use dev boxes to test. Disclosure over, you've been warned.

Replaying range  53514577 -> 53514577

- Total apply time reduced by 20%. 
- PathPaymentStrictRecieve 



# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
