### PR TITLE
Level 0 merge

### DIFF
--- a/src/bucket/BucketBase.h
+++ b/src/bucket/BucketBase.h
@@ -135,6 +135,18 @@ class BucketBase : public NonMovableOrCopyable
         MergeCounters& mc, uint32_t protocolVersion,
         std::vector<BucketInputIterator<BucketT>> const& shadowIterators);
 
+    // Helper function that implements the core merge algorithm logic for both
+    // iterator based and in-memory merges.
+    // PutFunc will be called to write entries that are the result of the merge.
+    // We have to use a template here to break a dependency on the BucketT type,
+    // but PutFuncT == std::function<void(typename BucketT::EntryT const&)>
+    template <typename InputSource, typename PutFuncT>
+    static void
+    mergeInternal(BucketManager& bucketManager, InputSource& inputSource,
+                  PutFuncT putFunc, uint32_t protocolVersion,
+                  std::vector<BucketInputIterator<BucketT>>& shadowIterators,
+                  bool keepShadowedLifecycleEntries, MergeCounters& mc);
+
     static std::string randomBucketName(std::string const& tmpDir);
     static std::string randomBucketIndexName(std::string const& tmpDir);
 

--- a/src/bucket/BucketBase.h
+++ b/src/bucket/BucketBase.h
@@ -4,12 +4,12 @@
 // under the apache license, version 2.0. see the copying file at the root
 // of this distribution or at http://www.apache.org/licenses/license-2.0
 
+#include "bucket/BucketInputIterator.h"
 #include "bucket/BucketUtils.h"
 #include "util/NonCopyable.h"
 #include "util/ProtocolVersion.h"
 #include "xdr/Stellar-types.h"
 #include <filesystem>
-#include <optional>
 #include <string>
 
 namespace asio
@@ -129,6 +129,11 @@ class BucketBase : public NonMovableOrCopyable
           std::vector<std::shared_ptr<BucketT>> const& shadows,
           bool keepTombstoneEntries, bool countMergeEvents,
           asio::io_context& ctx, bool doFsync);
+
+    // Returns whether shadowed lifecycle entries should be kept
+    static bool updateMergeCountersForProtocolVersion(
+        MergeCounters& mc, uint32_t protocolVersion,
+        std::vector<BucketInputIterator<BucketT>> const& shadowIterators);
 
     static std::string randomBucketName(std::string const& tmpDir);
     static std::string randomBucketIndexName(std::string const& tmpDir);

