### PR TITLE
Changed random eviction cache to accounts only

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -235,13 +235,12 @@ MAX_DEX_TX_OPERATIONS_IN_TX_SET = 0
 # 0, indiviudal index is always used. Default page size 16 kb.
 BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT = 14
 
-# BUCKETLIST_DB_CACHED_PERCENT (Integer) default 10
-# Percentage of entries cached by BucketListDB when Bucket size is larger
-# than BUCKETLIST_DB_INDEX_CUTOFF. Note that this value does not impact
-# Buckets smaller than BUCKETLIST_DB_INDEX_CUTOFF, as they are always
-# completely held in memory. Roughly speaking, RAM usage for BucketList
-# cache == BucketListSize * (BUCKETLIST_DB_CACHED_PERCENT / 100).
-BUCKETLIST_DB_CACHED_PERCENT = 10
+# BUCKETLIST_DB_MEMORY_FOR_CACHING (Integer) default 3000
+# Memory used for caching entries by BucketListDB when Bucket size is
+# larger than BUCKETLIST_DB_INDEX_CUTOFF, in MB. Note that this value does
+# not impact Buckets smaller than BUCKETLIST_DB_INDEX_CUTOFF, as they are
+# always completely held in memory. If set to 0, caching is disabled.
+BUCKETLIST_DB_MEMORY_FOR_CACHING = 3000
 
 # BUCKETLIST_DB_INDEX_CUTOFF (Integer) default 100
 # Size, in MB, determining whether a bucket should have an individual

