### PR TITLE
re-test sorobans against their observations with core-chosen rust compiler

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -119,6 +119,10 @@ RUST_TOOLCHAIN_FILE=$(top_srcdir)/rust-toolchain.toml
 RUST_TOOLCHAIN_CHANNEL=$(shell sed -n 's/channel *= *"\([^"]*\)"/\1/p' $(RUST_TOOLCHAIN_FILE))
 CARGO=cargo +$(RUST_TOOLCHAIN_CHANNEL)
 
+# we pass RUST_TOOLCHAIN_CHANNEL by environment variable
+# to tests since they can't take command-line arguments.
+export RUST_TOOLCHAIN_CHANNEL
+
 RUST_BUILD_DIR=$(top_builddir)/src/rust
 RUST_BIN_DIR=$(RUST_BUILD_DIR)/bin
 RUST_TARGET_DIR=$(top_builddir)/target
@@ -313,6 +317,7 @@ else # !USE_POSTGRES
 TESTS=test/selftest-nopg
 endif # !USE_POSTGRES
 TESTS += test/check-nondet
+TESTS += test/check-sorobans
 
 format: always
 if USE_CLANG_FORMAT

--- a/src/test/check-sorobans
+++ b/src/test/check-sorobans
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# Copyright 2025 Stellar Development Foundation and contributors. Licensed
+# under the Apache License, Version 2.0. See the COPYING file at the root
+# of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+# This file re-runs all the tests in each soroban submodule, using the rustc
+# that stellar-core is compiled with. In theory these tests shouldn't be broken
+# very often since there's CI on the soroban repos, but it's still possible that
+# the soroban CI ran on a different rust compiler / stdlib version than
+# stellar-core was built with, and the fine-grained "observations" stored in the
+# soroban repos are worth re-checking.
+
+if [ -z "${RUST_TOOLCHAIN_CHANNEL}" ];
+then
+    echo "RUST_TOOLCHAIN_CHANNEL must be set to the channel of the rust compiler that stellar-core was built with"
+    exit 1
+fi
+
+set -e
+set -x
+
+cd rust/soroban
+for i in p??; do
+    cd $i
+    RUSTFLAGS="-Cmetadata=${i}" cargo +${RUST_TOOLCHAIN_CHANNEL} \
+        test \
+        --locked \
+        --package soroban-env-host \
+        --features testutils \
+        --profile test-opt
+    cd ..
+done


### PR DESCRIPTION
# Description

This just adds an entry to `make check` to re-run the tests of each soroban module using the toolchain that stellar-core is building soroban with. This will catch early any divergence from observation caused by differences between the rust toolchain soroban tested itself against in CI vs. the one core is being built with. It's a small window of difference, but possible. 

Resolves https://github.com/stellar/rs-soroban-env/issues/1518 
