### PR TITLE
Start next ledger trigger timer after nomination accept

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -177,6 +177,7 @@ scp.sync.lost                             | meter     | validator lost sync
 scp.timeout.nominate                      | meter     | timeouts in nomination
 scp.timeout.prepare                       | meter     | timeouts in ballot protocol
 scp.timing.nominated                      | timer     | time spent in nomination
+scp.timing.first-accept                   | timer     | time spent from the start of nomination to the first accept
 scp.timing.externalized                   | timer     | time spent in ballot protocol
 scp.timing.first-to-self-externalize-lag  | timer     | delay between first externalize message and local node externalizing
 scp.timing.self-to-others-externalize-lag | timer     | delay between local node externalizing and later externalize messages from other nodes

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1223,7 +1223,17 @@ HerderImpl::setupTriggerNextLedger()
     // the ballot protocol started last
     auto now = mApp.getClock().now();
     auto lastBallotStart = now - seconds;
-    auto lastStart = mHerderSCPDriver.getPrepareStart(lastIndex);
+    std::optional<VirtualClock::time_point> lastStart = std::nullopt;
+    if (protocolVersionStartsFrom(lcl.header.ledgerVersion,
+                                  ProtocolVersion::V_23))
+    {
+        lastStart = mHerderSCPDriver.getNominationAccept(lastIndex);
+    }
+    else
+    {
+        lastStart = mHerderSCPDriver.getPrepareStart(lastIndex);
+    }
+
     if (lastStart)
     {
         lastBallotStart = *lastStart;

--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -109,11 +109,17 @@ class HerderSCPDriver : public SCPDriver
                                SCPBallot const& ballot) override;
     void acceptedBallotPrepared(uint64_t slotIndex,
                                 SCPBallot const& ballot) override;
+    void acceptedNomination(uint64_t slotIndex) override;
     void confirmedBallotPrepared(uint64_t slotIndex,
                                  SCPBallot const& ballot) override;
     void acceptedCommit(uint64_t slotIndex, SCPBallot const& ballot) override;
 
     std::optional<VirtualClock::time_point> getPrepareStart(uint64_t slotIndex);
+
+    // Returns the time when we first voted to accept for the given slotIndex,
+    // or std::nullopt if we haven't voted to accept yet.
+    std::optional<VirtualClock::time_point>
+    getNominationAccept(uint64_t slotIndex);
 
     // converts a Value into a StellarValue
     // returns false on error
@@ -163,6 +169,9 @@ class HerderSCPDriver : public SCPDriver
 
         // Timers for nomination and ballot protocols
         medida::Timer& mNominateToPrepare;
+
+        // Tracks time from the start of nomination to the first accept
+        medida::Timer& mNominationStartToFirstAccept;
         medida::Timer& mPrepareToExternalize;
 
         // Timers tracking externalize messages
@@ -186,8 +195,9 @@ class HerderSCPDriver : public SCPDriver
 
     struct SCPTiming
     {
-        std::optional<VirtualClock::time_point> mNominationStart;
-        std::optional<VirtualClock::time_point> mPrepareStart;
+        std::optional<VirtualClock::time_point> mNominationStart{};
+        std::optional<VirtualClock::time_point> mNominationAccept{};
+        std::optional<VirtualClock::time_point> mPrepareStart{};
 
         // Nomination timeouts before first prepare
         int64_t mNominationTimeoutCount{0};

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -431,6 +431,8 @@ NominationProtocol::processEnvelope(SCPEnvelopeWrapperPtr envelope)
                 if (vl == SCPDriver::kFullyValidatedValue)
                 {
                     mAccepted.emplace(vw);
+                    mSlot.getSCPDriver().acceptedNomination(
+                        mSlot.getSlotIndex());
                     mVotes.emplace(vw);
                     modified = true;
                 }

--- a/src/scp/SCPDriver.h
+++ b/src/scp/SCPDriver.h
@@ -225,6 +225,12 @@ class SCPDriver
     {
     }
 
+    // `acceptedNomination` every time a nomination is accepted
+    virtual void
+    acceptedNomination(uint64 slotIndex)
+    {
+    }
+
     // `confirmedBallotPrepared` every time a ballot is confirmed prepared
     virtual void
     confirmedBallotPrepared(uint64 slotIndex, SCPBallot const& ballot)


### PR DESCRIPTION
# Description

Helps alleviate https://github.com/stellar/stellar-core-internal/issues/343.

This change makes validators base the next ledger trigger timer on nomination accept instead of prepare. Specifically, validators start the next ledger timer when they accept the first nomination message for the given ledger. Because we trigger at acceptance, there's still a rough synchronization point for the timer. Moving the timer trigger earlier in consensus should bring block times closer to the target 5s value.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
