### PR TITLE
Add config option to skip some validator checks for testing (for v22.3.0 release)

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -762,6 +762,11 @@ TESTING_STARTING_EVICTION_SCAN_LEVEL=6
 # in load generator.
 GENESIS_TEST_ACCOUNT_COUNT=0
 
+# SKIP_HIGH_CRITICAL_VALIDATOR_CHECKS_FOR_TESTING (bool) default false
+# If set to true, skips certain checks on HIGH and CRITICAL validator
+# specifications. This option is only configurable on builds with tests enabled.
+SKIP_HIGH_CRITICAL_VALIDATOR_CHECKS_FOR_TESTING=false
+
 #####################
 ##  Tables must come at the end. (TOML you are almost perfect!)
 

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -69,7 +69,8 @@ static const std::unordered_set<std::string> TESTING_ONLY_OPTIONS = {
     "ARTIFICIALLY_SLEEP_MAIN_THREAD_FOR_TESTING",
     "ARTIFICIALLY_SKIP_CONNECTION_ADJUSTMENT_FOR_TESTING",
     "ARTIFICIALLY_DELAY_LEDGER_CLOSE_FOR_TESTING",
-    "EXPERIMENTAL_TX_BATCH_MAX_SIZE_FOR_TESTING"};
+    "EXPERIMENTAL_TX_BATCH_MAX_SIZE_FOR_TESTING",
+    "SKIP_HIGH_CRITICAL_VALIDATOR_CHECKS_FOR_TESTING"};
 
 // Options that should only be used for testing
 static const std::unordered_set<std::string> TESTING_SUGGESTED_OPTIONS = {
@@ -316,6 +317,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     TEST_CASES_ENABLED = false;
     CATCHUP_SKIP_KNOWN_RESULTS_FOR_TESTING = false;
     MODE_USES_IN_MEMORY_LEDGER = false;
+    SKIP_HIGH_CRITICAL_VALIDATOR_CHECKS_FOR_TESTING = false;
 #endif
 
 #ifdef BEST_OFFER_DEBUGGING
@@ -698,7 +700,8 @@ Config::parseValidators(
         {
             addHistoryArchive(ve.mName, hist, "", "");
         }
-        if ((ve.mQuality == ValidatorQuality::VALIDATOR_HIGH_QUALITY ||
+        if (!skipHighCriticalValidatorChecks() &&
+            (ve.mQuality == ValidatorQuality::VALIDATOR_HIGH_QUALITY ||
              ve.mQuality == ValidatorQuality::VALIDATOR_CRITICAL_QUALITY) &&
             hist.empty())
         {
@@ -1170,6 +1173,11 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                 {"CATCHUP_SKIP_KNOWN_RESULTS_FOR_TESTING",
                  [&]() {
                      CATCHUP_SKIP_KNOWN_RESULTS_FOR_TESTING = readBool(item);
+                 }},
+                {"SKIP_HIGH_CRITICAL_VALIDATOR_CHECKS_FOR_TESTING",
+                 [&]() {
+                     SKIP_HIGH_CRITICAL_VALIDATOR_CHECKS_FOR_TESTING =
+                         readBool(item);
                  }},
 #endif // BUILD_TESTS
                 {"ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING",
@@ -2432,6 +2440,15 @@ Config::setNoPublish()
     }
 }
 
+bool
+Config::skipHighCriticalValidatorChecks() const
+{
+#ifdef BUILD_TESTS
+    return SKIP_HIGH_CRITICAL_VALIDATOR_CHECKS_FOR_TESTING;
+#endif
+    return false;
+}
+
 SCPQuorumSet
 Config::generateQuorumSetHelper(
     std::vector<ValidatorEntry>::const_iterator begin,
@@ -2456,7 +2473,7 @@ Config::generateQuorumSetHelper(
             }
             vals.emplace_back(it2->mKey);
         }
-        if (vals.size() < 3 &&
+        if (!skipHighCriticalValidatorChecks() && vals.size() < 3 &&
             (it->mQuality == ValidatorQuality::VALIDATOR_HIGH_QUALITY ||
              it->mQuality == ValidatorQuality::VALIDATOR_CRITICAL_QUALITY))
         {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -101,12 +101,16 @@ class Config : public std::enable_shared_from_this<Config>
     UnorderedMap<std::string, ValidatorQuality>
     parseDomainsQuality(std::shared_ptr<cpptoml::base> domainsQuality);
 
-    static SCPQuorumSet
+    // Returns `true` if checks specific to HIGH and CRITICAL validators should
+    // be skipped. Always returns `false` on builds without BUILD_TESTS enabled.
+    bool skipHighCriticalValidatorChecks() const;
+
+    SCPQuorumSet
     generateQuorumSetHelper(std::vector<ValidatorEntry>::const_iterator begin,
                             std::vector<ValidatorEntry>::const_iterator end,
                             ValidatorQuality curQuality);
 
-    static SCPQuorumSet
+    SCPQuorumSet
     generateQuorumSet(std::vector<ValidatorEntry> const& validators);
 
     void addSelfToValidators(
@@ -779,6 +783,10 @@ class Config : public std::enable_shared_from_this<Config>
     // offers are still commited to the SQL DB even when this mode is enabled.
     // Should only be used for testing.
     bool MODE_USES_IN_MEMORY_LEDGER;
+
+    // If set to true, skips certain checks on HIGH and CRITICAL validator
+    // specifications.
+    bool SKIP_HIGH_CRITICAL_VALIDATOR_CHECKS_FOR_TESTING;
 
     // Set QUORUM_SET using automatic quorum set configuration based on
     // `validators`.

--- a/src/main/test/ConfigTests.cpp
+++ b/src/main/test/ConfigTests.cpp
@@ -600,3 +600,34 @@ PUBLIC_KEY="GBVZFVEARURUJTN5ABZPKW36FHKVJK2GHXEVY2SZCCNU5I3CQMTZ3OES"
         c.load(ss),
         "At least one validator must have a quality level higher than LOW");
 }
+
+// Test that a config with 2 HIGH quality validators and no history archives
+// loads when `SKIP_HIGH_CRITICAL_VALIDATOR_CHECKS_FOR_TESTING` is set.
+TEST_CASE("skip validator checks", "[config]")
+{
+    Config c;
+    std::string const configStr = R"(
+NODE_SEED="SA7FGJMMUIHNE3ZPI2UO5I632A7O5FBAZTXFAIEVFA4DSSGLHXACLAIT a3"
+NODE_HOME_DOMAIN="domain"
+NODE_IS_VALIDATOR=true
+DEPRECATED_SQL_LEDGER_STATE=false
+UNSAFE_QUORUM=true
+SKIP_HIGH_CRITICAL_VALIDATOR_CHECKS_FOR_TESTING=true
+
+[[HOME_DOMAINS]]
+HOME_DOMAIN="domain"
+QUALITY="HIGH"
+
+[[VALIDATORS]]
+NAME="a1"
+HOME_DOMAIN="domain"
+PUBLIC_KEY="GDUTST3TG4MNDLY6WLB5CIASIBZAWWWJKZDHA4HFEVKQOVTYQ2F5GKYZ"
+
+[[VALIDATORS]]
+NAME="a2"
+HOME_DOMAIN="domain"
+PUBLIC_KEY="GBVZFVEARURUJTN5ABZPKW36FHKVJK2GHXEVY2SZCCNU5I3CQMTZ3OES"
+)";
+    std::stringstream ss(configStr);
+    c.load(ss);
+}


### PR DESCRIPTION
This PR is just #4703 cherry-picked over to the `release/v22.3.0` branch. It will allow us to use the new nomination algorithm while testing the 22.3.0 release.