### PR TITLE
Add option to validate transaction signatures in the background

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -267,6 +267,12 @@ BACKGROUND_OVERLAY_PROCESSING = true
 # performance on multicore machines. Note that this is not compatible with SQLite.
 EXPERIMENTAL_PARALLEL_LEDGER_APPLY = false
 
+# EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION (bool) default false
+# Check signatures in the background for transactions received
+# over the network. Does nothing if `BACKGROUND_OVERLAY_PROCESSING` is not
+# also enabled. (experimental)
+EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION = false
+
 # PREFERRED_PEERS (list of strings) default is empty
 # These are IP:port strings that this server will add to its DB of peers.
 # This server will try to always stay connected to the other peers on this list.

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -3234,6 +3234,19 @@ TEST_CASE("overlay parallel processing")
             });
     }
 
+    SECTION("background signature validation")
+    {
+        // Set threshold to 1 so all have to vote
+        simulation =
+            Topologies::core(4, 1, Simulation::OVER_TCP, networkID, [](int i) {
+                auto cfg = getTestConfig(i);
+                cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE = 100;
+                cfg.BACKGROUND_OVERLAY_PROCESSING = true;
+                cfg.EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION = true;
+                return cfg;
+            });
+    }
+
 // Background ledger close requires postgres
 #ifdef USE_POSTGRES
     SECTION("background ledger close")

--- a/src/ledger/LedgerStateSnapshot.cpp
+++ b/src/ledger/LedgerStateSnapshot.cpp
@@ -239,6 +239,11 @@ LedgerSnapshot::LedgerSnapshot(Application& app)
             app.getLedgerManager().getLastClosedSnaphot());
 }
 
+LedgerSnapshot::LedgerSnapshot(SearchableSnapshotConstPtr snapshot)
+    : mGetter(std::make_unique<BucketSnapshotState>(snapshot))
+{
+}
+
 LedgerHeaderWrapper
 LedgerSnapshot::getLedgerHeader() const
 {

--- a/src/ledger/LedgerStateSnapshot.h
+++ b/src/ledger/LedgerStateSnapshot.h
@@ -143,6 +143,7 @@ class LedgerSnapshot : public NonMovableOrCopyable
   public:
     LedgerSnapshot(AbstractLedgerTxn& ltx);
     LedgerSnapshot(Application& app);
+    explicit LedgerSnapshot(SearchableSnapshotConstPtr snapshot);
     LedgerHeaderWrapper getLedgerHeader() const;
     LedgerEntryWrapper getAccount(AccountID const& account) const;
     LedgerEntryWrapper

--- a/src/main/AppConnector.cpp
+++ b/src/main/AppConnector.cpp
@@ -153,4 +153,19 @@ AppConnector::copySearchableHotArchiveBucketListSnapshot()
         .getBucketSnapshotManager()
         .copySearchableHotArchiveBucketListSnapshot();
 }
+
+void
+AppConnector::maybeCopySearchableBucketListSnapshot(
+    SearchableSnapshotConstPtr& snapshot)
+{
+    mApp.getBucketManager()
+        .getBucketSnapshotManager()
+        .maybeCopySearchableBucketListSnapshot(snapshot);
+}
+
+SearchableSnapshotConstPtr&
+AppConnector::getOverlayThreadSnapshot()
+{
+    return mApp.getOverlayManager().getOverlayThreadSnapshot();
+}
 }

--- a/src/main/AppConnector.h
+++ b/src/main/AppConnector.h
@@ -62,5 +62,13 @@ class AppConnector
     medida::MetricsRegistry& getMetrics() const;
     SearchableHotArchiveSnapshotConstPtr
     copySearchableHotArchiveBucketListSnapshot();
+
+    // Refreshes `snapshot` if a newer snapshot is available. No-op otherwise.
+    void
+    maybeCopySearchableBucketListSnapshot(SearchableSnapshotConstPtr& snapshot);
+
+    // Get a snapshot of ledger state for use by the overlay thread only. Must
+    // only be called from the overlay thread.
+    SearchableSnapshotConstPtr& getOverlayThreadSnapshot();
 };
 }

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -164,6 +164,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     CATCHUP_RECENT = 0;
     BACKGROUND_OVERLAY_PROCESSING = true;
     EXPERIMENTAL_PARALLEL_LEDGER_APPLY = false;
+    EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION = false;
     BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT = 14; // 2^14 == 16 kb
     BUCKETLIST_DB_INDEX_CUTOFF = 20;             // 20 mb
     BUCKETLIST_DB_MEMORY_FOR_CACHING = 0;
@@ -1082,6 +1083,11 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                 {"EXPERIMENTAL_PARALLEL_LEDGER_APPLY",
                  [&]() {
                      EXPERIMENTAL_PARALLEL_LEDGER_APPLY = readBool(item);
+                 }},
+                {"EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION",
+                 [&]() {
+                     EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION =
+                         readBool(item);
                  }},
                 {"ARTIFICIALLY_DELAY_LEDGER_CLOSE_FOR_TESTING",
                  [&]() {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -492,6 +492,11 @@ class Config : public std::enable_shared_from_this<Config>
     // Has no effect on non-test builds.
     size_t EXPERIMENTAL_TX_BATCH_MAX_SIZE;
 
+    // Check signatures in the background for transactions received
+    // over the network. Does nothing if `BACKGROUND_OVERLAY_PROCESSING` is not
+    // also enabled. (experimental)
+    bool EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION;
+
     // When set to true, BucketListDB indexes are persisted on-disk so that the
     // BucketList does not need to be reindexed on startup. Defaults to true.
     // This should only be set to false for testing purposes

--- a/src/overlay/OverlayManager.h
+++ b/src/overlay/OverlayManager.h
@@ -211,5 +211,9 @@ class OverlayManager
     // synchorization is needed
     virtual bool
     checkScheduledAndCache(std::shared_ptr<CapacityTrackedMessage> tracker) = 0;
+
+    // Get a snapshot of ledger state for use by the overlay thread only. Caller
+    // is responsible for updating the snapshot as needed.
+    virtual SearchableSnapshotConstPtr& getOverlayThreadSnapshot() = 0;
 };
 }

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -1429,4 +1429,18 @@ OverlayManagerImpl::recordMessageMetric(StellarMessage const& stellarMsg,
     }
 }
 
