### PR TITLE
Better behavior when BucketListDB account cache disabled

### DIFF
--- a/src/bucket/LiveBucketIndex.cpp
+++ b/src/bucket/LiveBucketIndex.cpp
@@ -103,15 +103,15 @@ LiveBucketIndex::maybeInitializeCache(size_t totalBucketListAccountsSizeBytes,
         mDiskIndex->getBucketEntryCounters().entryTypeCounts.at(
             LedgerEntryTypeAndDurability::ACCOUNT);
 
-    // Nothing to cache
-    if (accountsInThisBucket == 0)
-    {
-        return;
-    }
-
     // Convert from MB to bytes, max size for entire BucketList cache
     auto maxBucketListBytesToCache =
         cfg.BUCKETLIST_DB_MEMORY_FOR_CACHING * 1024 * 1024;
+
+    // Nothing to cache. or cache is disabled
+    if (accountsInThisBucket == 0 || maxBucketListBytesToCache == 0)
+    {
+        return;
+    }
 
     std::unique_lock<std::shared_mutex> lock(mCacheMutex);
     if (totalBucketListAccountsSizeBytes < maxBucketListBytesToCache)


### PR DESCRIPTION
# Description

This improves behavior when the account cache is disabled in BucketListDB. Previously, `BUCKETLIST_DB_MEMORY_FOR_CACHING == 0` was still valid, but we would still create a random eviction cache object that had no capacity. This change makes is such that we don't construct the cache at all in this case. I've also added an explicit test.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
