### PR TITLE
Introduce an experimental flag to batch transactions to flood

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -133,6 +133,7 @@ overlay.flood.abandoned-demands           | meter     | tx hash pull demands tha
 overlay.flood.broadcast                   | meter     | message sent as broadcast per peer
 overlay.flood.duplicate_recv              | meter     | number of bytes of flooded messages that have already been received
 overlay.flood.unique_recv                 | meter     | number of bytes of flooded messages that have not yet been received
+overlay.flood.tx-batch-size               | histogram | number of transactions in a batch
 overlay.inbound.attempt                   | meter     | inbound connection attempted (accepted on socket)
 overlay.inbound.drop                      | meter     | inbound connection dropped
 overlay.inbound.establish                 | meter     | inbound connection established (added to pending)
@@ -156,14 +157,6 @@ overlay.recv-transaction.count            | counter   | number of transaction me
 overlay.send.<X>                          | meter     | sent message <X>
 overlay.timeout.idle                      | meter     | idle peer timeout
 overlay.timeout.straggler                 | meter     | straggler peer timeout
-overlay.recv.start-survey-collecting      | timer     | time spent in processing request to start survey collecting phase
-overlay.recv.stop-survey-collecting       | timer     | time spent in processing request to stop survey collecting phase
-overlay.recv.survey-request               | timer     | time spent in processing survey request
-overlay.recv.survey-response              | timer     | time spent in processing survey response
-overlay.send.start-survey-collecting      | timer     | sent request to start survey collecting phase
-overlay.send.stop-survey-collecting       | timer     | sent request to stop survey collecting phase
-overlay.send.survey-request               | meter     | sent survey request
-overlay.send.survey-response              | meter     | sent survey response
 process.action.queue                      | counter   | number of items waiting in internal action-queue
 process.action.overloaded                 | counter   | 0-or-1 value indicating action-queue overloading
 process.file.handles                      | counter   | number of open file handles

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -130,6 +130,7 @@ class HerderImpl : public Herder
     uint32_t mTriggerNextLedgerSeq{0};
 
     std::optional<uint32_t> mMaxClassicTxSize;
