### PR TITLE
Removed peer authenticated assert in Floodgate::broadcast

### DIFF
--- a/src/overlay/Floodgate.cpp
+++ b/src/overlay/Floodgate.cpp
@@ -86,6 +86,7 @@ bool
 Floodgate::broadcast(std::shared_ptr<StellarMessage const> msg,
                      std::optional<Hash> const& hash)
 {
+    releaseAssert(threadIsMain());
     ZoneScoped;
     if (mShuttingDown)
     {
@@ -120,10 +121,6 @@ Floodgate::broadcast(std::shared_ptr<StellarMessage const> msg,
     bool broadcasted = false;
     for (auto peer : peers)
     {
-        // Assert must hold since only main thread is allowed to modify
-        // authenticated peers and peer state during drop
-        peer.second->assertAuthenticated();
-
         bool pullMode = msg->type() == TRANSACTION;
 
         if (peersTold.insert(peer.second->toString()).second)

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -464,13 +464,6 @@ class Peer : public std::enable_shared_from_this<Peer>,
 
     // Public thread-safe methods that access Peer's state
     void
-    assertAuthenticated() const
-    {
-        RecursiveLockGuard guard(mStateMutex);
-        releaseAssert(isAuthenticated(guard));
-    }
-
-    void
     assertShuttingDown() const
     {
         RecursiveLockGuard guard(mStateMutex);


### PR DESCRIPTION
# Description

Resolves https://github.com/stellar/stellar-core-internal/issues/335

This PR removes an expensive assert in `Floodgate::broadcast`. This assert had to acquire `mStateMutex` from the main thread, but would often be blocked by the background thread. During periods of high load (1850 TPS), waiting for this mutex would double the median time of broadcast. Because a peer's authenticated state can only be changed from the mainthread anyway, the assert was replaced with a lockless main thread assert. During testing at 1850 TPS, this change resulted in a 15% decrease of txset fetch time, as well as a 10% decrease in nomination latency.


# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