--- a/src/bucket/BucketListBase.cpp
+++ b/src/bucket/BucketListBase.cpp
@@ -131,8 +131,10 @@ BucketLevel<BucketT>::commit()
 {
     if (mNextCurrInMemory)
     {
-        // If we have an in-memory merged result, use that
+        // If we have an in-memory merged result, use that. Should only be valid
+        // on top level buckets.
         setCurr(mNextCurrInMemory);
+        releaseAssertOrThrow(mLevel == 0);
     }
     else if (mNextCurr.isLive())
     {

--- a/src/bucket/BucketListBase.cpp
+++ b/src/bucket/BucketListBase.cpp
@@ -222,6 +222,10 @@ BucketLevel<LiveBucket>::prepareFirstLevel(Application& app,
         return;
     }
 
+    // This bucket is the "level -1" snap bucket, which is created and
+    // immediately merges with level 0 curr. This merge will produce a
+    // BucketIndex for the result, so there's no reason to index this Bucket
+    // before it merges.
     auto snap = LiveBucket::fresh(
         app.getBucketManager(), currLedgerProtocol, inputVectors...,
         countMergeEvents, app.getClock().getIOContext(), doFsync,

--- a/src/bucket/BucketListBase.h
+++ b/src/bucket/BucketListBase.h
@@ -6,6 +6,7 @@
 
 #include "bucket/BucketUtils.h"
 #include "bucket/FutureBucket.h"
+#include <variant>
 
 namespace medida
 {
@@ -360,10 +361,18 @@ template <class BucketT> class BucketLevel
     BUCKET_TYPE_ASSERT(BucketT);
 
     uint32_t mLevel;
-    FutureBucket<BucketT> mNextCurr;
+    // Variant to hold either a FutureBucket (for async merges) or a
+    // shared_ptr<BucketT> (for in-memory merges)
+    std::variant<FutureBucket<BucketT>, std::shared_ptr<BucketT>> mNextCurr;
     std::shared_ptr<BucketT> mCurr;
     std::shared_ptr<BucketT> mSnap;
-    std::shared_ptr<BucketT> mNextCurrInMemory;
+
+    void setNextInMemory(std::shared_ptr<BucketT>&& b);
+
+    bool hasInMemoryMerge() const;
+    bool hasFutureBucketMerge() const;
+    bool hasInProgressMerge() const;
+    void clearNext();
 
   public:
     BucketLevel(uint32_t i);

--- a/src/bucket/BucketListBase.h
+++ b/src/bucket/BucketListBase.h
@@ -363,6 +363,7 @@ template <class BucketT> class BucketLevel
     FutureBucket<BucketT> mNextCurr;
     std::shared_ptr<BucketT> mCurr;
     std::shared_ptr<BucketT> mSnap;
+    std::shared_ptr<BucketT> mNextCurrInMemory;
 
   public:
     BucketLevel(uint32_t i);
@@ -379,6 +380,16 @@ template <class BucketT> class BucketLevel
                  uint32_t currLedgerProtocol, std::shared_ptr<BucketT> snap,
                  std::vector<std::shared_ptr<BucketT>> const& shadows,
                  bool countMergeEvents);
+
+    // Special version of prepare for level 0 that does an in-memory merge if
+    // possible. Falls back to regular prepare if in-memory merge is not
+    // possible., such as for the HotArchiveBucketList, or in some edge cases
+    // on startup.
+    template <typename... VectorT>
+    void prepareFirstLevel(Application& app, uint32_t currLedger,
+                           uint32_t currLedgerProtocol, bool countMergeEvents,
+                           bool doFsync, VectorT const&... inputVectors);
+
     std::shared_ptr<BucketT> snap();
 };
 

--- a/src/bucket/BucketMergeAdapter.h
+++ b/src/bucket/BucketMergeAdapter.h
@@ -1,0 +1,176 @@
+#pragma once
+
+// Copyright 2024 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "bucket/BucketInputIterator.h"
+#include "bucket/LedgerCmp.h"
+#include <vector>
+
+namespace stellar
+{
+
+// These classes provide wrappers around the inputs to a BucketMerge, namely
+// either BucketInputIterators for file based merges, or a vector of bucket
+// entries for in-memory merges.
+template <class BucketT> class MergeInput
+{
+  public:
+    // Check if we're done - both iterators are exhausted
+    virtual bool isDone() const = 0;
+
+    // Check if old entry should go first (old < new or new is exhausted)
+    virtual bool oldFirst() const = 0;
+
+    // Check if new entry should go first (new < old or old is exhausted)
+    virtual bool newFirst() const = 0;
+
+    // Check if old and new entries have equal keys and are both not exhausted
+    virtual bool equalKeys() const = 0;
+
+    virtual typename BucketT::EntryT const& getOldEntry() = 0;
+    virtual typename BucketT::EntryT const& getNewEntry() = 0;
+
+    // Advance iterators
+    virtual void advanceOld() = 0;
+    virtual void advanceNew() = 0;
+
+    virtual ~MergeInput() = default;
+};
+
+template <class BucketT> class FileMergeInput : public MergeInput<BucketT>
+{
+  private:
+    BucketInputIterator<BucketT>& mOldIter;
+    BucketInputIterator<BucketT>& mNewIter;
+    BucketEntryIdCmp<BucketT> mCmp;
+
+  public:
+    FileMergeInput(BucketInputIterator<BucketT>& oldIter,
+                   BucketInputIterator<BucketT>& newIter)
+        : mOldIter(oldIter), mNewIter(newIter)
+    {
+    }
+
+    bool
+    isDone() const override
+    {
+        return !mOldIter && !mNewIter;
+    }
+
+    bool
+    oldFirst() const override
+    {
+        return !mNewIter || (mOldIter && mCmp(*mOldIter, *mNewIter));
+    }
+
+    bool
+    newFirst() const override
+    {
+        return !mOldIter || (mNewIter && mCmp(*mNewIter, *mOldIter));
+    }
+
+    bool
+    equalKeys() const override
+    {
+        return mOldIter && mNewIter && !mCmp(*mOldIter, *mNewIter) &&
+               !mCmp(*mNewIter, *mOldIter);
+    }
+
+    typename BucketT::EntryT const&
+    getOldEntry() override
+    {
+        return *mOldIter;
+    }
+
+    typename BucketT::EntryT const&
+    getNewEntry() override
+    {
+        return *mNewIter;
+    }
+
+    void
+    advanceOld() override
+    {
+        ++mOldIter;
+    }
+
+    void
+    advanceNew() override
+    {
+        ++mNewIter;
+    }
+};
+
+template <class BucketT> class MemoryMergeInput : public MergeInput<BucketT>
+{
+  private:
+    std::vector<typename BucketT::EntryT> const& mOldEntries;
+    std::vector<typename BucketT::EntryT> const& mNewEntries;
+    BucketEntryIdCmp<BucketT> mCmp;
+    size_t mOldIdx = 0;
+    size_t mNewIdx = 0;
+
+  public:
+    MemoryMergeInput(std::vector<typename BucketT::EntryT> const& oldEntries,
+                     std::vector<typename BucketT::EntryT> const& newEntries)
+        : mOldEntries(oldEntries), mNewEntries(newEntries)
+    {
+    }
+
+    bool
+    isDone() const override
+    {
+        return mOldIdx >= mOldEntries.size() && mNewIdx >= mNewEntries.size();
+    }
+
+    bool
+    oldFirst() const override
+    {
+        return mNewIdx >= mNewEntries.size() ||
+               (mOldIdx < mOldEntries.size() &&
+                mCmp(mOldEntries.at(mOldIdx), mNewEntries.at(mNewIdx)));
+    }
+
+    bool
+    newFirst() const override
+    {
+        return mOldIdx >= mOldEntries.size() ||
+               (mNewIdx < mNewEntries.size() &&
+                mCmp(mNewEntries.at(mNewIdx), mOldEntries.at(mOldIdx)));
+    }
+
+    bool
+    equalKeys() const override
+    {
+        return mOldIdx < mOldEntries.size() && mNewIdx < mNewEntries.size() &&
+               !mCmp(mOldEntries.at(mOldIdx), mNewEntries.at(mNewIdx)) &&
+               !mCmp(mNewEntries.at(mNewIdx), mOldEntries.at(mOldIdx));
+    }
+
+    typename BucketT::EntryT const&
+    getOldEntry() override
+    {
+        return mOldEntries.at(mOldIdx);
+    }
+
+    typename BucketT::EntryT const&
+    getNewEntry() override
+    {
+        return mNewEntries.at(mNewIdx);
+    }
+
+    void
+    advanceOld() override
+    {
+        ++mOldIdx;
+    }
+
+    void
+    advanceNew() override
+    {
+        ++mNewIdx;
+    }
+};
+}

--- a/src/bucket/BucketMergeAdapter.h
+++ b/src/bucket/BucketMergeAdapter.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// Copyright 2024 Stellar Development Foundation and contributors. Licensed
+// Copyright 2025 Stellar Development Foundation and contributors. Licensed
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 

--- a/src/bucket/BucketOutputIterator.h
+++ b/src/bucket/BucketOutputIterator.h
@@ -52,7 +52,10 @@ template <typename BucketT> class BucketOutputIterator
 
     void put(typename BucketT::EntryT const& e);
 
-    std::shared_ptr<BucketT> getBucket(BucketManager& bucketManager,
-                                       MergeKey* mergeKey = nullptr);
+    std::shared_ptr<BucketT> getBucket(
+        BucketManager& bucketManager, MergeKey* mergeKey = nullptr,
+        std::optional<std::vector<typename BucketT::EntryT>> inMemoryState =
+            std::nullopt,
+        bool shouldIndex = true);
 };
 }

