### PR TITLE
Initialize Soroban live state cache on startup

### DIFF
--- a/src/bucket/BucketSnapshot.h
+++ b/src/bucket/BucketSnapshot.h
@@ -87,6 +87,9 @@ class LiveBucketSnapshot : public BucketSnapshotBase<LiveBucket>
                          std::list<EvictionResultEntry>& evictableKeys,
                          SearchableLiveBucketListSnapshot const& bl,
                          uint32_t ledgerVers) const;
+
+    Loop scanForSorobanEntries(
+        std::function<Loop(BucketEntry const&)> callback) const;
 };
 
 class HotArchiveBucketSnapshot : public BucketSnapshotBase<HotArchiveBucket>

--- a/src/bucket/InMemoryIndex.h
+++ b/src/bucket/InMemoryIndex.h
@@ -64,6 +64,9 @@ class InMemoryIndex
     BucketEntryCounters mCounters{};
     std::optional<std::pair<std::streamoff, std::streamoff>> mOfferRange;
 
+    // Range of data/code entries in the Bucket
+    std::optional<std::pair<std::streamoff, std::streamoff>> mSorobanRange;
+
   public:
     using IterT = InMemoryBucketState::IterT;
 
@@ -103,6 +106,12 @@ class InMemoryIndex
     getOfferRange() const
     {
         return mOfferRange;
+    }
+
+    std::optional<std::pair<std::streamoff, std::streamoff>>
+    getSorobanRange() const
+    {
+        return mSorobanRange;
     }
 
 #ifdef BUILD_TESTS

--- a/src/bucket/LiveBucket.cpp
+++ b/src/bucket/LiveBucket.cpp
@@ -327,6 +327,12 @@ LiveBucket::getOfferRange() const
     return getIndex().getOfferRange();
 }
 
+std::optional<std::pair<std::streamoff, std::streamoff>>
+LiveBucket::getSorobanRange() const
+{
+    return getIndex().getSorobanRange();
+}
+
 std::vector<BucketEntry>
 LiveBucket::convertToBucketEntry(bool useInit,
                                  std::vector<LedgerEntry> const& initEntries,

--- a/src/bucket/LiveBucket.h
+++ b/src/bucket/LiveBucket.h
@@ -91,6 +91,12 @@ class LiveBucket : public BucketBase<LiveBucket, LiveBucketIndex>,
     std::optional<std::pair<std::streamoff, std::streamoff>>
     getOfferRange() const;
 
+    // Returns [lowerBound, upperBound) of file offsets for all soroban entries
+    // (CONTRACT_DATA and CONTRACT_CODE) in the bucket, or std::nullopt if no
+    // soroban entries exist
+    std::optional<std::pair<std::streamoff, std::streamoff>>
+    getSorobanRange() const;
+
     // Create a fresh bucket from given vectors of init (created) and live
     // (updated) LedgerEntries, and dead LedgerEntryKeys. The bucket will
     // be sorted, hashed, and adopted in the provided BucketManager.

--- a/src/bucket/LiveBucketIndex.h
+++ b/src/bucket/LiveBucketIndex.h
@@ -136,6 +136,9 @@ class LiveBucketIndex : public NonMovableOrCopyable
     std::optional<std::pair<std::streamoff, std::streamoff>>
     getOfferRange() const;
 
+    std::optional<std::pair<std::streamoff, std::streamoff>>
+    getSorobanRange() const;
+
     void maybeAddToCache(std::shared_ptr<BucketEntry const> const& entry) const;
 
     BucketEntryCounters const& getBucketEntryCounters() const;

--- a/src/bucket/SearchableBucketList.cpp
+++ b/src/bucket/SearchableBucketList.cpp
@@ -64,6 +64,16 @@ SearchableLiveBucketListSnapshot::scanForEviction(
     return result;
 }
 
+void
+SearchableLiveBucketListSnapshot::scanForSorobanEntries(
+    std::function<Loop(BucketEntry const&)> callback) const
+{
+    releaseAssert(mSnapshot);
+    auto f = [&](auto const& b) { return b.scanForSorobanEntries(callback); };
+
+    loopAllBuckets(f, *mSnapshot);
+}
+
 // This query has two steps:
 //  1. For each bucket, determine what PoolIDs contain the target asset via the
 //     assetToPoolID index

--- a/src/bucket/SearchableBucketList.h
+++ b/src/bucket/SearchableBucketList.h
@@ -35,6 +35,11 @@ class SearchableLiveBucketListSnapshot
         std::shared_ptr<EvictionStatistics> stats,
         StateArchivalSettings const& sas, uint32_t ledgerVers) const;
 