+    std::optional<uint32_t> mMaxTxSizeOverride;
     void
     setMaxClassicTxSize(uint32 bytes) override
     {
@@ -138,7 +139,7 @@ class HerderImpl : public Herder
     void
     setMaxTxSize(uint32 bytes) override
     {
-        mMaxTxSize = bytes;
+        mMaxTxSizeOverride = bytes;
     }
     std::optional<uint32_t> mFlowControlExtraBuffer;
     void
@@ -164,6 +165,12 @@ class HerderImpl : public Herder
     uint32_t
     getMaxTxSize() const override
     {
+#ifdef BUILD_TESTS
+        if (mMaxTxSizeOverride)
+        {
+            return *mMaxTxSizeOverride;
+        }
+#endif
         return mMaxTxSize;
     }
 

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -68,7 +68,8 @@ static const std::unordered_set<std::string> TESTING_ONLY_OPTIONS = {
     "ARTIFICIALLY_DELAY_BUCKET_APPLICATION_FOR_TESTING",
     "ARTIFICIALLY_SLEEP_MAIN_THREAD_FOR_TESTING",
     "ARTIFICIALLY_SKIP_CONNECTION_ADJUSTMENT_FOR_TESTING",
-    "ARTIFICIALLY_DELAY_LEDGER_CLOSE_FOR_TESTING"};
+    "ARTIFICIALLY_DELAY_LEDGER_CLOSE_FOR_TESTING",
+    "EXPERIMENTAL_TX_BATCH_MAX_SIZE_FOR_TESTING"};
 
 // Options that should only be used for testing
 static const std::unordered_set<std::string> TESTING_SUGGESTED_OPTIONS = {
@@ -253,6 +254,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     FLOOD_DEMAND_PERIOD_MS = std::chrono::milliseconds(200);
     FLOOD_ADVERT_PERIOD_MS = std::chrono::milliseconds(100);
     FLOOD_DEMAND_BACKOFF_DELAY_MS = std::chrono::milliseconds(500);
+    EXPERIMENTAL_TX_BATCH_MAX_SIZE = 0;
 
     MAX_BATCH_WRITE_COUNT = 1024;
     MAX_BATCH_WRITE_BYTES = 1 * 1024 * 1024;
@@ -1317,6 +1319,10 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                  [&]() {
                      FLOOD_DEMAND_BACKOFF_DELAY_MS =
                          std::chrono::milliseconds(readInt<int>(item, 1));
+                 }},
+                {"EXPERIMENTAL_TX_BATCH_MAX_SIZE",
+                 [&]() {
+                     EXPERIMENTAL_TX_BATCH_MAX_SIZE = readInt<size_t>(item, 0);
                  }},
                 {"FLOOD_ARB_TX_BASE_ALLOWANCE",
                  [&]() {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -484,6 +484,10 @@ class Config : public std::enable_shared_from_this<Config>
     // Enable parallel block application (experimental)
     bool EXPERIMENTAL_PARALLEL_LEDGER_APPLY;
 
+    // Batch transactions for flooding purposes (experimental).
+    // Has no effect on non-test builds.
+    size_t EXPERIMENTAL_TX_BATCH_MAX_SIZE;
+
     // When set to true, BucketListDB indexes are persisted on-disk so that the
     // BucketList does not need to be reindexed on startup. Defaults to true.
     // This should only be set to false for testing purposes

--- a/src/overlay/Floodgate.cpp
+++ b/src/overlay/Floodgate.cpp
@@ -56,8 +56,7 @@ Floodgate::clearBelow(uint32_t maxLedger)
 }
 
 bool
-Floodgate::addRecord(StellarMessage const& msg, Peer::pointer peer,
-                     Hash const& index)
+Floodgate::addRecord(Peer::pointer peer, Hash const& index)
 {
     ZoneScoped;
     if (mShuttingDown)

--- a/src/overlay/Floodgate.h
+++ b/src/overlay/Floodgate.h
@@ -56,8 +56,7 @@ class Floodgate
     void clearBelow(uint32_t maxLedger);
     // returns true if this is a new record
     // fills msgID with msg's hash
-    bool addRecord(StellarMessage const& msg, Peer::pointer fromPeer,
-                   Hash const& msgID);
+    bool addRecord(Peer::pointer fromPeer, Hash const& msgID);
 
     // returns true if msg was sent to at least one peer
     // The hash required for transactions

--- a/src/overlay/FlowControl.cpp
+++ b/src/overlay/FlowControl.cpp
@@ -139,8 +139,12 @@ FlowControl::getNextBatchToSend()
 
             switch (front.mMessage->type())
             {
+#ifdef BUILD_TESTS
+            case TX_SET:
+#endif
             case TRANSACTION:
             {
+                releaseAssert(OverlayManager::isFloodMessage(msg));
                 size_t s = mFlowControlBytesCapacity.getMsgResourceCount(msg);
                 releaseAssert(mTxQueueByteCount >= s);
                 mTxQueueByteCount -= s;
@@ -194,6 +198,10 @@ FlowControl::updateMsgMetrics(std::shared_ptr<StellarMessage const> msg,
     switch (msg->type())
     {
     case TRANSACTION:
+#ifdef BUILD_TESTS
+    case TX_SET:
+#endif
+        releaseAssert(OverlayManager::isFloodMessage(*msg));
         updateQueueDelay(om.mOutboundQueueDelayTxs,
                          mMetrics.mOutboundQueueDelayTxs);
         break;
@@ -368,7 +376,11 @@ FlowControl::addMsgAndMaybeTrimQueue(std::shared_ptr<StellarMessage const> msg)
     }
     break;
     case TRANSACTION:
+#ifdef BUILD_TESTS
+    case TX_SET:
+#endif
     {
+        releaseAssert(OverlayManager::isFloodMessage(*msg));
         msgQInd = 1;
         auto bytes = mFlowControlBytesCapacity.getMsgResourceCount(*msg);
         // Don't accept transactions that are over allowed byte limit: those

--- a/src/overlay/OverlayManager.h
+++ b/src/overlay/OverlayManager.h
@@ -62,6 +62,7 @@ class OverlayManager
     // Drop all PeerRecords from the Database
     static void dropAll(Database& db);
     static bool isFloodMessage(StellarMessage const& msg);
+    static std::shared_ptr<StellarMessage> createTxBatch();
     static uint32_t getFlowControlBytesBatch(Config const& cfg);
 
     // Flush all FloodGate and ItemFetcher state for ledgers older than
@@ -83,18 +84,17 @@ class OverlayManager
     // that, call broadcastMessage, above.
     // Returns true if this is a new message
     // fills msgID with msg's hash
-    virtual bool recvFloodedMsgID(StellarMessage const& msg, Peer::pointer peer,
-                                  Hash const& msgID) = 0;
+    virtual bool recvFloodedMsgID(Peer::pointer peer, Hash const& msgID) = 0;
 
     bool
     recvFloodedMsg(StellarMessage const& msg, Peer::pointer peer)
     {
-        return recvFloodedMsgID(msg, peer, xdrBlake2(msg));
+        return recvFloodedMsgID(peer, xdrBlake2(msg));
     }
 
     // Process incoming transaction, pass it down to the transaction queue
-    virtual void recvTransaction(StellarMessage const& msg, Peer::pointer peer,
-                                 Hash const& index) = 0;
+    virtual void recvTransaction(TransactionFrameBasePtr transaction,
+                                 Peer::pointer peer, Hash const& index) = 0;
 
     // removes msgID from the floodgate's internal state
     // as it's not tracked anymore, calling "broadcast" with a (now forgotten)

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -1093,11 +1093,38 @@ OverlayManagerImpl::isPreferred(Peer* peer) const
     return false;
 }
 
+static const xdr::opaque_array<32> TX_BATCH_HASH = [] {
+    xdr::opaque_array<32> bytes{};
+    for (auto& b : bytes)
+    {
+        b = 0x1;
+    }
+    return bytes;
+}();
+
+std::shared_ptr<StellarMessage>
+OverlayManager::createTxBatch()
+{
+    // In testing, allow legacy TX_SET messages to represent a "batch" of
+    // transactions to flood by hard-coding a special previousLedgerHash.
+    auto msg = std::make_shared<StellarMessage>();
+    msg->type(TX_SET);
+    msg->txSet().previousLedgerHash = TX_BATCH_HASH;
+    return msg;
+}
+
 bool
 OverlayManager::isFloodMessage(StellarMessage const& msg)
 {
-    return msg.type() == SCP_MESSAGE || msg.type() == TRANSACTION ||
-           msg.type() == FLOOD_DEMAND || msg.type() == FLOOD_ADVERT;
+    bool isFlood = msg.type() == SCP_MESSAGE || msg.type() == TRANSACTION ||
+                   msg.type() == FLOOD_DEMAND || msg.type() == FLOOD_ADVERT;
+#ifdef BUILD_TESTS
+    isFlood = isFlood || (msg.type() == TX_SET &&
+                          msg.txSet().previousLedgerHash ==
+                              createTxBatch()->txSet().previousLedgerHash);
+#endif
+
+    return isFlood;
 }
 std::vector<Peer::pointer>
 OverlayManagerImpl::getRandomAuthenticatedPeers()
@@ -1150,11 +1177,10 @@ OverlayManagerImpl::shufflePeerList(std::vector<Peer::pointer>& peerList)
 }
 
 bool
-OverlayManagerImpl::recvFloodedMsgID(StellarMessage const& msg,
-                                     Peer::pointer peer, Hash const& msgID)
+OverlayManagerImpl::recvFloodedMsgID(Peer::pointer peer, Hash const& msgID)
 {
     ZoneScoped;
-    return mFloodGate.addRecord(msg, peer, msgID);
+    return mFloodGate.addRecord(peer, msgID);
 }
 
 bool
@@ -1183,18 +1209,16 @@ OverlayManagerImpl::checkScheduledAndCache(
 }
 
 void
-OverlayManagerImpl::recvTransaction(StellarMessage const& msg,
+OverlayManagerImpl::recvTransaction(TransactionFrameBasePtr transaction,
                                     Peer::pointer peer, Hash const& index)
 {
     ZoneScoped;
-    auto transaction = TransactionFrameBase::makeTransactionFromWire(
-        mApp.getNetworkID(), msg.transaction());
+    releaseAssert(threadIsMain());
     if (transaction)
     {
         // record that this peer sent us this transaction
         // add it to the floodmap so that this peer gets credit for it
-        recvFloodedMsgID(msg, peer, index);
-
+        recvFloodedMsgID(peer, index);
         mTxDemandsManager.recordTxPullLatency(transaction->getFullHash(), peer);
 
         // add it to our current set

--- a/src/overlay/OverlayManagerImpl.h
+++ b/src/overlay/OverlayManagerImpl.h
@@ -112,10 +112,9 @@ class OverlayManagerImpl : public OverlayManager
     ~OverlayManagerImpl();
 
     void clearLedgersBelow(uint32_t ledgerSeq, uint32_t lclSeq) override;
-    bool recvFloodedMsgID(StellarMessage const& msg, Peer::pointer peer,
-                          Hash const& msgID) override;
-    void recvTransaction(StellarMessage const& msg, Peer::pointer peer,
-                         Hash const& index) override;
+    bool recvFloodedMsgID(Peer::pointer peer, Hash const& msgID) override;
+    void recvTransaction(TransactionFrameBasePtr transaction,
+                         Peer::pointer peer, Hash const& index) override;
     void forgetFloodedMsg(Hash const& msgID) override;
     void recvTxDemand(FloodDemand const& dmd, Peer::pointer peer) override;
     bool

--- a/src/overlay/OverlayMetrics.cpp
+++ b/src/overlay/OverlayMetrics.cpp
@@ -84,6 +84,8 @@ OverlayMetrics::OverlayMetrics(Application& app)
           app.getMetrics().NewTimer({"overlay", "recv", "flood-advert"}))
     , mRecvFloodDemandTimer(
           app.getMetrics().NewTimer({"overlay", "recv", "flood-demand"}))
+    , mRecvTxBatchTimer(
+          app.getMetrics().NewTimer({"overlay", "recv", "tx-batch"}))
 
     , mMessageDelayInWriteQueueTimer(
           app.getMetrics().NewTimer({"overlay", "delay", "write-queue"}))
@@ -178,6 +180,8 @@ OverlayMetrics::OverlayMetrics(Application& app)
           {"overlay", "fetch", "unique-recv"}, "byte"))
     , mDuplicateFetchBytesRecv(app.getMetrics().NewMeter(
           {"overlay", "fetch", "duplicate-recv"}, "byte"))
+    , mTxBatchSizeHistogram(
+          app.getMetrics().NewHistogram({"overlay", "flood", "tx-batch-size"}))
 {
 }
 }

--- a/src/overlay/OverlayMetrics.h
+++ b/src/overlay/OverlayMetrics.h
@@ -12,6 +12,7 @@ namespace medida
 class Timer;
 class Meter;
 class Counter;
+class Histogram;
 }
 
 namespace stellar
@@ -78,6 +79,7 @@ struct OverlayMetrics
 
     medida::Timer& mRecvFloodAdvertTimer;
     medida::Timer& mRecvFloodDemandTimer;
+    medida::Timer& mRecvTxBatchTimer;
 
     medida::Timer& mMessageDelayInWriteQueueTimer;
     medida::Timer& mMessageDelayInAsyncWriteTimer;
@@ -133,5 +135,6 @@ struct OverlayMetrics
     medida::Meter& mDuplicateFloodBytesRecv;
     medida::Meter& mUniqueFetchBytesRecv;
     medida::Meter& mDuplicateFetchBytesRecv;
+    medida::Histogram& mTxBatchSizeHistogram;
 };
 }

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -11,6 +11,7 @@
 #include "medida/timer.h"
 #include "overlay/Hmac.h"
 #include "overlay/PeerBareAddress.h"