--- a/src/bucket/FutureBucket.cpp
+++ b/src/bucket/FutureBucket.cpp
@@ -350,7 +350,6 @@ FutureBucket<BucketT>::startMerge(Application& app, uint32_t maxProtocolVersion,
 
     std::shared_ptr<BucketT> curr = mInputCurrBucket;
     std::shared_ptr<BucketT> snap = mInputSnapBucket;
-    std::vector<std::shared_ptr<BucketT>> shadows = mInputShadowBuckets;
 
     releaseAssert(curr);
     releaseAssert(snap);
@@ -365,10 +364,17 @@ FutureBucket<BucketT>::startMerge(Application& app, uint32_t maxProtocolVersion,
         {"bucket", "merge-time", "level-" + std::to_string(level)});
 
     std::vector<Hash> shadowHashes;
-    shadowHashes.reserve(shadows.size());
-    for (auto const& b : shadows)
+    std::vector<std::shared_ptr<BucketT>> shadows;
+
+    // Shadows are only supported for LiveBucket
+    if constexpr (std::is_same_v<BucketT, LiveBucket>)
     {
-        shadowHashes.emplace_back(b->getHash());
+        shadows = mInputShadowBuckets;
+        shadowHashes.reserve(shadows.size());
+        for (auto const& b : shadows)
+        {
+            shadowHashes.emplace_back(b->getHash());
+        }
     }
 
     // It's possible we're running a merge that's already running, for example

--- a/src/bucket/HotArchiveBucket.cpp
+++ b/src/bucket/HotArchiveBucket.cpp
@@ -79,12 +79,8 @@ HotArchiveBucket::convertToBucketEntry(
 void
 HotArchiveBucket::maybePut(
     std::function<void(HotArchiveBucketEntry const&)> putFunc,
-    HotArchiveBucketEntry const& entry,
-    std::vector<HotArchiveBucketInputIterator>& shadowIterators,
-    bool keepShadowedLifecycleEntries, MergeCounters& mc)
+    HotArchiveBucketEntry const& entry, MergeCounters& mc)
 {
-    // Archived BucketList is only present after protocol 21, so shadows are
-    // never supported
     putFunc(entry);
 }
 
@@ -93,8 +89,7 @@ void
 HotArchiveBucket::mergeCasesWithEqualKeys(
     MergeCounters& mc, InputSource& inputSource,
     std::function<void(HotArchiveBucketEntry const&)> putFunc,
-    std::vector<HotArchiveBucketInputIterator>& shadowIterators,
-    uint32_t protocolVersion, bool keepShadowedLifecycleEntries)
+    uint32_t protocolVersion)
 {
     auto const& oldEntry = inputSource.getOldEntry();
     auto const& newEntry = inputSource.getNewEntry();
@@ -148,13 +143,11 @@ template void
 HotArchiveBucket::mergeCasesWithEqualKeys<FileMergeInput<HotArchiveBucket>>(
     MergeCounters& mc, FileMergeInput<HotArchiveBucket>& inputSource,
     std::function<void(HotArchiveBucketEntry const&)> putFunc,
-    std::vector<HotArchiveBucketInputIterator>& shadowIterators,
-    uint32_t protocolVersion, bool keepShadowedLifecycleEntries);
+    uint32_t protocolVersion);
 
 template void
 HotArchiveBucket::mergeCasesWithEqualKeys<MemoryMergeInput<HotArchiveBucket>>(
     MergeCounters& mc, MemoryMergeInput<HotArchiveBucket>& inputSource,
     std::function<void(HotArchiveBucketEntry const&)> putFunc,
-    std::vector<HotArchiveBucketInputIterator>& shadowIterators,
-    uint32_t protocolVersion, bool keepShadowedLifecycleEntries);
+    uint32_t protocolVersion);
 }

