### PR TITLE
Rename various close things to apply, add comment.

### DIFF
--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -869,7 +869,7 @@ TEST_CASE_VERSIONS("network config snapshots BucketList size", "[bucketlist]")
         LedgerManagerForBucketTests& lm = app->getLedgerManager();
 
         auto& networkConfig =
-            app->getLedgerManager().getSorobanNetworkConfigReadOnly();
+            app->getLedgerManager().getLastClosedSorobanNetworkConfig();
 
         uint32_t windowSize = networkConfig.stateArchivalSettings()
                                   .bucketListSizeWindowSampleSize;
@@ -967,7 +967,8 @@ TEST_CASE_VERSIONS("eviction scan", "[bucketlist][archival]")
 
         auto& networkCfg = [&]() -> SorobanNetworkConfig& {
             LedgerTxn ltx(app->getLedgerTxnRoot());
-            return app->getLedgerManager().getMutableSorobanNetworkConfig();
+            return app->getLedgerManager()
+                .getMutableSorobanNetworkConfigForApply();
         }();
 
         auto& stateArchivalSettings = networkCfg.stateArchivalSettings();

--- a/src/bucket/test/BucketTestUtils.cpp
+++ b/src/bucket/test/BucketTestUtils.cpp
@@ -188,7 +188,7 @@ template size_t countEntries(std::shared_ptr<LiveBucket> bucket);
 template size_t countEntries(std::shared_ptr<HotArchiveBucket> bucket);
 
 void
-LedgerManagerForBucketTests::transferLedgerEntriesToBucketList(
+LedgerManagerForBucketTests::sealLedgerTxnAndTransferEntriesToBucketList(
     AbstractLedgerTxn& ltx,
     std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta,
     LedgerHeader lh, uint32_t initialLedgerVers)
@@ -269,7 +269,7 @@ LedgerManagerForBucketTests::transferLedgerEntriesToBucketList(
                 ltxEvictions.commit();
             }
             mApp.getLedgerManager()
-                .getMutableSorobanNetworkConfig()
+                .getMutableSorobanNetworkConfigForApply()
                 .maybeSnapshotBucketListSize(lh.ledgerSeq, ltx, mApp);
         }
 
@@ -293,7 +293,7 @@ LedgerManagerForBucketTests::transferLedgerEntriesToBucketList(
     }
     else
     {
-        LedgerManagerImpl::transferLedgerEntriesToBucketList(
+        LedgerManagerImpl::sealLedgerTxnAndTransferEntriesToBucketList(
             ltx, ledgerCloseMeta, lh, initialLedgerVers);
     }
 }

--- a/src/bucket/test/BucketTestUtils.cpp
+++ b/src/bucket/test/BucketTestUtils.cpp
@@ -101,6 +101,11 @@ closeLedger(Application& app, std::optional<SecretKey> skToSignValue,
     app.getHerder().externalizeValue(TxSetXDRFrame::makeEmpty(lcl), ledgerNum,
                                      lcl.header.scpValue.closeTime, upgrades,
                                      skToSignValue);
+    // NB: this assert will probably stop being true when background apply is
+    // turned on by default: externalize will have handed the ledger off to
+    // apply but not yet received the results of apply or updated LCL. The fix
+    // should be just to crank here until LCL advances to ledgerSeq.
+    releaseAssert(lm.getLastClosedLedgerNum() == ledgerNum);
     return lm.getLastClosedLedgerHeader().hash;
 }
 

--- a/src/bucket/test/BucketTestUtils.h
+++ b/src/bucket/test/BucketTestUtils.h
@@ -67,7 +67,7 @@ class LedgerManagerForBucketTests : public LedgerManagerImpl
     std::vector<LedgerKey> mTestDeadEntries;
 
   protected:
-    void transferLedgerEntriesToBucketList(
+    void sealLedgerTxnAndTransferEntriesToBucketList(
         AbstractLedgerTxn& ltx,
         std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta,
         LedgerHeader lh, uint32_t initialLedgerVers) override;

--- a/src/catchup/ApplyLedgerWork.cpp
+++ b/src/catchup/ApplyLedgerWork.cpp
@@ -23,7 +23,7 @@ BasicWork::State
 ApplyLedgerWork::onRun()
 {
     ZoneScoped;
-    mApp.getLedgerManager().closeLedger(mLedgerCloseData,
+    mApp.getLedgerManager().applyLedger(mLedgerCloseData,
                                         /* externalize */ false);
     return BasicWork::State::WORK_SUCCESS;
 }

--- a/src/catchup/LedgerApplyManagerImpl.h
+++ b/src/catchup/LedgerApplyManagerImpl.h
@@ -49,23 +49,10 @@ class LedgerApplyManagerImpl : public LedgerApplyManager
     std::map<uint32_t, LedgerCloseData> mSyncingLedgers;
     medida::Counter& mSyncingLedgersSize;
 
-    // Conceptually, there are three ledger sequences that LedgerManager, Herder
-    // and LedgerApplyManager rely on:
-    //  - L (mLargestLedgerSeqHeard) = maximum ledger that core heard the
-    //  network externalize, may or may not be applied.
-    //  - Q (mLastQueuedToApply) = Tracks maximum ledger dequeued from
-    //  mSyncingLedgers and passed to apply -- either synchronously or posted to
-    //  background thread queue. Note: Member variable is an optional<> only
-    //  because it is lazily initialized after LCL, it's supposed to have a
-    //  definite value (>= LCL) from then on.
-    //  - LCL = last closed ledger, the last ledger that was externalized, and
-    //  applied by core.
-    //  - Core maintains the following invariant: LCL <= Q <= L. New ledgers
-    //  cause each number to increment, from right to left. First externalize
-    //  enqueues a ledger in mSyncingLedgers, incrementing L. Then a ledger
-    //  is dequeued from mSyncingLedgers and sent to apply, incrementing Q
-    //  towards L. Then a ledger finishes apply, incrementing LCL towards Q.
-    //  Eventually every ledger passes through each of these phases.
+    // These state variables track the flow of ledgers through mSyncingLedgers,
+    // they are the variables Q and L in the diagram in LedgerManager.h. See
+    // that diagram for details and discussion of the threading model and
+    // flow of ledgers between LedgerApplyManager and LedgerManager.
     std::optional<uint32_t> mLastQueuedToApply;
     uint32_t mLargestLedgerSeqHeard;
 

--- a/src/catchup/ReplayDebugMetaWork.cpp
+++ b/src/catchup/ReplayDebugMetaWork.cpp
@@ -163,7 +163,7 @@ ReplayDebugMetaWork::applyLastLedger()
     auto lcl = mApp.getLedgerManager().getLastClosedLedgerNum();
     if (lcl + 1 == debugTxSet.ledgerSeq)
     {
-        mApp.getLedgerManager().closeLedger(
+        mApp.getLedgerManager().applyLedger(
             LedgerCloseData::toLedgerCloseData(debugTxSet),
             /* externalize */ false);
     }

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1165,7 +1165,7 @@ HerderImpl::lastClosedLedgerIncreased(bool latest, TxSetXDRFrameConstPtr txSet)
     {
         // Re-start heartbeat tracking _after_ applying the most up-to-date
         // ledger. This guarantees out-of-sync timer won't fire while we have
-        // ledgers to apply (applicable during parallel ledger close).
+        // ledgers to apply (applicable during parallel ledger apply).
         trackingHeartBeat();
 
         // Ensure out of sync recovery did not get triggered while we were

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -2145,7 +2145,7 @@ HerderImpl::maybeHandleUpgrade()
             return;
         }
         auto const& conf =
-            mApp.getLedgerManager().getSorobanNetworkConfigReadOnly();
+            mApp.getLedgerManager().getLastClosedSorobanNetworkConfig();
 
         auto maybeNewMaxTxSize =
             conf.txMaxSizeBytes() + getFlowControlExtraBuffer();
@@ -2197,7 +2197,7 @@ HerderImpl::start()
         if (protocolVersionStartsFrom(version, SOROBAN_PROTOCOL_VERSION))
         {
             auto const& conf =
-                mApp.getLedgerManager().getSorobanNetworkConfigReadOnly();
+                mApp.getLedgerManager().getLastClosedSorobanNetworkConfig();
             mMaxTxSize = std::max(mMaxTxSize, conf.txMaxSizeBytes() +
                                                   getFlowControlExtraBuffer());
         }

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -382,7 +382,7 @@ TransactionQueue::canAdd(
                 if (!tx->checkSorobanResourceAndSetError(
                         mApp.getAppConnector(),
                         mApp.getLedgerManager()
-                            .getSorobanNetworkConfigReadOnly(),
+                            .getLastClosedSorobanNetworkConfig(),
                         mApp.getLedgerManager()
                             .getLastClosedLedgerHeader()
                             .header.ledgerVersion,

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -1610,7 +1610,7 @@ TxSetPhaseFrame::checkValid(Application& app,
         isSoroban
             ? checkValidSoroban(
                   lcl.header,
-                  app.getLedgerManager().getSorobanNetworkConfigReadOnly())
+                  app.getLedgerManager().getLastClosedSorobanNetworkConfig())
             : checkValidClassic(lcl.header);
     if (!checkPhaseSpecific)
     {

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -995,7 +995,7 @@ TEST_CASE("tx set hits overlay byte limit during construction",
     });
 
     auto const& conf =
-        app->getLedgerManager().getSorobanNetworkConfigReadOnly();
+        app->getLedgerManager().getLastClosedSorobanNetworkConfig();
     uint32_t maxContractSize = 0;
     maxContractSize = conf.maxContractSizeBytes();
 
@@ -1150,7 +1150,7 @@ TEST_CASE("surge pricing", "[herder][txset][soroban]")
         auto tx = makeMultiPayment(acc1, root, 1, 100, 0, 1);
 
         SorobanNetworkConfig conf =
-            app->getLedgerManager().getSorobanNetworkConfigReadOnly();
+            app->getLedgerManager().getLastClosedSorobanNetworkConfig();
 
         uint32_t const baseFee = 10'000'000;
         SorobanResources resources;
@@ -3390,7 +3390,7 @@ TEST_CASE("soroban txs accepted by the network",
             for (auto node : nodes)
             {
                 REQUIRE(node->getLedgerManager()
-                            .getSorobanNetworkConfigReadOnly()
+                            .getLastClosedSorobanNetworkConfig()
                             .ledgerMaxTxCount() == ledgerWideLimit * 10);
             }
 

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -3232,7 +3232,7 @@ TEST_CASE("overlay parallel processing")
             Topologies::core(4, 1, Simulation::OVER_TCP, networkID, [](int i) {
                 auto cfg = getTestConfig(i, Config::TESTDB_POSTGRESQL);
                 cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE = 100;
-                cfg.EXPERIMENTAL_PARALLEL_LEDGER_CLOSE = true;
+                cfg.EXPERIMENTAL_PARALLEL_LEDGER_APPLY = true;
                 cfg.ARTIFICIALLY_DELAY_LEDGER_CLOSE_FOR_TESTING =
                     std::chrono::milliseconds(500);
                 return cfg;
@@ -3535,14 +3535,14 @@ herderExternalizesValuesWithProtocol(uint32_t version,
 #ifdef USE_POSTGRES
                 dbMode = Config::TESTDB_POSTGRESQL;
 #else
-                FAIL("Parallel ledger close requires postgres");
+                FAIL("Parallel ledger apply requires postgres");
 #endif
             }
             auto cfg = getTestConfig(i, dbMode);
             cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION = version;
             if (parallelLedgerClose)
             {
-                cfg.EXPERIMENTAL_PARALLEL_LEDGER_CLOSE = true;
+                cfg.EXPERIMENTAL_PARALLEL_LEDGER_APPLY = true;
                 // Add artifical delay to ledger close to increase chances of
                 // conflicts
                 cfg.ARTIFICIALLY_DELAY_LEDGER_CLOSE_FOR_TESTING =

--- a/src/herder/test/TransactionQueueTests.cpp
+++ b/src/herder/test/TransactionQueueTests.cpp
@@ -1259,7 +1259,7 @@ TEST_CASE("Soroban TransactionQueue limits",
     auto account2 = root.create("a2", minBalance2);
 
     SorobanNetworkConfig conf =
-        app->getLedgerManager().getSorobanNetworkConfigReadOnly();
+        app->getLedgerManager().getLastClosedSorobanNetworkConfig();
 
     SorobanResources resources;
     resources.instructions = 2'000'000;

--- a/src/herder/test/TxSetTests.cpp
+++ b/src/herder/test/TxSetTests.cpp
@@ -1768,7 +1768,7 @@ TEST_CASE("txset nomination", "[txset]")
             });
 
             auto const& sorobanConfig =
-                app->getLedgerManager().getSorobanNetworkConfigReadOnly();
+                app->getLedgerManager().getLastClosedSorobanNetworkConfig();
             stellar::uniform_int_distribution<> txReadEntriesDistr(
                 1, sorobanConfig.txMaxReadLedgerEntries());
 

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -2062,7 +2062,7 @@ TEST_CASE("upgrade to version 11", "[upgrades]")
         StellarValue sv = app->getHerder().makeStellarValue(
             txSet->getContentsHash(), closeTime, upgrades,
             app->getConfig().NODE_SEED);
-        lm.closeLedger(LedgerCloseData(ledgerSeq, txSet, sv));
+        lm.applyLedger(LedgerCloseData(ledgerSeq, txSet, sv));
         auto& bm = app->getBucketManager();
         auto& bl = bm.getLiveBucketList();
         while (!bl.futuresAllResolved())
@@ -2185,7 +2185,7 @@ TEST_CASE("upgrade to version 12", "[upgrades]")
         StellarValue sv = app->getHerder().makeStellarValue(
             txSet->getContentsHash(), closeTime, upgrades,
             app->getConfig().NODE_SEED);
-        lm.closeLedger(LedgerCloseData(ledgerSeq, txSet, sv));
+        lm.applyLedger(LedgerCloseData(ledgerSeq, txSet, sv));
         auto& bm = app->getBucketManager();
         auto& bl = bm.getLiveBucketList();
         while (!bl.futuresAllResolved())

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -251,7 +251,7 @@ makeBucketListSizeWindowSampleSizeTestUpgrade(Application& app,
 {
     // Modify window size
     auto sas = app.getLedgerManager()
-                   .getSorobanNetworkConfigReadOnly()
+                   .getLastClosedSorobanNetworkConfig()
                    .stateArchivalSettings();
     sas.bucketListSizeWindowSampleSize = newWindowSize;
 
@@ -917,7 +917,7 @@ TEST_CASE("config upgrades applied to ledger", "[soroban][upgrades]")
     executeUpgrade(*app, makeProtocolVersionUpgrade(
                              static_cast<uint32_t>(SOROBAN_PROTOCOL_VERSION)));
     auto const& sorobanConfig =
-        app->getLedgerManager().getSorobanNetworkConfigReadOnly();
+        app->getLedgerManager().getLastClosedSorobanNetworkConfig();
     SECTION("unknown config upgrade set is ignored")
     {
         auto contractID = autocheck::generator<Hash>()(5);
@@ -958,8 +958,8 @@ TEST_CASE("config upgrades applied to ledger", "[soroban][upgrades]")
             ConfigUpgradeSetFrameConstPtr configUpgradeSet;
             {
                 LedgerTxn ltx2(app->getLedgerTxnRoot());
-                auto& cfg =
-                    app->getLedgerManager().getMutableSorobanNetworkConfig();
+                auto& cfg = app->getLedgerManager()
+                                .getMutableSorobanNetworkConfigForApply();
 
                 // Populate sliding window with interesting values
                 auto i = 0;
@@ -985,7 +985,7 @@ TEST_CASE("config upgrades applied to ledger", "[soroban][upgrades]")
             auto const newSize = 20;
             populateValuesAndUpgradeSize(newSize);
             auto const& cfg2 =
-                app->getLedgerManager().getSorobanNetworkConfigReadOnly();
+                app->getLedgerManager().getLastClosedSorobanNetworkConfig();
 
             // Verify that we popped the 10 oldest values
             auto sum = 0;
@@ -1007,7 +1007,7 @@ TEST_CASE("config upgrades applied to ledger", "[soroban][upgrades]")
             auto const newSize = 40;
             populateValuesAndUpgradeSize(newSize);
             auto const& cfg2 =
-                app->getLedgerManager().getSorobanNetworkConfigReadOnly();
+                app->getLedgerManager().getLastClosedSorobanNetworkConfig();
 
             // Verify that we backfill 10 copies of the oldest value
             auto sum = 0;
@@ -1037,7 +1037,7 @@ TEST_CASE("config upgrades applied to ledger", "[soroban][upgrades]")
                 LedgerTxn ltx2(app->getLedgerTxnRoot());
 
                 auto const& cfg =
-                    app->getLedgerManager().getSorobanNetworkConfigReadOnly();
+                    app->getLedgerManager().getLastClosedSorobanNetworkConfig();
                 initialSize =
                     cfg.mStateArchivalSettings.bucketListSizeWindowSampleSize;
                 initialWindow = cfg.mBucketListSizeSnapshots;
@@ -1053,7 +1053,7 @@ TEST_CASE("config upgrades applied to ledger", "[soroban][upgrades]")
             executeUpgrade(*app, makeConfigUpgrade(*configUpgradeSet));
 
             auto const& cfg =
-                app->getLedgerManager().getSorobanNetworkConfigReadOnly();
+                app->getLedgerManager().getLastClosedSorobanNetworkConfig();
             REQUIRE(cfg.mStateArchivalSettings.bucketListSizeWindowSampleSize ==
                     initialSize);
             REQUIRE(cfg.mBucketListSizeSnapshots == initialWindow);
@@ -1167,7 +1167,7 @@ TEST_CASE("Soroban max tx set size upgrade applied to ledger",
                              static_cast<uint32_t>(SOROBAN_PROTOCOL_VERSION)));
 
     auto const& sorobanConfig =
-        app->getLedgerManager().getSorobanNetworkConfigReadOnly();
+        app->getLedgerManager().getLastClosedSorobanNetworkConfig();
 
     executeUpgrade(*app, makeMaxSorobanTxSizeUpgrade(123));
     REQUIRE(sorobanConfig.ledgerMaxTxCount() == 123);
@@ -2326,7 +2326,7 @@ TEST_CASE("configuration initialized in version upgrade", "[upgrades]")
 
     // Check that BucketList size window initialized with current BL size
     auto& networkConfig =
-        app->getLedgerManager().getSorobanNetworkConfigReadOnly();
+        app->getLedgerManager().getLastClosedSorobanNetworkConfig();
     REQUIRE(networkConfig.getAverageBucketListSize() == blSize);
 
     // Check in memory window
@@ -2396,7 +2396,7 @@ TEST_CASE("parallel Soroban settings upgrade", "[upgrades]")
         // Check that BucketList size window initialized with current BL
         // size
         auto const& networkConfig =
-            app->getLedgerManager().getSorobanNetworkConfigReadOnly();
+            app->getLedgerManager().getLastClosedSorobanNetworkConfig();
         REQUIRE(networkConfig.ledgerMaxDependentTxClusters() ==
                 InitialSorobanNetworkConfig::LEDGER_MAX_DEPENDENT_TX_CLUSTERS);
     }
@@ -2417,7 +2417,7 @@ TEST_CASE("parallel Soroban settings upgrade", "[upgrades]")
                 .contractParallelCompute()
                 .ledgerMaxDependentTxClusters == 5);
     REQUIRE(app->getLedgerManager()
-                .getSorobanNetworkConfigReadOnly()
+                .getLastClosedSorobanNetworkConfig()
                 .ledgerMaxDependentTxClusters() == 5);
 }
 #endif

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -1241,7 +1241,7 @@ TEST_CASE("Catchup non-initentry buckets to initentry-supporting works",
             StellarValue sv = a->getHerder().makeStellarValue(
                 txSet->getContentsHash(), closeTime, upgrades,
                 a->getConfig().NODE_SEED);
-            lm.closeLedger(LedgerCloseData(ledgerSeq, txSet, sv));
+            lm.applyLedger(LedgerCloseData(ledgerSeq, txSet, sv));
         }
 
         // Check that we did in fact use INITENTRY code.

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -532,7 +532,7 @@ CatchupSimulation::generateRandomLedger(uint32_t version)
         getApp().getMetrics().NewCounter({"ledger", "apply", "success"});
     auto lastSucceeded = txsSucceeded.count();
 
-    lm.closeLedger(mLedgerCloseDatas.back());
+    lm.applyLedger(mLedgerCloseDatas.back());
 
     if (check)
     {

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -243,18 +243,18 @@ class LedgerManager
 
     virtual Resource maxLedgerResources(bool isSoroban) = 0;
     virtual Resource maxSorobanTransactionResources() = 0;
-    virtual void updateNetworkConfig(AbstractLedgerTxn& ltx) = 0;
+    virtual void updateSorobanNetworkConfigForApply(AbstractLedgerTxn& ltx) = 0;
     // Return the network config for Soroban.
     // The config is automatically refreshed on protocol upgrades.
     // Ledger txn here is needed for the sake of lazy load; it won't be
     // used most of the time.
-    virtual SorobanNetworkConfig const& getSorobanNetworkConfigReadOnly() = 0;
+    virtual SorobanNetworkConfig const& getLastClosedSorobanNetworkConfig() = 0;
     virtual SorobanNetworkConfig const& getSorobanNetworkConfigForApply() = 0;
 
-    virtual bool hasSorobanNetworkConfig() const = 0;
+    virtual bool hasLastClosedSorobanNetworkConfig() const = 0;
 
 #ifdef BUILD_TESTS
-    virtual SorobanNetworkConfig& getMutableSorobanNetworkConfig() = 0;
+    virtual SorobanNetworkConfig& getMutableSorobanNetworkConfigForApply() = 0;
     virtual std::vector<TransactionMetaFrame> const&
     getLastClosedLedgerTxMeta() = 0;
     virtual void storeCurrentLedgerForTest(LedgerHeader const& header) = 0;

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -148,7 +148,7 @@ class SorobanMetrics;
 // ledger" is fairly atomic, and there is no distinction made between "apply"
 // and "close". But now that we have two threads, at least _within these
 // classes_ we endeavour to use the term "close" and "last closed" to refer to
-// the actions taken and varaibles updated by the main thread _after_ apply, and
+// the actions taken and variables updated by the main thread _after_ apply, and
 // the term "apply" to refer to actions taken and variables updated by the apply
 // thread.
 class LedgerManager

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -25,7 +25,7 @@ class SorobanMetrics;
 // A "logical" ledger takes on more structure as it flows through the system. It
 // begins as LedgerCloseData, which is just a txset and hash reference to a
 // ledger, coming out of SCP. But during apply it is transformed into an
-// ApplyLedgerOutput, which carries with it a full shapshot of the bucketlist.
+// ApplyLedgerOutput, which carries with it a full snapshot of the bucketlist.
 //
 // The tricky part of this flow involves the fact that work is being done by
 // _two threads_: on the left there is work by the main thread, and on the right

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -16,27 +16,141 @@ class LedgerCloseData;
 class Database;
 class SorobanMetrics;
 
-/**
- * LedgerManager maintains, in memory, a logical pair of ledgers:
- *
- *     1. The "current ledger", to which the transactions currently accumulating
- *        in memory (in the Herder) will be applied on the next ledger-close.
- *
- *     2. The "last-closed ledger" (LCL), which is the result of the most recent
- *        ledger-close. This ledger is the state most recently committed to the
- *        SQL store, is immutable, and is the basis for the transactions applied
- *        in "current". In other words, "current" begins as a copy of LCL and
- *        then is mutated by the transactions applied to it.
- *
- * LedgerManager also coordinates the incremental advance of these ledgers: the
- * process of closing ledgers, turning the current ledger into the next LCL, and
- * producing a new current ledger.
- *
- * Finally, LedgerManager triggers and responds to boundary conditions in the
- * life cycle of the application that "suddenly" alter the notions of "current"
- * and "LCL": process startup, desynchronization and resynchronization of the
- * current process with the rest of the network.
- */
+// This diagram provides a schematic of the flow of (logical) ledgers coming in
+// from the SCP-and-Herder consensus complex, passing through the
+// LedgerApplyManager (LAM) and LedgerManager (LM), and finally coming to rest
+// in the "last closed ledger" (LCL) variables in the LM. These will
+// subsequently be published to history but that's not relevant to this diagram.
+//
+// A "logical" ledger takes on more structure as it flows through the system. It
+// begins as LedgerCloseData, which is just a txset and hash reference to a
+// ledger, coming out of SCP. But during apply it is transformed into an
+// ApplyLedgerOutput, which carries with it a full shapshot of the bucketlist.
+//
+// The tricky part of this flow involves the fact that work is being done by
+// _two threads_: on the left there is work by the main thread, and on the right
+// the apply thread. Logical ledgers begin on the main thread, are transferred
+// over to the apply thread for the computationally intensive act of applying,
+// and are then transferred _back_ to the main thread (with a new bucketlist
+// snapshot) in order to update the LCL variables in the LM.
+//
+//                      ┌────────────────────┐
+//             ┌───┐    │      Herder        │   ┌─────┐
+//             │   │    │                    ├──►│     │
+//             │   │    │  Feeds SCP module, │◄──┤ SCP │
+//             │   │    │  emits consensus   │   │     │
+//             │   │    └──┬─────────────────┘   └─────┘
+//             │   │       │
+//             │   │       │
+//             │   │       │
+//        │    │   │    ┌──┼───────────────────────────┐
+//        │    │   │    │  │   LedgerApplyManager      │
+//        │    │   │    │  │                           │
+//        │    │   │    │  │  Assembles contiguous     │
+//      T │    │ M │    │  │  ledger sequence and      │
+//      i │    │ a │    │  │  feeds to apply thread    │
+//      m │    │ i │    │  │  (or triggers catchup)    │
+//      e │    │ n │    │  │                           │
+//        │    │   │    │  │ ┌───────────────────┐     │    ┌───┐
+//      p │    │ T │    │  ▼ │  mSyncingLedgers  │─────┼───►│   │
+//      a │    │ h │    │    └───────────────────┘     │    │   │
+//      s │    │ r │    │   L                     Q    │    │   │
+//      s │    │ e │    └──────────────────────────────┘    │   │
+//      i │    │ a │                                        │ A │
+//      n │    │ d │                                        │ p │
+//      g │    │   │    ┌──────────────────────┐            │ p │
+//        │    │   │    │                      │            │ l │
+//        │    │   │    │                      │            │ y │
+//        │    │   │    │                      │            │   │
+//        │    │   │    │    LedgerManager     │         A  │ T │
+//        │    │   │    │                      │            │ h │
+//        │    │   │    │ State and logic for  │            │ r │
+//        ▼    │   │    │ apply thread and     │            │ e │
+//             │   │    │ close, including     │            │ a │
+//             │   │    │ storing snapshot of  │            │ d │
+//             │   │    │ "last closed ledger" │            │   │
+//             │   │    │                      │            │   │
+//             │   │    │             LCL ◄────┼────────────┤   │
+//             │   │    │                      │            └──┬┘
+//             │   │    │                      │             ▲ ▼
+//             └───┘    │ mLastClosedLedger    │      ┌──────┴───┐
+//                      │ mLastClosedLedgerHAS │      │ DB       │
+//                      │ mLastClosedSnapshot ─┼─────►│ &        │
+//                      │                      │      │ Buckets  │
+//                      └──────────────────────┘      └──────────┘
+//
+//
+// The apply thread uses the buckets and database, as well as some state
+// variables in the LM. The remaining state variables of the LM, including the
+// LCL variables, are for the main thread. One of the LCL state variables is a
+// snapshot of the bucketlist. The bucketlist snapshots are immutable and
+// therefore trivially threadsafe, but may be lagging behind the newest
+// bucketlist formed by the apply thread.
+//
+// In more precise terms, 4 points on the diagram are labeled: L, Q, A, and LCL.
+// These are points where we can identify and relate some state variables and an
+// invariant order between them:
+//
+//     L -- LedgerApplyManagerImpl::mLargestLedgerSeqHeard tracks this, it is
+//          the ledger sequence number of the most recent ledger added to
+//          mSyncingLedgers (whether or not any ledgers are still _in_
+//          mSyncingLedgers, it may have been emptied by the apply thread).
+//
+//     Q -- LedgerApplyManagerImpl::mLastQueuedToApply tracks this, it is the
+//          ledger sequence number of the most recent ledger _dequeued_ from
+//          mSyncingLedgers and posted over to the apply thread. This does not
+//          mean it has been applied! Just posted to the apply thread.
+//
+//     A -- The LedgerCloseData::mLedgerSeq of the argument passed to
+//          LedgerManagerImpl::applyLedger tracks this, as well as the live
+//          state of the database and live bucketlist: they are updated
+//          synchronously from A-1 to A by applyLedger (and its callees).
+//          In other words A is the ledger _currently being applied_ by the
+//          apply thread, which might be behind Q if multiple ledgers have
+//          been posted to the apply thread but also moves ahead of LCL when
+//          the apply thread is running.
+//
+//   LCL -- LedgerManagerImpl::mLastClosedLedger.header.ledgerSeq tracks this.
+//          It is the ledger sequence number of the most recent ledger that has
+//          been posted back to the main thread _and received there and copied
+//          into the LCL variables_. It may be more than 1 ledger behind A if
+//          A is closing quickly and the main thread is busy: results are posted
+//          back to the main thread using a queue.
+//
+// The invariant is that LCL <= A <= Q <= L. Each can get arbitrarily far ahead
+// of the previous (for example of the network votes ahead of the current node,
+// or the current node is doing bulk catchup), and they can also all be equal
+// (for example if the current node just booted up, or is idle between ledgers);
+// but they must always be in this order.
+//
+// Note also that SCP nominates a value containing a txset which contains, by
+// hash reference, the LCL; so voting cannot actually start on ledger N until
+// LCL has arrived at N-1. This limits the maximum potential parallelism between
+// voting and applying. But we can still at least overlap the apply thread's big
+// synchronous CPU-and-IO-consuming activity with "other stuff the main thread
+// has to do" such as queueing and validating transactions, as well as stepping
+// SCP state machines through incoming SCP messages. In particular: if a _fast
+// supermajority_ of nodes votes to adopt ledger N, then a slower minority will
+// accept the externalize without voting themselves, and can do so even before
+// they've managed to catch their _own_ LCL up to ledger N-1. So there is some
+// benefit to the complexity here.
+//
+// To complicate matters a little more: applyLedger _can_ be called
+// synchronously from the main thread. It detects this condition and
+// synchronously completes ledger close, rather than posting back to itself.
+// This happens in the testsuite, we well as if the user disables parallel
+// ledger apply.
+//
+// Finally, a terminology note: the LedgerManager was originally only accessed
+// by a single thread (the main thread) but now has state variables used by both
+// main and apply threads, which can be confusing. Moreover from the perspective
+// of the protocol -- SCP messages and XDR structs -- the action of "closing a
+// ledger" is fairly atomic, and there is no distinction made between "apply"
+// and "close". But now that we have two threads, at least _within these
+// classes_ we endeavour to use the term "close" and "last closed" to refer to
+// the actions taken and varaibles updated by the main thread _after_ apply, and
+// the term "apply" to refer to actions taken and variables updated by the apply
+// thread.
 class LedgerManager
 {
   public:
@@ -98,8 +212,8 @@ class LedgerManager
     virtual LedgerHeaderHistoryEntry const&
     getLastClosedLedgerHeader() const = 0;
 
-    // Get bucketlist snapshot
-    virtual SearchableSnapshotConstPtr getCurrentLedgerStateSnaphot() = 0;
+    // Get bucketlist snapshot of LCL
+    virtual SearchableSnapshotConstPtr getLastClosedSnaphot() = 0;
 
     // return the HAS that corresponds to the last closed ledger as persisted in
     // the database
@@ -175,18 +289,18 @@ class LedgerManager
                  std::shared_ptr<HistoryArchive> archive,
                  std::set<std::shared_ptr<LiveBucket>> bucketsToRetain) = 0;
 
-    // Forcibly close the current ledger, applying `ledgerData` as the consensus
-    // changes.  This is normally done automatically as part of
-    // `valueExternalized()` during normal operation (in which case
-    // `calledViaExternalize` should be set to true), but can also be called
-    // directly by catchup (with `calledViaExternalize` false in this case).
-    virtual void closeLedger(LedgerCloseData const& ledgerData,
+    // Forcibly apply `ledgerData` to the current ledger, causing it to close.
+    // This is normally done automatically as part of `valueExternalized()`
+    // during normal operation (in which case `calledViaExternalize` should be
+    // set to true), but can also be called directly by catchup (with
+    // `calledViaExternalize` false in this case).
+    virtual void applyLedger(LedgerCloseData const& ledgerData,
                              bool calledViaExternalize) = 0;
 #ifdef BUILD_TESTS
     void
-    closeLedger(LedgerCloseData const& ledgerData)
+    applyLedger(LedgerCloseData const& ledgerData)
     {
-        closeLedger(ledgerData, /* externalize */ false);
+        applyLedger(ledgerData, /* externalize */ false);
     }
 #endif
 

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -54,7 +54,7 @@ class SorobanMetrics;
 //        │    │   │    │  │ ┌───────────────────┐     │    ┌───┐
 //      p │    │ T │    │  ▼ │  mSyncingLedgers  │─────┼───►│   │
 //      a │    │ h │    │    └───────────────────┘     │    │   │
-//      s │    │ r │    │   L                     Q    │    │   │
+//      s │    │ r │    │   H                     Q    │    │   │
 //      s │    │ e │    └──────────────────────────────┘    │   │
 //      i │    │ a │                                        │ A │
 //      n │    │ d │                                        │ p │
@@ -91,7 +91,7 @@ class SorobanMetrics;
 // These are points where we can identify and relate some state variables and an
 // invariant order between them:
 //
-//     L -- LedgerApplyManagerImpl::mLargestLedgerSeqHeard tracks this, it is
+//     H -- LedgerApplyManagerImpl::mLargestLedgerSeqHeard tracks this, it is
 //          the ledger sequence number of the most recent ledger added to
 //          mSyncingLedgers (whether or not any ledgers are still _in_
 //          mSyncingLedgers, it may have been emptied by the apply thread).
@@ -117,7 +117,7 @@ class SorobanMetrics;
 //          A is closing quickly and the main thread is busy: results are posted
 //          back to the main thread using a queue.
 //
-// The invariant is that LCL <= A <= Q <= L. Each can get arbitrarily far ahead
+// The invariant is that LCL <= A <= Q <= H. Each can get arbitrarily far ahead
 // of the previous (for example of the network votes ahead of the current node,
 // or the current node is doing bulk catchup), and they can also all be equal
 // (for example if the current node just booted up, or is idle between ledgers);

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -138,7 +138,7 @@ class SorobanMetrics;
 // To complicate matters a little more: applyLedger _can_ be called
 // synchronously from the main thread. It detects this condition and
 // synchronously completes ledger close, rather than posting back to itself.
-// This happens in the testsuite, we well as if the user disables parallel
+// This happens in the testsuite, as well as if the user disables parallel
 // ledger apply.
 //
 // Finally, a terminology note: the LedgerManager was originally only accessed

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -220,8 +220,7 @@ LedgerManagerImpl::getLCLState() const
     return mLastClosedLedgerState;
 }
 
-
-LedgerManagerImpl::LedgerState &
+LedgerManagerImpl::LedgerState&
 LedgerManagerImpl::getLCLState()
 {
     releaseAssert(threadIsMain());
@@ -365,11 +364,9 @@ LedgerManagerImpl::loadLastKnownLedger(bool restoreBucketlist)
     {
         // In no-history mode, this method should only be called when
         // the LCL is genesis.
-        releaseAssertOrThrow(getLCLState().ledgerHeader.hash ==
-                             lastLedgerHash);
-        releaseAssertOrThrow(
-            getLCLState().ledgerHeader.header.ledgerSeq ==
-            GENESIS_LEDGER_SEQ);
+        releaseAssertOrThrow(getLCLState().ledgerHeader.hash == lastLedgerHash);
+        releaseAssertOrThrow(getLCLState().ledgerHeader.header.ledgerSeq ==
+                             GENESIS_LEDGER_SEQ);
         CLOG_INFO(Ledger, "LCL is genesis: {}",
                   ledgerAbbrev(getLCLState().ledgerHeader));
         latestLedgerHeader = getLCLState().ledgerHeader.header;
@@ -425,8 +422,7 @@ LedgerManagerImpl::loadLastKnownLedger(bool restoreBucketlist)
         // configs right away
         LedgerTxn ltx(mApp.getLedgerTxnRoot());
         updateSorobanNetworkConfigForApply(ltx);
-        getLCLState().sorobanConfig =
-            mApplyState.mSorobanNetworkConfig;
+        getLCLState().sorobanConfig = mApplyState.mSorobanNetworkConfig;
     }
 }
 
@@ -1334,10 +1330,9 @@ LedgerManagerImpl::getLastClosedSnaphot()
 {
     if (!getLCLState().snapshot)
     {
-        getLCLState().snapshot =
-            mApp.getBucketManager()
-                .getBucketSnapshotManager()
-                .copySearchableLiveBucketListSnapshot();
+        getLCLState().snapshot = mApp.getBucketManager()
+                                     .getBucketSnapshotManager()
+                                     .copySearchableLiveBucketListSnapshot();
     }
     return getLCLState().snapshot;
 }
@@ -1612,10 +1607,12 @@ LedgerManagerImpl::applyTransactions(
     // Record counts
     if (numTxs > 0)
     {
-        mLedgerApplyMetrics.mTransactionCount.Update(static_cast<int64_t>(numTxs));
+        mLedgerApplyMetrics.mTransactionCount.Update(
+            static_cast<int64_t>(numTxs));
         TracyPlot("ledger.transaction.count", static_cast<int64_t>(numTxs));
 
-        mLedgerApplyMetrics.mOperationCount.Update(static_cast<int64_t>(numOps));
+        mLedgerApplyMetrics.mOperationCount.Update(
+            static_cast<int64_t>(numOps));
         TracyPlot("ledger.operation.count", static_cast<int64_t>(numOps));
         CLOG_INFO(Tx, "applying ledger {} ({})",
                   ltx.loadHeader().current().ledgerSeq, txSet.summary());
@@ -1707,7 +1704,8 @@ LedgerManagerImpl::applyTransactions(
 
     mLedgerApplyMetrics.mTransactionApplySucceeded.inc(txSucceeded);
     mLedgerApplyMetrics.mTransactionApplyFailed.inc(txFailed);
-    mLedgerApplyMetrics.mSorobanTransactionApplySucceeded.inc(sorobanTxSucceeded);
+    mLedgerApplyMetrics.mSorobanTransactionApplySucceeded.inc(
+        sorobanTxSucceeded);
     mLedgerApplyMetrics.mSorobanTransactionApplyFailed.inc(sorobanTxFailed);
     logTxApplyMetrics(ltx, numTxs, numOps);
     return txResultSet;

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -125,39 +125,40 @@ LedgerManager::ledgerAbbrev(LedgerHeaderHistoryEntry const& he)
     return ledgerAbbrev(he.header, he.hash);
 }
 
+LedgerManagerImpl::LedgerMetrics::LedgerMetrics(
+    medida::MetricsRegistry& registry)
+    : mTransactionApply(registry.NewTimer({"ledger", "transaction", "apply"}))
+    , mTransactionCount(
+          registry.NewHistogram({"ledger", "transaction", "count"}))
+    , mOperationCount(registry.NewHistogram({"ledger", "operation", "count"}))
+    , mPrefetchHitRate(
+          registry.NewHistogram({"ledger", "prefetch", "hit-rate"}))
+    , mLedgerClose(registry.NewTimer({"ledger", "ledger", "close"}))
+    , mLedgerAgeClosed(registry.NewBuckets({"ledger", "age", "closed"},
+                                           {5000.0, 7000.0, 10000.0, 20000.0}))
+    , mLedgerAge(registry.NewCounter({"ledger", "age", "current-seconds"}))
+    , mTransactionApplySucceeded(
+          registry.NewCounter({"ledger", "apply", "success"}))
+    , mTransactionApplyFailed(
+          registry.NewCounter({"ledger", "apply", "failure"}))
+    , mSorobanTransactionApplySucceeded(
+          registry.NewCounter({"ledger", "apply-soroban", "success"}))
+    , mSorobanTransactionApplyFailed(
+          registry.NewCounter({"ledger", "apply-soroban", "failure"}))
+    , mMetaStreamBytes(
+          registry.NewMeter({"ledger", "metastream", "bytes"}, "byte"))
+    , mMetaStreamWriteTime(registry.NewTimer({"ledger", "metastream", "write"}))
+{
+}
+
 LedgerManagerImpl::LedgerManagerImpl(Application& app)
     : mApp(app)
+    , mLedgerMetrics(app.getMetrics())
     , mSorobanMetrics(app.getMetrics())
-    , mTransactionApply(
-          app.getMetrics().NewTimer({"ledger", "transaction", "apply"}))
-    , mTransactionCount(
-          app.getMetrics().NewHistogram({"ledger", "transaction", "count"}))
-    , mOperationCount(
-          app.getMetrics().NewHistogram({"ledger", "operation", "count"}))
-    , mPrefetchHitRate(
-          app.getMetrics().NewHistogram({"ledger", "prefetch", "hit-rate"}))
-    , mLedgerClose(app.getMetrics().NewTimer({"ledger", "ledger", "close"}))
-    , mLedgerAgeClosed(app.getMetrics().NewBuckets(
-          {"ledger", "age", "closed"}, {5000.0, 7000.0, 10000.0, 20000.0}))
-    , mLedgerAge(
-          app.getMetrics().NewCounter({"ledger", "age", "current-seconds"}))
-    , mTransactionApplySucceeded(
-          app.getMetrics().NewCounter({"ledger", "apply", "success"}))
-    , mTransactionApplyFailed(
-          app.getMetrics().NewCounter({"ledger", "apply", "failure"}))
-    , mSorobanTransactionApplySucceeded(
-          app.getMetrics().NewCounter({"ledger", "apply-soroban", "success"}))
-    , mSorobanTransactionApplyFailed(
-          app.getMetrics().NewCounter({"ledger", "apply-soroban", "failure"}))
-    , mMetaStreamBytes(
-          app.getMetrics().NewMeter({"ledger", "metastream", "bytes"}, "byte"))
-    , mMetaStreamWriteTime(
-          app.getMetrics().NewTimer({"ledger", "metastream", "write"}))
     , mLastClose(mApp.getClock().now())
     , mCatchupDuration(
           app.getMetrics().NewTimer({"ledger", "catchup", "duration"}))
     , mState(LM_BOOTING_STATE)
-
 {
     setupLedgerCloseMetaStream();
 }
@@ -171,6 +172,8 @@ LedgerManagerImpl::moveToSynced()
 void
 LedgerManagerImpl::beginApply()
 {
+    releaseAssert(threadIsMain());
+
     // Go into "applying" state, this will prevent catchup from starting
     mCurrentlyApplyingLedger = true;
 
@@ -228,7 +231,7 @@ LedgerManager::genesisLedger()
 void
 LedgerManagerImpl::startNewLedger(LedgerHeader const& genesisLedger)
 {
-    auto ledgerTime = mLedgerClose.TimeScope();
+    auto ledgerTime = mLedgerMetrics.mLedgerClose.TimeScope();
     SecretKey skey = SecretKey::fromSeed(mApp.getNetworkID());
 
     LedgerTxn ltx(mApp.getLedgerTxnRoot(), false);
@@ -253,9 +256,10 @@ LedgerManagerImpl::startNewLedger(LedgerHeader const& genesisLedger)
     CLOG_INFO(Ledger, "Established genesis ledger, closing");
     CLOG_INFO(Ledger, "Root account: {}", skey.getStrKeyPublic());
     CLOG_INFO(Ledger, "Root account seed: {}", skey.getStrKeySeed().value);
-    auto output = ledgerApplied(ltx, /*ledgerCloseMeta*/ nullptr,
-                                /*initialLedgerVers*/ 0);
-    advanceLastClosedLedgerPointers(output);
+    auto output =
+        sealLedgerTxnAndStoreInBucketsAndDB(ltx, /*ledgerCloseMeta*/ nullptr,
+                                            /*initialLedgerVers*/ 0);
+    advanceLastClosedLedgerState(output);
 
     ltx.commit();
 }
@@ -346,12 +350,14 @@ LedgerManagerImpl::loadLastKnownLedger(bool restoreBucketlist)
     {
         // In no-history mode, this method should only be called when
         // the LCL is genesis.
-        releaseAssertOrThrow(mLastClosedLedger.hash == lastLedgerHash);
-        releaseAssertOrThrow(mLastClosedLedger.header.ledgerSeq ==
-                             GENESIS_LEDGER_SEQ);
+        releaseAssertOrThrow(mLastClosedLedgerState.ledgerHeader.hash ==
+                             lastLedgerHash);
+        releaseAssertOrThrow(
+            mLastClosedLedgerState.ledgerHeader.header.ledgerSeq ==
+            GENESIS_LEDGER_SEQ);
         CLOG_INFO(Ledger, "LCL is genesis: {}",
-                  ledgerAbbrev(mLastClosedLedger));
-        latestLedgerHeader = mLastClosedLedger.header;
+                  ledgerAbbrev(mLastClosedLedgerState.ledgerHeader));
+        latestLedgerHeader = mLastClosedLedgerState.ledgerHeader.header;
     }
 
     releaseAssert(latestLedgerHeader.has_value());
@@ -388,8 +394,9 @@ LedgerManagerImpl::loadLastKnownLedger(bool restoreBucketlist)
     }
 
     // Step 4. Restore LedgerManager's internal state
-    auto output = advanceLedgerStateSnapshot(*latestLedgerHeader, has);
-    advanceLastClosedLedgerPointers(output);
+    auto output =
+        advanceBucketListSnapshotAndMakeLedgerState(*latestLedgerHeader, has);
+    advanceLastClosedLedgerState(output);
 
     // Maybe truncate checkpoint files if we're restarting after a crash
     // in applyLedger (in which case any modifications to the ledger state have
@@ -402,8 +409,9 @@ LedgerManagerImpl::loadLastKnownLedger(bool restoreBucketlist)
         // Step 5. If ledger state is ready and core is in v20, load network
         // configs right away
         LedgerTxn ltx(mApp.getLedgerTxnRoot());
-        updateNetworkConfig(ltx);
-        mLastClosedSorobanNetworkConfig = mSorobanNetworkConfigForApply;
+        updateSorobanNetworkConfigForApply(ltx);
+        mLastClosedLedgerState.sorobanConfig =
+            mApplyState.mSorobanNetworkConfig;
     }
 }
 
@@ -417,16 +425,17 @@ uint32_t
 LedgerManagerImpl::getLastMaxTxSetSize() const
 {
     releaseAssert(threadIsMain());
-    return mLastClosedLedger.header.maxTxSetSize;
+    return mLastClosedLedgerState.ledgerHeader.header.maxTxSetSize;
 }
 
 uint32_t
 LedgerManagerImpl::getLastMaxTxSetSizeOps() const
 {
     releaseAssert(threadIsMain());
-    auto n = mLastClosedLedger.header.maxTxSetSize;
-    return protocolVersionStartsFrom(mLastClosedLedger.header.ledgerVersion,
-                                     ProtocolVersion::V_11)
+    auto n = mLastClosedLedgerState.ledgerHeader.header.maxTxSetSize;
+    return protocolVersionStartsFrom(
+               mLastClosedLedgerState.ledgerHeader.header.ledgerVersion,
+               ProtocolVersion::V_11)
                ? n
                : (n * MAX_OPS_PER_TX);
 }
@@ -438,7 +447,7 @@ LedgerManagerImpl::maxLedgerResources(bool isSoroban)
 
     if (isSoroban)
     {
-        return getSorobanNetworkConfigReadOnly().maxLedgerResources();
+        return getLastClosedSorobanNetworkConfig().maxLedgerResources();
     }
     else
     {
@@ -453,7 +462,7 @@ LedgerManagerImpl::maxSorobanTransactionResources()
     ZoneScoped;
 
     auto const& conf =
-        mApp.getLedgerManager().getSorobanNetworkConfigReadOnly();
+        mApp.getLedgerManager().getLastClosedSorobanNetworkConfig();
     int64_t const opCount = 1;
     std::vector<int64_t> limits = {opCount,
                                    conf.txMaxInstructions(),
@@ -469,7 +478,7 @@ int64_t
 LedgerManagerImpl::getLastMinBalance(uint32_t ownerCount) const
 {
     releaseAssert(threadIsMain());
-    auto const& lh = mLastClosedLedger.header;
+    auto const& lh = mLastClosedLedgerState.ledgerHeader.header;
     if (protocolVersionIsBefore(lh.ledgerVersion, ProtocolVersion::V_9))
         return (2 + ownerCount) * lh.baseReserve;
     else
@@ -480,65 +489,65 @@ uint32_t
 LedgerManagerImpl::getLastReserve() const
 {
     releaseAssert(threadIsMain());
-    return mLastClosedLedger.header.baseReserve;
+    return mLastClosedLedgerState.ledgerHeader.header.baseReserve;
 }
 
 uint32_t
 LedgerManagerImpl::getLastTxFee() const
 {
     releaseAssert(threadIsMain());
-    return mLastClosedLedger.header.baseFee;
+    return mLastClosedLedgerState.ledgerHeader.header.baseFee;
 }
 
 LedgerHeaderHistoryEntry const&
 LedgerManagerImpl::getLastClosedLedgerHeader() const
 {
     releaseAssert(threadIsMain());
-    return mLastClosedLedger;
+    return mLastClosedLedgerState.ledgerHeader;
 }
 
 HistoryArchiveState
 LedgerManagerImpl::getLastClosedLedgerHAS()
 {
     releaseAssert(threadIsMain());
-    return mLastClosedLedgerHAS;
+    return mLastClosedLedgerState.has;
 }
 
 uint32_t
 LedgerManagerImpl::getLastClosedLedgerNum() const
 {
     releaseAssert(threadIsMain());
-    return mLastClosedLedger.header.ledgerSeq;
+    return mLastClosedLedgerState.ledgerHeader.header.ledgerSeq;
 }
 
 SorobanNetworkConfig const&
-LedgerManagerImpl::getSorobanNetworkConfigReadOnly()
+LedgerManagerImpl::getLastClosedSorobanNetworkConfig()
 {
     releaseAssert(threadIsMain());
-    releaseAssert(hasSorobanNetworkConfig());
-    return *mLastClosedSorobanNetworkConfig;
+    releaseAssert(hasLastClosedSorobanNetworkConfig());
+    return *mLastClosedLedgerState.sorobanConfig;
 }
 
 SorobanNetworkConfig const&
 LedgerManagerImpl::getSorobanNetworkConfigForApply()
 {
-    releaseAssert(mSorobanNetworkConfigForApply);
-    return *mSorobanNetworkConfigForApply;
+    releaseAssert(mApplyState.mSorobanNetworkConfig);
+    return *mApplyState.mSorobanNetworkConfig;
 }
 
 bool
-LedgerManagerImpl::hasSorobanNetworkConfig() const
+LedgerManagerImpl::hasLastClosedSorobanNetworkConfig() const
 {
     releaseAssert(threadIsMain());
-    return static_cast<bool>(mLastClosedSorobanNetworkConfig);
+    return static_cast<bool>(mLastClosedLedgerState.sorobanConfig);
 }
 
 #ifdef BUILD_TESTS
 SorobanNetworkConfig&
-LedgerManagerImpl::getMutableSorobanNetworkConfig()
+LedgerManagerImpl::getMutableSorobanNetworkConfigForApply()
 {
     releaseAssert(threadIsMain());
-    return *mSorobanNetworkConfigForApply;
+    return *mApplyState.mSorobanNetworkConfig;
 }
 
 std::vector<TransactionMetaFrame> const&
@@ -550,7 +559,7 @@ LedgerManagerImpl::getLastClosedLedgerTxMeta()
 void
 LedgerManagerImpl::storeCurrentLedgerForTest(LedgerHeader const& header)
 {
-    storeCurrentLedger(header, true, true);
+    storePersistentStateAndLedgerHeaderInDB(header, true, true);
 }
 #endif
 
@@ -673,7 +682,7 @@ LedgerManagerImpl::secondsSinceLastLedgerClose() const
 void
 LedgerManagerImpl::syncMetrics()
 {
-    mLedgerAge.set_count(secondsSinceLastLedgerClose());
+    mLedgerMetrics.mLedgerAge.set_count(secondsSinceLastLedgerClose());
     mApp.syncOwnMetrics();
 }
 
@@ -687,13 +696,13 @@ LedgerManagerImpl::emitNextMeta()
     auto timer = LogSlowExecution("MetaStream write",
                                   LogSlowExecution::Mode::AUTOMATIC_RAII,
                                   "took", std::chrono::milliseconds(100));
-    auto streamWrite = mMetaStreamWriteTime.TimeScope();
+    auto streamWrite = mLedgerMetrics.mMetaStreamWriteTime.TimeScope();
     if (mMetaStream)
     {
         size_t written = 0;
         mMetaStream->writeOne(mNextMetaToEmit->getXDR(), nullptr, &written);
         mMetaStream->flush();
-        mMetaStreamBytes.Mark(written);
+        mLedgerMetrics.mMetaStreamBytes.Mark(written);
     }
     if (mMetaDebugStream)
     {
@@ -805,7 +814,7 @@ LedgerManagerImpl::applyLedger(LedgerCloseData const& ledgerData,
     mLastLedgerTxMeta.clear();
 #endif
     ZoneScoped;
-    auto ledgerTime = mLedgerClose.TimeScope();
+    auto ledgerTime = mLedgerMetrics.mLedgerClose.TimeScope();
     LogSlowExecution applyLedgerTime{"applyLedger",
                                      LogSlowExecution::Mode::MANUAL, "",
                                      std::chrono::milliseconds::max()};
@@ -834,11 +843,11 @@ LedgerManagerImpl::applyLedger(LedgerCloseData const& ledgerData,
     ZoneValue(static_cast<int64_t>(header.current().ledgerSeq));
 
     auto now = mApp.getClock().now();
-    mLedgerAgeClosed.Update(now - mLastClose);
+    mLedgerMetrics.mLedgerAgeClosed.Update(now - mLastClose);
     // mLastClose is only accessed by a single thread, so no synchronization
     // needed
     mLastClose = now;
-    mLedgerAge.set_count(0);
+    mLedgerMetrics.mLedgerAge.set_count(0);
 
     TxSetXDRFrameConstPtr txSet = ledgerData.getTxSet();
 
@@ -991,14 +1000,14 @@ LedgerManagerImpl::applyLedger(LedgerCloseData const& ledgerData,
     auto ledgerSeq = ltx.loadHeader().current().ledgerSeq;
     if (protocolVersionStartsFrom(maybeNewVersion, SOROBAN_PROTOCOL_VERSION))
     {
-        updateNetworkConfig(ltx);
+        updateSorobanNetworkConfigForApply(ltx);
     }
 
-    auto applyLedgerResult =
-        ledgerApplied(ltx, ledgerCloseMeta, initialLedgerVers);
+    LedgerState appliedLedgerState = sealLedgerTxnAndStoreInBucketsAndDB(
+        ltx, ledgerCloseMeta, initialLedgerVers);
 
     if (ledgerData.getExpectedHash() &&
-        *ledgerData.getExpectedHash() != applyLedgerResult.ledgerHeader.hash)
+        *ledgerData.getExpectedHash() != appliedLedgerState.ledgerHeader.hash)
     {
         throw std::runtime_error("Local node's ledger corrupted during close");
     }
@@ -1006,7 +1015,7 @@ LedgerManagerImpl::applyLedger(LedgerCloseData const& ledgerData,
     if (mMetaStream || mMetaDebugStream)
     {
         releaseAssert(ledgerCloseMeta);
-        ledgerCloseMeta->ledgerHeader() = applyLedgerResult.ledgerHeader;
+        ledgerCloseMeta->ledgerHeader() = appliedLedgerState.ledgerHeader;
 
         // At this point we've got a complete meta and we can store it to the
         // member variable: if we throw while committing below, we will at worst
@@ -1071,10 +1080,10 @@ LedgerManagerImpl::applyLedger(LedgerCloseData const& ledgerData,
     // Invoke completion handler on the _main_ thread: kick off publishing,
     // cleanup bucket files, notify herder to trigger next ledger
     auto completionHandler = [this, ledgerSeq, calledViaExternalize, ledgerData,
-                              ledgerOutput =
-                                  std::move(applyLedgerResult)]() mutable {
+                              appliedLedgerState =
+                                  std::move(appliedLedgerState)]() mutable {
         releaseAssert(threadIsMain());
-        advanceLastClosedLedgerPointers(ledgerOutput);
+        advanceLastClosedLedgerState(appliedLedgerState);
 
         // Step 5. Maybe kick off publishing on complete checkpoint files
         auto& hm = mApp.getHistoryManager();
@@ -1139,19 +1148,20 @@ LedgerManagerImpl::setLastClosedLedger(
     LedgerTxn ltx(mApp.getLedgerTxnRoot());
     auto header = ltx.loadHeader();
     header.current() = lastClosed.header;
-    auto has = storeCurrentLedger(header.current(), storeInDB,
-                                  /* appendToCheckpoint */ false);
+    auto has =
+        storePersistentStateAndLedgerHeaderInDB(header.current(), storeInDB,
+                                                /* appendToCheckpoint */ false);
     ltx.commit();
 
     mRebuildInMemoryState = false;
-    advanceLastClosedLedgerPointers(
-        advanceLedgerStateSnapshot(lastClosed.header, has));
+    advanceLastClosedLedgerState(
+        advanceBucketListSnapshotAndMakeLedgerState(lastClosed.header, has));
 
     LedgerTxn ltx2(mApp.getLedgerTxnRoot());
     if (protocolVersionStartsFrom(ltx2.loadHeader().current().ledgerVersion,
                                   SOROBAN_PROTOCOL_VERSION))
     {
-        mApp.getLedgerManager().updateNetworkConfig(ltx2);
+        mApp.getLedgerManager().updateSorobanNetworkConfigForApply(ltx2);
     }
 }
 
@@ -1168,8 +1178,8 @@ LedgerManagerImpl::manuallyAdvanceLedgerHeader(LedgerHeader const& header)
     has.fromString(mApp.getPersistentState().getState(
         PersistentState::kHistoryArchiveState,
         mApp.getDatabase().getSession()));
-    auto output = advanceLedgerStateSnapshot(header, has);
-    advanceLastClosedLedgerPointers(output);
+    auto output = advanceBucketListSnapshotAndMakeLedgerState(header, has);
+    advanceLastClosedLedgerState(output);
 }
 
 void
@@ -1305,42 +1315,39 @@ LedgerManagerImpl::maybeResetLedgerCloseMetaDebugStream(uint32_t ledgerSeq)
 SearchableSnapshotConstPtr
 LedgerManagerImpl::getLastClosedSnaphot()
 {
-    if (!mLastClosedSnapshot)
+    if (!mLastClosedLedgerState.snapshot)
     {
-        mLastClosedSnapshot = mApp.getBucketManager()
-                                  .getBucketSnapshotManager()
-                                  .copySearchableLiveBucketListSnapshot();
+        mLastClosedLedgerState.snapshot =
+            mApp.getBucketManager()
+                .getBucketSnapshotManager()
+                .copySearchableLiveBucketListSnapshot();
     }
-    return mLastClosedSnapshot;
+    return mLastClosedLedgerState.snapshot;
 }
 
 void
-LedgerManagerImpl::advanceLastClosedLedgerPointers(
-    ApplyLedgerOutput const& output)
+LedgerManagerImpl::advanceLastClosedLedgerState(LedgerState const& output)
 {
     releaseAssert(threadIsMain());
-    CLOG_DEBUG(
-        Ledger, "Advancing LCL: {} -> {}", ledgerAbbrev(mLastClosedLedger),
-        ledgerAbbrev(output.ledgerHeader.header, output.ledgerHeader.hash));
+    CLOG_DEBUG(Ledger, "Advancing LCL: {} -> {}",
+               ledgerAbbrev(mLastClosedLedgerState.ledgerHeader),
+               ledgerAbbrev(output.ledgerHeader));
 
     // Update ledger state as seen by the main thread
-    mLastClosedLedger = output.ledgerHeader;
-    mLastClosedLedgerHAS = output.has;
-    mLastClosedSorobanNetworkConfig = output.sorobanConfig;
-    mLastClosedSnapshot = output.snapshot;
+    mLastClosedLedgerState = output;
 }
 
-LedgerManagerImpl::ApplyLedgerOutput
-LedgerManagerImpl::advanceLedgerStateSnapshot(LedgerHeader const& header,
-                                              HistoryArchiveState const& has)
+LedgerManagerImpl::LedgerState
+LedgerManagerImpl::advanceBucketListSnapshotAndMakeLedgerState(
+    LedgerHeader const& header, HistoryArchiveState const& has)
 {
     auto ledgerHash = xdrSha256(header);
 
-    ApplyLedgerOutput res;
+    LedgerState res;
     res.ledgerHeader.hash = ledgerHash;
     res.ledgerHeader.header = header;
     res.has = has;
-    res.sorobanConfig = mSorobanNetworkConfigForApply;
+    res.sorobanConfig = mApplyState.mSorobanNetworkConfig;
 
     auto& bm = mApp.getBucketManager();
     auto liveSnapshot = std::make_unique<BucketListSnapshot<LiveBucket>>(
@@ -1358,19 +1365,19 @@ LedgerManagerImpl::advanceLedgerStateSnapshot(LedgerHeader const& header,
 }
 
 void
-LedgerManagerImpl::updateNetworkConfig(AbstractLedgerTxn& ltx)
+LedgerManagerImpl::updateSorobanNetworkConfigForApply(AbstractLedgerTxn& ltx)
 {
     ZoneScoped;
     uint32_t ledgerVersion = ltx.loadHeader().current().ledgerVersion;
 
     if (protocolVersionStartsFrom(ledgerVersion, SOROBAN_PROTOCOL_VERSION))
     {
-        if (!mSorobanNetworkConfigForApply)
+        if (!mApplyState.mSorobanNetworkConfig)
         {
-            mSorobanNetworkConfigForApply =
+            mApplyState.mSorobanNetworkConfig =
                 std::make_shared<SorobanNetworkConfig>();
         }
-        mSorobanNetworkConfigForApply->loadFromLedger(
+        mApplyState.mSorobanNetworkConfig->loadFromLedger(
             ltx, mApp.getConfig().CURRENT_LEDGER_PROTOCOL_VERSION,
             ledgerVersion);
         publishSorobanMetrics();
@@ -1588,10 +1595,10 @@ LedgerManagerImpl::applyTransactions(
     // Record counts
     if (numTxs > 0)
     {
-        mTransactionCount.Update(static_cast<int64_t>(numTxs));
+        mLedgerMetrics.mTransactionCount.Update(static_cast<int64_t>(numTxs));
         TracyPlot("ledger.transaction.count", static_cast<int64_t>(numTxs));
 
-        mOperationCount.Update(static_cast<int64_t>(numOps));
+        mLedgerMetrics.mOperationCount.Update(static_cast<int64_t>(numOps));
         TracyPlot("ledger.operation.count", static_cast<int64_t>(numOps));
         CLOG_INFO(Tx, "applying ledger {} ({})",
                   ltx.loadHeader().current().ledgerSeq, txSet.summary());
@@ -1616,7 +1623,7 @@ LedgerManagerImpl::applyTransactions(
             ZoneNamedN(txZone, "applyTransaction", true);
             auto mutableTxResult = mutableTxResults.at(resultIndex++);
 
-            auto txTime = mTransactionApply.TimeScope();
+            auto txTime = mLedgerMetrics.mTransactionApply.TimeScope();
             TransactionMetaFrame tm(ltx.loadHeader().current().ledgerVersion);
             CLOG_DEBUG(Tx, " tx#{} = {} ops={} txseq={} (@ {})", index,
                        hexAbbrev(tx->getContentsHash()), tx->getNumOperations(),
@@ -1681,10 +1688,10 @@ LedgerManagerImpl::applyTransactions(
         }
     }
 
-    mTransactionApplySucceeded.inc(txSucceeded);
-    mTransactionApplyFailed.inc(txFailed);
-    mSorobanTransactionApplySucceeded.inc(sorobanTxSucceeded);
-    mSorobanTransactionApplyFailed.inc(sorobanTxFailed);
+    mLedgerMetrics.mTransactionApplySucceeded.inc(txSucceeded);
+    mLedgerMetrics.mTransactionApplyFailed.inc(txFailed);
+    mLedgerMetrics.mSorobanTransactionApplySucceeded.inc(sorobanTxSucceeded);
+    mLedgerMetrics.mSorobanTransactionApplyFailed.inc(sorobanTxFailed);
     logTxApplyMetrics(ltx, numTxs, numOps);
     return txResultSet;
 }
@@ -1700,13 +1707,13 @@ LedgerManagerImpl::logTxApplyMetrics(AbstractLedgerTxn& ltx, size_t numTxs,
                ledgerSeq, numTxs, numOps, hitRate);
 
     // We lose a bit of precision here, as medida only accepts int64_t
-    mPrefetchHitRate.Update(std::llround(hitRate));
+    mLedgerMetrics.mPrefetchHitRate.Update(std::llround(hitRate));
     TracyPlot("ledger.prefetch.hit-rate", hitRate);
 }
 
 HistoryArchiveState
-LedgerManagerImpl::storeCurrentLedger(LedgerHeader const& header,
-                                      bool storeHeader, bool appendToCheckpoint)
+LedgerManagerImpl::storePersistentStateAndLedgerHeaderInDB(
+    LedgerHeader const& header, bool storeHeader, bool appendToCheckpoint)
 {
     ZoneScoped;
 
@@ -1751,7 +1758,7 @@ LedgerManagerImpl::storeCurrentLedger(LedgerHeader const& header,
 
 // NB: This is a separate method so a testing subclass can override it.
 void
-LedgerManagerImpl::transferLedgerEntriesToBucketList(
+LedgerManagerImpl::sealLedgerTxnAndTransferEntriesToBucketList(
     AbstractLedgerTxn& ltx,
     std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta,
     LedgerHeader lh, uint32_t initialLedgerVers)
@@ -1777,7 +1784,7 @@ LedgerManagerImpl::transferLedgerEntriesToBucketList(
             auto evictedState =
                 mApp.getBucketManager().resolveBackgroundEvictionScan(
                     ltxEvictions, lh.ledgerSeq, keys, initialLedgerVers,
-                    *mSorobanNetworkConfigForApply);
+                    *mApplyState.mSorobanNetworkConfig);
 
             if (protocolVersionStartsFrom(
                     initialLedgerVers,
@@ -1806,10 +1813,11 @@ LedgerManagerImpl::transferLedgerEntriesToBucketList(
             ltxEvictions.commit();
         }
 
-        mSorobanNetworkConfigForApply->maybeSnapshotBucketListSize(lh.ledgerSeq,
-                                                                   ltx, mApp);
+        mApplyState.mSorobanNetworkConfig->maybeSnapshotBucketListSize(
+            lh.ledgerSeq, ltx, mApp);
     }
 
+    // NB: getAllEntries seals the ltx.
     ltx.getAllEntries(initEntries, liveEntries, deadEntries);
     if (blEnabled)
     {
@@ -1818,8 +1826,8 @@ LedgerManagerImpl::transferLedgerEntriesToBucketList(
     }
 }
 
-LedgerManagerImpl::ApplyLedgerOutput
-LedgerManagerImpl::ledgerApplied(
+LedgerManagerImpl::LedgerState
+LedgerManagerImpl::sealLedgerTxnAndStoreInBucketsAndDB(
     AbstractLedgerTxn& ltx,
     std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta,
     uint32_t initialLedgerVers)
@@ -1853,7 +1861,7 @@ LedgerManagerImpl::ledgerApplied(
     // protocol version prior to the upgrade. Due to this, we must check the
     // initial protocol version of ledger instead of the ledger version of
     // the current ltx header, which may have been modified via an upgrade.
-    transferLedgerEntriesToBucketList(
+    sealLedgerTxnAndTransferEntriesToBucketList(
         ltx, ledgerCloseMeta, ltx.loadHeader().current(), initialLedgerVers);
     if (ledgerCloseMeta &&
         protocolVersionStartsFrom(initialLedgerVers, SOROBAN_PROTOCOL_VERSION))
@@ -1863,12 +1871,13 @@ LedgerManagerImpl::ledgerApplied(
             mApp.getConfig().EMIT_LEDGER_CLOSE_META_EXT_V1);
     }
 
-    ApplyLedgerOutput res;
+    LedgerState res;
     ltx.unsealHeader([this, &res](LedgerHeader& lh) {
         mApp.getBucketManager().snapshotLedger(lh);
-        auto has = storeCurrentLedger(lh, /* storeHeader */ true,
-                                      /* appendToCheckpoint */ true);
-        res = advanceLedgerStateSnapshot(lh, has);
+        auto has = storePersistentStateAndLedgerHeaderInDB(
+            lh, /* storeHeader */ true,
+            /* appendToCheckpoint */ true);
+        res = advanceBucketListSnapshotAndMakeLedgerState(lh, has);
     });
 
     return res;

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -70,7 +70,7 @@ class LedgerManagerImpl : public LedgerManager
         std::shared_ptr<SorobanNetworkConfig> mSorobanNetworkConfig;
     };
 
-    struct LedgerMetrics
+    struct LedgerApplyMetrics
     {
         medida::Timer& mTransactionApply;
         medida::Histogram& mTransactionCount;
@@ -85,7 +85,7 @@ class LedgerManagerImpl : public LedgerManager
         medida::Counter& mSorobanTransactionApplyFailed;
         medida::Meter& mMetaStreamBytes;
         medida::Timer& mMetaStreamWriteTime;
-        LedgerMetrics(medida::MetricsRegistry& registry);
+        LedgerApplyMetrics(medida::MetricsRegistry& registry);
     };
 
     // This state is private to the apply thread and holds work-in-progress
@@ -95,7 +95,7 @@ class LedgerManagerImpl : public LedgerManager
     // Cached LCL state output from last apply (or loaded from DB on startup).
     LedgerState mLastClosedLedgerState;
 
-    LedgerMetrics mLedgerMetrics;
+    LedgerApplyMetrics mLedgerApplyMetrics;
     SorobanMetrics mSorobanMetrics;
 
     VirtualClock::time_point mLastClose;
@@ -111,6 +111,9 @@ class LedgerManagerImpl : public LedgerManager
     // Use in the context of parallel ledger apply to indicate background thread
     // is currently closing a ledger or has ledgers queued to apply.
     bool mCurrentlyApplyingLedger{false};
+
+    LedgerState &getLCLState();
+    LedgerState const&getLCLState() const;
 
     static std::vector<MutableTxResultPtr> processFeesSeqNums(
         ApplicableTxSetFrame const& txSet, AbstractLedgerTxn& ltxOuter,

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -112,8 +112,8 @@ class LedgerManagerImpl : public LedgerManager
     // is currently closing a ledger or has ledgers queued to apply.
     bool mCurrentlyApplyingLedger{false};
 
-    LedgerState &getLCLState();
-    LedgerState const&getLCLState() const;
+    LedgerState& getLCLState();
+    LedgerState const& getLCLState() const;
 
     static std::vector<MutableTxResultPtr> processFeesSeqNums(
         ApplicableTxSetFrame const& txSet, AbstractLedgerTxn& ltxOuter,

--- a/src/ledger/LedgerStateSnapshot.cpp
+++ b/src/ledger/LedgerStateSnapshot.cpp
@@ -236,7 +236,7 @@ LedgerSnapshot::LedgerSnapshot(Application& app)
     else
 #endif
         mGetter = std::make_unique<BucketSnapshotState>(
-            app.getLedgerManager().getCurrentLedgerStateSnaphot());
+            app.getLedgerManager().getLastClosedSnaphot());
 }
 
 LedgerHeaderWrapper

--- a/src/ledger/test/LedgerHeaderTests.cpp
+++ b/src/ledger/test/LedgerHeaderTests.cpp
@@ -76,7 +76,7 @@ TEST_CASE("ledgerheader", "[ledger]")
             txSet->getContentsHash(), 1, emptyUpgradeSteps,
             app->getConfig().NODE_SEED);
         LedgerCloseData ledgerData(lcl.header.ledgerSeq + 1, txSet, sv);
-        app->getLedgerManager().closeLedger(ledgerData);
+        app->getLedgerManager().applyLedger(ledgerData);
 
         saved = app->getLedgerManager().getLastClosedLedgerHeader().hash;
     }

--- a/src/ledger/test/LedgerTests.cpp
+++ b/src/ledger/test/LedgerTests.cpp
@@ -26,7 +26,7 @@ TEST_CASE("cannot close ledger with unsupported ledger version", "[ledger]")
             app->getConfig().NODE_SEED);
 
         LedgerCloseData ledgerData(lcl.header.ledgerSeq + 1, txSet, sv);
-        app->getLedgerManager().closeLedger(ledgerData);
+        app->getLedgerManager().applyLedger(ledgerData);
     };
 
     applyEmptyLedger();

--- a/src/main/AppConnector.cpp
+++ b/src/main/AppConnector.cpp
@@ -47,10 +47,10 @@ AppConnector::getBanManager()
 }
 
 SorobanNetworkConfig const&
-AppConnector::getSorobanNetworkConfigReadOnly() const
+AppConnector::getLastClosedSorobanNetworkConfig() const
 {
     releaseAssert(threadIsMain());
-    return mApp.getLedgerManager().getSorobanNetworkConfigReadOnly();
+    return mApp.getLedgerManager().getLastClosedSorobanNetworkConfig();
 }
 
 SorobanNetworkConfig const&

--- a/src/main/AppConnector.h
+++ b/src/main/AppConnector.h
@@ -55,7 +55,7 @@ class AppConnector
     // This method is always exclusively called from one thread
     bool
     checkScheduledAndCache(std::shared_ptr<CapacityTrackedMessage> msgTracker);
-    SorobanNetworkConfig const& getSorobanNetworkConfigReadOnly() const;
+    SorobanNetworkConfig const& getLastClosedSorobanNetworkConfig() const;
     SorobanNetworkConfig const& getSorobanNetworkConfigForApply() const;
     bool threadIsType(Application::ThreadType type) const;
 

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -439,7 +439,7 @@ ApplicationImpl::getJsonInfo(bool verbose)
     info["ledger"]["baseFee"] = lcl.header.baseFee;
     info["ledger"]["baseReserve"] = lcl.header.baseReserve;
     info["ledger"]["maxTxSetSize"] = lcl.header.maxTxSetSize;
-    if (lm.hasSorobanNetworkConfig())
+    if (lm.hasLastClosedSorobanNetworkConfig())
     {
         info["ledger"]["maxSorobanTxSetSize"] =
             static_cast<Json::Int64>(lm.maxLedgerResources(/* isSoroban */ true)

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -744,7 +744,7 @@ CommandHandler::sorobanInfo(std::string const& params, std::string& retStr)
     ZoneScoped;
     auto& lm = mApp.getLedgerManager();
 
-    if (lm.hasSorobanNetworkConfig())
+    if (lm.hasLastClosedSorobanNetworkConfig())
     {
         std::map<std::string, std::string> retMap;
         http::server::server::parseParams(params, retMap);
@@ -761,7 +761,7 @@ CommandHandler::sorobanInfo(std::string const& params, std::string& retStr)
         if (format == "basic")
         {
             Json::Value res;
-            auto const& conf = lm.getSorobanNetworkConfigReadOnly();
+            auto const& conf = lm.getLastClosedSorobanNetworkConfig();
 
             // Contract size
             res["max_contract_size"] = conf.maxContractSizeBytes();

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -159,7 +159,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     CATCHUP_COMPLETE = false;
     CATCHUP_RECENT = 0;
     BACKGROUND_OVERLAY_PROCESSING = true;
-    EXPERIMENTAL_PARALLEL_LEDGER_CLOSE = false;
+    EXPERIMENTAL_PARALLEL_LEDGER_APPLY = false;
     BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT = 14; // 2^14 == 16 kb
     BUCKETLIST_DB_INDEX_CUTOFF = 250;            // 250 mb
     BUCKETLIST_DB_CACHED_PERCENT = 10;
@@ -1070,9 +1070,9 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                  }},
                 {"BACKGROUND_OVERLAY_PROCESSING",
                  [&]() { BACKGROUND_OVERLAY_PROCESSING = readBool(item); }},
-                {"EXPERIMENTAL_PARALLEL_LEDGER_CLOSE",
+                {"EXPERIMENTAL_PARALLEL_LEDGER_APPLY",
                  [&]() {
-                     EXPERIMENTAL_PARALLEL_LEDGER_CLOSE = readBool(item);
+                     EXPERIMENTAL_PARALLEL_LEDGER_APPLY = readBool(item);
                  }},
                 {"ARTIFICIALLY_DELAY_LEDGER_CLOSE_FOR_TESTING",
                  [&]() {
@@ -1793,12 +1793,12 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             throw std::runtime_error(msg);
         }
 
-        if (EXPERIMENTAL_PARALLEL_LEDGER_CLOSE && !parallelLedgerClose())
+        if (EXPERIMENTAL_PARALLEL_LEDGER_APPLY && !parallelLedgerClose())
         {
             std::string msg =
-                "Invalid configuration: EXPERIMENTAL_PARALLEL_LEDGER_CLOSE "
+                "Invalid configuration: EXPERIMENTAL_PARALLEL_LEDGER_APPLY "
                 "does not support SQLite. Either switch to Postgres or set "
-                "EXPERIMENTAL_PARALLEL_LEDGER_CLOSE=false";
+                "EXPERIMENTAL_PARALLEL_LEDGER_APPLY=false";
             throw std::runtime_error(msg);
         }
 
@@ -2105,9 +2105,9 @@ Config::logBasicInfo() const
              "{}",
              BACKGROUND_OVERLAY_PROCESSING ? "true" : "false");
     LOG_INFO(DEFAULT_LOG,
-             "EXPERIMENTAL_PARALLEL_LEDGER_CLOSE="
+             "EXPERIMENTAL_PARALLEL_LEDGER_APPLY="
              "{}",
-             EXPERIMENTAL_PARALLEL_LEDGER_CLOSE ? "true" : "false");
+             EXPERIMENTAL_PARALLEL_LEDGER_APPLY ? "true" : "false");
 }
 
 void
@@ -2405,7 +2405,7 @@ Config::modeStoresAnyHistory() const
 bool
 Config::parallelLedgerClose() const
 {
-    return EXPERIMENTAL_PARALLEL_LEDGER_CLOSE &&
+    return EXPERIMENTAL_PARALLEL_LEDGER_APPLY &&
            !(DATABASE.value.find("sqlite3://") != std::string::npos);
 }
 

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -478,7 +478,7 @@ class Config : public std::enable_shared_from_this<Config>
     bool BACKGROUND_OVERLAY_PROCESSING;
 
     // Enable parallel block application (experimental)
-    bool EXPERIMENTAL_PARALLEL_LEDGER_CLOSE;
+    bool EXPERIMENTAL_PARALLEL_LEDGER_APPLY;
 
     // When set to true, BucketListDB indexes are persisted on-disk so that the
     // BucketList does not need to be reindexed on startup. Defaults to true.

--- a/src/overlay/TxAdverts.cpp
+++ b/src/overlay/TxAdverts.cpp
@@ -204,7 +204,7 @@ TxAdverts::getMaxAdvertSize() const
                                       SOROBAN_PROTOCOL_VERSION))
         {
             auto limits =
-                mApp.getLedgerManager().getSorobanNetworkConfigReadOnly();
+                mApp.getLedgerManager().getLastClosedSorobanNetworkConfig();
             opsToFloodPerLedger += getOpsFloodLedger(
                 limits.ledgerMaxTxCount(), cfg.FLOOD_SOROBAN_RATE_PER_LEDGER);
         }

--- a/src/simulation/TxGenerator.cpp
+++ b/src/simulation/TxGenerator.cpp
@@ -1018,7 +1018,7 @@ TxGenerator::sorobanRandomUploadResources()
     // the chance that this instruction count is sufficient.
     ContractCostParamEntry vmInstantiationCosts =
         mApp.getLedgerManager()
-            .getSorobanNetworkConfigReadOnly()
+            .getLastClosedSorobanNetworkConfig()
             .cpuCostParams()[VmInstantiation];
     // Amount to right shift `vmInstantiationCosts.linearTerm * wasmSize` by
     uint32_t constexpr vmShiftTerm = 7;

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -929,7 +929,7 @@ class FuzzTransactionFrame : public TransactionFrame
         auto isInvalidOperation = [&](auto const& op, auto& opResult) {
             return !op->checkValid(
                 app.getAppConnector(), signatureChecker,
-                app.getAppConnector().getSorobanNetworkConfigReadOnly(),
+                app.getAppConnector().getLastClosedSorobanNetworkConfig(),
                 ltxStmt, false, opResult, mTxResult->getSorobanData());
         };
 

--- a/src/test/TestUtils.cpp
+++ b/src/test/TestUtils.cpp
@@ -254,7 +254,7 @@ upgradeSorobanNetworkConfig(std::function<void(SorobanNetworkConfig&)> modifyFn,
         LoadGenMode::SOROBAN_CREATE_UPGRADE, 1, 1, 1);
     createUpgradeLoadGenConfig.offset = offset;
     // Get current network config.
-    auto cfg = nodes[0]->getLedgerManager().getSorobanNetworkConfigReadOnly();
+    auto cfg = nodes[0]->getLedgerManager().getLastClosedSorobanNetworkConfig();
     modifyFn(cfg);
     createUpgradeLoadGenConfig.copySorobanNetworkConfigToUpgradeConfig(cfg);
     auto upgradeSetKey = lg.getConfigUpgradeSetKey(
@@ -283,7 +283,7 @@ upgradeSorobanNetworkConfig(std::function<void(SorobanNetworkConfig&)> modifyFn,
         simulation->crankUntil(
             [&]() {
                 auto netCfg =
-                    app.getLedgerManager().getSorobanNetworkConfigReadOnly();
+                    app.getLedgerManager().getLastClosedSorobanNetworkConfig();
                 return netCfg == cfg;
             },
             2 * Herder::EXP_LEDGER_TIMESPAN_SECONDS, false);
@@ -299,8 +299,8 @@ modifySorobanNetworkConfig(Application& app,
         return;
     }
     LedgerTxn ltx(app.getLedgerTxnRoot());
-    app.getLedgerManager().updateNetworkConfig(ltx);
-    auto& cfg = app.getLedgerManager().getMutableSorobanNetworkConfig();
+    app.getLedgerManager().updateSorobanNetworkConfigForApply(ltx);
+    auto& cfg = app.getLedgerManager().getMutableSorobanNetworkConfigForApply();
     modifyFn(cfg);
     cfg.writeAllSettings(ltx, app);
     ltx.commit();

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -372,7 +372,7 @@ applyCheck(TransactionTestFramePtr tx, Application& app, bool checkSeqNum)
         recordOrCheckGlobalTestTxMetadata(tm.getXDR());
     }
 
-    // TODO: in-memory mode doesn't work with parallel ledger close because
+    // TODO: in-memory mode doesn't work with parallel ledger apply because
     // it manually modifies LedgerTxn without closing a ledger; this results
     // in a different ledger header stored inside of LedgerTxn
     ltx.commit();
@@ -568,6 +568,10 @@ closeLedgerOn(Application& app, uint32 ledgerSeq, TimePoint closeTime,
     }
     app.getHerder().externalizeValue(txSet.first, ledgerSeq, closeTime,
                                      upgrades);
+    // NB: this assert will probably stop being true when background apply is
+    // turned on by default: externalize will have handed the ledger off to
+    // apply but not yet received the results of apply or updated LCL. The fix
+    // should be just to crank here until LCL advances to ledgerSeq.
     releaseAssert(app.getLedgerManager().getLastClosedLedgerNum() == ledgerSeq);
     auto& lm = static_cast<LedgerManagerImpl&>(app.getLedgerManager());
     return lm.mLatestTxResultSet;

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -933,7 +933,7 @@ sorobanResourceFee(Application& app, SorobanResources const& resources,
     auto feePair = TransactionFrame::computeSorobanResourceFee(
         app.getLedgerManager().getLastClosedLedgerHeader().header.ledgerVersion,
         resources, static_cast<uint32>(txSize), eventsSize,
-        app.getLedgerManager().getSorobanNetworkConfigReadOnly(),
+        app.getLedgerManager().getLastClosedSorobanNetworkConfig(),
         app.getConfig());
     return feePair.non_refundable_fee + feePair.refundable_fee;
 }

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -1558,7 +1558,7 @@ TransactionFrame::checkValidWithOptionallyChargedFee(
         isSoroban())
     {
         sorobanConfig =
-            app.getLedgerManager().getSorobanNetworkConfigReadOnly();
+            app.getLedgerManager().getLastClosedSorobanNetworkConfig();
         sorobanResourceFee = computePreApplySorobanResourceFee(
             ls.getLedgerHeader().current().ledgerVersion, sorobanConfig.value(),
             app.getConfig());

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -1030,7 +1030,7 @@ TEST_CASE("Soroban non-refundable resource fees are stable", "[tx][soroban]")
                 app.getLedgerManager()
                     .getLastClosedLedgerHeader()
                     .header.ledgerVersion,
-                app.getLedgerManager().getSorobanNetworkConfigReadOnly(),
+                app.getLedgerManager().getLastClosedSorobanNetworkConfig(),
                 app.getConfig());
         REQUIRE(expectedNonRefundableFee == actualFeePair.non_refundable_fee);
 
@@ -1121,7 +1121,7 @@ TEST_CASE("Soroban non-refundable resource fees are stable", "[tx][soroban]")
     // the test.
     test.getApp()
         .getLedgerManager()
-        .getMutableSorobanNetworkConfig()
+        .getMutableSorobanNetworkConfigForApply()
         .mFeeWrite1KB = 5000;
 
     SECTION("readBytes fee")
@@ -3455,7 +3455,7 @@ TEST_CASE("settings upgrade command line utils", "[tx][soroban][upgrades]")
     // Update bucketListTargetSizeBytes so bucketListWriteFeeGrowthFactor comes
     // into play
     auto const& blSize = app->getLedgerManager()
-                             .getSorobanNetworkConfigReadOnly()
+                             .getLastClosedSorobanNetworkConfig()
                              .getAverageBucketListSize();
     {
         LedgerTxn ltx(app->getLedgerTxnRoot());

--- a/src/transactions/test/SorobanTxTestUtils.cpp
+++ b/src/transactions/test/SorobanTxTestUtils.cpp
@@ -1055,7 +1055,7 @@ SorobanTest::getDummyAccount()
 SorobanNetworkConfig const&
 SorobanTest::getNetworkCfg()
 {
-    return getApp().getLedgerManager().getMutableSorobanNetworkConfig();
+    return getApp().getLedgerManager().getMutableSorobanNetworkConfigForApply();
 }
 
 uint32_t


### PR DESCRIPTION
This does a few things:
  1. Adds a big block comment to LedgerManager.h explaining the flow of ledgers through LedgerApplyManager and LedgerManager in more detail, as well as showing/describing the threading behaviour (assuming parallel apply).
  2. Renames various bits named "close" to "apply" when they are things-done-by-the-apply-thread or variables-touched-by-the-apply-thread, in order to more clearly differentiate "close" stuff (on main thread, tracking LCL) from "apply" stuff (on apply thread, possibly ahead of LCL).
  3. Partitions state between two structs in the LM, one for apply-state and one for LCL state.
  4. Recycles the output-from-the-apply-phase struct to _store_ the LCL state, since they had the same content.
  5. Moves the ledger metrics into a sub-struct just so they're a little less cluttered.
  6. Renames a few of the later-stages-of-apply/close from generic terms like `ledgerApplied` to more specific terms like `sealLedgerTxnAndStoreInBucketsAndDB`. It's a mouthful but you at least don't have to go re-read the function body each time you see a call to remember what it does.

The change is _nearly_ a no-op. Functionality-wise I only added two asserts that ought to (and appear to) always be true.