### PR TITLE
Change expensive timer metrics to trend counters

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -47,7 +47,8 @@ bucketlistDB-live.bulk.poolshareTrustlines  | timer     | time to load poolshare
 bucketlistDB-live.bulk.prefetch             | timer     | time to prefetch
 bucketlistDB-live.bulk.eviction           | timer     | time to load for eviction scan
 bucketlistDB-live.bulk.query              | timer     | time to load for query server
-bucketlistDB-<X>.point.<Y>                | timer     | time to load single entry of type <Y> on BucketList <X> (live/hotArchive)
+bucketlistDB-<X>.<Y>.sum                  | counter   | sum of time (microseconds) to load single entry of type <Y> on BucketList <X> (live/hotArchive)
+bucketlistDB-<X>.<Y>.count                | counter   | number of times single entry of type <Y> on BucketList <X> (live/hotArchive) is loaded
 bucketlistDB-cache.hit                    | meter     | number of cache hits on Live BucketList Disk random eviction cache
 bucketlistDB-cache.miss                   | meter     | number of cache misses on Live BucketList Disk random eviction cache
 crypto.verify.hit                         | meter     | number of signature cache hits
@@ -58,8 +59,10 @@ herder.pending[-soroban]-txs.age1         | counter   | number of gen1 pending t
 herder.pending[-soroban]-txs.age2         | counter   | number of gen2 pending transactions
 herder.pending[-soroban]-txs.age3         | counter   | number of gen3 pending transactions
 herder.pending[-soroban]-txs.banned       | counter   | number of transactions that got banned
-herder.pending[-soroban]-txs.delay        | timer     | time for transactions to be included in a ledger
-herder.pending[-soroban]-txs.self-delay   | timer     | time for transactions submitted from this node to be included in a ledger
+herder.pending[-soroban]-txs.sum          | counter   | sum of time (milliseconds) for transactions to be included in a ledger
+herder.pending[-soroban]-txs.count        | counter   | number of transactions to be included in a ledger
+herder.pending[-soroban]-txs.self-sum     | counter   | sum of time (milliseconds) for transactions submitted from this node to be included in a ledger
+herder.pending[-soroban]-txs.self-count   | counter   | number of transactions submitted from this node to be included in a ledger
 history.check.failure                     | meter     | history archive status checks failed
 history.check.success                     | meter     | history archive status checks succeeded
 history.publish.failure                   | meter     | published failed
@@ -126,7 +129,6 @@ overlay.flood.peer-tx-pull-latency        | timer     | time to pull a transacti
 overlay.demand.timeout                    | meter     | pull mode timeouts
 overlay.flood.relevant-txs                | meter     | relevant transactions pulled from peers
 overlay.flood.irrelevant-txs              | meter     | irrelevant transactions pulled from peers
-overlay.flood.advert-delay                | timer     | time each advert sits in the inbound queue
 overlay.flood.abandoned-demands           | meter     | tx hash pull demands that no peers responded
 overlay.flood.broadcast                   | meter     | message sent as broadcast per peer
 overlay.flood.duplicate_recv              | meter     | number of bytes of flooded messages that have already been received
@@ -148,7 +150,9 @@ overlay.outbound.attempt                  | meter     | outbound connection atte
 overlay.outbound.cancel                   | meter     | outbound connection cancelled
 overlay.outbound.drop                     | meter     | outbound connection dropped
 overlay.outbound.establish                | meter     | outbound connection established (added to pending)
-overlay.recv.<X>                          | timer     | received message <X>
+overlay.recv.<X>                          | timer     | received message <X> (except transaction)
+overlay.recv-transaction.sum              | counter   | sum of time (microseconds) to receive transaction message
+overlay.recv-transaction.count            | counter   | number of transaction messages received
 overlay.send.<X>                          | meter     | sent message <X>
 overlay.timeout.idle                      | meter     | idle peer timeout
 overlay.timeout.straggler                 | meter     | straggler peer timeout

--- a/src/bucket/BucketListSnapshotBase.h
+++ b/src/bucket/BucketListSnapshotBase.h
@@ -15,6 +15,7 @@
 namespace medida
 {
 class Timer;
+class Counter;
 }
 
 namespace stellar
@@ -91,8 +92,14 @@ class SearchableBucketListSnapshotBase : public NonMovableOrCopyable
     std::map<uint32_t, SnapshotPtrT<BucketT>> mHistoricalSnapshots;
     AppConnector const& mAppConnector;
 
