### PR TITLE
Add rust CKMS backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quantiles"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c10fa813fb26fb6c321a6f3085b5ade4cb4730d08d0b9e70a3759136940957f2"
+
+[[package]]
 name = "quote"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,6 +535,7 @@ dependencies = [
  "cxx",
  "itertools",
  "log",
+ "quantiles",
  "rand",
  "rustc-simple-version",
  "soroban-synth-wasm",

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -10,6 +10,7 @@
 #include "main/Config.h"
 #include "main/StellarCoreVersion.h"
 #include "rust/RustBridge.h"
+#include "rust/RustCKMS.h"
 #include "util/Backtrace.h"
 #include "util/FileSystemException.h"
 #include "util/Logging.h"
@@ -346,6 +347,8 @@ main(int argc, char* const* argv)
     }
     initializeAllGlobalState();
     xdr::marshaling_stack_limit = 1000;
+
+    register_rust_ckms();
 
     checkStellarCoreMajorVersionProtocolIdentity();
     rust_bridge::check_sensible_soroban_config_for_protocol(

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -18,6 +18,8 @@ rustc-simple-version = "=0.1.0"
 # will complain if it does not match)
 rand = "=0.8.5"
 
+quantiles = "0.7.1"
+
 itertools = "=0.10.5"
 
 # NB: tracy is quite particular about version compatibility. There must only be

--- a/src/rust/RustCKMS.h
+++ b/src/rust/RustCKMS.h
@@ -1,0 +1,37 @@
+#pragma once
+
+// Copyright 2025 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "rust/RustBridge.h"
+#include "medida/stats/ckms.h"
+#include <Tracy.hpp>
+
+namespace stellar {
+    class RustCKMS : public medida::stats::CKMS {
+        rust::Box<rust_bridge::CkmsState> impl;
+    public:
+        RustCKMS() : impl(rust_bridge::ckms_new()) {}
+        ~RustCKMS() override = default;
+
+        void insert(double value) override {
+            ZoneScoped;
+            impl->ckms_insert(value);
+        }
+        double get(double q) override { return impl->ckms_get(q); }
+        void reset() override { impl->ckms_reset(); }
+        std::size_t count() const override { return impl->ckms_count(); }
+        double max() const override { return impl->ckms_max(); }
+
+        // Factory function for medida registration
+        static std::shared_ptr<medida::stats::CKMS> create() {
+            return std::shared_ptr<medida::stats::CKMS>(new RustCKMS());
+        }
+    };
+
+    // Function to register RustCKMS as the default CKMS implementation
+    inline void register_rust_ckms() {
+        medida::stats::createCKMS = RustCKMS::create;
+    }
+}


### PR DESCRIPTION
This is a sketch of a hookup between medida and a rust library that provides CKMS estimators. There are two reasons:

1. The rust code is much faster than the prometheus C++ client code we copied into medida previously
2. The rust code is more correct! Apparently the CKMS paper had two versions, one of which corrected a bunch of mistakes in the first, and the prometheus code is based on the first, where the rust is based on the second.

I don't claim to understand point 2 super well, but it is a claim made by the rust implementation. I can empirically validate point 1 -- it is faster! -- and that is the original motivation here, since CKMS metrics updates are expensive enough to risk lagging core if done accidentally in a hot loop.