--- a/src/bucket/HotArchiveBucket.cpp
+++ b/src/bucket/HotArchiveBucket.cpp
@@ -4,6 +4,7 @@
 
 #include "bucket/HotArchiveBucket.h"
 #include "bucket/BucketInputIterator.h"
+#include "bucket/BucketMergeAdapter.h"
 #include "bucket/BucketOutputIterator.h"
 #include "bucket/BucketUtils.h"
 #include "ledger/LedgerTypeUtils.h"
@@ -77,26 +78,29 @@ HotArchiveBucket::convertToBucketEntry(
 
 void
 HotArchiveBucket::maybePut(
-    HotArchiveBucketOutputIterator& out, HotArchiveBucketEntry const& entry,
+    std::function<void(HotArchiveBucketEntry const&)> putFunc,
+    HotArchiveBucketEntry const& entry,
     std::vector<HotArchiveBucketInputIterator>& shadowIterators,
     bool keepShadowedLifecycleEntries, MergeCounters& mc)
 {
     // Archived BucketList is only present after protocol 21, so shadows are
     // never supported
-    out.put(entry);
+    putFunc(entry);
 }
 
+template <typename InputSource>
 void
 HotArchiveBucket::mergeCasesWithEqualKeys(
-    MergeCounters& mc, HotArchiveBucketInputIterator& oi,
-    HotArchiveBucketInputIterator& ni, HotArchiveBucketOutputIterator& out,
+    MergeCounters& mc, InputSource& inputSource,
+    std::function<void(HotArchiveBucketEntry const&)> putFunc,
     std::vector<HotArchiveBucketInputIterator>& shadowIterators,
     uint32_t protocolVersion, bool keepShadowedLifecycleEntries)
 {
+    auto const& oldEntry = inputSource.getOldEntry();
+    auto const& newEntry = inputSource.getNewEntry();
+
     // If two identical keys have the same type, throw an error. Otherwise,
     // take the newer key.
-    HotArchiveBucketEntry const& oldEntry = *oi;
-    HotArchiveBucketEntry const& newEntry = *ni;
     if (oldEntry.type() == newEntry.type())
     {
         throw std::runtime_error(
@@ -104,9 +108,9 @@ HotArchiveBucket::mergeCasesWithEqualKeys(
             "the same type.");
     }
 
-    out.put(newEntry);
-    ++ni;
-    ++oi;
+    putFunc(newEntry);
+    inputSource.advanceNew();
+    inputSource.advanceOld();
 }
 
 uint32_t
@@ -140,4 +144,17 @@ HotArchiveBucket::bucketEntryToLoadResult(
     return isTombstoneEntry(*be) ? nullptr : be;
 }
 
+template void
+HotArchiveBucket::mergeCasesWithEqualKeys<FileMergeInput<HotArchiveBucket>>(
+    MergeCounters& mc, FileMergeInput<HotArchiveBucket>& inputSource,
+    std::function<void(HotArchiveBucketEntry const&)> putFunc,
+    std::vector<HotArchiveBucketInputIterator>& shadowIterators,
+    uint32_t protocolVersion, bool keepShadowedLifecycleEntries);
+
+template void
+HotArchiveBucket::mergeCasesWithEqualKeys<MemoryMergeInput<HotArchiveBucket>>(
+    MergeCounters& mc, MemoryMergeInput<HotArchiveBucket>& inputSource,
+    std::function<void(HotArchiveBucketEntry const&)> putFunc,
+    std::vector<HotArchiveBucketInputIterator>& shadowIterators,
+    uint32_t protocolVersion, bool keepShadowedLifecycleEntries);
 }

--- a/src/bucket/HotArchiveBucket.h
+++ b/src/bucket/HotArchiveBucket.h
@@ -58,7 +58,7 @@ class HotArchiveBucket
     static bool isTombstoneEntry(HotArchiveBucketEntry const& e);
 
     // Note: this functions is called maybePut for interoperability with
-    // LiveBucket. This function always writes te given entry to the output
+    // LiveBucket. This function always writes the given entry to the output
     // iterator using putFunc.
     static void
     maybePut(std::function<void(HotArchiveBucketEntry const&)> putFunc,

--- a/src/bucket/HotArchiveBucket.h
+++ b/src/bucket/HotArchiveBucket.h
@@ -62,9 +62,7 @@ class HotArchiveBucket
     // iterator using putFunc.
     static void
     maybePut(std::function<void(HotArchiveBucketEntry const&)> putFunc,
-             HotArchiveBucketEntry const& entry,
-             std::vector<HotArchiveBucketInputIterator>& shadowIterators,
-             bool keepShadowedLifecycleEntries, MergeCounters& mc);
+             HotArchiveBucketEntry const& entry, MergeCounters& mc);
 
     // For now, we only count LiveBucket merge events
     static void
@@ -87,8 +85,7 @@ class HotArchiveBucket
     static void mergeCasesWithEqualKeys(
         MergeCounters& mc, InputSource& inputSource,
         std::function<void(HotArchiveBucketEntry const&)> putFunc,
-        std::vector<HotArchiveBucketInputIterator>& shadowIterators,
-        uint32_t protocolVersion, bool keepShadowedLifecycleEntries);
+        uint32_t protocolVersion);
 
     static std::shared_ptr<LoadT const>
     bucketEntryToLoadResult(std::shared_ptr<EntryT const> const& be);