-    // Metrics
-    UnorderedMap<LedgerEntryType, medida::Timer&> mPointTimers{};
+    // Tracks the sum of point load times for each LedgerEntryType, in
+    // microseconds. For point loads, Timers are too expensive to maintain, so
+    // we use a Counter to keep track of the total trend instead.
+    UnorderedMap<LedgerEntryType, medida::Counter&> mPointAccumulators{};
+    UnorderedMap<LedgerEntryType, medida::Counter&> mPointCounters{};
+
+    // Bulk load timers take significantly longer, so the timer overhead is
+    // comparatively negligible.
     mutable UnorderedMap<std::string, medida::Timer&> mBulkTimers{};
 
     medida::Meter& mBulkLoadMeter;

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -181,18 +181,29 @@ class TransactionQueue
     {
         QueueMetrics(std::vector<medida::Counter*> sizeByAge,
                      medida::Counter& bannedTransactionsCounter,
-                     medida::Timer& transactionsDelay,
-                     medida::Timer& transactionsSelfDelay)
+                     medida::Counter& transactionsDelayAccumulator,
+                     medida::Counter& transactionsDelayCounter,
+                     medida::Counter& transactionsSelfDelayAccumulator,
+                     medida::Counter& transactionsSelfDelayCounter)
             : mSizeByAge(std::move(sizeByAge))
             , mBannedTransactionsCounter(bannedTransactionsCounter)
-            , mTransactionsDelay(transactionsDelay)
-            , mTransactionsSelfDelay(transactionsSelfDelay)
+            , mTransactionsDelayAccumulator(transactionsDelayAccumulator)
+            , mTransactionsSelfDelayAccumulator(
+                  transactionsSelfDelayAccumulator)
+            , mTransactionsDelayCounter(transactionsDelayCounter)
+            , mTransactionsSelfDelayCounter(transactionsSelfDelayCounter)
         {
         }
         std::vector<medida::Counter*> mSizeByAge;
         medida::Counter& mBannedTransactionsCounter;
-        medida::Timer& mTransactionsDelay;
-        medida::Timer& mTransactionsSelfDelay;
+
+        // Sum of total delay, in milliseconds
+        medida::Counter& mTransactionsDelayAccumulator;
+        medida::Counter& mTransactionsSelfDelayAccumulator;
+
+        // Count of transactions delay events
+        medida::Counter& mTransactionsDelayCounter;
+        medida::Counter& mTransactionsSelfDelayCounter;
     };
 
     std::unique_ptr<QueueMetrics> mQueueMetrics;

--- a/src/overlay/OverlayMetrics.cpp
+++ b/src/overlay/OverlayMetrics.cpp
@@ -47,8 +47,10 @@ OverlayMetrics::OverlayMetrics(Application& app)
     , mRecvGetTxSetTimer(
           app.getMetrics().NewTimer({"overlay", "recv", "get-txset"}))
     , mRecvTxSetTimer(app.getMetrics().NewTimer({"overlay", "recv", "txset"}))
-    , mRecvTransactionTimer(
-          app.getMetrics().NewTimer({"overlay", "recv", "transaction"}))
+    , mRecvTransactionAccumulator(
+          app.getMetrics().NewCounter({"overlay", "recv-transaction", "sum"}))
+    , mRecvTransactionCounter(
+          app.getMetrics().NewCounter({"overlay", "recv-transaction", "count"}))
     , mRecvGetSCPQuorumSetTimer(
           app.getMetrics().NewTimer({"overlay", "recv", "get-scp-qset"}))
     , mRecvSCPQuorumSetTimer(
@@ -154,8 +156,6 @@ OverlayMetrics::OverlayMetrics(Application& app)
           app.getMetrics().NewTimer({"overlay", "flood", "tx-pull-latency"}))
     , mPeerTxPullLatency(app.getMetrics().NewTimer(
           {"overlay", "flood", "peer-tx-pull-latency"}))
