### PR TITLE
Fix race in DownloadBucketsWork

### DIFF
--- a/src/historywork/DownloadBucketsWork.h
+++ b/src/historywork/DownloadBucketsWork.h
@@ -25,6 +25,9 @@ class DownloadBucketsWork : public BatchWork
 
     // Store indexes of downloaded buckets
     std::map<int, std::unique_ptr<LiveBucketIndex const>> mIndexMap;
+
+    // Must be held when accessing mIndexMap
+    std::mutex mIndexMapMutex;
     int mIndexId{0};
 
   public:


### PR DESCRIPTION
# Description

Fixes a potential race in `DownloadBucketsWork`, where the parent `Work` could modify a map while the child `Work` on a potentially different thread held an iterator to that map.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