+    // Calls callback on each CONTRACT_CODE and CONTRACT_DATA entry in
+    // BucketList
+    void scanForSorobanEntries(
+        std::function<Loop(BucketEntry const&)> callback) const;
+
     friend SearchableSnapshotConstPtr
     BucketSnapshotManager::copySearchableLiveBucketListSnapshot() const;
 };

--- a/src/catchup/AssumeStateWork.cpp
+++ b/src/catchup/AssumeStateWork.cpp
@@ -9,6 +9,7 @@
 #include "crypto/Hex.h"
 #include "history/HistoryArchive.h"
 #include "invariant/InvariantManager.h"
+#include "ledger/LedgerManager.h"
 #include "work/WorkSequence.h"
 #include "work/WorkWithCallback.h"
 
@@ -80,6 +81,9 @@ AssumeStateWork::doWork()
 
             // Check invariants after state has been assumed
             app.getInvariantManager().checkAfterAssumeState(has.currentLedger);
+
+            // Populate the ledger apply cache with assumed BucketList state
+            app.getLedgerManager().populateApplyStateCacheFromBucketList();
 
             return true;
         };

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -15,6 +15,7 @@ namespace stellar
 class LedgerCloseData;
 class Database;
 class SorobanMetrics;
+class LedgerStateCache;
 
 // This diagram provides a schematic of the flow of (logical) ledgers coming in
 // from the SCP-and-Herder consensus complex, passing through the
@@ -302,10 +303,17 @@ class LedgerManager
     {
         applyLedger(ledgerData, /* externalize */ false);
     }
+
+    virtual LedgerStateCache const& getLedgerStateCacheForTesting() const = 0;
+    virtual void clearLedgerStateCacheForTesting() = 0;
 #endif
 
     virtual void
     setLastClosedLedger(LedgerHeaderHistoryEntry const& lastClosed) = 0;
+
+    // Populates the live Soroban state cache based on the current live
+    // BucketList.
+    virtual void populateApplyStateCacheFromBucketList() = 0;
 
     virtual void manuallyAdvanceLedgerHeader(LedgerHeader const& header) = 0;
 