--- a/src/bucket/BucketIndexUtils.cpp
+++ b/src/bucket/BucketIndexUtils.cpp
@@ -19,8 +19,7 @@ namespace stellar
 std::streamoff
 getPageSizeFromConfig(Config const& cfg)
 {
-    if (cfg.BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT == 0 ||
-        cfg.BUCKETLIST_DB_CACHED_PERCENT == 100)
+    if (cfg.BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT == 0)
     {
         return 0;
     }

--- a/src/bucket/BucketIndexUtils.h
+++ b/src/bucket/BucketIndexUtils.h
@@ -98,6 +98,8 @@ std::streamoff getPageSizeFromConfig(Config const& cfg);
 // Builds index for given bucketfile. This is expensive (> 20 seconds
 // for the largest buckets) and should only be called once. Constructs a
 // DiskIndex or InMemoryIndex depending on config and Bucket size.
+// Note: Constructor does not initialize the cache for live bucket indexes,
+// as this must be done when the Bucket is being added to the BucketList
 template <class BucketT>
 std::unique_ptr<typename BucketT::IndexT const>
 createIndex(BucketManager& bm, std::filesystem::path const& filename,
@@ -105,6 +107,8 @@ createIndex(BucketManager& bm, std::filesystem::path const& filename,
 
 // Loads index from given file. If file does not exist or if saved
 // index does not have expected version or pageSize, return null
+// Note: Constructor does not initialize the cache for live bucket indexes,
+// as this must be done when the Bucket is being added to the BucketList
 template <class BucketT>
 std::unique_ptr<typename BucketT::IndexT const>
 loadIndex(BucketManager const& bm, std::filesystem::path const& filename,

--- a/src/bucket/BucketManager.cpp
+++ b/src/bucket/BucketManager.cpp
@@ -1291,6 +1291,9 @@ BucketManager::assumeState(HistoryArchiveState const& has,
         mLiveBucketList->getLevel(i).setNext(nextFuture);
     }
 
+    mLiveBucketList->maybeInitializeCaches(
+        mConfig.maxAccountsInBucketListCache());
+
     if (restartMerges)
     {
         mLiveBucketList->restartMerges(mApp, maxProtocolVersion,

--- a/src/bucket/BucketManager.cpp
+++ b/src/bucket/BucketManager.cpp
@@ -1291,8 +1291,7 @@ BucketManager::assumeState(HistoryArchiveState const& has,
         mLiveBucketList->getLevel(i).setNext(nextFuture);
     }
 
-    mLiveBucketList->maybeInitializeCaches(
-        mConfig.maxAccountsInBucketListCache());
+    mLiveBucketList->maybeInitializeCaches(mConfig);
 
     if (restartMerges)
     {

--- a/src/bucket/BucketUtils.cpp
+++ b/src/bucket/BucketUtils.cpp
@@ -348,6 +348,18 @@ BucketEntryCounters::numEntries() const
     return num;
 }
 
+BucketEntryCounters::BucketEntryCounters()
+{
+    for (uint32_t type =
+             static_cast<uint32_t>(LedgerEntryTypeAndDurability::ACCOUNT);
+         type < static_cast<uint32_t>(LedgerEntryTypeAndDurability::NUM_TYPES);
+         ++type)
+    {
+        entryTypeCounts[static_cast<LedgerEntryTypeAndDurability>(type)] = 0;
+        entryTypeSizes[static_cast<LedgerEntryTypeAndDurability>(type)] = 0;
+    }
+}
+
 template void
 BucketEntryCounters::count<LiveBucket>(LiveBucket::EntryT const& be);
 template void BucketEntryCounters::count<HotArchiveBucket>(

--- a/src/bucket/BucketUtils.h
+++ b/src/bucket/BucketUtils.h
@@ -208,6 +208,8 @@ struct BucketEntryCounters
     {
         ar(entryTypeCounts, entryTypeSizes);
     }
+
+    BucketEntryCounters();
 };
 
 template <class BucketT>

--- a/src/bucket/LiveBucket.cpp
+++ b/src/bucket/LiveBucket.cpp
@@ -431,6 +431,15 @@ LiveBucket::getBucketVersion() const
     return it.getMetadata().ledgerVersion;
 }
 
+void
+LiveBucket::maybeInitializeCache(size_t bucketListTotalAccounts,
+                                 size_t maxBucketListAccountsToCache) const
+{
+    releaseAssert(mIndex);
+    mIndex->maybeInitializeCache(bucketListTotalAccounts,
+                                 maxBucketListAccountsToCache);
+}
+
 BucketEntryCounters const&
 LiveBucket::getBucketEntryCounters() const
 {

--- a/src/bucket/LiveBucket.cpp
+++ b/src/bucket/LiveBucket.cpp
@@ -308,6 +308,17 @@ LiveBucket::apply(Application& app) const
     }
     counters.logInfo("direct", 0, app.getClock().now());
 }
+
+size_t
+LiveBucket::getMaxCacheSize() const
+{
+    if (!isEmpty())
+    {
+        return getIndex().getMaxCacheSize();
+    }
+
+    return 0;
+}
 #endif // BUILD_TESTS
 
 std::optional<std::pair<std::streamoff, std::streamoff>>
@@ -432,12 +443,11 @@ LiveBucket::getBucketVersion() const
 }
 
 void
-LiveBucket::maybeInitializeCache(size_t bucketListTotalAccounts,
-                                 size_t maxBucketListAccountsToCache) const
+LiveBucket::maybeInitializeCache(size_t totalBucketListAccountsSizeBytes,
+                                 Config const& cfg) const
 {
     releaseAssert(mIndex);
-    mIndex->maybeInitializeCache(bucketListTotalAccounts,
-                                 maxBucketListAccountsToCache);
+    mIndex->maybeInitializeCache(totalBucketListAccountsSizeBytes, cfg);
 }
 
 BucketEntryCounters const&

--- a/src/bucket/LiveBucket.h
+++ b/src/bucket/LiveBucket.h
@@ -83,6 +83,7 @@ class LiveBucket : public BucketBase<LiveBucket, LiveBucketIndex>,
     // entry in the database (respectively; if the entry is dead (a
     // tombstone), deletes the corresponding entry in the database.
     void apply(Application& app) const;
+    size_t getMaxCacheSize() const;
 #endif
 
     // Returns [lowerBound, upperBound) of file offsets for all offers in the
@@ -120,8 +121,12 @@ class LiveBucket : public BucketBase<LiveBucket, LiveBucketIndex>,
 
     uint32_t getBucketVersion() const;
 
-    void maybeInitializeCache(size_t bucketListTotalAccounts,
-                              size_t maxBucketListAccountsToCache) const;
+    // Initializes the random eviction cache if it has not already been
+    // initialized. totalBucketListAccountsSizeBytes is the total size, in
+    // bytes, of all BucketEntries in the BucketList that hold ACCOUNT entries,
+    // including INIT, LIVE and DEAD entries.
+    void maybeInitializeCache(size_t totalBucketListAccountsSizeBytes,
+                              Config const& cfg) const;
 
     BucketEntryCounters const& getBucketEntryCounters() const;
 

--- a/src/bucket/LiveBucket.h
+++ b/src/bucket/LiveBucket.h
@@ -120,6 +120,9 @@ class LiveBucket : public BucketBase<LiveBucket, LiveBucketIndex>,
 
     uint32_t getBucketVersion() const;
 
+    void maybeInitializeCache(size_t bucketListTotalAccounts,
+                              size_t maxBucketListAccountsToCache) const;
+
     BucketEntryCounters const& getBucketEntryCounters() const;
 
     friend class LiveBucketSnapshot;

--- a/src/bucket/LiveBucketIndex.h
+++ b/src/bucket/LiveBucketIndex.h
@@ -113,8 +113,12 @@ class LiveBucketIndex : public NonMovableOrCopyable
     // expose a memory limit in the validator config. To account for this, we
     // check what percentage of the total number of accounts are in this bucket
     // and allocate space accordingly.
-    void maybeInitializeCache(size_t bucketListTotalAccounts,
-                              size_t maxBucketListAccountsToCache) const;
+    //
+    // bucketListTotalAccountSizeBytes is the total size, in bytes, of all
+    // BucketEntries in the BucketList that hold ACCOUNT entries, including
+    // INIT, LIVE and DEAD entries.
+    void maybeInitializeCache(size_t bucketListTotalAccountSizeBytes,
+                              Config const& cfg) const;
 
     // Returns true if LedgerEntryType not supported by BucketListDB
     static bool typeNotSupported(LedgerEntryType t);
@@ -142,8 +146,7 @@ class LiveBucketIndex : public NonMovableOrCopyable
     void markBloomMiss() const;
 #ifdef BUILD_TESTS
     bool operator==(LiveBucketIndex const& in) const;
-
-    void clearCache() const;
+    size_t getMaxCacheSize() const;
 #endif
 };
 }

--- a/src/bucket/LiveBucketIndex.h
+++ b/src/bucket/LiveBucketIndex.h
@@ -59,13 +59,13 @@ class LiveBucketIndex : public NonMovableOrCopyable
         RandomEvictionCache<LedgerKey, std::shared_ptr<BucketEntry const>>;
 
   private:
-    std::unique_ptr<DiskIndex<LiveBucket> const> mDiskIndex;
-    std::unique_ptr<InMemoryIndex const> mInMemoryIndex;
-    std::unique_ptr<CacheT> mCache;
+    std::unique_ptr<DiskIndex<LiveBucket> const> mDiskIndex{};
+    std::unique_ptr<InMemoryIndex const> mInMemoryIndex{};
 
     // The indexes themselves are thread safe, as they are immutable after
     // construction. The cache is not, all accesses must first acquire this
     // mutex.
+    mutable std::unique_ptr<CacheT> mCache{};
     mutable std::shared_mutex mCacheMutex;
 
     medida::Meter& mCacheHitMeter;
@@ -83,11 +83,12 @@ class LiveBucketIndex : public NonMovableOrCopyable
         return std::get<InMemoryIndex::IterT>(iter);
     }
 
