### PR TITLE
Reduce BucketListDB configs

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -235,20 +235,20 @@ MAX_DEX_TX_OPERATIONS_IN_TX_SET = 0
 # 0, indiviudal index is always used. Default page size 16 kb.
 BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT = 14
 
-# BUCKETLIST_DB_MEMORY_FOR_CACHING (Integer) default 3000
+# BUCKETLIST_DB_MEMORY_FOR_CACHING (Integer) default 0
 # Memory used for caching entries by BucketListDB when Bucket size is
 # larger than BUCKETLIST_DB_INDEX_CUTOFF, in MB. Note that this value does
 # not impact Buckets smaller than BUCKETLIST_DB_INDEX_CUTOFF, as they are
 # always completely held in memory. If set to 0, caching is disabled.
-BUCKETLIST_DB_MEMORY_FOR_CACHING = 3000
+BUCKETLIST_DB_MEMORY_FOR_CACHING = 0
 
-# BUCKETLIST_DB_INDEX_CUTOFF (Integer) default 100
+# BUCKETLIST_DB_INDEX_CUTOFF (Integer) default 50
 # Size, in MB, determining whether a bucket should have an individual
 # key index or a key range index. If bucket size is below this value, range
 # based index will be used. If set to 0, all buckets are range indexed. If
 # BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT == 0, value ignored and all
 # buckets have individual key index.
-BUCKETLIST_DB_INDEX_CUTOFF = 100
+BUCKETLIST_DB_INDEX_CUTOFF = 50
 
 # BUCKETLIST_DB_PERSIST_INDEX (bool) default true
 # Determines whether BucketListDB indexes are saved to disk for faster

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -161,8 +161,8 @@ Config::Config() : NODE_SEED(SecretKey::random())
     BACKGROUND_OVERLAY_PROCESSING = true;
     EXPERIMENTAL_PARALLEL_LEDGER_APPLY = false;
     BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT = 14; // 2^14 == 16 kb
-    BUCKETLIST_DB_INDEX_CUTOFF = 250;            // 250 mb
-    BUCKETLIST_DB_MEMORY_FOR_CACHING = 3'000;    // 3000 mb
+    BUCKETLIST_DB_INDEX_CUTOFF = 50;             // 50 mb
+    BUCKETLIST_DB_MEMORY_FOR_CACHING = 0;
     BUCKETLIST_DB_PERSIST_INDEX = true;
     PUBLISH_TO_ARCHIVE_DELAY = std::chrono::seconds{0};
     // automatic maintenance settings:


### PR DESCRIPTION
# Description

Reduces `BUCKETLIST_DB_INDEX_CUTOFF` to 50 and disables account caching by default.

During testing, I determined `BUCKETLIST_DB_INDEX_CUTOFF` to be a reasonable value wrt memory consumption. Unfortunately I was actually setting the default to 250 despite the comments and docs saying 100. While I think 100 is still fine, I've turned it down a bit more to be on the safe side and unblock the release.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