--- a/src/ledger/LedgerStateCache.cpp
+++ b/src/ledger/LedgerStateCache.cpp
@@ -1,0 +1,70 @@
+// Copyright 2025 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "ledger/LedgerStateCache.h"
+#include "util/GlobalChecks.h"
+
+namespace stellar
+{
+
+void
+LedgerStateCache::addContractDataEntry(LedgerEntry const& ledgerEntry,
+                                       uint32_t liveUntilLedgerSeq)
+{
+    mEntries.emplace(
+        InternalContractDataCacheEntry(ledgerEntry, liveUntilLedgerSeq));
+}
+
+void
+LedgerStateCache::addContractCodeTTL(LedgerKey const& ledgerKey,
+                                     uint32_t liveUntilLedgerSeq)
+{
+    mContractCodeTTLs.emplace(ledgerKey, liveUntilLedgerSeq);
+}
+
+void
+LedgerStateCache::evictKey(LedgerKey const& ledgerKey)
+{
+    if (ledgerKey.type() == LedgerEntryType::CONTRACT_DATA)
+    {
+        mEntries.erase(InternalContractDataCacheEntry(ledgerKey));
+    }
+    else if (ledgerKey.type() == LedgerEntryType::CONTRACT_CODE)
+    {
+        mContractCodeTTLs.erase(ledgerKey);
+    }
+    else
+    {
+        throw std::runtime_error("LedgerStateCache: Invalid ledger key type");
+    }
+}
+
+std::optional<ContractDataCacheT>
+LedgerStateCache::getContractDataEntry(LedgerKey const& ledgerKey) const
+{
+    releaseAssertOrThrow(ledgerKey.type() == LedgerEntryType::CONTRACT_DATA);
+
+    auto it = mEntries.find(InternalContractDataCacheEntry(ledgerKey));
+    if (it == mEntries.end())
+    {
+        return std::nullopt;
+    }
+
+    return it->get();
+}
+
+std::optional<uint32_t>
+LedgerStateCache::getContractCodeTTL(LedgerKey const& ledgerKey) const
+{
+    releaseAssertOrThrow(ledgerKey.type() == LedgerEntryType::CONTRACT_CODE);
+
+    auto it = mContractCodeTTLs.find(ledgerKey);
+    if (it == mContractCodeTTLs.end())
+    {
+        return std::nullopt;
+    }
+
+    return it->second;
+}
+}