-    bool
-    shouldUseCache() const
-    {
-        return mDiskIndex && mCache;
-    }
+    bool shouldUseCache() const;
+
+    // Because we already have an LTX level cache at apply time, we only need to
+    // cache entry types that are used during TX validation and flooding.
+    // Currently, that is only ACCOUNT.
+    static bool isCachedType(LedgerKey const& lk);
 
     // Returns nullptr if cache is not enabled or entry not found
     std::shared_ptr<BucketEntry const> getCachedEntry(LedgerKey const& k) const;
@@ -97,13 +98,23 @@ class LiveBucketIndex : public NonMovableOrCopyable
     inline static const uint32_t BUCKET_INDEX_VERSION = 5;
 
     // Constructor for creating new index from Bucketfile
+    // Note: Constructor does not initialize the cache
     LiveBucketIndex(BucketManager& bm, std::filesystem::path const& filename,
                     Hash const& hash, asio::io_context& ctx, SHA256* hasher);
 
     // Constructor for loading pre-existing index from disk
+    // Note: Constructor does not initialize the cache
     template <class Archive>
     LiveBucketIndex(BucketManager const& bm, Archive& ar,
                     std::streamoff pageSize);
+
+    // Initializes the random eviction cache if it has not already been
+    // initialized. The random eviction cache itself has an entry limit, but we
+    // expose a memory limit in the validator config. To account for this, we
+    // check what percentage of the total number of accounts are in this bucket
+    // and allocate space accordingly.
+    void maybeInitializeCache(size_t bucketListTotalAccounts,
+                              size_t maxBucketListAccountsToCache) const;
 
     // Returns true if LedgerEntryType not supported by BucketListDB
     static bool typeNotSupported(LedgerEntryType t);

