### PR TITLE
Fix the tx count metric

### DIFF
--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -841,12 +841,12 @@ TransactionFrame::updateSorobanMetrics(AppConnector& app) const
     releaseAssertOrThrow(isSoroban());
     SorobanMetrics& metrics = app.getSorobanMetrics();
     auto txSize = static_cast<int64_t>(this->getSize());
-    auto r = sorobanResources();
+    auto const& r = sorobanResources();
     // update the tx metrics
     metrics.mTxSizeByte.Update(txSize);
     // accumulate the ledger-wide metrics, which will get emitted at the ledger
     // close
-    metrics.accumulateLedgerTxCount(1);
+    metrics.accumulateLedgerTxCount(getNumOperations());
     metrics.accumulateLedgerCpuInsn(r.instructions);
     metrics.accumulateLedgerTxsSizeByte(txSize);
     metrics.accumulateLedgerReadEntry(static_cast<int64_t>(


### PR DESCRIPTION


# Description

Fix the tx count metric - it should actually count the ops.

The current naming is rather misleading, but it's not worth changing the metric name right now, as we might update the protocol to actually count the transactions for the purpose of the respective network limit.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