--- a/src/ledger/LedgerStateCache.h
+++ b/src/ledger/LedgerStateCache.h
@@ -1,0 +1,198 @@
+#pragma once
+
+// Copyright 2025 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include <cstddef>
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "ledger/LedgerHashUtils.h"
+#include "util/NonCopyable.h"
+#include "util/types.h"
+
+namespace stellar
+{
+
+struct ContractDataCacheT
+{
+    std::shared_ptr<LedgerEntry const> ledgerEntry;
+    uint32_t liveUntilLedgerSeq;
+
+    explicit ContractDataCacheT(LedgerEntry const& ledgerEntry,
+                                uint32_t liveUntilLedgerSeq)
+        : ledgerEntry(std::make_shared<LedgerEntry>(ledgerEntry))
+        , liveUntilLedgerSeq(liveUntilLedgerSeq)
+    {
+    }
+};
+
+// Soroban keys sizes usually dominate LedgerEntry size, so we don't want to
+// store a key-value map to be memory efficient. Instead, we store a set of
+// InternalContractDataCacheEntry objects, which is a wrapper around either a
+// LedgerKey or cache entry. This allows us to use std::unordered_set to
+// efficiently store cache entries, but allows lookup by key only.
+// Note that C++20 allows heterogeneous lookup in unordered_set, so we can
+// simplify this class once we upgrade.
+class InternalContractDataCacheEntry
+{
+  private:
+    struct AbstractEntry
+    {
+        virtual ~AbstractEntry() = default;
+        virtual LedgerKey copyKey() const = 0;
+        virtual size_t hash() const = 0;
+        virtual ContractDataCacheT const& get() const = 0;
+
+        virtual bool
+        operator==(const AbstractEntry& other) const
+        {
+            return copyKey() == other.copyKey();
+        }
+    };
+
+    // "Value" entry type used for storing ContractData entries in cache
+    struct ValueEntry : public AbstractEntry
+    {
+      private:
+        ContractDataCacheT entry;
+
+      public:
+        ValueEntry(LedgerEntry const& ledgerEntry, uint32_t liveUntilLedgerSeq)
+            : entry(ledgerEntry, liveUntilLedgerSeq)
+        {
+        }
+
+        LedgerKey
+        copyKey() const override
+        {
+            return LedgerEntryKey(*entry.ledgerEntry);
+        }
+
+        size_t
+        hash() const override
+        {
+            return std::hash<LedgerKey>{}(LedgerEntryKey(*entry.ledgerEntry));
+        }
+
+        ContractDataCacheT const&
+        get() const override
+        {
+            return entry;
+        }
+    };
+
+    // "Key" entry type only used for querying the cache
+    // Warning: We take a reference to the LedgerKey here to avoid extra copies
+    // for lookups, so the caller must ensure that the LedgerKey remains valid
+    // for the lifetime of the QueryKey object.
+    struct QueryKey : public AbstractEntry
+    {
+      private:
+        LedgerKey const& ledgerKey;
+
+      public:
+        QueryKey(LedgerKey const& ledgerKey) : ledgerKey(ledgerKey)
+        {
+        }
+
+        LedgerKey
+        copyKey() const override
+        {
+            return ledgerKey;
+        }
+
+        size_t
+        hash() const override
+        {
+            return std::hash<LedgerKey>{}(ledgerKey);
+        }
+
+        ContractDataCacheT const&
+        get() const override
+        {
+            throw std::runtime_error("Called get() on QueryKey");
+        }
+    };
+
+    std::unique_ptr<AbstractEntry> impl;
+
+  public:
+    InternalContractDataCacheEntry(LedgerEntry const& ledgerEntry,
+                                   uint32_t liveUntilLedgerSeq)
+        : impl(std::make_unique<ValueEntry>(ledgerEntry, liveUntilLedgerSeq))
+    {
+    }
+
+    InternalContractDataCacheEntry(LedgerKey const& ledgerKey)
+        : impl(std::make_unique<QueryKey>(ledgerKey))
+    {
+    }
+
+    size_t
+    hash() const
+    {
+        return impl->hash();
+    }
+
+    bool
+    operator==(InternalContractDataCacheEntry const& other) const
+    {
+        return impl->operator==(*other.impl);
+    }
+
+    ContractDataCacheT const&
+    get() const
+    {
+        return impl->get();
+    }
+};
+
+struct InternalContractDataEntryHash
+{
+    size_t
+    operator()(InternalContractDataCacheEntry const& entry) const
+    {
+        return entry.hash();
+    }
+};
+
+// This class caches all Soroban state required for Soroban tx application
+// (except for the module cache, which is managed separately). Specifically,
+// it caches these LedgerEntry types in the following way:
+//
+// ContractData: <LedgerEntry, liveUntilLedgerSeq>
+// ContractCode: <sizeForFeeCalculation, liveUntilLedgerSeq>
+//
+// We don't need to store explicit TTL entries, nor do we need to store WASM, we
+// just need to keep track of TTLs.
+class LedgerStateCache : public NonMovableOrCopyable
+{
+#ifdef BUILD_TESTS
+  public:
+#endif
+
+    std::unordered_set<InternalContractDataCacheEntry,
+                       InternalContractDataEntryHash>
+        mEntries;
+    std::unordered_map<LedgerKey, uint32_t> mContractCodeTTLs;
+
+  public:
+    void addContractDataEntry(LedgerEntry const& ledgerEntry,
+                              uint32_t liveUntilLedgerSeq);
+    void addContractCodeTTL(LedgerKey const& ledgerKey,
+                            uint32_t liveUntilLedgerSeq);
+
+    void evictKey(LedgerKey const& ledgerKey);
+
+    // Returns nullopt if the entry is not in the cache
+    std::optional<ContractDataCacheT>
+    getContractDataEntry(LedgerKey const& ledgerKey) const;
+
+    // Returns nullopt if the entry is not in the cache
+    std::optional<uint32_t>
+    getContractCodeTTL(LedgerKey const& ledgerKey) const;
+};
+}


### PR DESCRIPTION
# Description

Defines the cache required by #4556 and initialized it on startup. 

This PR introduces the live Soroban state cache required by CAP-66 and populates it on startup. It does not yet actually use the cache, nor is the cache maintained after startup. The reason for this is that soroban parallel apply (the consumer of this cache) is still in development, and it looks like we're moving away from `ltx` state access in that work. I think it's best to hold off on implementing access and cache maintenance until the parallel apply work is in a more final state.

In the meantime, this PR will add about 50 mb of RAM usage and delay startup on master for no gain, but this should be fine since 23.0 is our next planned release.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