--- a/src/bucket/HotArchiveBucket.h
+++ b/src/bucket/HotArchiveBucket.h
@@ -59,9 +59,9 @@ class HotArchiveBucket
 
     // Note: this functions is called maybePut for interoperability with
     // LiveBucket. This function always writes te given entry to the output
-    // iterator.
+    // iterator using putFunc.
     static void
-    maybePut(HotArchiveBucketOutputIterator& out,
+    maybePut(std::function<void(HotArchiveBucketEntry const&)> putFunc,
              HotArchiveBucketEntry const& entry,
              std::vector<HotArchiveBucketInputIterator>& shadowIterators,
              bool keepShadowedLifecycleEntries, MergeCounters& mc);
@@ -83,9 +83,10 @@ class HotArchiveBucket
     {
     }
 
+    template <typename InputSource>
     static void mergeCasesWithEqualKeys(
-        MergeCounters& mc, HotArchiveBucketInputIterator& oi,
-        HotArchiveBucketInputIterator& ni, HotArchiveBucketOutputIterator& out,
+        MergeCounters& mc, InputSource& inputSource,
+        std::function<void(HotArchiveBucketEntry const&)> putFunc,
         std::vector<HotArchiveBucketInputIterator>& shadowIterators,
         uint32_t protocolVersion, bool keepShadowedLifecycleEntries);
 

--- a/src/bucket/InMemoryIndex.cpp
+++ b/src/bucket/InMemoryIndex.cpp
@@ -36,10 +36,87 @@ InMemoryBucketState::scan(IterT start, LedgerKey const& searchKey) const
     return {IndexReturnT(), mEntries.begin()};
 }
 
