### PR TITLE
Remove redundant loads from checkValid path

### DIFF
--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -31,8 +31,11 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
                         LedgerEntryWrapper const& account,
                         int32_t neededWeight) const;
 
-    bool commonValidPreSeqNum(LedgerSnapshot const& ls,
-                              MutableTransactionResultBase& txResult) const;
+    // If check passes, returns the fee source account. Otherwise returns
+    // nullopt.
+    std::optional<LedgerEntryWrapper>
+    commonValidPreSeqNum(LedgerSnapshot const& ls,
+                         MutableTransactionResultBase& txResult) const;
 
     enum ValidationType
     {

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -254,7 +254,14 @@ OperationFrame::checkValid(AppConnector& app,
         {
             // for ledger versions >= 10 we need to load account here, as for
             // previous versions it is done in checkSignature call
-            if (!ls.getAccount(ls.getLedgerHeader(), mParentTx, getSourceID()))
+            // If we get to operation checkvalid, we know the tx source account
+            // has already been checked for existence. If we're not applying,
+            // it's guaranteed that the tx source account exists, since ledger
+            // state hasn't changed, so we can skip this redundant check.
+            // If we're applying, it's possible an earlier op modified the TX
+            // source, so we need to check again.
+            if ((mOperation.sourceAccount || forApply) &&
+                !ls.getAccount(ls.getLedgerHeader(), mParentTx, getSourceID()))
             {
                 res.code(opNO_ACCOUNT);
                 validationResult = false;

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -94,13 +94,13 @@ class TransactionFrame : public TransactionFrameBase
                               LedgerEntryWrapper const& sourceAccount,
                               uint64_t lowerBoundCloseTimeOffset) const;
 
-    bool commonValidPreSeqNum(AppConnector& app,
-                              std::optional<SorobanNetworkConfig> const& cfg,
-                              LedgerSnapshot const& ls, bool chargeFee,
-                              uint64_t lowerBoundCloseTimeOffset,
-                              uint64_t upperBoundCloseTimeOffset,
-                              std::optional<FeePair> sorobanResourceFee,
-                              MutableTxResultPtr txResult) const;
+    // If check passes, returns the source account. Otherwise returns nullopt.
+    std::optional<LedgerEntryWrapper> commonValidPreSeqNum(
+        AppConnector& app, std::optional<SorobanNetworkConfig> const& cfg,
+        LedgerSnapshot const& ls, bool chargeFee,
+        uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+        std::optional<FeePair> sorobanResourceFee,
+        MutableTxResultPtr txResult) const;
 
     virtual bool isBadSeq(LedgerHeaderWrapper const& header,
                           int64_t seqNum) const;


### PR DESCRIPTION
# Description

This change refactor transaction and operation `checkValid` to reduce the number of redundant loads. Initially, TransactionFrame cached source accounts, making loads cheap. This resulted in calling load 3-4 times during check valid. However, that cache has been removed, resulting in reading from disk 3-4 times per call to checkValid.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
