### PR TITLE
Increase maximum number of postgres connections used in tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
       # bother filing another.
       - name: Probe Cache
         id: cache
-        uses: actions/cache/restore@v3.3.1
+        uses: actions/cache/restore@v4
         with:
           path: ${{ env.CACHED_PATHS }}
           key: ${{ runner.os }}-${{ matrix.toolchain }}-${{ matrix.protocol }}-${{ github.sha }}
@@ -92,7 +92,7 @@ jobs:
       # This will restore the most-recently-written cache (github does this date ordering itself).
       - name: Restore Cache
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/cache/restore@v3.3.1
+        uses: actions/cache/restore@v4
         with:
           path: ${{ env.CACHED_PATHS }}
           key: ${{ steps.cache.outputs.cache-primary-key }}
@@ -144,7 +144,7 @@ jobs:
           ./ci-build.sh --use-temp-db --protocol ${{ matrix.protocol }} ${{ matrix.scenario }}
 
       # We only _save_ to the cache when we had a cache miss, are running on master, and are the non-txmeta scenario.
-      - uses: actions/cache/save@v3.3.1
+      - uses: actions/cache/save@v4
         if: ${{ steps.cache.outputs.cache-hit != 'true' && github.ref_name == 'master' && matrix.scenario == ''}}
         with:
           path: ${{ env.CACHED_PATHS }}

--- a/src/test/run-selftest-pg
+++ b/src/test/run-selftest-pg
@@ -84,6 +84,7 @@ logging_collector = yes
 fsync = no
 synchronous_commit = off
 full_page_writes = off
+max_connections = 1000
 EOF
     $PGCTL start -w -s &> /dev/null
 }


### PR DESCRIPTION
# Description

When running tests with lots of parallel partitions, tests would spin up too many connections to the temporary Postgres server we spin up for tests. This increases the maximum number of allowed connections to the temporary test server.

Also updates actions/cache to v4 since Github is deprecating it soon.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