+InMemoryIndex::InMemoryIndex(BucketManager& bm,
+                             std::vector<BucketEntry> const& inMemoryState,
+                             BucketMetadata const& metadata)
+{
+    ZoneScoped;
+
+    // 4 bytes of size info between BucketEntries on disk
+    constexpr std::streamoff xdrOverheadBetweenEntries = 4;
+
+    // 4 bytes of BucketEntry overhead for METAENTRY
+    constexpr std::streamoff xdrOverheadForMetaEntry = 4;
+
+    std::streamoff lastOffset = xdr::xdr_size(metadata) +
+                                xdrOverheadForMetaEntry +
+                                xdrOverheadBetweenEntries;
+    std::optional<std::streamoff> firstOffer;
+    std::optional<std::streamoff> lastOffer;
+
+    for (auto const& be : inMemoryState)
+    {
+        releaseAssertOrThrow(be.type() != METAENTRY);
+        mCounters.template count<LiveBucket>(be);
+
+        // Populate assetPoolIDMap
+        LedgerKey lk = getBucketLedgerKey(be);
+        if (be.type() == INITENTRY)
+        {
+            if (lk.type() == LIQUIDITY_POOL)
+            {
+                auto const& poolParams = be.liveEntry()
+                                             .data.liquidityPool()
+                                             .body.constantProduct()
+                                             .params;
+                mAssetPoolIDMap[poolParams.assetA].emplace_back(
+                    lk.liquidityPool().liquidityPoolID);
+                mAssetPoolIDMap[poolParams.assetB].emplace_back(
+                    lk.liquidityPool().liquidityPoolID);
+            }
+        }
+
+        // Populate inMemoryState
+        mInMemoryState.insert(be);
+
+        // Populate offerRange
+        if (!firstOffer && lk.type() == OFFER)
+        {
+            firstOffer = lastOffset;
+        }
+        if (!lastOffer && lk.type() > OFFER)
+        {
+            lastOffer = lastOffset;
+        }
+
+        lastOffset += xdr::xdr_size(be) + xdrOverheadBetweenEntries;
+    }
+
+    if (firstOffer)
+    {
+        if (lastOffer)
+        {
+            mOfferRange = {*firstOffer, *lastOffer};
+        }
+        // If we didn't see any entries after offers, then the upper bound is
+        // EOF
+        else
+        {
+            mOfferRange = {*firstOffer,
+                           std::numeric_limits<std::streamoff>::max()};
+        }
+    }
+    else
+    {
+        mOfferRange = std::nullopt;
+    }
+}
+
 InMemoryIndex::InMemoryIndex(BucketManager const& bm,
                              std::filesystem::path const& filename,
                              SHA256* hasher)
 {
+    ZoneScoped;
     XDRInputFileStream in;
     in.open(filename.string());
     BucketEntry be;
@@ -151,4 +228,14 @@ InMemoryIndex::InMemoryIndex(BucketManager const& bm,
         mContractCodeRange = std::nullopt;
     }
 }
+
+#ifdef BUILD_TESTS
+bool
+InMemoryIndex::operator==(InMemoryIndex const& in) const
+{
+    return mInMemoryState == in.mInMemoryState &&
+           mAssetPoolIDMap == in.mAssetPoolIDMap &&
+           mOfferRange == in.mOfferRange && mCounters == in.mCounters;
+}
+#endif
 }

--- a/src/bucket/InMemoryIndex.h
+++ b/src/bucket/InMemoryIndex.h
@@ -198,6 +198,10 @@ class InMemoryIndex
     InMemoryIndex(BucketManager const& bm,
                   std::filesystem::path const& filename, SHA256* hasher);
 
+    InMemoryIndex(BucketManager& bm,
+                  std::vector<BucketEntry> const& inMemoryState,
+                  BucketMetadata const& metadata);
+
     IterT
     begin() const
     {
@@ -240,13 +244,7 @@ class InMemoryIndex
     }
 
 #ifdef BUILD_TESTS
-    bool
-    operator==(InMemoryIndex const& in) const
-    {
-        return mInMemoryState == in.mInMemoryState &&
-               mAssetPoolIDMap == in.mAssetPoolIDMap &&
-               mCounters == in.mCounters;
-    }
+    bool operator==(InMemoryIndex const& in) const;
 #endif
 };
 }

