### PR TITLE
Add function to allow checking thread type

### DIFF
--- a/src/main/AppConnector.cpp
+++ b/src/main/AppConnector.cpp
@@ -140,6 +140,12 @@ AppConnector::checkScheduledAndCache(
     return mApp.getOverlayManager().checkScheduledAndCache(msgTracker);
 }
 
+bool
+AppConnector::threadIsType(Application::ThreadType type) const
+{
+    return mApp.threadIsType(type);
+}
+
 SearchableHotArchiveSnapshotConstPtr
 AppConnector::copySearchableHotArchiveBucketListSnapshot()
 {

--- a/src/main/AppConnector.h
+++ b/src/main/AppConnector.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include "bucket/BucketUtils.h"
+#include "main/Application.h"
 #include "main/Config.h"
 #include "medida/metrics_registry.h"
 
 namespace stellar
 {
-class Application;
 class OverlayManager;
 class LedgerManager;
 class Herder;
@@ -57,6 +57,7 @@ class AppConnector
     checkScheduledAndCache(std::shared_ptr<CapacityTrackedMessage> msgTracker);
     SorobanNetworkConfig const& getSorobanNetworkConfigReadOnly() const;
     SorobanNetworkConfig const& getSorobanNetworkConfigForApply() const;
+    bool threadIsType(Application::ThreadType type) const;
 
     medida::MetricsRegistry& getMetrics() const;
     SearchableHotArchiveSnapshotConstPtr

--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -164,6 +164,16 @@ class Application
         APP_NUM_STATE
     };
 
+    // Types of threads that may be running
+    enum class ThreadType
+    {
+        MAIN,
+        WORKER,
+        EVICTION,
+        OVERLAY,
+        APPLY
+    };
+
     virtual ~Application(){};
 
     virtual void initialize(bool createNewDB, bool forceRebuild) = 0;
@@ -329,6 +339,9 @@ class Application
 
         return ret;
     }
+
+    // Returns true iff the calling thread has the same type as `type`
+    virtual bool threadIsType(ThreadType type) const = 0;
 
     virtual AppConnector& getAppConnector() = 0;
 

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -115,6 +115,8 @@ class ApplicationImpl : public Application
     manualClose(std::optional<uint32_t> const& manualLedgerSeq,
                 std::optional<TimePoint> const& manualCloseTime) override;
 
+    bool threadIsType(ThreadType type) const override;
+
 #ifdef BUILD_TESTS
     virtual void generateLoad(GeneratedLoadConfig cfg) override;
 
@@ -219,6 +221,11 @@ class ApplicationImpl : public Application
     // higher-priority worker thread type, but for now we only need a single
     // thread for eviction scans.
     std::optional<std::thread> mEvictionThread;
+
+    // NOTE: It is important that this map not be updated outside of the
+    // constructor. `unordered_map` is safe for multiple threads to read from,
+    // so long as there are no concurrent writers.
+    std::unordered_map<std::thread::id, Application::ThreadType> mThreadTypes;
 
     asio::signal_set mStopSignals;
 

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -460,7 +460,8 @@ void
 Peer::maybeExecuteInBackground(std::string const& jobName,
                                std::function<void(std::shared_ptr<Peer>)> f)
 {
-    if (useBackgroundThread() && threadIsMain())
+    if (useBackgroundThread() &&
+        !mAppConnector.threadIsType(Application::ThreadType::OVERLAY))
     {
         mAppConnector.postOnOverlayThread(
             [self = shared_from_this(), f]() { f(self); }, jobName);


### PR DESCRIPTION
Closes #4613

This change adds a function `threadIsType` function to `Application` that allows a thread to check its type. This is intended to support more detailed assertions than the usual `releaseAssert(threadIsMain())` assertions we're currently using everywhere.

The implementation differs a bit from the proposed solution in #4613 as it uses a mapping in `ApplicationImpl` to track thread types, rather than using static variables. I chose this approach because as far as I can tell, it's not possible to assign a thread an id.  Given that, `ApplicationImpl` would need to set these variables in its constructor, and the variables would hold meaningless values prior to that. I figure it's safer to ensure that thread types can only be reasoned about after the creation of the threads themselves in `ApplicationImpl`'s constructor. However, if it's important that thread types be reasoned about without an `Application` or `AppConnector`, then I'm open to changing the design.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