--- a/src/bucket/LiveBucketList.h
+++ b/src/bucket/LiveBucketList.h
@@ -50,6 +50,10 @@ class LiveBucketList : public BucketListBase<LiveBucket>
                   std::vector<LedgerKey> const& deadEntries);
 
     BucketEntryCounters sumBucketEntryCounters() const;
+
+    // Initializes any uninitialized caches in the BucketIndex. Should be called
+    // after every time buckets may have changed in the LiveBucketList.
+    void maybeInitializeCaches(size_t maxBucketListAccountsToCache) const;
 };
 
 }

--- a/src/bucket/LiveBucketList.h
+++ b/src/bucket/LiveBucketList.h
@@ -53,7 +53,7 @@ class LiveBucketList : public BucketListBase<LiveBucket>
 
     // Initializes any uninitialized caches in the BucketIndex. Should be called
     // after every time buckets may have changed in the LiveBucketList.
-    void maybeInitializeCaches(size_t maxBucketListAccountsToCache) const;
+    void maybeInitializeCaches(Config const& cfg) const;
 };
 
 }

--- a/src/bucket/readme.md
+++ b/src/bucket/readme.md
@@ -97,8 +97,8 @@ lookup speed and memory overhead. The following configuration flags control thes
     on startup. Defaults to true, should only be set to false for testing purposes.
     Validators do not currently support persisted indexes. If NODE_IS_VALIDATOR=true,
     this value is ignored and indexes are never persisted.
-- `BUCKETLIST_DB_CACHED_PERCENT`
-  - Percentage of entries cached by BucketListDB when Bucket size is larger
-    than `BUCKETLIST_DB_INDEX_CUTOFF`. Note that this value does not impact
+- `BUCKETLIST_DB_MEMORY_FOR_CACHING`
+  - Memory used for caching entries by BucketListDB when Bucket size is larger
+    than `BUCKETLIST_DB_INDEX_CUTOFF`, in MB. Note that this value does not impact
     Buckets smaller than `BUCKETLIST_DB_INDEX_CUTOFF`, as they are always
     completely held in memory.

--- a/src/ledger/test/LedgerTestUtils.cpp
+++ b/src/ledger/test/LedgerTestUtils.cpp
@@ -788,6 +788,28 @@ generateValidUniqueLedgerEntriesWithTypes(
     return entries;
 }
 
