### PR TITLE
Remove from_muxed_id and allow memo/muxed info in mint event

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.82.0"
+channel = "1.84.0"

--- a/src/invariant/EventsAreConsistentWithEntryDiffs.cpp
+++ b/src/invariant/EventsAreConsistentWithEntryDiffs.cpp
@@ -155,7 +155,7 @@ calculateDeltaBalance(AggregatedEvents const& agg, LedgerEntry const* current,
         Asset native(ASSET_TYPE_NATIVE);
 
         auto eventDiff =
-            consumeAmount(accountToSCAddress(lk.account().accountID), native,
+            consumeAmount(makeAccountAddress(lk.account().accountID), native,
                           agg.mEventAmounts);
 
         auto entryDiff = (current ? current->data.account().balance : 0) -
@@ -192,7 +192,7 @@ calculateDeltaBalance(AggregatedEvents const& agg, LedgerEntry const* current,
                                          ? current->data.trustLine().accountID
                                          : previous->data.trustLine().accountID;
 
-        auto eventDiff = consumeAmount(accountToSCAddress(trustlineOwner),
+        auto eventDiff = consumeAmount(makeAccountAddress(trustlineOwner),
                                        asset, agg.mEventAmounts);
 
         auto entryDiff = (current ? current->data.trustLine().balance : 0) -
@@ -212,8 +212,8 @@ calculateDeltaBalance(AggregatedEvents const& agg, LedgerEntry const* current,
                                     : previous->data.claimableBalance().asset;
 
         auto eventDiff = consumeAmount(
-            claimableBalanceIDToSCAddress(lk.claimableBalance().balanceID),
-            asset, agg.mEventAmounts);
+            makeClaimableBalanceAddress(lk.claimableBalance().balanceID), asset,
+            agg.mEventAmounts);
         auto entryDiff =
             (current ? current->data.claimableBalance().amount : 0) -
             (previous ? previous->data.claimableBalance().amount : 0);
@@ -243,7 +243,7 @@ calculateDeltaBalance(AggregatedEvents const& agg, LedgerEntry const* current,
                              (previousBody ? previousBody->reserveB : 0);
 
         auto poolAddress =
-            liquidityPoolIDToSCAddress(lk.liquidityPool().liquidityPoolID);
+            makeLiquidityPoolAddress(lk.liquidityPool().liquidityPoolID);
         auto eventADiff = consumeAmount(poolAddress, assetA, agg.mEventAmounts);
         auto eventBDiff = consumeAmount(poolAddress, assetB, agg.mEventAmounts);
 

--- a/src/rust/src/dep-trees/p23-expect.txt
+++ b/src/rust/src/dep-trees/p23-expect.txt
@@ -42,29 +42,31 @@ soroban-env-host v23.0.0 (src/rust/soroban/p23/soroban-env-host)
 │   │   │   │   │       │       └── getrandom v0.2.11
 │   │   │   │   │       │           ├── cfg-if v1.0.0
 │   │   │   │   │       │           ├── js-sys v0.3.64
-│   │   │   │   │       │           │   └── wasm-bindgen v0.2.87
+│   │   │   │   │       │           │   └── wasm-bindgen v0.2.100
 │   │   │   │   │       │           │       ├── cfg-if v1.0.0
-│   │   │   │   │       │           │       └── wasm-bindgen-macro v0.2.87 (proc-macro)
+│   │   │   │   │       │           │       ├── once_cell v1.19.0
+│   │   │   │   │       │           │       ├── rustversion v1.0.14 (proc-macro)
+│   │   │   │   │       │           │       └── wasm-bindgen-macro v0.2.100 (proc-macro)
 │   │   │   │   │       │           │           ├── quote v1.0.33 (*)
-│   │   │   │   │       │           │           └── wasm-bindgen-macro-support v0.2.87
+│   │   │   │   │       │           │           └── wasm-bindgen-macro-support v0.2.100
 │   │   │   │   │       │           │               ├── proc-macro2 v1.0.69 (*)
 │   │   │   │   │       │           │               ├── quote v1.0.33 (*)
 │   │   │   │   │       │           │               ├── syn v2.0.39
 │   │   │   │   │       │           │               │   ├── proc-macro2 v1.0.69 (*)
 │   │   │   │   │       │           │               │   ├── quote v1.0.33 (*)
 │   │   │   │   │       │           │               │   └── unicode-ident v1.0.9
-│   │   │   │   │       │           │               ├── wasm-bindgen-backend v0.2.87
+│   │   │   │   │       │           │               ├── wasm-bindgen-backend v0.2.100
 │   │   │   │   │       │           │               │   ├── bumpalo v3.13.0
 │   │   │   │   │       │           │               │   ├── log v0.4.19
-│   │   │   │   │       │           │               │   ├── once_cell v1.19.0
 │   │   │   │   │       │           │               │   ├── proc-macro2 v1.0.69 (*)
 │   │   │   │   │       │           │               │   ├── quote v1.0.33 (*)
 │   │   │   │   │       │           │               │   ├── syn v2.0.39 (*)
-│   │   │   │   │       │           │               │   └── wasm-bindgen-shared v0.2.87
-│   │   │   │   │       │           │               └── wasm-bindgen-shared v0.2.87
+│   │   │   │   │       │           │               │   └── wasm-bindgen-shared v0.2.100
+│   │   │   │   │       │           │               │       └── unicode-ident v1.0.9
+│   │   │   │   │       │           │               └── wasm-bindgen-shared v0.2.100 (*)
 │   │   │   │   │       │           ├── libc v0.2.150
 │   │   │   │   │       │           ├── wasi v0.11.0+wasi-snapshot-preview1
-│   │   │   │   │       │           └── wasm-bindgen v0.2.87 (*)
+│   │   │   │   │       │           └── wasm-bindgen v0.2.100 (*)
 │   │   │   │   │       └── rand_core v0.6.4 (*)
 │   │   │   │   ├── digest v0.10.7
 │   │   │   │   │   ├── block-buffer v0.10.4
@@ -245,7 +247,7 @@ soroban-env-host v23.0.0 (src/rust/soroban/p23/soroban-env-host)
 │   │   │   ├── itoa v1.0.6
 │   │   │   ├── ryu v1.0.13
 │   │   │   └── serde v1.0.192 (*)
-│   │   ├── stellar-xdr v22.1.0 (https://github.com/stellar/rs-stellar-xdr?rev=4413ebb265fedd4e194487846289c804bae4c574#4413ebb2)
+│   │   ├── stellar-xdr v22.1.0 (https://github.com/stellar/rs-stellar-xdr?rev=fdd0c4f467ea654c3aaf139e8e914e1c416a39b8#fdd0c4f4)
 │   │   │   ├── escape-bytes v0.1.1
 │   │   │   ├── hex v0.4.3
 │   │   │   └── stellar-strkey v0.0.13
@@ -270,7 +272,7 @@ soroban-env-host v23.0.0 (src/rust/soroban/p23/soroban-env-host)
 │   │   └── wasmparser-nostd v0.100.2
 │   │       └── indexmap-nostd v0.4.0
 │   ├── static_assertions v1.1.0
-│   ├── stellar-xdr v22.1.0 (https://github.com/stellar/rs-stellar-xdr?rev=4413ebb265fedd4e194487846289c804bae4c574#4413ebb2)
+│   ├── stellar-xdr v22.1.0 (https://github.com/stellar/rs-stellar-xdr?rev=fdd0c4f467ea654c3aaf139e8e914e1c416a39b8#fdd0c4f4)
 │   │   ├── base64 v0.13.1
 │   │   ├── escape-bytes v0.1.1
 │   │   ├── hex v0.4.3

--- a/src/transactions/ClaimClaimableBalanceOpFrame.cpp
+++ b/src/transactions/ClaimClaimableBalanceOpFrame.cpp
@@ -140,8 +140,8 @@ ClaimClaimableBalanceOpFrame::doApply(
 
     // Emit event before we erase the claimable balance
     opEventManager.eventForTransferWithIssuerCheck(
-        asset, claimableBalanceIDToSCAddress(mClaimClaimableBalance.balanceID),
-        accountToSCAddress(getSourceAccount()), amount);
+        asset, makeClaimableBalanceAddress(mClaimClaimableBalance.balanceID),
+        makeMuxedAccountAddress(getSourceAccount()), amount);
 
     claimableBalanceLtxEntry.erase();
 

--- a/src/transactions/ClawbackClaimableBalanceOpFrame.cpp
+++ b/src/transactions/ClawbackClaimableBalanceOpFrame.cpp
@@ -74,7 +74,7 @@ ClawbackClaimableBalanceOpFrame::doApply(
     // Emit event before we erase the claimable balance
     opEventManager.newClawbackEvent(
         asset(),
-        claimableBalanceIDToSCAddress(mClawbackClaimableBalance.balanceID),
+        makeClaimableBalanceAddress(mClawbackClaimableBalance.balanceID),
         claimableBalanceLtxEntry.current().data.claimableBalance().amount);
 
     claimableBalanceLtxEntry.erase();

--- a/src/transactions/ClawbackOpFrame.cpp
+++ b/src/transactions/ClawbackOpFrame.cpp
@@ -53,8 +53,9 @@ ClawbackOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
         return false;
     }
 
-    opEventManager.newClawbackEvent(
-        mClawback.asset, accountToSCAddress(mClawback.from), mClawback.amount);
+    opEventManager.newClawbackEvent(mClawback.asset,
+                                    makeMuxedAccountAddress(mClawback.from),
+                                    mClawback.amount);
 
     innerResult(res).code(CLAWBACK_SUCCESS);
     return true;

--- a/src/transactions/CreateAccountOpFrame.cpp
+++ b/src/transactions/CreateAccountOpFrame.cpp
@@ -165,8 +165,8 @@ CreateAccountOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
     {
         Asset native(ASSET_TYPE_NATIVE);
         opEventManager.newTransferEvent(
-            native, accountToSCAddress(getSourceAccount()),
-            accountToSCAddress(mCreateAccount.destination),
+            native, makeMuxedAccountAddress(getSourceAccount()),
+            makeAccountAddress(mCreateAccount.destination),
             mCreateAccount.startingBalance);
     }
 

--- a/src/transactions/CreateClaimableBalanceOpFrame.cpp
+++ b/src/transactions/CreateClaimableBalanceOpFrame.cpp
@@ -250,8 +250,8 @@ CreateClaimableBalanceOpFrame::doApply(
     ltx.create(newClaimableBalance);
 
     opEventManager.eventForTransferWithIssuerCheck(
-        asset, accountToSCAddress(getSourceAccount()),
-        claimableBalanceIDToSCAddress(claimableBalanceEntry.balanceID), amount);
+        asset, makeMuxedAccountAddress(getSourceAccount()),
+        makeClaimableBalanceAddress(claimableBalanceEntry.balanceID), amount);
 
     innerResult(res).code(CREATE_CLAIMABLE_BALANCE_SUCCESS);
     innerResult(res).balanceID() = claimableBalanceEntry.balanceID;

--- a/src/transactions/EventManager.cpp
+++ b/src/transactions/EventManager.cpp
@@ -235,7 +235,7 @@ OpEventManager::eventsForClaimAtoms(
         return;
     }
 
-    auto sourceSCAddress = accountToSCAddress(source);
+    auto sourceSCAddress = makeMuxedAccountAddress(source);
 
     for (auto const& atom : claimAtoms)
     {
@@ -260,7 +260,7 @@ OpEventManager::eventsForClaimAtoms(
         }
         case CLAIM_ATOM_TYPE_ORDER_BOOK:
         {
-            auto seller = accountToSCAddress(atom.orderBook().sellerID);
+            auto seller = makeAccountAddress(atom.orderBook().sellerID);
 
             auto amountToSeller = atom.orderBook().amountBought;
             auto assetToSeller = atom.orderBook().assetBought;
@@ -276,8 +276,8 @@ OpEventManager::eventsForClaimAtoms(
         }
         case CLAIM_ATOM_TYPE_LIQUIDITY_POOL:
         {
-            auto poolID = liquidityPoolIDToSCAddress(
-                atom.liquidityPool().liquidityPoolID);
+            auto poolID =
+                makeLiquidityPoolAddress(atom.liquidityPool().liquidityPoolID);
 
             auto amountToPool = atom.liquidityPool().amountBought;
             auto assetToPool = atom.liquidityPool().assetBought;

--- a/src/transactions/EventManager.cpp
+++ b/src/transactions/EventManager.cpp
@@ -90,6 +90,45 @@ getAssetFromEvent(ContractEvent const& event, Hash const& networkID)
     return asset;
 }
 
+SCVal
+getPossibleMuxedData(SCAddress const& to, int64 amount, Memo const& memo)
+{
+    // mux follows order of precedence
+    // no mux no memo -- data is just i128
+    // else data is an scmap
+
+    bool is_to_mux = to.type() == SC_ADDRESS_TYPE_MUXED_ACCOUNT;
+    bool has_memo = memo.type() != MemoType::MEMO_NONE;
+
+    SCVal amountVal = makeI128SCVal(amount);
+
+    bool is_to_muxed_with_memo =
+        has_memo && to.type() == SC_ADDRESS_TYPE_ACCOUNT;
+    if (!is_to_mux && !is_to_muxed_with_memo)
+    {
+        return amountVal;
+    }
+    else
+    {
+        // data is ScMap
+        SCVal data(SCV_MAP);
+        SCMap& dataMap = data.map().activate();
+
+        SCMapEntry amountEntry;
+        amountEntry.key = makeSymbolSCVal("amount");
+        amountEntry.val = amountVal;
+        dataMap.push_back(amountEntry);
+
+        SCMapEntry toEntry;
+        toEntry.key = makeSymbolSCVal("to_muxed_id");
+        toEntry.val = is_to_mux ? makeMuxIDSCVal(to.muxedAccount())
+                                : makeClassicMemoSCVal(memo);
+        dataMap.push_back(toEntry);
+
+        return data;
+    }
+}
+
 DiagnosticEventBuffer::DiagnosticEventBuffer(Config const& config)
     : mConfig(config)
 {
@@ -308,58 +347,7 @@ OpEventManager::newTransferEvent(Asset const& asset, SCAddress const& from,
                     makeSep0011AssetStringSCVal(asset)};
     ev.body.v0().topics = topics;
 
-    // mux follows order of precedence
-    // no mux no memo -- data is just i128
-    // else data is an scmap
-
-    bool is_from_mux = from.type() == SC_ADDRESS_TYPE_MUXED_ACCOUNT;
-    bool is_to_mux = to.type() == SC_ADDRESS_TYPE_MUXED_ACCOUNT;
-    bool has_memo = mMemo.type() != MemoType::MEMO_NONE;
-
-    SCVal amountVal = makeI128SCVal(amount);
-
-    bool is_to_muxed_with_memo =
-        has_memo && to.type() == SC_ADDRESS_TYPE_ACCOUNT;
-    if (!is_from_mux && !is_to_mux && !is_to_muxed_with_memo)
-    {
-        ev.body.v0().data = amountVal;
-    }
-    else
-    {
-        // data is ScMap
-        SCVal data(SCV_MAP);
-        SCMap& dataMap = data.map().activate();
-
-        SCMapEntry amountEntry;
-        amountEntry.key = makeSymbolSCVal("amount");
-        amountEntry.val = amountVal;
-        dataMap.push_back(amountEntry);
-
-        if (is_from_mux)
-        {
-            SCMapEntry fromEntry;
-            fromEntry.key = makeSymbolSCVal("from_muxed_id");
-            fromEntry.val = makeMuxIDSCVal(from.muxedAccount());
-            dataMap.push_back(fromEntry);
-        }
-
-        if (is_to_mux)
-        {
-            SCMapEntry toEntry;
-            toEntry.key = makeSymbolSCVal("to_muxed_id");
-            toEntry.val = makeMuxIDSCVal(to.muxedAccount());
-            dataMap.push_back(toEntry);
-        }
-        else if (is_to_muxed_with_memo)
-        {
-            SCMapEntry toEntry;
-            toEntry.key = makeSymbolSCVal("to_muxed_id");
-            toEntry.val = makeClassicMemoSCVal(mMemo);
-            dataMap.push_back(toEntry);
-        }
-
-        ev.body.v0().data = data;
-    }
+    ev.body.v0().data = getPossibleMuxedData(to, amount, mMemo);
     mContractEvents.emplace_back(std::move(ev));
 }
 
@@ -382,7 +370,7 @@ OpEventManager::newMintEvent(Asset const& asset, SCAddress const& to,
                     makeSep0011AssetStringSCVal(asset)};
     ev.body.v0().topics = topics;
 
-    ev.body.v0().data = makeI128SCVal(amount);
+    ev.body.v0().data = getPossibleMuxedData(to, amount, mMemo);
 
     if (insertAtBeginning)
     {

--- a/src/transactions/InflationOpFrame.cpp
+++ b/src/transactions/InflationOpFrame.cpp
@@ -121,7 +121,7 @@ InflationOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
     {
         Asset native(ASSET_TYPE_NATIVE);
         opEventManager.newMintEvent(
-            native, accountToSCAddress(payout.destination), payout.amount);
+            native, makeAccountAddress(payout.destination), payout.amount);
     }
 
     return true;

--- a/src/transactions/LiquidityPoolDepositOpFrame.cpp
+++ b/src/transactions/LiquidityPoolDepositOpFrame.cpp
@@ -316,13 +316,13 @@ LiquidityPoolDepositOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
     }
 
     opEventManager.eventForTransferWithIssuerCheck(
-        cpp().assetA, accountToSCAddress(getSourceAccount()),
-        liquidityPoolIDToSCAddress(mLiquidityPoolDeposit.liquidityPoolID),
+        cpp().assetA, makeMuxedAccountAddress(getSourceAccount()),
+        makeLiquidityPoolAddress(mLiquidityPoolDeposit.liquidityPoolID),
         amountA);
 
     opEventManager.eventForTransferWithIssuerCheck(
-        cpp().assetB, accountToSCAddress(getSourceAccount()),
-        liquidityPoolIDToSCAddress(mLiquidityPoolDeposit.liquidityPoolID),
+        cpp().assetB, makeMuxedAccountAddress(getSourceAccount()),
+        makeLiquidityPoolAddress(mLiquidityPoolDeposit.liquidityPoolID),
         amountB);
 
     innerResult(res).code(LIQUIDITY_POOL_DEPOSIT_SUCCESS);

--- a/src/transactions/LiquidityPoolWithdrawOpFrame.cpp
+++ b/src/transactions/LiquidityPoolWithdrawOpFrame.cpp
@@ -103,13 +103,13 @@ LiquidityPoolWithdrawOpFrame::doApply(
 
     opEventManager.eventForTransferWithIssuerCheck(
         constantProduct().params.assetA,
-        liquidityPoolIDToSCAddress(mLiquidityPoolWithdraw.liquidityPoolID),
-        accountToSCAddress(getSourceAccount()), amountA);
+        makeLiquidityPoolAddress(mLiquidityPoolWithdraw.liquidityPoolID),
+        makeMuxedAccountAddress(getSourceAccount()), amountA);
 
     opEventManager.eventForTransferWithIssuerCheck(
         constantProduct().params.assetB,
-        liquidityPoolIDToSCAddress(mLiquidityPoolWithdraw.liquidityPoolID),
-        accountToSCAddress(getSourceAccount()), amountB);
+        makeLiquidityPoolAddress(mLiquidityPoolWithdraw.liquidityPoolID),
+        makeMuxedAccountAddress(getSourceAccount()), amountB);
 
     innerResult(res).code(LIQUIDITY_POOL_WITHDRAW_SUCCESS);
     return true;

--- a/src/transactions/LumenEventReconciler.cpp
+++ b/src/transactions/LumenEventReconciler.cpp
@@ -68,13 +68,13 @@ reconcileEvents(AccountID const& txSourceAccount, Operation const& operation,
         operation.body.type() == PAYMENT)
     {
 
-        opEventManager.newMintEvent(native, accountToSCAddress(opSource),
+        opEventManager.newMintEvent(native, makeAccountAddress(opSource),
                                     deltaBalances,
                                     true /*Insert mint at the beginning*/);
     }
     else if (operation.body.type() == PATH_PAYMENT_STRICT_RECEIVE)
     {
-        opEventManager.newBurnEvent(native, accountToSCAddress(opSource),
+        opEventManager.newBurnEvent(native, makeAccountAddress(opSource),
                                     std::abs(deltaBalances));
     }
     else

--- a/src/transactions/MergeOpFrame.cpp
+++ b/src/transactions/MergeOpFrame.cpp
@@ -185,8 +185,8 @@ MergeOpFrame::doApplyBeforeV16(AbstractLedgerTxn& ltx, OperationResult& res,
 
     Asset native(ASSET_TYPE_NATIVE);
     opEventManager.newTransferEvent(
-        native, accountToSCAddress(getSourceAccount()),
-        accountToSCAddress(mOperation.body.destination()), sourceBalance);
+        native, makeMuxedAccountAddress(getSourceAccount()),
+        makeMuxedAccountAddress(mOperation.body.destination()), sourceBalance);
 
     innerResult(res).code(ACCOUNT_MERGE_SUCCESS);
     innerResult(res).sourceAccountBalance() = sourceBalance;
@@ -266,8 +266,8 @@ MergeOpFrame::doApplyFromV16(AbstractLedgerTxn& ltx, OperationResult& res,
 
     Asset native(ASSET_TYPE_NATIVE);
     opEventManager.newTransferEvent(
-        native, accountToSCAddress(getSourceAccount()),
-        accountToSCAddress(mOperation.body.destination()), sourceBalance);
+        native, makeMuxedAccountAddress(getSourceAccount()),
+        makeMuxedAccountAddress(mOperation.body.destination()), sourceBalance);
 
     innerResult(res).code(ACCOUNT_MERGE_SUCCESS);
     innerResult(res).sourceAccountBalance() = sourceBalance;

--- a/src/transactions/PathPaymentStrictReceiveOpFrame.cpp
+++ b/src/transactions/PathPaymentStrictReceiveOpFrame.cpp
@@ -140,8 +140,9 @@ PathPaymentStrictReceiveOpFrame::doApply(
     // Emit the final event between the source and destination account wrt the
     // dest asset.
     opEventManager.eventForTransferWithIssuerCheck(
-        getDestAsset(), accountToSCAddress(getSourceAccount()),
-        accountToSCAddress(getDestMuxedAccount()), mPathPayment.destAmount);
+        getDestAsset(), makeMuxedAccountAddress(getSourceAccount()),
+        makeMuxedAccountAddress(getDestMuxedAccount()),
+        mPathPayment.destAmount);
 
     return true;
 }

--- a/src/transactions/PathPaymentStrictSendOpFrame.cpp
+++ b/src/transactions/PathPaymentStrictSendOpFrame.cpp
@@ -133,8 +133,8 @@ PathPaymentStrictSendOpFrame::doApply(
     // Emit the final event between the source and destination account wrt the
     // dest asset.
     opEventManager.eventForTransferWithIssuerCheck(
-        getDestAsset(), accountToSCAddress(getSourceAccount()),
-        accountToSCAddress(getDestMuxedAccount()), maxAmountSend);
+        getDestAsset(), makeMuxedAccountAddress(getSourceAccount()),
+        makeMuxedAccountAddress(getDestMuxedAccount()), maxAmountSend);
 
     return true;
 }

--- a/src/transactions/PaymentOpFrame.cpp
+++ b/src/transactions/PaymentOpFrame.cpp
@@ -47,8 +47,8 @@ PaymentOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
     if (instantSuccess)
     {
         opEventManager.eventForTransferWithIssuerCheck(
-            mPayment.asset, accountToSCAddress(getSourceAccount()),
-            accountToSCAddress(mPayment.destination), mPayment.amount);
+            mPayment.asset, makeMuxedAccountAddress(getSourceAccount()),
+            makeMuxedAccountAddress(mPayment.destination), mPayment.amount);
         innerResult(res).code(PAYMENT_SUCCESS);
         return true;
     }

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -1554,7 +1554,7 @@ removeOffersAndPoolShareTrustLines(AbstractLedgerTxn& ltx,
             {
 
                 opEventManager.newBurnEvent(
-                    assetInPool, liquidityPoolIDToSCAddress(poolID), amount);
+                    assetInPool, makeLiquidityPoolAddress(poolID), amount);
 
                 return RemoveResult::SUCCESS;
             }
@@ -1574,8 +1574,8 @@ removeOffersAndPoolShareTrustLines(AbstractLedgerTxn& ltx,
                 makeUnconditionalClaimant(accountID)};
 
             opEventManager.newTransferEvent(
-                assetInPool, liquidityPoolIDToSCAddress(poolID),
-                claimableBalanceIDToSCAddress(claimableBalanceEntry.balanceID),
+                assetInPool, makeLiquidityPoolAddress(poolID),
+                makeClaimableBalanceAddress(claimableBalanceEntry.balanceID),
                 amount);
 
             // if this asset isn't native
@@ -1981,7 +1981,7 @@ makeAccountIDSCVal(AccountID const& id)
 }
 
 SCAddress
-accountToSCAddress(MuxedAccount const& account)
+makeMuxedAccountAddress(MuxedAccount const& account)
 {
     switch (account.type())
     {
@@ -2005,7 +2005,7 @@ accountToSCAddress(MuxedAccount const& account)
 }
 
 SCAddress
-accountToSCAddress(AccountID const& account)
+makeAccountAddress(AccountID const& account)
 {
     SCAddress addr(SC_ADDRESS_TYPE_ACCOUNT);
     addr.accountId() = account;
@@ -2013,7 +2013,7 @@ accountToSCAddress(AccountID const& account)
 }
 
 SCAddress
-claimableBalanceIDToSCAddress(ClaimableBalanceID const& id)
+makeClaimableBalanceAddress(ClaimableBalanceID const& id)
 {
     SCAddress addr(SC_ADDRESS_TYPE_CLAIMABLE_BALANCE);
     addr.claimableBalanceId() = id;
@@ -2021,7 +2021,7 @@ claimableBalanceIDToSCAddress(ClaimableBalanceID const& id)
 }
 
 SCAddress
-liquidityPoolIDToSCAddress(PoolID const& id)
+makeLiquidityPoolAddress(PoolID const& id)
 {
     SCAddress addr(SC_ADDRESS_TYPE_LIQUIDITY_POOL);
     addr.liquidityPoolId() = id;

--- a/src/transactions/TransactionUtils.h
+++ b/src/transactions/TransactionUtils.h
@@ -348,10 +348,10 @@ SCVal makeSep0011AssetStringSCVal(Asset const& asset);
 SCVal makeClassicMemoSCVal(Memo const& memo);
 SCVal makeMuxIDSCVal(MuxedEd25519Account const& acc);
 
-SCAddress accountToSCAddress(MuxedAccount const& account);
-SCAddress accountToSCAddress(AccountID const& account);
-SCAddress claimableBalanceIDToSCAddress(ClaimableBalanceID const& id);
-SCAddress liquidityPoolIDToSCAddress(PoolID const& id);
+SCAddress makeMuxedAccountAddress(MuxedAccount const& account);
+SCAddress makeAccountAddress(AccountID const& account);
+SCAddress makeClaimableBalanceAddress(ClaimableBalanceID const& id);
+SCAddress makeLiquidityPoolAddress(PoolID const& id);
 SCAddress getAddressWithDroppedMuxedInfo(SCAddress const& addr);
 bool isIssuer(SCAddress const& addr, Asset const& asset);
 }

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -485,13 +485,14 @@ TEST_CASE("Stellar asset contract transfer with CAP-67 address types",
         }
         {
             INFO("transfer to liquidity pool fails");
-            REQUIRE(!client.transfer(a1, makeLiqudityPoolAddress(PoolID()), 1));
+            REQUIRE(
+                !client.transfer(a1, makeLiquidityPoolAddress(PoolID()), 1));
             REQUIRE(client.lastEvent() == std::nullopt);
         }
         {
             INFO("transfer to claimable balance fails");
-            REQUIRE(
-                !client.transfer(a1, makeClaimableBalanceAddress(Hash()), 1));
+            REQUIRE(!client.transfer(
+                a1, makeClaimableBalanceAddress(ClaimableBalanceID()), 1));
             REQUIRE(client.lastEvent() == std::nullopt);
         }
     };

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -428,23 +428,21 @@ TEST_CASE("Stellar asset contract transfer with CAP-67 address types",
         Asset tokenAsset = useNativeAsset ? txtest::makeNativeAsset() : asset;
         AssetContractTestClient client(test, tokenAsset);
         {
-            INFO("transfer from muxed account to muxed account");
+            INFO("transfer to muxed account");
             REQUIRE(client.transfer(
                 a1, makeMuxedAccountAddress(a2.getPublicKey(), 123'456'789),
-                100'000'000, std::numeric_limits<uint64_t>::max()));
+                100'000'000));
             REQUIRE(*client.lastEvent() ==
-                    client.makeTransferEvent(
-                        a1Address, a2Address, 100'000'000,
-                        std::numeric_limits<uint64_t>::max(), 123'456'789));
+                    client.makeTransferEvent(a1Address, a2Address, 100'000'000,
+                                             123'456'789));
         }
         {
-            INFO("transfer from muxed account to contract");
+            INFO("transfer from account to contract");
             REQUIRE(client.transfer(a2, transferContract.getAddress(),
-                                    200'000'000, 0));
+                                    200'000'000));
             REQUIRE(*client.lastEvent() ==
-                    client.makeTransferEvent(a2Address,
-                                             transferContract.getAddress(),
-                                             200'000'000, 0));
+                    client.makeTransferEvent(
+                        a2Address, transferContract.getAddress(), 200'000'000));
         }
         {
             INFO("transfer from contract not supporting muxed accounts")
@@ -483,7 +481,6 @@ TEST_CASE("Stellar asset contract transfer with CAP-67 address types",
                 300'000'000));
             REQUIRE(*client.lastEvent() ==
                     client.makeTransferEvent(a1Address, a2Address, 300'000'000,
-                                             std::nullopt,
                                              123'456'789'123'456'789ULL));
         }
         {

--- a/src/transactions/test/SorobanTxTestUtils.cpp
+++ b/src/transactions/test/SorobanTxTestUtils.cpp
@@ -290,7 +290,6 @@ makeContractEvent(Hash const& contractId, std::vector<SCVal> const& topics,
 
 ContractEvent
 makeTransferEvent(SCAddress const& from, SCAddress const& to, int64_t amount,
-                  std::optional<int64_t> fromMuxId,
                   std::optional<int64_t> toMuxId)
 {
     return ContractEvent();
@@ -1369,7 +1368,6 @@ AssetContractTestClient::lastEvent() const
 ContractEvent
 AssetContractTestClient::makeTransferEvent(SCAddress const& from,
                                            SCAddress const& to, int64_t amount,
-                                           std::optional<uint64_t> fromMuxId,
                                            std::optional<uint64_t> toMuxId)
 {
     std::string name;
@@ -1394,21 +1392,13 @@ AssetContractTestClient::makeTransferEvent(SCAddress const& from,
                                  makeAddressSCVal(from), makeAddressSCVal(to),
                                  makeStringSCVal(std::move(name))};
     SCVal data;
-    if (fromMuxId || toMuxId)
+    if (toMuxId)
     {
         data.type(SCValType::SCV_MAP);
         data.map().activate().push_back(
             SCMapEntry(makeSymbolSCVal("amount"), makeI128(amount)));
-        if (fromMuxId)
-        {
-            data.map().activate().push_back(SCMapEntry(
-                makeSymbolSCVal("from_muxed_id"), makeU64(*fromMuxId)));
-        }
-        if (toMuxId)
-        {
-            data.map().activate().push_back(
-                SCMapEntry(makeSymbolSCVal("to_muxed_id"), makeU64(*toMuxId)));
-        }
+        data.map().activate().push_back(
+            SCMapEntry(makeSymbolSCVal("to_muxed_id"), makeU64(*toMuxId)));
     }
     else
     {
@@ -1420,19 +1410,10 @@ AssetContractTestClient::makeTransferEvent(SCAddress const& from,
 bool
 AssetContractTestClient::transfer(TestAccount& fromAcc,
                                   SCAddress const& maybeMuxedToAddr,
-                                  int64_t amount,
-                                  std::optional<uint64_t> fromMuxId)
+                                  int64_t amount)
 {
     SCVal fromVal(SCV_ADDRESS);
-    if (!fromMuxId)
-    {
-        fromVal.address() = makeAccountAddress(fromAcc.getPublicKey());
-    }
-    else
-    {
-        fromVal.address() =
-            makeMuxedAccountAddress(fromAcc.getPublicKey(), *fromMuxId);
-    }
+    fromVal.address() = makeAccountAddress(fromAcc.getPublicKey());
 
     SCVal toVal(SCV_ADDRESS);
     SCAddress toAddr = maybeMuxedToAddr;

--- a/src/transactions/test/SorobanTxTestUtils.cpp
+++ b/src/transactions/test/SorobanTxTestUtils.cpp
@@ -55,35 +55,11 @@ makeContractAddress(Hash const& hash)
 }
 
 SCAddress
-makeAccountAddress(AccountID const& accountID)
-{
-    SCAddress addr(SC_ADDRESS_TYPE_ACCOUNT);
-    addr.accountId() = accountID;
-    return addr;
-}
-
-SCAddress
 makeMuxedAccountAddress(AccountID const& accountID, uint64_t id)
 {
     SCAddress addr(SC_ADDRESS_TYPE_MUXED_ACCOUNT);
     addr.muxedAccount().ed25519 = accountID.ed25519();
     addr.muxedAccount().id = id;
-    return addr;
-}
-
-SCAddress
-makeClaimableBalanceAddress(Hash const& id)
-{
-    SCAddress addr(SC_ADDRESS_TYPE_CLAIMABLE_BALANCE);
-    addr.claimableBalanceId().v0() = id;
-    return addr;
-}
-
-SCAddress
-makeLiqudityPoolAddress(PoolID const& id)
-{
-    SCAddress addr(SC_ADDRESS_TYPE_LIQUIDITY_POOL);
-    addr.liquidityPoolId() = id;
     return addr;
 }
 

--- a/src/transactions/test/SorobanTxTestUtils.h
+++ b/src/transactions/test/SorobanTxTestUtils.h
@@ -18,10 +18,7 @@ namespace txtest
 {
 
 SCAddress makeContractAddress(Hash const& hash);
-SCAddress makeAccountAddress(AccountID const& accountID);
 SCAddress makeMuxedAccountAddress(AccountID const& accountID, uint64_t id);
-SCAddress makeClaimableBalanceAddress(Hash const& id);
-SCAddress makeLiqudityPoolAddress(PoolID const& id);
 SCVal makeI32(int32_t i32);
 SCVal makeI128(uint64_t u64);
 SCSymbol makeSymbol(std::string const& str);

--- a/src/transactions/test/SorobanTxTestUtils.h
+++ b/src/transactions/test/SorobanTxTestUtils.h
@@ -348,8 +348,7 @@ class AssetContractTestClient
     int64_t getBalance(SCAddress const& addr);
     SorobanInvocationSpec defaultSpec() const;
 
-    bool transfer(TestAccount& from, SCAddress const& toAddr, int64_t amount,
-                  std::optional<uint64_t> fromMuxId = std::nullopt);
+    bool transfer(TestAccount& from, SCAddress const& toAddr, int64_t amount);
     bool mint(TestAccount& admin, SCAddress const& toAddr, int64_t amount);
     bool burn(TestAccount& from, int64_t amount);
     bool clawback(TestAccount& admin, SCAddress const& fromAddr,
@@ -360,7 +359,6 @@ class AssetContractTestClient
     ContractEvent
     makeTransferEvent(SCAddress const& from, SCAddress const& to,
                       int64_t amount,
-                      std::optional<uint64_t> fromMuxId = std::nullopt,
                       std::optional<uint64_t> toMuxId = std::nullopt);
 };
 


### PR DESCRIPTION
# Description

The core change for https://github.com/stellar/stellar-protocol/pull/1705.

We need to add tests for memo and muxed info as part of https://github.com/stellar/stellar-core/pull/4690.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