-    , mAdvertQueueDelay(
-          app.getMetrics().NewTimer({"overlay", "flood", "advert-delay"}))
     , mDemandTimeouts(app.getMetrics().NewMeter(
           {"overlay", "demand", "timeout"}, "timeout"))
     , mPulledRelevantTxs(app.getMetrics().NewMeter(

--- a/src/overlay/OverlayMetrics.h
+++ b/src/overlay/OverlayMetrics.h
@@ -47,7 +47,19 @@ struct OverlayMetrics
     medida::Timer& mRecvPeersTimer;
     medida::Timer& mRecvGetTxSetTimer;
     medida::Timer& mRecvTxSetTimer;
-    medida::Timer& mRecvTransactionTimer;
+
+    // For frequently occurring events, using medida timers can be very
+    // expensive, as we are constantly compressing and copying data to maintain
+    // histograms. To avoid this, we use counters to sum the total time. This
+    // means we don't have histogram data, but the runtime cost of counters is
+    // negligible.
+    // Sum of total delay to process transaction message, in
+    // microseconds
+    medida::Counter& mRecvTransactionAccumulator;
+
+    // Count of transaction messages received
+    medida::Counter& mRecvTransactionCounter;
+
     medida::Timer& mRecvGetSCPQuorumSetTimer;
     medida::Timer& mRecvSCPQuorumSetTimer;
     medida::Timer& mRecvSCPMessageTimer;
@@ -106,7 +118,6 @@ struct OverlayMetrics
     medida::Meter& mUnknownMessageUnfulfilledMeter;
     medida::Timer& mTxPullLatency;
     medida::Timer& mPeerTxPullLatency;
-    medida::Timer& mAdvertQueueDelay;
 
     medida::Meter& mDemandTimeouts;
     medida::Meter& mPulledRelevantTxs;

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -14,6 +14,7 @@
 #include "util/NonCopyable.h"
 #include "util/Timer.h"
 #include "xdrpp/message.h"
+#include <medida/counter.h>
 
 namespace stellar
 {
@@ -133,7 +134,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
 
         medida::Timer mMessageDelayInWriteQueueTimer;
         medida::Timer mMessageDelayInAsyncWriteTimer;
-        medida::Timer mAdvertQueueDelay;
+
         medida::Timer mPullLatency;
 
         std::atomic<uint64_t> mDemandTimeouts;
@@ -410,7 +411,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
     // Does this peer have any transaction hashes to process?
     bool hasAdvert();
     // Pop the next transaction hash to process
-    std::pair<Hash, std::optional<VirtualClock::time_point>> popAdvert();
+    Hash popAdvert();
     // Clear pull mode state below `ledgerSeq`
     void clearBelow(uint32_t ledgerSeq);
 

--- a/src/overlay/TxAdverts.cpp
+++ b/src/overlay/TxAdverts.cpp
@@ -133,10 +133,9 @@ TxAdverts::queueIncomingAdvert(TxAdvertVector const& txHashes, uint32_t seq)
         it += txHashes.size() - limit;
     }
 
-    auto now = mApp.getClock().now();
     while (it != txHashes.end())
     {
-        mIncomingTxHashes.emplace_back(*it, now);
+        mIncomingTxHashes.emplace_back(*it);
         it++;
     }
 
@@ -146,7 +145,7 @@ TxAdverts::queueIncomingAdvert(TxAdvertVector const& txHashes, uint32_t seq)
     }
 }
 
-std::pair<Hash, std::optional<VirtualClock::time_point>>
+Hash
 TxAdverts::popIncomingAdvert()
 {
     if (size() <= 0)
@@ -158,14 +157,13 @@ TxAdverts::popIncomingAdvert()
     {
         auto const h = mTxHashesToRetry.front();
         mTxHashesToRetry.pop_front();
-        return std::make_pair(h, std::nullopt);
+        return h;
     }
     else
     {
         auto const h = mIncomingTxHashes.front();
         mIncomingTxHashes.pop_front();
-        return std::make_pair(
-            h.first, std::make_optional<VirtualClock::time_point>(h.second));
+        return h;
     }
 }
 

--- a/src/overlay/TxAdverts.h
+++ b/src/overlay/TxAdverts.h
@@ -28,7 +28,7 @@ class TxAdverts
   private:
     Application& mApp;
 
-    std::deque<std::pair<Hash, VirtualClock::time_point>> mIncomingTxHashes;
+    std::deque<Hash> mIncomingTxHashes;
     std::list<Hash> mTxHashesToRetry;
 
     // Cache seen hashes for a bit to avoid re-broadcasting the same data
@@ -48,8 +48,7 @@ class TxAdverts
     // Total transaction hashes to process including demand retries.
     size_t size() const;
     // Pop the next advert hash to process, size() must be > 0
