### PR TITLE
Remove limit on QUERY_SNAPSHOT_LEDGERS

### DIFF
--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -1363,7 +1363,7 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                  }},
                 {"QUERY_SNAPSHOT_LEDGERS",
                  [&]() {
-                     QUERY_SNAPSHOT_LEDGERS = readInt<uint32_t>(item, 0, 10);
+                     QUERY_SNAPSHOT_LEDGERS = readInt<uint32_t>(item, 0);
                  }},
                 {"MAX_CONCURRENT_SUBPROCESSES",
                  [&]() {


### PR DESCRIPTION
### What
Remove the max value limit on QUERY_SNAPSHOT_LEDGERS configuration parameter.

### Why
Allows operators to configure more than 10 ledgers for query snapshots if needed. 10 ledgers is arbitrarily low and larger numbers are usable.

Close #4682 