--- a/src/bucket/LiveBucket.cpp
+++ b/src/bucket/LiveBucket.cpp
@@ -514,7 +514,7 @@ LiveBucket::mergeInMemory(BucketManager& bucketManager,
 
     if (countMergeEvents)
     {
-        bucketManager.incrMergeCounters(mc);
+        bucketManager.incrMergeCounters<LiveBucket>(mc);
     }
 
     // Write merge output to a bucket and save to disk

--- a/src/bucket/LiveBucket.h
+++ b/src/bucket/LiveBucket.h
@@ -81,8 +81,9 @@ class LiveBucket : public BucketBase<LiveBucket, LiveBucketIndex>,
     static void mergeCasesWithEqualKeys(
         MergeCounters& mc, InputSource& inputSource,
         std::function<void(BucketEntry const&)> putFunc,
+        uint32_t protocolVersion,
         std::vector<LiveBucketInputIterator>& shadowIterators,
-        uint32_t protocolVersion, bool keepShadowedLifecycleEntries);
+        bool keepShadowedLifecycleEntries);
 
 #ifdef BUILD_TESTS
     // "Applies" the bucket to the database. For each entry in the bucket,
@@ -127,9 +128,9 @@ class LiveBucket : public BucketBase<LiveBucket, LiveBucketIndex>,
     // iterator if the entry is not shadowed.
     // putFunc will be called to actually write the result of maybePut.
     static void maybePut(std::function<void(BucketEntry const&)> putFunc,
-                         BucketEntry const& entry,
+                         BucketEntry const& entry, MergeCounters& mc,
                          std::vector<LiveBucketInputIterator>& shadowIterators,
-                         bool keepShadowedLifecycleEntries, MergeCounters& mc);
+                         bool keepShadowedLifecycleEntries);
 
     // Merge two buckets in memory without using FutureBucket.
     // This is used only for level 0 merges. Note that the resulting Bucket is
@@ -142,6 +143,11 @@ class LiveBucket : public BucketBase<LiveBucket, LiveBucketIndex>,
 
     static void countOldEntryType(MergeCounters& mc, BucketEntry const& e);
     static void countNewEntryType(MergeCounters& mc, BucketEntry const& e);
+
+    // Returns whether shadowed lifecycle entries should be kept
+    static bool updateMergeCountersForProtocolVersion(
+        MergeCounters& mc, uint32_t protocolVersion,
+        std::vector<LiveBucketInputIterator> const& shadowIterators);
 
     uint32_t getBucketVersion() const;
 

--- a/src/bucket/LiveBucket.h
+++ b/src/bucket/LiveBucket.h
@@ -77,9 +77,10 @@ class LiveBucket : public BucketBase<LiveBucket, LiveBucketIndex>,
                          std::vector<LedgerEntry> const& liveEntries,
                          std::vector<LedgerKey> const& deadEntries);
 
+    template <typename InputSource>
     static void mergeCasesWithEqualKeys(
-        MergeCounters& mc, LiveBucketInputIterator& oi,
-        LiveBucketInputIterator& ni, LiveBucketOutputIterator& out,
+        MergeCounters& mc, InputSource& inputSource,
+        std::function<void(BucketEntry const&)> putFunc,
         std::vector<LiveBucketInputIterator>& shadowIterators,
         uint32_t protocolVersion, bool keepShadowedLifecycleEntries);
 
@@ -124,7 +125,8 @@ class LiveBucket : public BucketBase<LiveBucket, LiveBucketIndex>,
     // Whenever a given BucketEntry is "eligible" to be written as the merge
     // result in the output bucket, this function writes the entry to the output
     // iterator if the entry is not shadowed.
