### PR TITLE
Fixed loadgen bug for soroban upgrades

### DIFF
--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -506,7 +506,7 @@ this survey mechanism, just set `SURVEYOR_KEYS` to `$self` or a bogus key
     `create_upgrade`. This mode must be run before `create_upgrade`.
   * `create_upgrade` mode write a soroban upgrade set and returns the
     ConfigUpgradeSetKey. Most network config settings are supported. If a given
-    setting is omitted or set to 0, it is not upgraded and maintains the current
+    setting is omitted, it is not upgraded and maintains the current
     value. To not exceed HTTP string limits, the names are very short. See
     `CommandHandler::generateLoad` for available options.
   * `mixed_classic_soroban` mode creates a mix of `pay`, `soroban_upload`,

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -1207,47 +1207,47 @@ CommandHandler::generateLoad(std::string const& params, std::string& retStr)
         {
             auto& upgradeCfg = cfg.getMutSorobanUpgradeConfig();
             upgradeCfg.maxContractSizeBytes =
-                parseOptionalParamOrDefault<uint32_t>(map, "mxcntrctsz", 0);
+                parseOptionalParam<uint32_t>(map, "mxcntrctsz");
             upgradeCfg.maxContractDataKeySizeBytes =
-                parseOptionalParamOrDefault<uint32_t>(map, "mxcntrctkeysz", 0);
+                parseOptionalParam<uint32_t>(map, "mxcntrctkeysz");
             upgradeCfg.maxContractDataEntrySizeBytes =
-                parseOptionalParamOrDefault<uint32_t>(map, "mxcntrctdatasz", 0);
+                parseOptionalParam<uint32_t>(map, "mxcntrctdatasz");
             upgradeCfg.ledgerMaxInstructions =
-                parseOptionalParamOrDefault<uint64_t>(map, "ldgrmxinstrc", 0);
+                parseOptionalParam<uint64_t>(map, "ldgrmxinstrc");
             upgradeCfg.txMaxInstructions =
-                parseOptionalParamOrDefault<uint64_t>(map, "txmxinstrc", 0);
+                parseOptionalParam<uint64_t>(map, "txmxinstrc");
             upgradeCfg.txMemoryLimit =
-                parseOptionalParamOrDefault<uint64_t>(map, "txmemlim", 0);
+                parseOptionalParam<uint64_t>(map, "txmemlim");
             upgradeCfg.ledgerMaxReadLedgerEntries =
-                parseOptionalParamOrDefault<uint32_t>(map, "ldgrmxrdntry", 0);
+                parseOptionalParam<uint32_t>(map, "ldgrmxrdntry");
             upgradeCfg.ledgerMaxReadBytes =
-                parseOptionalParamOrDefault<uint32_t>(map, "ldgrmxrdbyt", 0);
+                parseOptionalParam<uint32_t>(map, "ldgrmxrdbyt");
             upgradeCfg.ledgerMaxWriteLedgerEntries =
-                parseOptionalParamOrDefault<uint32_t>(map, "ldgrmxwrntry", 0);
+                parseOptionalParam<uint32_t>(map, "ldgrmxwrntry");
             upgradeCfg.ledgerMaxWriteBytes =
-                parseOptionalParamOrDefault<uint32_t>(map, "ldgrmxwrbyt", 0);
+                parseOptionalParam<uint32_t>(map, "ldgrmxwrbyt");
             upgradeCfg.ledgerMaxTxCount =
-                parseOptionalParamOrDefault<uint32_t>(map, "ldgrmxtxcnt", 0);
+                parseOptionalParam<uint32_t>(map, "ldgrmxtxcnt");
             upgradeCfg.txMaxReadLedgerEntries =
-                parseOptionalParamOrDefault<uint32_t>(map, "txmxrdntry", 0);
+                parseOptionalParam<uint32_t>(map, "txmxrdntry");
             upgradeCfg.txMaxReadBytes =
-                parseOptionalParamOrDefault<uint32_t>(map, "txmxrdbyt", 0);
+                parseOptionalParam<uint32_t>(map, "txmxrdbyt");
             upgradeCfg.txMaxWriteLedgerEntries =
-                parseOptionalParamOrDefault<uint32_t>(map, "txmxwrntry", 0);
+                parseOptionalParam<uint32_t>(map, "txmxwrntry");
             upgradeCfg.txMaxWriteBytes =
-                parseOptionalParamOrDefault<uint32_t>(map, "txmxwrbyt", 0);
+                parseOptionalParam<uint32_t>(map, "txmxwrbyt");
             upgradeCfg.txMaxContractEventsSizeBytes =
-                parseOptionalParamOrDefault<uint32_t>(map, "txmxevntsz", 0);
+                parseOptionalParam<uint32_t>(map, "txmxevntsz");
             upgradeCfg.ledgerMaxTransactionsSizeBytes =
-                parseOptionalParamOrDefault<uint32_t>(map, "ldgrmxtxsz", 0);
+                parseOptionalParam<uint32_t>(map, "ldgrmxtxsz");
             upgradeCfg.txMaxSizeBytes =
-                parseOptionalParamOrDefault<uint32_t>(map, "txmxsz", 0);
+                parseOptionalParam<uint32_t>(map, "txmxsz");
             upgradeCfg.bucketListSizeWindowSampleSize =
-                parseOptionalParamOrDefault<uint32_t>(map, "wndowsz", 0);
+                parseOptionalParam<uint32_t>(map, "wndowsz");
             upgradeCfg.evictionScanSize =
-                parseOptionalParamOrDefault<uint64_t>(map, "evctsz", 0);
+                parseOptionalParam<uint64_t>(map, "evctsz");
             upgradeCfg.startingEvictionScanLevel =
-                parseOptionalParamOrDefault<uint32_t>(map, "evctlvl", 0);
+                parseOptionalParam<uint32_t>(map, "evctlvl");
         }
 
         if (cfg.mode == LoadGenMode::MIXED_CLASSIC_SOROBAN)


### PR DESCRIPTION
# Description

Fixes issue in loadgen, where Soroban upgrades would always be invalid. This also introduces a minor change to the loadgen upgrade interface. Previously, a config setting was not upgrade if the upgrade query string omitted the field or had a value of 0. This changes the interface such that the field is not upgraded when it is omitted. A value of 0 means the config parameter will be upgraded to the value of 0. I think this is a better interface, and I checked loadgen and we're not using any 0 value currently anyway.


# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