+#include "transactions/TransactionFrameBase.h"
 #include "util/NonCopyable.h"
 #include "util/Timer.h"
 #include "xdrpp/message.h"
@@ -289,6 +290,9 @@ class Peer : public std::enable_shared_from_this<Peer>,
     void recvTxSet(StellarMessage const& msg);
     void recvGeneralizedTxSet(StellarMessage const& msg);
     void recvTransaction(CapacityTrackedMessage const& msgTracker);
+#ifdef BUILD_TESTS
+    void recvTxBatch(CapacityTrackedMessage const& msgTracker);
+#endif
     void recvGetSCPQuorumSet(StellarMessage const& msg);
     void recvSCPQuorumSet(StellarMessage const& msg);
     void recvSCPMessage(CapacityTrackedMessage const& msgTracker);
@@ -504,11 +508,18 @@ class CapacityTrackedMessage : private NonMovableOrCopyable
     std::weak_ptr<Peer> const mWeakPeer;
     StellarMessage const mMsg;
     std::optional<Hash> mMaybeHash;
+    // xdrBlake2 -> txFrame (with pre-populated hashes)
+    std::unordered_map<Hash, TransactionFrameBasePtr> mTxsMap;
 
   public:
     CapacityTrackedMessage(std::weak_ptr<Peer> peer, StellarMessage const& msg);
     StellarMessage const& getMessage() const;
     ~CapacityTrackedMessage();
     std::optional<Hash> maybeGetHash() const;
+    std::unordered_map<Hash, TransactionFrameBasePtr> const&
+    getTxMap() const
+    {
+        return mTxsMap;
+    }
 };
 }

--- a/src/overlay/test/ItemFetcherTests.cpp
+++ b/src/overlay/test/ItemFetcherTests.cpp
@@ -465,8 +465,7 @@ TEST_CASE("next peer strategy", "[overlay][ItemFetcher]")
         {
             StellarMessage msg(SCP_MESSAGE);
             msg.envelope() = hundredEnvelope1;
-            app->getOverlayManager().recvFloodedMsgID(msg, peer1,
-                                                      xdrBlake2(msg));
+            app->getOverlayManager().recvFloodedMsgID(peer1, xdrBlake2(msg));
             tracker->tryNextPeer();
             REQUIRE(askCount == 2);
             auto trPeer1b = tracker->getLastAskedPeer();


### PR DESCRIPTION
Testing-only change (for now) to batch transactions to flood. Note that because this is for testing only currently, I did not want to introduce a new XDR structure to avoid handling malformed XDR manually in prod paths. As a result, currently a batch is represented via a slightly hacky "legacy TX_SET with a hard-coded previousLedgerHash". When we actually want to enable this in prod, we can switch to proper XDR then. 