+SearchableSnapshotConstPtr&
+OverlayManagerImpl::getOverlayThreadSnapshot()
+{
+    releaseAssert(mApp.threadIsType(Application::ThreadType::OVERLAY));
+    if (!mOverlayThreadSnapshot)
+    {
+        // Create a new snapshot
+        mOverlayThreadSnapshot = mApp.getBucketManager()
+                                     .getBucketSnapshotManager()
+                                     .copySearchableLiveBucketListSnapshot();
+    }
+    return mOverlayThreadSnapshot;
+}
+
 }

--- a/src/overlay/OverlayManagerImpl.h
+++ b/src/overlay/OverlayManagerImpl.h
@@ -168,6 +168,8 @@ class OverlayManagerImpl : public OverlayManager
     void recordMessageMetric(StellarMessage const& stellarMsg,
                              Peer::pointer peer) override;
 
+    SearchableSnapshotConstPtr& getOverlayThreadSnapshot() override;
+
   private:
     struct ResolvedPeers
     {
@@ -182,6 +184,9 @@ class OverlayManagerImpl : public OverlayManager
     int mResolvingPeersRetryCount;
     RandomEvictionCache<Hash, std::weak_ptr<CapacityTrackedMessage>>
         mScheduledMessages;
+
+    // Snapshot of ledger state for use ONLY by the overlay thread
+    SearchableSnapshotConstPtr mOverlayThreadSnapshot;
 
     void triggerPeerResolution();
     std::pair<std::vector<PeerBareAddress>, bool>

--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -29,7 +29,7 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
 
     bool checkSignature(SignatureChecker& signatureChecker,
                         LedgerEntryWrapper const& account,
-                        int32_t neededWeight) const;
+                        int32_t neededWeight) const override;
 
     bool commonValidPreSeqNum(LedgerSnapshot const& ls,
                               MutableTransactionResultBase& txResult) const;

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -203,7 +203,7 @@ class TransactionFrame : public TransactionFrameBase
 
     bool checkSignature(SignatureChecker& signatureChecker,
                         LedgerEntryWrapper const& account,
-                        int32_t neededWeight) const;
+                        int32_t neededWeight) const override;
 
     bool checkSignatureNoAccount(SignatureChecker& signatureChecker,
                                  AccountID const& accountID) const;

--- a/src/transactions/TransactionFrameBase.h
+++ b/src/transactions/TransactionFrameBase.h
@@ -26,6 +26,7 @@ class OperationFrame;
 class TransactionFrame;
 class FeeBumpTransactionFrame;
 class AppConnector;
+class SignatureChecker;
 
 class MutableTransactionResultBase;
 using MutableTxResultPtr = std::shared_ptr<MutableTransactionResultBase>;
@@ -61,6 +62,10 @@ class TransactionFrameBase
                                       bool applying) const = 0;
 
     virtual TransactionEnvelope const& getEnvelope() const = 0;
+
+    virtual bool checkSignature(SignatureChecker& signatureChecker,
+                                LedgerEntryWrapper const& account,
+                                int32_t neededWeight) const = 0;
 
 #ifdef BUILD_TESTS
     virtual TransactionEnvelope& getMutableEnvelope() const = 0;

--- a/src/transactions/test/TransactionTestFrame.cpp
+++ b/src/transactions/test/TransactionTestFrame.cpp
@@ -198,6 +198,15 @@ TransactionTestFrame::getFee(LedgerHeader const& header,
     return mTransactionFrame->getFee(header, baseFee, applying);
 }
 
+bool
+TransactionTestFrame::checkSignature(SignatureChecker& signatureChecker,
+                                     LedgerEntryWrapper const& account,
+                                     int32_t neededWeight) const
+{
+    return mTransactionFrame->checkSignature(signatureChecker, account,
+                                             neededWeight);
+}
+
 Hash const&
 TransactionTestFrame::getContentsHash() const
 {

--- a/src/transactions/test/TransactionTestFrame.h
+++ b/src/transactions/test/TransactionTestFrame.h
@@ -96,6 +96,10 @@ class TransactionTestFrame : public TransactionFrameBase
     int64_t getFee(LedgerHeader const& header, std::optional<int64_t> baseFee,
                    bool applying) const override;
 
+    bool checkSignature(SignatureChecker& signatureChecker,
+                        LedgerEntryWrapper const& account,
+                        int32_t neededWeight) const override;
+
     Hash const& getContentsHash() const override;
     Hash const& getFullHash() const override;
 


### PR DESCRIPTION
This change adds an experimental config option to validate transaction signatures in the background when receiving transactions over the network.

This PR may need updating to integrate with #4692.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md) (testing in progress)