-    static void maybePut(LiveBucketOutputIterator& out,
+    // putFunc will be called to actually write the result of maybePut.
+    static void maybePut(std::function<void(BucketEntry const&)> putFunc,
                          BucketEntry const& entry,
                          std::vector<LiveBucketInputIterator>& shadowIterators,
                          bool keepShadowedLifecycleEntries, MergeCounters& mc);

--- a/src/bucket/LiveBucketIndex.cpp
+++ b/src/bucket/LiveBucketIndex.cpp
@@ -81,6 +81,16 @@ LiveBucketIndex::LiveBucketIndex(BucketManager const& bm, Archive& ar,
     releaseAssertOrThrow(pageSize != 0);
 }
 
+LiveBucketIndex::LiveBucketIndex(BucketManager& bm,
+                                 std::vector<BucketEntry> const& inMemoryState,
+                                 BucketMetadata const& metadata)
+    : mInMemoryIndex(
+          std::make_unique<InMemoryIndex>(bm, inMemoryState, metadata))
+    , mCacheHitMeter(bm.getCacheHitMeter())
+    , mCacheMissMeter(bm.getCacheMissMeter())
+{
+}
+
 void
 LiveBucketIndex::maybeInitializeCache(size_t totalBucketListAccountsSizeBytes,
                                       Config const& cfg) const

--- a/src/bucket/LiveBucketIndex.h
+++ b/src/bucket/LiveBucketIndex.h
@@ -108,6 +108,11 @@ class LiveBucketIndex : public NonMovableOrCopyable
     LiveBucketIndex(BucketManager const& bm, Archive& ar,
                     std::streamoff pageSize);
 
+    // Constructor for creating new index from in-memory state
+    LiveBucketIndex(BucketManager& bm,
+                    std::vector<BucketEntry> const& inMemoryState,
+                    BucketMetadata const& metadata);
+
     // Initializes the random eviction cache if it has not already been
     // initialized. The random eviction cache itself has an entry limit, but we
     // expose a memory limit in the validator config. To account for this, we

--- a/src/bucket/test/BucketManagerTests.cpp
+++ b/src/bucket/test/BucketManagerTests.cpp
@@ -237,7 +237,15 @@ TEST_CASE_VERSIONS("bucketmanager ownership", "[bucket][bucketmanager]")
             std::string indexFilename =
                 app->getBucketManager().bucketIndexFilename(b->getHash());
             CHECK(fs::exists(filename));
-            CHECK(fs::exists(indexFilename));
+
+            if (b->getIndexForTesting().getPageSize() == 0)
+            {
+                CHECK(!fs::exists(indexFilename));
+            }
+            else
+            {
+                CHECK(fs::exists(indexFilename));
+            }
 
             b.reset();
             app->getBucketManager().forgetUnreferencedBuckets(

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -2099,13 +2099,12 @@ TEST_CASE("upgrade to version 11", "[upgrades]")
             // Check several subtle characteristics of the post-upgrade
             // environment:
             //   - Old-protocol merges stop happening (there should have
-            //     been 6 before the upgrade, but we re-use a merge we did
-            //     at ledger 1 for ledger 2 spill, so the counter is at 5)
+            //     been 6 before the upgrade)
             //   - New-protocol merges start happening.
             //   - At the upgrade (5), we find 1 INITENTRY in lev[0].curr
             //   - The next two (6, 7), propagate INITENTRYs to lev[0].snap
             //   - From 8 on, the INITENTRYs propagate to lev[1].curr
-            REQUIRE(mc.mPreInitEntryProtocolMerges == 5);
+            REQUIRE(mc.mPreInitEntryProtocolMerges == 6);
             REQUIRE(mc.mPostInitEntryProtocolMerges != 0);
             auto& lev0 = bm.getLiveBucketList().getLevel(0);
             auto& lev1 = bm.getLiveBucketList().getLevel(1);
@@ -2215,25 +2214,25 @@ TEST_CASE("upgrade to version 12", "[upgrades]")
                 // One more old-style merge despite the upgrade
                 // At ledger 8, level 2 spills, and starts an old-style
                 // merge, as level 1 snap is still of old version
-                REQUIRE(mc.mPreShadowRemovalProtocolMerges == 6);
+                REQUIRE(mc.mPreShadowRemovalProtocolMerges == 7);
                 break;
             case 7:
                 REQUIRE(getVers(lev0Snap) == newProto);
                 REQUIRE(getVers(lev1Curr) == oldProto);
                 REQUIRE(mc.mPostShadowRemovalProtocolMerges == 4);
-                REQUIRE(mc.mPreShadowRemovalProtocolMerges == 5);
+                REQUIRE(mc.mPreShadowRemovalProtocolMerges == 6);
                 break;
             case 6:
                 REQUIRE(getVers(lev0Snap) == newProto);
                 REQUIRE(getVers(lev1Curr) == oldProto);
                 REQUIRE(mc.mPostShadowRemovalProtocolMerges == 3);
-                REQUIRE(mc.mPreShadowRemovalProtocolMerges == 5);
+                REQUIRE(mc.mPreShadowRemovalProtocolMerges == 6);
                 break;
             case 5:
                 REQUIRE(getVers(lev0Curr) == newProto);
                 REQUIRE(getVers(lev0Snap) == oldProto);
                 REQUIRE(mc.mPostShadowRemovalProtocolMerges == 1);
-                REQUIRE(mc.mPreShadowRemovalProtocolMerges == 5);
+                REQUIRE(mc.mPreShadowRemovalProtocolMerges == 6);
                 break;
             default:
                 break;


### PR DESCRIPTION
# Description

Resolves #4696

This change special cases level 0 Bucket merges to happen all in-memory, without file IO. To accomplish this, all level 0 buckets retain an in-memory vector of their contents. Instead of using file iterators to perform merges, these in-memory vectors are used. I've also reduced the number of times we index buckets during addBatch and use the in-memory vectors for indexing as well.

This reduces addBatch time by about 50% under high load as seen in max tps tests. 

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