+std::vector<LedgerEntry>
+generateValidUniqueLedgerEntriesWithTypes(
+    std::unordered_set<LedgerEntryType> const& types, size_t n,
+    UnorderedSet<LedgerKey>& seenKeys)
+{
+    std::vector<LedgerEntry> entries;
+    entries.reserve(n);
+    while (entries.size() < n)
+    {
+        auto entry = generateValidLedgerEntryWithTypes(types);
+        auto key = LedgerEntryKey(entry);
+        if (seenKeys.find(key) != seenKeys.end())
+        {
+            continue;
+        }
+
+        seenKeys.insert(key);
+        entries.push_back(entry);
+    }
+    return entries;
+}
+
 AccountEntry
 generateValidAccountEntry(size_t b)
 {

--- a/src/ledger/test/LedgerTestUtils.h
+++ b/src/ledger/test/LedgerTestUtils.h
@@ -69,6 +69,10 @@ LedgerEntry generateValidLedgerEntryWithTypes(
 std::vector<LedgerEntry> generateValidUniqueLedgerEntriesWithTypes(
     std::unordered_set<LedgerEntryType> const& types, size_t n);
 
+std::vector<LedgerEntry> generateValidUniqueLedgerEntriesWithTypes(
+    std::unordered_set<LedgerEntryType> const& types, size_t n,
+    UnorderedSet<LedgerKey>& seenKeys);
+
 AccountEntry generateValidAccountEntry(size_t b = 3);
 std::vector<AccountEntry> generateValidAccountEntries(size_t n);
 

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -2428,18 +2428,6 @@ Config::setNoPublish()
     }
 }
 
-size_t
-Config::maxAccountsInBucketListCache() const
-{
-    // Default BucketEntry is a LIVEENTRY with an account, so we can use it to
-    // convert from max memory to max account entries
-    size_t const accountSize =
-        xdr::xdr_traits<BucketEntry>::serial_size(BucketEntry{});
-
-    // Convert from MB to bytes
-    return (BUCKETLIST_DB_MEMORY_FOR_CACHING * 1024 * 1024) / accountSize;
-}
-
 SCPQuorumSet
 Config::generateQuorumSetHelper(
     std::vector<ValidatorEntry>::const_iterator begin,

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -4,6 +4,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "main/Config.h"
+#include "bucket/BucketIndexUtils.h"
 #include "bucket/LiveBucketList.h"
 #include "crypto/KeyUtils.h"
 #include "herder/Herder.h"
@@ -162,7 +163,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     EXPERIMENTAL_PARALLEL_LEDGER_APPLY = false;
     BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT = 14; // 2^14 == 16 kb
     BUCKETLIST_DB_INDEX_CUTOFF = 250;            // 250 mb
-    BUCKETLIST_DB_CACHED_PERCENT = 10;
+    BUCKETLIST_DB_MEMORY_FOR_CACHING = 3'000;    // 3000 mb
     BUCKETLIST_DB_PERSIST_INDEX = true;
     PUBLISH_TO_ARCHIVE_DELAY = std::chrono::seconds{0};
     // automatic maintenance settings:
@@ -1142,10 +1143,9 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                      BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT =
                          readInt<size_t>(item);
                  }},
-                {"BUCKETLIST_DB_CACHED_PERCENT",
+                {"BUCKETLIST_DB_MEMORY_FOR_CACHING",
                  [&]() {
-                     BUCKETLIST_DB_CACHED_PERCENT =
-                         readInt<size_t>(item, 0, 100);
+                     BUCKETLIST_DB_MEMORY_FOR_CACHING = readInt<size_t>(item);
                  }},
                 {"BUCKETLIST_DB_INDEX_CUTOFF",
                  [&]() { BUCKETLIST_DB_INDEX_CUTOFF = readInt<size_t>(item); }},
@@ -2426,6 +2426,18 @@ Config::setNoPublish()
     {
         item.second.mPutCmd = "";
     }
+}
+
+size_t
+Config::maxAccountsInBucketListCache() const
+{
+    // Default BucketEntry is a LIVEENTRY with an account, so we can use it to
+    // convert from max memory to max account entries
+    size_t const accountSize =
+        xdr::xdr_traits<BucketEntry>::serial_size(BucketEntry{});
+
+    // Convert from MB to bytes
+    return (BUCKETLIST_DB_MEMORY_FOR_CACHING * 1024 * 1024) / accountSize;
 }
 
 SCPQuorumSet

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -812,10 +812,6 @@ class Config : public std::enable_shared_from_this<Config>
     void setNoListen();
     void setNoPublish();
 