-    std::pair<Hash, std::optional<VirtualClock::time_point>>
-    popIncomingAdvert();
+    Hash popIncomingAdvert();
     // Queue up a transaction hash to advertise to neighbours
     void queueOutgoingAdvert(Hash const& txHash);
     // Queue up a transaction hash from a neighbour to try demanding

--- a/src/overlay/TxDemandsManager.cpp
+++ b/src/overlay/TxDemandsManager.cpp
@@ -171,14 +171,7 @@ TxDemandsManager::demand()
             while (demand.size() < getMaxDemandSize() && peer->hasAdvert() &&
                    !addedNewDemand)
             {
-                auto hashPair = peer->popAdvert();
-                auto txHash = hashPair.first;
-                if (hashPair.second)
-                {
-                    auto delta = now - *(hashPair.second);
-                    om.mAdvertQueueDelay.Update(delta);
-                    peer->getPeerMetrics().mAdvertQueueDelay.Update(delta);
-                }
+                auto txHash = peer->popAdvert();
                 switch (demandStatus(txHash, peer))
                 {
                 case DemandStatus::DEMAND:

--- a/src/overlay/test/OverlayTests.cpp
+++ b/src/overlay/test/OverlayTests.cpp
@@ -371,8 +371,8 @@ TEST_CASE("flow control byte capacity", "[overlay][flowcontrol]")
             txtest::executeUpgrade(*app, txtest::makeConfigUpgrade(*res));
         };
 
-        auto& txsRecv =
-            app2->getMetrics().NewTimer({"overlay", "recv", "transaction"});
+        auto& txsRecv = app2->getMetrics().NewCounter(
+            {"overlay", "recv-transaction", "count"});
         auto start = txsRecv.count();
         conn.getInitiator()->sendMessage(std::make_shared<StellarMessage>(tx1));
 
@@ -2604,7 +2604,7 @@ TEST_CASE("overlay pull mode", "[overlay][pullmode]")
                         .count() == 2);
             REQUIRE(apps[2]
                         ->getMetrics()
-                        .NewTimer({"overlay", "recv", "transaction"})
+                        .NewCounter({"overlay", "recv-transaction", "count"})
                         .count() == 1);
             REQUIRE(getAdvertisedHashCount(apps[2]) == 0);
         }

--- a/src/overlay/test/TxAdvertsTests.cpp
+++ b/src/overlay/test/TxAdvertsTests.cpp
@@ -49,7 +49,7 @@ TEST_CASE("advert queue", "[flood][pullmode][acceptance]")
             // Since the advert queue is "FIFO",
             // the retry hashes gets popped first.
             // Therefore, we should only have the new hashes.
-            auto h = pullMode.popIncomingAdvert().first;
+            auto h = pullMode.popIncomingAdvert();
             REQUIRE(h == getHash(i));
         }
         REQUIRE(pullMode.size() == 0);
@@ -66,13 +66,13 @@ TEST_CASE("advert queue", "[flood][pullmode][acceptance]")
         for (uint32_t i = 0; i < limit / 2; i++)
         {
             // We pop retry hashes first.
-            auto h = pullMode.popIncomingAdvert().first;
+            auto h = pullMode.popIncomingAdvert();
             REQUIRE(h == getHash(limit + i));
         }
         for (uint32_t i = 0; i < limit / 2; i++)
         {
             // We pop new hashes next.
-            auto h = pullMode.popIncomingAdvert().first;
+            auto h = pullMode.popIncomingAdvert();
             REQUIRE(h == getHash(i));
         }
         REQUIRE(pullMode.size() == 0);


### PR DESCRIPTION
# Description

Resolves https://github.com/stellar/stellar-core-internal/issues/336

Changes expensive timer metrics to counters.

For timer and histogram metrics, we store data points in a buffer. When this buffer "fills up" we must to a compaction step, which involves many copies. For metrics that measure short lived functions (runtime in the ns or us range) that get called very frequently, the cost of this compaction step dominates the function runtime. For example, for BucketList in memory loads, metric overhead accounted for 75% of the load's total runtime.

This changes several short lived metrics to trends instead of timer based histograms. Specifically, we no longer track individual data samples, but keep a running sum of runtime instead. This still gives us insight into trends, but no longer gives us info on individual calls. However, it is significantly cheaper runtime wise.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