-    // Returns max number of accounts that can be cached in the entire
-    // BucketList
-    size_t maxAccountsInBucketListCache() const;
-
     // function to stringify a quorum set
     std::string toString(SCPQuorumSet const& qset);
 

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -461,11 +461,11 @@ class Config : public std::enable_shared_from_this<Config>
     // 2^BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT.
     size_t BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT;
 
-    // Percentage of entries cached by BucketListDB when Bucket size is larger
-    // than BUCKETLIST_DB_INDEX_CUTOFF. Note that this value does not impact
-    // Buckets smaller than BUCKETLIST_DB_INDEX_CUTOFF, as they are always
-    // completely held in memory.
-    size_t BUCKETLIST_DB_CACHED_PERCENT;
+    // Memory used for caching entries by BucketListDB when Bucket size is
+    // larger than BUCKETLIST_DB_INDEX_CUTOFF, in MB. Note that this value does
+    // not impact Buckets smaller than BUCKETLIST_DB_INDEX_CUTOFF, as they are
+    // always completely held in memory. If set to 0, caching is disabled.
+    size_t BUCKETLIST_DB_MEMORY_FOR_CACHING;
 
     // Size, in MB, determining whether a bucket should have an individual
     // key index or a key range index. If bucket size is below this value, range
@@ -811,6 +811,10 @@ class Config : public std::enable_shared_from_this<Config>
     bool parallelLedgerClose() const;
     void setNoListen();
     void setNoPublish();
+
+    // Returns max number of accounts that can be cached in the entire
+    // BucketList
+    size_t maxAccountsInBucketListCache() const;
 
     // function to stringify a quorum set
     std::string toString(SCPQuorumSet const& qset);

--- a/src/util/RandomEvictionCache.h
+++ b/src/util/RandomEvictionCache.h
@@ -95,14 +95,11 @@ class RandomEvictionCache : public NonMovableOrCopyable
         mValuePtrs.reserve(maxSize + 1);
     }
 
-    RandomEvictionCache(size_t maxSize, bool separatePRNG, bool reserve = true)
+    RandomEvictionCache(size_t maxSize, bool separatePRNG)
         : mMaxSize(maxSize), mSeparatePRNG(separatePRNG)
     {
-        if (reserve)
-        {
-            mValueMap.reserve(maxSize + 1);
-            mValuePtrs.reserve(maxSize + 1);
-        }
+        mValueMap.reserve(maxSize + 1);
+        mValuePtrs.reserve(maxSize + 1);
     }
 
     void


### PR DESCRIPTION
# Description

This change adds a configurable memory based cap to the LiveBucketList random eviction cache. It also modifies the cache such that only accounts are stored.

Following initial testing, the random eviction cache improved TX flooding performance, but had virtually no effect on apply time. This makes sense, since apply time already leverages the ltx cache and only makes at most one disk read per ledger entry. TX flooding on the other hand has no such queue and constantly re reads entries off disk. Given that we already have an ltx cache for apply time, it makes sense to only cache the entry types that are used by transaction flooding (i.e. `ACCOUNT`).

My initial default setting is to cache 3 GB. Currently accounts take up about 2.5 GB in the BucketList, so this allows us to cache all accounts with some room for growth, and 3 GB seems like a modest increase in RAM requirements for validators.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
