### PR TITLE
Autorestore

### DIFF
--- a/src/bucket/test/BucketTestUtils.cpp
+++ b/src/bucket/test/BucketTestUtils.cpp
@@ -247,7 +247,7 @@ LedgerManagerForBucketTests::sealLedgerTxnAndTransferEntriesToBucketList(
                 {
                     std::vector<LedgerKey> restoredKeys;
                     auto restoredKeysMap = ltx.getRestoredHotArchiveKeys();
-                    for (auto const& key : restoredKeysMap)
+                    for (auto const& [key, entry] : restoredKeysMap)
                     {
                         // Hot Archive does not track TTLs
                         if (key.type() == CONTRACT_DATA ||

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1976,7 +1976,7 @@ LedgerManagerImpl::sealLedgerTxnAndTransferEntriesToBucketList(
             {
                 std::vector<LedgerKey> restoredKeys;
                 auto const& restoredKeyMap = ltx.getRestoredHotArchiveKeys();
-                for (auto const& key : restoredKeyMap)
+                for (auto const& [key, entry] : restoredKeyMap)
                 {
                     // TTL keys are not recorded in the hot archive BucketList
                     if (key.type() == CONTRACT_DATA ||

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -825,13 +825,13 @@ LedgerTxn::Impl::erase(InternalLedgerKey const& key)
     }
 }
 
-void
+LedgerTxnEntry
 LedgerTxn::restoreFromHotArchive(LedgerEntry const& entry, uint32_t ttl)
 {
-    getImpl()->restoreFromHotArchive(*this, entry, ttl);
+    return getImpl()->restoreFromHotArchive(*this, entry, ttl);
 }
 
-void
+LedgerTxnEntry
 LedgerTxn::Impl::restoreFromHotArchive(LedgerTxn& self,
                                        LedgerEntry const& entry, uint32_t ttl)
 {
@@ -852,7 +852,7 @@ LedgerTxn::Impl::restoreFromHotArchive(LedgerTxn& self,
     ttlEntry.data.type(TTL);
     ttlEntry.data.ttl().liveUntilLedgerSeq = ttl;
     ttlEntry.data.ttl().keyHash = ttlKey.ttl().keyHash;
-    create(self, ttlEntry);
+    auto ttlLtxe = create(self, ttlEntry);
 
     // Mark the keys as restored
     auto addKey = [this](LedgerKey const& key) {
@@ -864,15 +864,17 @@ LedgerTxn::Impl::restoreFromHotArchive(LedgerTxn& self,
     };
     addKey(LedgerEntryKey(entry));
     addKey(ttlKey);
+
+    return ttlLtxe;
 }
 
-void
+LedgerTxnEntry
 LedgerTxn::restoreFromLiveBucketList(LedgerKey const& key, uint32_t ttl)
 {
-    getImpl()->restoreFromLiveBucketList(*this, key, ttl);
+    return getImpl()->restoreFromLiveBucketList(*this, key, ttl);
 }
 
-void
+LedgerTxnEntry
 LedgerTxn::Impl::restoreFromLiveBucketList(LedgerTxn& self,
                                            LedgerKey const& key, uint32_t ttl)
 {
@@ -908,6 +910,8 @@ LedgerTxn::Impl::restoreFromLiveBucketList(LedgerTxn& self,
     };
     addKey(key);
     addKey(ttlKey);
+
+    return ttlLtxe;
 }
 
 void

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -581,20 +581,20 @@ class AbstractLedgerTxn : public AbstractLedgerTxnParent
     //     will create both data data/contract entry and
     //     corresponding TTL entry. Prior to this call, the data/contract key
     //     and TTL key must not exist in the live BucketList or any parent ltx,
-    //     throws otherwise.
+    //     throws otherwise. Returns the TTL entry created.
     // - restoreFromLiveBucketlist:
     //     Indicates that an entry in the live BucketList is being restored and
     //     updates the TTL entry accordingly. TTL key must exist, throws
-    //     otherwise.
+    //     otherwise. Returns the TTL entry that was modified.
     // All of these functions throw if the AbstractLedgerTxn is sealed or if
     // the AbstractLedgerTxn has a child.
     virtual LedgerTxnHeader loadHeader() = 0;
     virtual LedgerTxnEntry create(InternalLedgerEntry const& entry) = 0;
     virtual void erase(InternalLedgerKey const& key) = 0;
-    virtual void restoreFromHotArchive(LedgerEntry const& entry,
-                                       uint32_t ttl) = 0;
-    virtual void restoreFromLiveBucketList(LedgerKey const& key,
-                                           uint32_t ttl) = 0;
+    virtual LedgerTxnEntry restoreFromHotArchive(LedgerEntry const& entry,
+                                                 uint32_t ttl) = 0;
+    virtual LedgerTxnEntry restoreFromLiveBucketList(LedgerKey const& key,
+                                                     uint32_t ttl) = 0;
     virtual LedgerTxnEntry load(InternalLedgerKey const& key) = 0;
     virtual ConstLedgerTxnEntry
     loadWithoutRecord(InternalLedgerKey const& key) = 0;
@@ -740,8 +740,10 @@ class LedgerTxn : public AbstractLedgerTxn
     LedgerTxnEntry create(InternalLedgerEntry const& entry) override;
 
     void erase(InternalLedgerKey const& key) override;
-    void restoreFromHotArchive(LedgerEntry const& entry, uint32_t ttl) override;
-    void restoreFromLiveBucketList(LedgerKey const& key, uint32_t ttl) override;
+    LedgerTxnEntry restoreFromHotArchive(LedgerEntry const& entry,
+                                         uint32_t ttl) override;
+    LedgerTxnEntry restoreFromLiveBucketList(LedgerKey const& key,
+                                             uint32_t ttl) override;
 
     UnorderedMap<LedgerKey, LedgerEntry> getAllOffers() override;
 

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -365,15 +365,17 @@ class LedgerTxn::Impl
     // throws an exception, then
     // - the prepared statement cache may be, but is not guaranteed to be,
     //   modified
-    void restoreFromHotArchive(LedgerTxn& self, LedgerEntry const& entry,
-                               uint32_t ttl);
+    LedgerTxnEntry restoreFromHotArchive(LedgerTxn& self,
+                                         LedgerEntry const& entry,
+                                         uint32_t ttl);
 
     // restoreFromLiveBucketList has the basic exception safety guarantee. If it
     // throws an exception, then
     // - the prepared statement cache may be, but is not guaranteed to be,
     //   modified
-    void restoreFromLiveBucketList(LedgerTxn& self, LedgerKey const& key,
-                                   uint32_t ttl);
+    LedgerTxnEntry restoreFromLiveBucketList(LedgerTxn& self,
+                                             LedgerKey const& key,
+                                             uint32_t ttl);
 
     // getAllOffers has the basic exception safety guarantee. If it throws an
     // exception, then

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -374,7 +374,7 @@ class LedgerTxn::Impl
     // - the prepared statement cache may be, but is not guaranteed to be,
     //   modified
     LedgerTxnEntry restoreFromLiveBucketList(LedgerTxn& self,
-                                             LedgerKey const& key,
+                                             LedgerEntry const& entry,
                                              uint32_t ttl);
 
     // getAllOffers has the basic exception safety guarantee. If it throws an
@@ -452,8 +452,8 @@ class LedgerTxn::Impl
                        std::vector<LedgerKey>& deadEntries);
     // getRestoredHotArchiveKeys and getRestoredLiveBucketListKeys
     // have the strong exception safety guarantee
-    UnorderedSet<LedgerKey> const& getRestoredHotArchiveKeys() const;
-    UnorderedSet<LedgerKey> const& getRestoredLiveBucketListKeys() const;
+    UnorderedMap<LedgerKey, LedgerEntry> const& getRestoredHotArchiveKeys() const;
+    UnorderedMap<LedgerKey, LedgerEntry> const& getRestoredLiveBucketListKeys() const;
 
     LedgerKeySet getAllTTLKeysWithoutSealing() const;
 

--- a/src/ledger/test/InMemoryLedgerTxn.cpp
+++ b/src/ledger/test/InMemoryLedgerTxn.cpp
@@ -282,7 +282,7 @@ InMemoryLedgerTxn::restoreFromHotArchive(LedgerEntry const& entry, uint32_t ttl)
 }
 
 LedgerTxnEntry
-InMemoryLedgerTxn::restoreFromLiveBucketList(LedgerKey const& key, uint32_t ttl)
+InMemoryLedgerTxn::restoreFromLiveBucketList(LedgerEntry const& entry, uint32_t ttl)
 {
     throw std::runtime_error(
         "called restoreFromLiveBucketList on InMemoryLedgerTxn");

--- a/src/ledger/test/InMemoryLedgerTxn.cpp
+++ b/src/ledger/test/InMemoryLedgerTxn.cpp
@@ -274,14 +274,14 @@ InMemoryLedgerTxn::erase(InternalLedgerKey const& key)
     throw std::runtime_error("called erase on InMemoryLedgerTxn");
 }
 
-void
+LedgerTxnEntry
 InMemoryLedgerTxn::restoreFromHotArchive(LedgerEntry const& entry, uint32_t ttl)
 {
     throw std::runtime_error(
         "called restoreFromHotArchive on InMemoryLedgerTxn");
 }
 
-void
+LedgerTxnEntry
 InMemoryLedgerTxn::restoreFromLiveBucketList(LedgerKey const& key, uint32_t ttl)
 {
     throw std::runtime_error(

--- a/src/ledger/test/InMemoryLedgerTxn.h
+++ b/src/ledger/test/InMemoryLedgerTxn.h
@@ -112,8 +112,10 @@ class InMemoryLedgerTxn : public LedgerTxn
 
     LedgerTxnEntry create(InternalLedgerEntry const& entry) override;
     void erase(InternalLedgerKey const& key) override;
-    void restoreFromHotArchive(LedgerEntry const& entry, uint32_t ttl) override;
-    void restoreFromLiveBucketList(LedgerKey const& key, uint32_t ttl) override;
+    LedgerTxnEntry restoreFromHotArchive(LedgerEntry const& entry,
+                                         uint32_t ttl) override;
+    LedgerTxnEntry restoreFromLiveBucketList(LedgerKey const& key,
+                                             uint32_t ttl) override;
     LedgerTxnEntry load(InternalLedgerKey const& key) override;
     ConstLedgerTxnEntry
     loadWithoutRecord(InternalLedgerKey const& key) override;

--- a/src/ledger/test/InMemoryLedgerTxn.h
+++ b/src/ledger/test/InMemoryLedgerTxn.h
@@ -114,7 +114,7 @@ class InMemoryLedgerTxn : public LedgerTxn
     void erase(InternalLedgerKey const& key) override;
     LedgerTxnEntry restoreFromHotArchive(LedgerEntry const& entry,
                                          uint32_t ttl) override;
-    LedgerTxnEntry restoreFromLiveBucketList(LedgerKey const& key,
+    LedgerTxnEntry restoreFromLiveBucketList(LedgerEntry const& entry,
                                              uint32_t ttl) override;
     LedgerTxnEntry load(InternalLedgerKey const& key) override;
     ConstLedgerTxnEntry

--- a/src/ledger/test/LedgerTxnTests.cpp
+++ b/src/ledger/test/LedgerTxnTests.cpp
@@ -256,7 +256,8 @@ TEST_CASE("LedgerTxn commit into LedgerTxn", "[ledgertxn]")
 
         SECTION("live BL restore key does not exist")
         {
-            REQUIRE_THROWS(ltx1.restoreFromLiveBucketList(randomKeys[0], 42));
+            REQUIRE_THROWS(
+                ltx1.restoreFromLiveBucketList(randomEntries[0], 42));
         }
 
         auto checkKey = [](auto const& keySet, auto const& dataKey) {
@@ -316,7 +317,7 @@ TEST_CASE("LedgerTxn commit into LedgerTxn", "[ledgertxn]")
                 // Populate live BL with key, then restore it
                 ltx1.create(randomEntries[0]);
                 ltx1.create(getTTLEntry(randomKeys[0]));
-                ltx1.restoreFromLiveBucketList(randomKeys[0], 42);
+                ltx1.restoreFromLiveBucketList(randomEntries[0], 42);
 
                 SECTION("rollback")
                 {
@@ -324,7 +325,7 @@ TEST_CASE("LedgerTxn commit into LedgerTxn", "[ledgertxn]")
                         LedgerTxn ltx2(ltx1);
                         ltx2.create(randomEntries[1]);
                         ltx2.create(getTTLEntry(randomKeys[1]));
-                        ltx2.restoreFromLiveBucketList(randomKeys[1], 42);
+                        ltx2.restoreFromLiveBucketList(randomEntries[1], 42);
                     }
 
                     REQUIRE(ltx1.getRestoredHotArchiveKeys().empty());
@@ -341,7 +342,7 @@ TEST_CASE("LedgerTxn commit into LedgerTxn", "[ledgertxn]")
                         LedgerTxn ltx2(ltx1);
                         ltx2.create(randomEntries[1]);
                         ltx2.create(getTTLEntry(randomKeys[1]));
-                        ltx2.restoreFromLiveBucketList(randomKeys[1], 42);
+                        ltx2.restoreFromLiveBucketList(randomEntries[1], 42);
                         ltx2.commit();
                     }
 

--- a/src/testdata/ledger-close-meta-enable-classic-events-v1-protocol-20-soroban.json
+++ b/src/testdata/ledger-close-meta-enable-classic-events-v1-protocol-20-soroban.json
@@ -1410,14 +1410,25 @@
                                     },
                                     "changes": [
                                         {
-                                            "type": "LEDGER_ENTRY_STATE",
-                                            "state": {
+                                            "type": "LEDGER_ENTRY_RESTORED",
+                                            "restored": {
                                                 "lastModifiedLedgerSeq": 10,
                                                 "data": {
-                                                    "type": "TTL",
-                                                    "ttl": {
-                                                        "keyHash": "4791962cd1e2c7b8f8af3f96514f9777f0156a48261fb885a571a7f69b33a058",
-                                                        "liveUntilLedgerSeq": 29
+                                                    "type": "CONTRACT_DATA",
+                                                    "contractData": {
+                                                        "ext": {
+                                                            "v": 0
+                                                        },
+                                                        "contract": "CAA3QKIP2SNVXUJTB4HKOGF55JTSSMQGED3FZYNHMNSXYV3DRRMAWA3Y",
+                                                        "key": {
+                                                            "type": "SCV_SYMBOL",
+                                                            "sym": "archived"
+                                                        },
+                                                        "durability": "PERSISTENT",
+                                                        "val": {
+                                                            "type": "SCV_U64",
+                                                            "u64": 42
+                                                        }
                                                     }
                                                 },
                                                 "ext": {
@@ -1426,8 +1437,8 @@
                                             }
                                         },
                                         {
-                                            "type": "LEDGER_ENTRY_UPDATED",
-                                            "updated": {
+                                            "type": "LEDGER_ENTRY_RESTORED",
+                                            "restored": {
                                                 "lastModifiedLedgerSeq": 31,
                                                 "data": {
                                                     "type": "TTL",

--- a/src/testdata/ledger-close-meta-enable-classic-events-v1-protocol-21-soroban.json
+++ b/src/testdata/ledger-close-meta-enable-classic-events-v1-protocol-21-soroban.json
@@ -2196,14 +2196,25 @@
                                     },
                                     "changes": [
                                         {
-                                            "type": "LEDGER_ENTRY_STATE",
-                                            "state": {
+                                            "type": "LEDGER_ENTRY_RESTORED",
+                                            "restored": {
                                                 "lastModifiedLedgerSeq": 10,
                                                 "data": {
-                                                    "type": "TTL",
-                                                    "ttl": {
-                                                        "keyHash": "4791962cd1e2c7b8f8af3f96514f9777f0156a48261fb885a571a7f69b33a058",
-                                                        "liveUntilLedgerSeq": 29
+                                                    "type": "CONTRACT_DATA",
+                                                    "contractData": {
+                                                        "ext": {
+                                                            "v": 0
+                                                        },
+                                                        "contract": "CAA3QKIP2SNVXUJTB4HKOGF55JTSSMQGED3FZYNHMNSXYV3DRRMAWA3Y",
+                                                        "key": {
+                                                            "type": "SCV_SYMBOL",
+                                                            "sym": "archived"
+                                                        },
+                                                        "durability": "PERSISTENT",
+                                                        "val": {
+                                                            "type": "SCV_U64",
+                                                            "u64": 42
+                                                        }
                                                     }
                                                 },
                                                 "ext": {
@@ -2212,8 +2223,8 @@
                                             }
                                         },
                                         {
-                                            "type": "LEDGER_ENTRY_UPDATED",
-                                            "updated": {
+                                            "type": "LEDGER_ENTRY_RESTORED",
+                                            "restored": {
                                                 "lastModifiedLedgerSeq": 31,
                                                 "data": {
                                                     "type": "TTL",

--- a/src/testdata/ledger-close-meta-enable-classic-events-v1-protocol-22-soroban.json
+++ b/src/testdata/ledger-close-meta-enable-classic-events-v1-protocol-22-soroban.json
@@ -1060,14 +1060,25 @@
                                     },
                                     "changes": [
                                         {
-                                            "type": "LEDGER_ENTRY_STATE",
-                                            "state": {
+                                            "type": "LEDGER_ENTRY_RESTORED",
+                                            "restored": {
                                                 "lastModifiedLedgerSeq": 10,
                                                 "data": {
-                                                    "type": "TTL",
-                                                    "ttl": {
-                                                        "keyHash": "4791962cd1e2c7b8f8af3f96514f9777f0156a48261fb885a571a7f69b33a058",
-                                                        "liveUntilLedgerSeq": 29
+                                                    "type": "CONTRACT_DATA",
+                                                    "contractData": {
+                                                        "ext": {
+                                                            "v": 0
+                                                        },
+                                                        "contract": "CAA3QKIP2SNVXUJTB4HKOGF55JTSSMQGED3FZYNHMNSXYV3DRRMAWA3Y",
+                                                        "key": {
+                                                            "type": "SCV_SYMBOL",
+                                                            "sym": "archived"
+                                                        },
+                                                        "durability": "PERSISTENT",
+                                                        "val": {
+                                                            "type": "SCV_U64",
+                                                            "u64": 42
+                                                        }
                                                     }
                                                 },
                                                 "ext": {
@@ -1076,8 +1087,8 @@
                                             }
                                         },
                                         {
-                                            "type": "LEDGER_ENTRY_UPDATED",
-                                            "updated": {
+                                            "type": "LEDGER_ENTRY_RESTORED",
+                                            "restored": {
                                                 "lastModifiedLedgerSeq": 31,
                                                 "data": {
                                                     "type": "TTL",

--- a/src/testdata/ledger-close-meta-enable-classic-events-v1-protocol-23-soroban.json
+++ b/src/testdata/ledger-close-meta-enable-classic-events-v1-protocol-23-soroban.json
@@ -1416,22 +1416,6 @@
                                             }
                                         },
                                         {
-                                            "type": "LEDGER_ENTRY_STATE",
-                                            "state": {
-                                                "lastModifiedLedgerSeq": 10,
-                                                "data": {
-                                                    "type": "TTL",
-                                                    "ttl": {
-                                                        "keyHash": "4791962cd1e2c7b8f8af3f96514f9777f0156a48261fb885a571a7f69b33a058",
-                                                        "liveUntilLedgerSeq": 29
-                                                    }
-                                                },
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        {
                                             "type": "LEDGER_ENTRY_RESTORED",
                                             "restored": {
                                                 "lastModifiedLedgerSeq": 31,

--- a/src/testdata/ledger-close-meta-v1-protocol-20-soroban.json
+++ b/src/testdata/ledger-close-meta-v1-protocol-20-soroban.json
@@ -1293,14 +1293,25 @@
                                 {
                                     "changes": [
                                         {
-                                            "type": "LEDGER_ENTRY_STATE",
-                                            "state": {
+                                            "type": "LEDGER_ENTRY_RESTORED",
+                                            "restored": {
                                                 "lastModifiedLedgerSeq": 10,
                                                 "data": {
-                                                    "type": "TTL",
-                                                    "ttl": {
-                                                        "keyHash": "4791962cd1e2c7b8f8af3f96514f9777f0156a48261fb885a571a7f69b33a058",
-                                                        "liveUntilLedgerSeq": 29
+                                                    "type": "CONTRACT_DATA",
+                                                    "contractData": {
+                                                        "ext": {
+                                                            "v": 0
+                                                        },
+                                                        "contract": "CAA3QKIP2SNVXUJTB4HKOGF55JTSSMQGED3FZYNHMNSXYV3DRRMAWA3Y",
+                                                        "key": {
+                                                            "type": "SCV_SYMBOL",
+                                                            "sym": "archived"
+                                                        },
+                                                        "durability": "PERSISTENT",
+                                                        "val": {
+                                                            "type": "SCV_U64",
+                                                            "u64": 42
+                                                        }
                                                     }
                                                 },
                                                 "ext": {
@@ -1309,8 +1320,8 @@
                                             }
                                         },
                                         {
-                                            "type": "LEDGER_ENTRY_UPDATED",
-                                            "updated": {
+                                            "type": "LEDGER_ENTRY_RESTORED",
+                                            "restored": {
                                                 "lastModifiedLedgerSeq": 31,
                                                 "data": {
                                                     "type": "TTL",

--- a/src/testdata/ledger-close-meta-v1-protocol-21-soroban.json
+++ b/src/testdata/ledger-close-meta-v1-protocol-21-soroban.json
@@ -1953,14 +1953,25 @@
                                 {
                                     "changes": [
                                         {
-                                            "type": "LEDGER_ENTRY_STATE",
-                                            "state": {
+                                            "type": "LEDGER_ENTRY_RESTORED",
+                                            "restored": {
                                                 "lastModifiedLedgerSeq": 10,
                                                 "data": {
-                                                    "type": "TTL",
-                                                    "ttl": {
-                                                        "keyHash": "4791962cd1e2c7b8f8af3f96514f9777f0156a48261fb885a571a7f69b33a058",
-                                                        "liveUntilLedgerSeq": 29
+                                                    "type": "CONTRACT_DATA",
+                                                    "contractData": {
+                                                        "ext": {
+                                                            "v": 0
+                                                        },
+                                                        "contract": "CAA3QKIP2SNVXUJTB4HKOGF55JTSSMQGED3FZYNHMNSXYV3DRRMAWA3Y",
+                                                        "key": {
+                                                            "type": "SCV_SYMBOL",
+                                                            "sym": "archived"
+                                                        },
+                                                        "durability": "PERSISTENT",
+                                                        "val": {
+                                                            "type": "SCV_U64",
+                                                            "u64": 42
+                                                        }
                                                     }
                                                 },
                                                 "ext": {
@@ -1969,8 +1980,8 @@
                                             }
                                         },
                                         {
-                                            "type": "LEDGER_ENTRY_UPDATED",
-                                            "updated": {
+                                            "type": "LEDGER_ENTRY_RESTORED",
+                                            "restored": {
                                                 "lastModifiedLedgerSeq": 31,
                                                 "data": {
                                                     "type": "TTL",

--- a/src/testdata/ledger-close-meta-v1-protocol-22-soroban.json
+++ b/src/testdata/ledger-close-meta-v1-protocol-22-soroban.json
@@ -994,14 +994,25 @@
                                 {
                                     "changes": [
                                         {
-                                            "type": "LEDGER_ENTRY_STATE",
-                                            "state": {
+                                            "type": "LEDGER_ENTRY_RESTORED",
+                                            "restored": {
                                                 "lastModifiedLedgerSeq": 10,
                                                 "data": {
-                                                    "type": "TTL",
-                                                    "ttl": {
-                                                        "keyHash": "4791962cd1e2c7b8f8af3f96514f9777f0156a48261fb885a571a7f69b33a058",
-                                                        "liveUntilLedgerSeq": 29
+                                                    "type": "CONTRACT_DATA",
+                                                    "contractData": {
+                                                        "ext": {
+                                                            "v": 0
+                                                        },
+                                                        "contract": "CAA3QKIP2SNVXUJTB4HKOGF55JTSSMQGED3FZYNHMNSXYV3DRRMAWA3Y",
+                                                        "key": {
+                                                            "type": "SCV_SYMBOL",
+                                                            "sym": "archived"
+                                                        },
+                                                        "durability": "PERSISTENT",
+                                                        "val": {
+                                                            "type": "SCV_U64",
+                                                            "u64": 42
+                                                        }
                                                     }
                                                 },
                                                 "ext": {
@@ -1010,8 +1021,8 @@
                                             }
                                         },
                                         {
-                                            "type": "LEDGER_ENTRY_UPDATED",
-                                            "updated": {
+                                            "type": "LEDGER_ENTRY_RESTORED",
+                                            "restored": {
                                                 "lastModifiedLedgerSeq": 31,
                                                 "data": {
                                                     "type": "TTL",

--- a/src/testdata/ledger-close-meta-v1-protocol-23-soroban.json
+++ b/src/testdata/ledger-close-meta-v1-protocol-23-soroban.json
@@ -1298,22 +1298,6 @@
                                             }
                                         },
                                         {
-                                            "type": "LEDGER_ENTRY_STATE",
-                                            "state": {
-                                                "lastModifiedLedgerSeq": 10,
-                                                "data": {
-                                                    "type": "TTL",
-                                                    "ttl": {
-                                                        "keyHash": "4791962cd1e2c7b8f8af3f96514f9777f0156a48261fb885a571a7f69b33a058",
-                                                        "liveUntilLedgerSeq": 29
-                                                    }
-                                                },
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        {
                                             "type": "LEDGER_ENTRY_RESTORED",
                                             "restored": {
                                                 "lastModifiedLedgerSeq": 31,

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -355,7 +355,7 @@ InvokeHostFunctionOpFrame::ApplyHelper::handleArchivedEntry(
         else
         {
             ttlEntry =
-                mLtx.restoreFromLiveBucketList(lk, restoredLiveUntilLedger);
+                mLtx.restoreFromLiveBucketList(le, restoredLiveUntilLedger);
         }
 
         // Finally, add the entries to the Cxx buffer as if they were live. If

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -102,145 +102,109 @@ metricsEvent(bool success, std::string&& topic, uint64_t value)
     de.event.body.v0().data = makeU64SCVal(value);
     return de;
 }
+}
 
-} // namespace
-
-struct HostFunctionMetrics
+HostFunctionMetrics::HostFunctionMetrics(SorobanMetrics& metrics)
+    : mMetrics(metrics)
 {
-    SorobanMetrics& mMetrics;
+}
 
-    uint32_t mReadEntry{0};
-    uint32_t mWriteEntry{0};
-
-    uint32_t mLedgerReadByte{0};
-    uint32_t mLedgerWriteByte{0};
-
-    uint32_t mReadKeyByte{0};
-    uint32_t mWriteKeyByte{0};
-
-    uint32_t mReadDataByte{0};
-    uint32_t mWriteDataByte{0};
-
-    uint32_t mReadCodeByte{0};
-    uint32_t mWriteCodeByte{0};
-
-    uint32_t mEmitEvent{0};
-    uint32_t mEmitEventByte{0};
-
-    // host runtime metrics
-    uint64_t mCpuInsn{0};
-    uint64_t mMemByte{0};
-    uint64_t mInvokeTimeNsecs{0};
-    uint64_t mCpuInsnExclVm{0};
-    uint64_t mInvokeTimeNsecsExclVm{0};
-    uint64_t mDeclaredCpuInsn{0};
-
-    // max single entity size metrics
-    uint32_t mMaxReadWriteKeyByte{0};
-    uint32_t mMaxReadWriteDataByte{0};
-    uint32_t mMaxReadWriteCodeByte{0};
-    uint32_t mMaxEmitEventByte{0};
-
-    bool mSuccess{false};
-
-    HostFunctionMetrics(SorobanMetrics& metrics) : mMetrics(metrics)
+void
+HostFunctionMetrics::noteReadEntry(bool isCodeEntry, uint32_t keySize,
+                                   uint32_t entrySize)
+{
+    mReadEntry++;
+    mReadKeyByte += keySize;
+    mMaxReadWriteKeyByte = std::max(mMaxReadWriteKeyByte, keySize);
+    mLedgerReadByte += entrySize;
+    if (isCodeEntry)
     {
+        mReadCodeByte += entrySize;
+        mMaxReadWriteCodeByte = std::max(mMaxReadWriteCodeByte, entrySize);
     }
-
-    void
-    noteReadEntry(bool isCodeEntry, uint32_t keySize, uint32_t entrySize)
+    else
     {
-        mReadEntry++;
-        mReadKeyByte += keySize;
-        mMaxReadWriteKeyByte = std::max(mMaxReadWriteKeyByte, keySize);
-        mLedgerReadByte += entrySize;
-        if (isCodeEntry)
-        {
-            mReadCodeByte += entrySize;
-            mMaxReadWriteCodeByte = std::max(mMaxReadWriteCodeByte, entrySize);
-        }
-        else
-        {
-            mReadDataByte += entrySize;
-            mMaxReadWriteDataByte = std::max(mMaxReadWriteDataByte, entrySize);
-        }
+        mReadDataByte += entrySize;
+        mMaxReadWriteDataByte = std::max(mMaxReadWriteDataByte, entrySize);
     }
+}
 
-    void
-    noteWriteEntry(bool isCodeEntry, uint32_t keySize, uint32_t entrySize)
+void
+HostFunctionMetrics::noteWriteEntry(bool isCodeEntry, uint32_t keySize,
+                                    uint32_t entrySize)
+{
+    mWriteEntry++;
+    mMaxReadWriteKeyByte = std::max(mMaxReadWriteKeyByte, keySize);
+    mLedgerWriteByte += entrySize;
+    if (isCodeEntry)
     {
-        mWriteEntry++;
-        mMaxReadWriteKeyByte = std::max(mMaxReadWriteKeyByte, keySize);
-        mLedgerWriteByte += entrySize;
-        if (isCodeEntry)
-        {
-            mWriteCodeByte += entrySize;
-            mMaxReadWriteCodeByte = std::max(mMaxReadWriteCodeByte, entrySize);
-        }
-        else
-        {
-            mWriteDataByte += entrySize;
-            mMaxReadWriteDataByte = std::max(mMaxReadWriteDataByte, entrySize);
-        }
+        mWriteCodeByte += entrySize;
+        mMaxReadWriteCodeByte = std::max(mMaxReadWriteCodeByte, entrySize);
     }
-
-    ~HostFunctionMetrics()
+    else
     {
-        mMetrics.mHostFnOpReadEntry.Mark(mReadEntry);
-        mMetrics.mHostFnOpWriteEntry.Mark(mWriteEntry);
-
-        mMetrics.mHostFnOpReadKeyByte.Mark(mReadKeyByte);
-        mMetrics.mHostFnOpWriteKeyByte.Mark(mWriteKeyByte);
-
-        mMetrics.mHostFnOpReadLedgerByte.Mark(mLedgerReadByte);
-        mMetrics.mHostFnOpReadDataByte.Mark(mReadDataByte);
-        mMetrics.mHostFnOpReadCodeByte.Mark(mReadCodeByte);
-
-        mMetrics.mHostFnOpWriteLedgerByte.Mark(mLedgerWriteByte);
-        mMetrics.mHostFnOpWriteDataByte.Mark(mWriteDataByte);
-        mMetrics.mHostFnOpWriteCodeByte.Mark(mWriteCodeByte);
-
-        mMetrics.mHostFnOpEmitEvent.Mark(mEmitEvent);
-        mMetrics.mHostFnOpEmitEventByte.Mark(mEmitEventByte);
-
-        mMetrics.mHostFnOpCpuInsn.Mark(mCpuInsn);
-        mMetrics.mHostFnOpMemByte.Mark(mMemByte);
-        mMetrics.mHostFnOpInvokeTimeNsecs.Update(
-            std::chrono::nanoseconds(mInvokeTimeNsecs));
-        mMetrics.mHostFnOpCpuInsnExclVm.Mark(mCpuInsnExclVm);
-        mMetrics.mHostFnOpInvokeTimeNsecsExclVm.Update(
-            std::chrono::nanoseconds(mInvokeTimeNsecsExclVm));
-        mMetrics.mHostFnOpInvokeTimeFsecsCpuInsnRatio.Update(
-            mInvokeTimeNsecs * 1000000 / std::max(mCpuInsn, uint64_t(1)));
-        mMetrics.mHostFnOpInvokeTimeFsecsCpuInsnRatioExclVm.Update(
-            mInvokeTimeNsecsExclVm * 1000000 /
-            std::max(mCpuInsnExclVm, uint64_t(1)));
-        mMetrics.mHostFnOpDeclaredInsnsUsageRatio.Update(
-            mCpuInsn * 1000000 / std::max(mDeclaredCpuInsn, uint64_t(1)));
-
-        mMetrics.mHostFnOpMaxRwKeyByte.Mark(mMaxReadWriteKeyByte);
-        mMetrics.mHostFnOpMaxRwDataByte.Mark(mMaxReadWriteDataByte);
-        mMetrics.mHostFnOpMaxRwCodeByte.Mark(mMaxReadWriteCodeByte);
-        mMetrics.mHostFnOpMaxEmitEventByte.Mark(mMaxEmitEventByte);
-
-        mMetrics.accumulateModelledCpuInsns(mCpuInsn, mCpuInsnExclVm,
-                                            mInvokeTimeNsecs);
-
-        if (mSuccess)
-        {
-            mMetrics.mHostFnOpSuccess.Mark();
-        }
-        else
-        {
-            mMetrics.mHostFnOpFailure.Mark();
-        }
+        mWriteDataByte += entrySize;
+        mMaxReadWriteDataByte = std::max(mMaxReadWriteDataByte, entrySize);
     }
-    medida::TimerContext
-    getExecTimer()
+}
+
+HostFunctionMetrics::~HostFunctionMetrics()
+{
+    mMetrics.mHostFnOpReadEntry.Mark(mReadEntry);
+    mMetrics.mHostFnOpWriteEntry.Mark(mWriteEntry);
+
+    mMetrics.mHostFnOpReadKeyByte.Mark(mReadKeyByte);
+    mMetrics.mHostFnOpWriteKeyByte.Mark(mWriteKeyByte);
+
+    mMetrics.mHostFnOpReadLedgerByte.Mark(mLedgerReadByte);
+    mMetrics.mHostFnOpReadDataByte.Mark(mReadDataByte);
+    mMetrics.mHostFnOpReadCodeByte.Mark(mReadCodeByte);
+
+    mMetrics.mHostFnOpWriteLedgerByte.Mark(mLedgerWriteByte);
+    mMetrics.mHostFnOpWriteDataByte.Mark(mWriteDataByte);
+    mMetrics.mHostFnOpWriteCodeByte.Mark(mWriteCodeByte);
+
+    mMetrics.mHostFnOpEmitEvent.Mark(mEmitEvent);
+    mMetrics.mHostFnOpEmitEventByte.Mark(mEmitEventByte);
+
+    mMetrics.mHostFnOpCpuInsn.Mark(mCpuInsn);
+    mMetrics.mHostFnOpMemByte.Mark(mMemByte);
+    mMetrics.mHostFnOpInvokeTimeNsecs.Update(
+        std::chrono::nanoseconds(mInvokeTimeNsecs));
+    mMetrics.mHostFnOpCpuInsnExclVm.Mark(mCpuInsnExclVm);
+    mMetrics.mHostFnOpInvokeTimeNsecsExclVm.Update(
+        std::chrono::nanoseconds(mInvokeTimeNsecsExclVm));
+    mMetrics.mHostFnOpInvokeTimeFsecsCpuInsnRatio.Update(
+        mInvokeTimeNsecs * 1000000 / std::max(mCpuInsn, uint64_t(1)));
+    mMetrics.mHostFnOpInvokeTimeFsecsCpuInsnRatioExclVm.Update(
+        mInvokeTimeNsecsExclVm * 1000000 /
+        std::max(mCpuInsnExclVm, uint64_t(1)));
+    mMetrics.mHostFnOpDeclaredInsnsUsageRatio.Update(
+        mCpuInsn * 1000000 / std::max(mDeclaredCpuInsn, uint64_t(1)));
+
+    mMetrics.mHostFnOpMaxRwKeyByte.Mark(mMaxReadWriteKeyByte);
+    mMetrics.mHostFnOpMaxRwDataByte.Mark(mMaxReadWriteDataByte);
+    mMetrics.mHostFnOpMaxRwCodeByte.Mark(mMaxReadWriteCodeByte);
+    mMetrics.mHostFnOpMaxEmitEventByte.Mark(mMaxEmitEventByte);
+
+    mMetrics.accumulateModelledCpuInsns(mCpuInsn, mCpuInsnExclVm,
+                                        mInvokeTimeNsecs);
+
+    if (mSuccess)
     {
-        return mMetrics.mHostFnOpExec.TimeScope();
+        mMetrics.mHostFnOpSuccess.Mark();
     }
-};
+    else
+    {
+        mMetrics.mHostFnOpFailure.Mark();
+    }
+}
+
+medida::TimerContext
+HostFunctionMetrics::getExecTimer()
+{
+    return mMetrics.mHostFnOpExec.TimeScope();
+}
 
 InvokeHostFunctionOpFrame::InvokeHostFunctionOpFrame(
     Operation const& op, TransactionFrame const& parentTx)
@@ -323,179 +287,174 @@ InvokeHostFunctionOpFrame::maybePopulateDiagnosticEvents(
 }
 
 bool
-InvokeHostFunctionOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
-                                   Hash const& sorobanBasePrngSeed,
-                                   OperationResult& res,
-                                   std::shared_ptr<SorobanTxData> sorobanData,
-                                   OpEventManager& opEventManager) const
+InvokeHostFunctionOpFrame::ApplyHelper::handleArchivedEntry(LedgerKey const& lk)
 {
-    releaseAssertOrThrow(sorobanData);
-    ZoneNamedN(applyZone, "InvokeHostFunctionOpFrame apply", true);
+    // TODO: Auto restore support in p23
 
-    Config const& appConfig = app.getConfig();
-    HostFunctionMetrics metrics(app.getSorobanMetrics());
-    auto timeScope = metrics.getExecTimer();
-    auto const& sorobanConfig = app.getSorobanNetworkConfigForApply();
+    // Push appropriate diagnostic error based on entry type
+    if (lk.type() == CONTRACT_CODE)
+    {
+        mDiagnosticEvents.pushApplyTimeDiagnosticError(
+            SCE_VALUE, SCEC_INVALID_INPUT,
+            "trying to access an archived contract code entry",
+            {makeBytesSCVal(lk.contractCode().hash)});
+    }
+    else if (lk.type() == CONTRACT_DATA)
+    {
+        mDiagnosticEvents.pushApplyTimeDiagnosticError(
+            SCE_VALUE, SCEC_INVALID_INPUT,
+            "trying to access an archived contract data entry",
+            {makeAddressSCVal(lk.contractData().contract),
+             lk.contractData().key});
+    }
 
-    // Get the entries for the footprint
-    rust::Vec<CxxBuf> ledgerEntryCxxBufs;
-    rust::Vec<CxxBuf> ttlEntryCxxBufs;
+    // Cannot access an archived entry
+    mOpFrame.innerResult(mRes).code(INVOKE_HOST_FUNCTION_ENTRY_ARCHIVED);
+    return false;
+}
 
-    auto const& resources = mParentTx.sorobanResources();
-    metrics.mDeclaredCpuInsn = resources.instructions;
+InvokeHostFunctionOpFrame::ApplyHelper::ApplyHelper(
+    AppConnector& app, AbstractLedgerTxn& ltx, Hash const& sorobanBasePrngSeed,
+    OperationResult& res, std::shared_ptr<SorobanTxData> sorobanData,
+    OpEventManager& opEventManager, InvokeHostFunctionOpFrame const& opFrame)
+    : mApp(app)
+    , mLtx(ltx)
+    , mRes(res)
+    , mSorobanData(sorobanData)
+    , mOpEventManager(opEventManager)
+    , mOpFrame(opFrame)
+    , mSorobanBasePrngSeed(sorobanBasePrngSeed)
+    , mResources(mOpFrame.mParentTx.sorobanResources())
+    , mSorobanConfig(app.getSorobanNetworkConfigForApply())
+    , mAppConfig(app.getConfig())
+    , mMetrics(app.getSorobanMetrics())
+    , mHotArchive(app.copySearchableHotArchiveBucketListSnapshot())
+    , mDiagnosticEvents(mOpEventManager.getDiagnosticEventsBuffer())
+{
+    mMetrics.mDeclaredCpuInsn = mResources.instructions;
 
-    auto const& footprint = resources.footprint;
+    auto const& footprint = mResources.footprint;
     auto footprintLength =
         footprint.readOnly.size() + footprint.readWrite.size();
-    auto hotArchive = app.copySearchableHotArchiveBucketListSnapshot();
 
-    ledgerEntryCxxBufs.reserve(footprintLength);
-    ttlEntryCxxBufs.reserve(footprintLength);
+    // Get the entries for the footprint
+    mLedgerEntryCxxBufs.reserve(footprintLength);
+    mTtlEntryCxxBufs.reserve(footprintLength);
+}
 
-    auto& diagnosticEvents = opEventManager.getDiagnosticEventsBuffer();
-    auto addReads = [&ledgerEntryCxxBufs, &ttlEntryCxxBufs, &ltx, &metrics,
-                     &resources, &sorobanConfig, &appConfig, &diagnosticEvents,
-                     &res, &hotArchive, this](auto const& keys) -> bool {
-        for (auto const& lk : keys)
+bool
+InvokeHostFunctionOpFrame::ApplyHelper::addReads(
+    xdr::xvector<LedgerKey> const& keys)
+{
+    for (auto const& lk : keys)
+    {
+        uint32_t keySize = static_cast<uint32_t>(xdr::xdr_size(lk));
+        uint32_t entrySize = 0u;
+        std::optional<TTLEntry> ttlEntry;
+        bool sorobanEntryLive = false;
+
+        // For soroban entries, check if the entry is expired before loading
+        if (isSorobanEntry(lk))
         {
-            uint32_t keySize = static_cast<uint32_t>(xdr::xdr_size(lk));
-            uint32_t entrySize = 0u;
-            std::optional<TTLEntry> ttlEntry;
-            bool sorobanEntryLive = false;
-
-            // For soroban entries, check if the entry is expired before loading
-            if (isSorobanEntry(lk))
+            auto ttlKey = getTTLKey(lk);
+            auto ttlLtxe = mLtx.loadWithoutRecord(ttlKey);
+            if (ttlLtxe)
             {
-                auto ttlKey = getTTLKey(lk);
-                auto ttlLtxe = ltx.loadWithoutRecord(ttlKey);
-                if (ttlLtxe)
+                if (!isLive(ttlLtxe.current(), mLtx.getHeader().ledgerSeq))
                 {
-                    if (!isLive(ttlLtxe.current(), ltx.getHeader().ledgerSeq))
+                    // For temporary entries, treat the expired entry as
+                    // if the key did not exist
+                    if (!isTemporaryEntry(lk))
                     {
-                        // For temporary entries, treat the expired entry as
-                        // if the key did not exist
-                        if (!isTemporaryEntry(lk))
+                        if (!handleArchivedEntry(lk))
                         {
-                            if (lk.type() == CONTRACT_CODE)
-                            {
-                                diagnosticEvents.pushApplyTimeDiagnosticError(
-                                    SCE_VALUE, SCEC_INVALID_INPUT,
-                                    "trying to access an archived contract "
-                                    "code "
-                                    "entry",
-                                    {makeBytesSCVal(lk.contractCode().hash)});
-                            }
-                            else if (lk.type() == CONTRACT_DATA)
-                            {
-                                diagnosticEvents.pushApplyTimeDiagnosticError(
-                                    SCE_VALUE, SCEC_INVALID_INPUT,
-                                    "trying to access an archived contract "
-                                    "data "
-                                    "entry",
-                                    {makeAddressSCVal(
-                                         lk.contractData().contract),
-                                     lk.contractData().key});
-                            }
-                            // Cannot access an archived entry
-                            this->innerResult(res).code(
-                                INVOKE_HOST_FUNCTION_ENTRY_ARCHIVED);
                             return false;
                         }
                     }
-                    else
-                    {
-                        sorobanEntryLive = true;
-                        ttlEntry = ttlLtxe.current().data.ttl();
-                    }
                 }
-                // If ttlLtxe doesn't exist, this is a new Soroban entry
-                // Starting in protocol 23, we must check the Hot Archive for
-                // new keys. If a new key is actually archived, fail the op.
-                else if (isPersistentEntry(lk) &&
-                         protocolVersionStartsFrom(
-                             ltx.getHeader().ledgerVersion,
-                             HotArchiveBucket::
-                                 FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
+                else
                 {
-                    auto archiveEntry = hotArchive->load(lk);
-                    if (archiveEntry)
+                    sorobanEntryLive = true;
+                    ttlEntry = ttlLtxe.current().data.ttl();
+                }
+            }
+            // If ttlLtxe doesn't exist, this is a new Soroban entry
+            // Starting in protocol 23, we must check the Hot Archive for
+            // new keys. If a new key is actually archived, fail the op.
+            else if (isPersistentEntry(lk) &&
+                     protocolVersionStartsFrom(
+                         mLtx.getHeader().ledgerVersion,
+                         HotArchiveBucket::
+                             FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
+            {
+                auto archiveEntry = mHotArchive->load(lk);
+                if (archiveEntry)
+                {
+                    if (!handleArchivedEntry(lk))
                     {
-                        if (lk.type() == CONTRACT_CODE)
-                        {
-                            diagnosticEvents.pushApplyTimeDiagnosticError(
-                                SCE_VALUE, SCEC_INVALID_INPUT,
-                                "trying to access an archived contract code "
-                                "entry",
-                                {makeBytesSCVal(lk.contractCode().hash)});
-                        }
-                        else if (lk.type() == CONTRACT_DATA)
-                        {
-                            diagnosticEvents.pushApplyTimeDiagnosticError(
-                                SCE_VALUE, SCEC_INVALID_INPUT,
-                                "trying to access an archived contract data "
-                                "entry",
-                                {makeAddressSCVal(lk.contractData().contract),
-                                 lk.contractData().key});
-                        }
-                        // Cannot access an archived entry
-                        this->innerResult(res).code(
-                            INVOKE_HOST_FUNCTION_ENTRY_ARCHIVED);
                         return false;
                     }
                 }
             }
+        }
 
-            if (!isSorobanEntry(lk) || sorobanEntryLive)
+        if (!isSorobanEntry(lk) || sorobanEntryLive)
+        {
+            auto ltxe = mLtx.loadWithoutRecord(lk);
+            if (ltxe)
             {
-                auto ltxe = ltx.loadWithoutRecord(lk);
-                if (ltxe)
-                {
-                    auto leBuf = toCxxBuf(ltxe.current());
-                    entrySize = static_cast<uint32_t>(leBuf.data->size());
+                auto leBuf = toCxxBuf(ltxe.current());
+                entrySize = static_cast<uint32_t>(leBuf.data->size());
 
-                    // For entry types that don't have an ttlEntry (i.e.
-                    // Accounts), the rust host expects an "empty" CxxBuf such
-                    // that the buffer has a non-null pointer that points to an
-                    // empty byte vector
-                    auto ttlBuf =
-                        ttlEntry
-                            ? toCxxBuf(*ttlEntry)
-                            : CxxBuf{std::make_unique<std::vector<uint8_t>>()};
+                // For entry types that don't have an ttlEntry (i.e.
+                // Accounts), the rust host expects an "empty" CxxBuf such
+                // that the buffer has a non-null pointer that points to an
+                // empty byte vector
+                auto ttlBuf =
+                    ttlEntry ? toCxxBuf(*ttlEntry)
+                             : CxxBuf{std::make_unique<std::vector<uint8_t>>()};
 
-                    ledgerEntryCxxBufs.emplace_back(std::move(leBuf));
-                    ttlEntryCxxBufs.emplace_back(std::move(ttlBuf));
-                }
-                else if (isSorobanEntry(lk))
-                {
-                    releaseAssertOrThrow(!ttlEntry);
-                }
+                mLedgerEntryCxxBufs.emplace_back(std::move(leBuf));
+                mTtlEntryCxxBufs.emplace_back(std::move(ttlBuf));
             }
-
-            metrics.noteReadEntry(isCodeKey(lk), keySize, entrySize);
-            if (!validateContractLedgerEntry(lk, entrySize, sorobanConfig,
-                                             appConfig, mParentTx,
-                                             diagnosticEvents))
+            else if (isSorobanEntry(lk))
             {
-                this->innerResult(res).code(
-                    INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
-                return false;
-            }
-
-            if (resources.readBytes < metrics.mLedgerReadByte)
-            {
-                diagnosticEvents.pushApplyTimeDiagnosticError(
-                    SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
-                    "operation byte-read resources exceeds amount specified",
-                    {makeU64SCVal(metrics.mLedgerReadByte),
-                     makeU64SCVal(resources.readBytes)});
-
-                this->innerResult(res).code(
-                    INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
-                return false;
+                releaseAssertOrThrow(!ttlEntry);
             }
         }
-        return true;
-    };
+
+        mMetrics.noteReadEntry(isCodeKey(lk), keySize, entrySize);
+        if (!validateContractLedgerEntry(lk, entrySize, mSorobanConfig,
+                                         mAppConfig, mOpFrame.mParentTx,
+                                         mDiagnosticEvents))
+        {
+            mOpFrame.innerResult(mRes).code(
+                INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
+            return false;
+        }
+
+        if (mResources.readBytes < mMetrics.mLedgerReadByte)
+        {
+            mDiagnosticEvents.pushApplyTimeDiagnosticError(
+                SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
+                "operation byte-read resources exceeds amount specified",
+                {makeU64SCVal(mMetrics.mLedgerReadByte),
+                 makeU64SCVal(mResources.readBytes)});
+
+            mOpFrame.innerResult(mRes).code(
+                INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
+            return false;
+        }
+    }
+    return true;
+}
+
+bool
+InvokeHostFunctionOpFrame::ApplyHelper::apply()
+{
+    ZoneNamedN(applyZone, "InvokeHostFunctionOpFrame apply", true);
+    auto timeScope = mMetrics.getExecTimer();
+    auto const& footprint = mResources.footprint;
 
     if (!addReads(footprint.readOnly))
     {
@@ -510,8 +469,8 @@ InvokeHostFunctionOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
     }
 
     rust::Vec<CxxBuf> authEntryCxxBufs;
-    authEntryCxxBufs.reserve(mInvokeHostFunction.auth.size());
-    for (auto const& authEntry : mInvokeHostFunction.auth)
+    authEntryCxxBufs.reserve(mOpFrame.mInvokeHostFunction.auth.size());
+    for (auto const& authEntry : mOpFrame.mInvokeHostFunction.auth)
     {
         authEntryCxxBufs.emplace_back(toCxxBuf(authEntry));
     }
@@ -522,27 +481,28 @@ InvokeHostFunctionOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
     {
         CxxBuf basePrngSeedBuf{};
         basePrngSeedBuf.data = std::make_unique<std::vector<uint8_t>>();
-        basePrngSeedBuf.data->assign(sorobanBasePrngSeed.begin(),
-                                     sorobanBasePrngSeed.end());
-        auto moduleCache = app.getModuleCache();
+        basePrngSeedBuf.data->assign(mSorobanBasePrngSeed.begin(),
+                                     mSorobanBasePrngSeed.end());
+        auto moduleCache = mApp.getModuleCache();
         out = rust_bridge::invoke_host_function(
-            appConfig.CURRENT_LEDGER_PROTOCOL_VERSION,
-            appConfig.ENABLE_SOROBAN_DIAGNOSTIC_EVENTS, resources.instructions,
-            toCxxBuf(mInvokeHostFunction.hostFunction), toCxxBuf(resources),
-            toCxxBuf(getSourceID()), authEntryCxxBufs,
-            getLedgerInfo(ltx, app, sorobanConfig), ledgerEntryCxxBufs,
-            ttlEntryCxxBufs, basePrngSeedBuf,
-            sorobanConfig.rustBridgeRentFeeConfiguration(), *moduleCache);
-        metrics.mCpuInsn = out.cpu_insns;
-        metrics.mMemByte = out.mem_bytes;
-        metrics.mInvokeTimeNsecs = out.time_nsecs;
-        metrics.mCpuInsnExclVm = out.cpu_insns_excluding_vm_instantiation;
-        metrics.mInvokeTimeNsecsExclVm =
+            mAppConfig.CURRENT_LEDGER_PROTOCOL_VERSION,
+            mAppConfig.ENABLE_SOROBAN_DIAGNOSTIC_EVENTS,
+            mResources.instructions,
+            toCxxBuf(mOpFrame.mInvokeHostFunction.hostFunction),
+            toCxxBuf(mResources), toCxxBuf(mOpFrame.getSourceID()),
+            authEntryCxxBufs, getLedgerInfo(mLtx, mApp, mSorobanConfig),
+            mLedgerEntryCxxBufs, mTtlEntryCxxBufs, basePrngSeedBuf,
+            mSorobanConfig.rustBridgeRentFeeConfiguration(), *moduleCache);
+        mMetrics.mCpuInsn = out.cpu_insns;
+        mMetrics.mMemByte = out.mem_bytes;
+        mMetrics.mInvokeTimeNsecs = out.time_nsecs;
+        mMetrics.mCpuInsnExclVm = out.cpu_insns_excluding_vm_instantiation;
+        mMetrics.mInvokeTimeNsecsExclVm =
             out.time_nsecs_excluding_vm_instantiation;
         if (!out.success)
         {
-            maybePopulateDiagnosticEvents(appConfig, out, metrics,
-                                          diagnosticEvents);
+            mOpFrame.maybePopulateDiagnosticEvents(mAppConfig, out, mMetrics,
+                                                   mDiagnosticEvents);
         }
     }
     catch (std::exception& e)
@@ -560,27 +520,29 @@ InvokeHostFunctionOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
             throw std::runtime_error(
                 "Got internal error during Soroban host invocation.");
         }
-        if (resources.instructions < out.cpu_insns)
+        if (mResources.instructions < out.cpu_insns)
         {
-            diagnosticEvents.pushApplyTimeDiagnosticError(
+            mDiagnosticEvents.pushApplyTimeDiagnosticError(
                 SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
                 "operation instructions exceeds amount specified",
                 {makeU64SCVal(out.cpu_insns),
-                 makeU64SCVal(resources.instructions)});
-            innerResult(res).code(INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
+                 makeU64SCVal(mResources.instructions)});
+            mOpFrame.innerResult(mRes).code(
+                INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
         }
-        else if (sorobanConfig.txMemoryLimit() < out.mem_bytes)
+        else if (mSorobanConfig.txMemoryLimit() < out.mem_bytes)
         {
-            diagnosticEvents.pushApplyTimeDiagnosticError(
+            mDiagnosticEvents.pushApplyTimeDiagnosticError(
                 SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
                 "operation memory usage exceeds network config limit",
                 {makeU64SCVal(out.mem_bytes),
-                 makeU64SCVal(sorobanConfig.txMemoryLimit())});
-            innerResult(res).code(INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
+                 makeU64SCVal(mSorobanConfig.txMemoryLimit())});
+            mOpFrame.innerResult(mRes).code(
+                INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
         }
         else
         {
-            innerResult(res).code(INVOKE_HOST_FUNCTION_TRAPPED);
+            mOpFrame.innerResult(mRes).code(INVOKE_HOST_FUNCTION_TRAPPED);
         }
         return false;
     }
@@ -593,10 +555,11 @@ InvokeHostFunctionOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
         LedgerEntry le;
         xdr::xdr_from_opaque(buf.data, le);
         if (!validateContractLedgerEntry(LedgerEntryKey(le), buf.data.size(),
-                                         sorobanConfig, appConfig, mParentTx,
-                                         diagnosticEvents))
+                                         mSorobanConfig, mAppConfig,
+                                         mOpFrame.mParentTx, mDiagnosticEvents))
         {
-            innerResult(res).code(INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
+            mOpFrame.innerResult(mRes).code(
+                INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
             return false;
         }
 
@@ -610,28 +573,28 @@ InvokeHostFunctionOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
         // accounted for by the host
         if (lk.type() != TTL)
         {
-            metrics.noteWriteEntry(isCodeKey(lk), keySize, entrySize);
-            if (resources.writeBytes < metrics.mLedgerWriteByte)
+            mMetrics.noteWriteEntry(isCodeKey(lk), keySize, entrySize);
+            if (mResources.writeBytes < mMetrics.mLedgerWriteByte)
             {
-                diagnosticEvents.pushApplyTimeDiagnosticError(
+                mDiagnosticEvents.pushApplyTimeDiagnosticError(
                     SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
                     "operation byte-write resources exceeds amount specified",
-                    {makeU64SCVal(metrics.mLedgerWriteByte),
-                     makeU64SCVal(resources.writeBytes)});
-                innerResult(res).code(
+                    {makeU64SCVal(mMetrics.mLedgerWriteByte),
+                     makeU64SCVal(mResources.writeBytes)});
+                mOpFrame.innerResult(mRes).code(
                     INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
                 return false;
             }
         }
 
-        auto ltxe = ltx.load(lk);
+        auto ltxe = mLtx.load(lk);
         if (ltxe)
         {
             ltxe.current() = le;
         }
         else
         {
-            ltx.create(le);
+            mLtx.create(le);
             createdKeys.insert(lk);
         }
     }
@@ -659,17 +622,17 @@ InvokeHostFunctionOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
     {
         if (createdAndModifiedKeys.find(lk) == createdAndModifiedKeys.end())
         {
-            auto ltxe = ltx.load(lk);
+            auto ltxe = mLtx.load(lk);
             if (ltxe)
             {
                 releaseAssertOrThrow(isSorobanEntry(lk));
-                ltx.erase(lk);
+                mLtx.erase(lk);
 
                 // Also delete associated ttlEntry
                 auto ttlLK = getTTLKey(lk);
-                auto ttlLtxe = ltx.load(ttlLK);
+                auto ttlLtxe = mLtx.load(ttlLK);
                 releaseAssertOrThrow(ttlLtxe);
-                ltx.erase(ttlLK);
+                mLtx.erase(ttlLK);
             }
         }
     }
@@ -680,20 +643,21 @@ InvokeHostFunctionOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
     success.events.reserve(out.contract_events.size());
     for (auto const& buf : out.contract_events)
     {
-        metrics.mEmitEvent++;
+        mMetrics.mEmitEvent++;
         uint32_t eventSize = static_cast<uint32_t>(buf.data.size());
-        metrics.mEmitEventByte += eventSize;
-        metrics.mMaxEmitEventByte =
-            std::max(metrics.mMaxEmitEventByte, eventSize);
-        if (sorobanConfig.txMaxContractEventsSizeBytes() <
-            metrics.mEmitEventByte)
+        mMetrics.mEmitEventByte += eventSize;
+        mMetrics.mMaxEmitEventByte =
+            std::max(mMetrics.mMaxEmitEventByte, eventSize);
+        if (mSorobanConfig.txMaxContractEventsSizeBytes() <
+            mMetrics.mEmitEventByte)
         {
-            diagnosticEvents.pushApplyTimeDiagnosticError(
+            mDiagnosticEvents.pushApplyTimeDiagnosticError(
                 SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
                 "total events size exceeds network config maximum",
-                {makeU64SCVal(metrics.mEmitEventByte),
-                 makeU64SCVal(sorobanConfig.txMaxContractEventsSizeBytes())});
-            innerResult(res).code(INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
+                {makeU64SCVal(mMetrics.mEmitEventByte),
+                 makeU64SCVal(mSorobanConfig.txMaxContractEventsSizeBytes())});
+            mOpFrame.innerResult(mRes).code(
+                INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
             return false;
         }
         ContractEvent evt;
@@ -701,37 +665,56 @@ InvokeHostFunctionOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
         success.events.emplace_back(evt);
     }
 
-    maybePopulateDiagnosticEvents(appConfig, out, metrics, diagnosticEvents);
+    mOpFrame.maybePopulateDiagnosticEvents(mAppConfig, out, mMetrics,
+                                           mDiagnosticEvents);
 
-    metrics.mEmitEventByte += static_cast<uint32>(out.result_value.data.size());
-    if (sorobanConfig.txMaxContractEventsSizeBytes() < metrics.mEmitEventByte)
+    mMetrics.mEmitEventByte +=
+        static_cast<uint32>(out.result_value.data.size());
+    if (mSorobanConfig.txMaxContractEventsSizeBytes() < mMetrics.mEmitEventByte)
     {
-        diagnosticEvents.pushApplyTimeDiagnosticError(
+        mDiagnosticEvents.pushApplyTimeDiagnosticError(
             SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
             "return value pushes events size above network config maximum",
-            {makeU64SCVal(metrics.mEmitEventByte),
-             makeU64SCVal(sorobanConfig.txMaxContractEventsSizeBytes())});
-        innerResult(res).code(INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
+            {makeU64SCVal(mMetrics.mEmitEventByte),
+             makeU64SCVal(mSorobanConfig.txMaxContractEventsSizeBytes())});
+        mOpFrame.innerResult(mRes).code(
+            INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
         return false;
     }
 
-    if (!sorobanData->consumeRefundableSorobanResources(
-            metrics.mEmitEventByte, out.rent_fee,
-            ltx.loadHeader().current().ledgerVersion, sorobanConfig, appConfig,
-            mParentTx, diagnosticEvents))
+    if (!mSorobanData->consumeRefundableSorobanResources(
+            mMetrics.mEmitEventByte, out.rent_fee,
+            mLtx.loadHeader().current().ledgerVersion, mSorobanConfig,
+            mAppConfig, mOpFrame.mParentTx, mDiagnosticEvents))
     {
-        innerResult(res).code(INVOKE_HOST_FUNCTION_INSUFFICIENT_REFUNDABLE_FEE);
+        mOpFrame.innerResult(mRes).code(
+            INVOKE_HOST_FUNCTION_INSUFFICIENT_REFUNDABLE_FEE);
         return false;
     }
 
     xdr::xdr_from_opaque(out.result_value.data, success.returnValue);
-    innerResult(res).code(INVOKE_HOST_FUNCTION_SUCCESS);
-    innerResult(res).success() = xdrSha256(success);
+    mOpFrame.innerResult(mRes).code(INVOKE_HOST_FUNCTION_SUCCESS);
+    mOpFrame.innerResult(mRes).success() = xdrSha256(success);
 
-    opEventManager.pushContractEvents(success.events);
-    sorobanData->setReturnValue(success.returnValue);
-    metrics.mSuccess = true;
+    mOpEventManager.pushContractEvents(success.events);
+    mSorobanData->setReturnValue(success.returnValue);
+    mMetrics.mSuccess = true;
     return true;
+}
+
+bool
+InvokeHostFunctionOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
+                                   Hash const& sorobanBasePrngSeed,
+                                   OperationResult& res,
+                                   std::shared_ptr<SorobanTxData> sorobanData,
+                                   OpEventManager& opEventManager) const
+{
+    releaseAssertOrThrow(sorobanData);
+
+    // Create ApplyHelper and delegate processing to it
+    ApplyHelper helper(app, ltx, sorobanBasePrngSeed, res, sorobanData,
+                       opEventManager, *this);
+    return helper.apply();
 }
 
 bool

--- a/src/transactions/InvokeHostFunctionOpFrame.h
+++ b/src/transactions/InvokeHostFunctionOpFrame.h
@@ -105,15 +105,22 @@ class InvokeHostFunctionOpFrame : public OperationFrame
         SearchableHotArchiveSnapshotConstPtr mHotArchive;
         DiagnosticEventBuffer& mDiagnosticEvents;
 
+        // Contains restoration info for all autorestored entries, will be
+        // charged following invocation.
+        rust::Vec<CxxLedgerEntryRentChange> mAutorestoreRustEntryRentChanges;
+
         // Helper called on all archived keys in the footprint. Returns false if
         // the operation should fail and populates result code and diagnostic
         // events. Returns true if no failure occurred.
-        bool handleArchivedEntry(LedgerKey const& lk);
+        bool handleArchivedEntry(LedgerKey const& lk, LedgerEntry const& le,
+                                 bool isReadOnly,
+                                 uint32_t restoredLiveUntilLedger,
+                                 bool isHotArchiveEntry);
 
         // Checks and meters the given keys. Returns false if the operation
         // should fail and populates result code and diagnostic events. Returns
         // true if no failure occurred.
-        bool addReads(xdr::xvector<LedgerKey> const& keys);
+        bool addReads(xdr::xvector<LedgerKey> const& keys, bool isReadOnly);
 
       public:
         ApplyHelper(AppConnector& app, AbstractLedgerTxn& ltx,

--- a/src/transactions/RestoreFootprintOpFrame.cpp
+++ b/src/transactions/RestoreFootprintOpFrame.cpp
@@ -186,7 +186,10 @@ RestoreFootprintOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
         {
             // Entry exists in the live BucketList if we get this this point due
             // to the constTTLLtxe loadWithoutRecord logic above.
-            ltx.restoreFromLiveBucketList(lk, restoredLiveUntilLedger);
+            // Get the actual ledger entry (since we know it exists already at this point)
+            auto entry = ltx.getNewestVersion(lk);
+            releaseAssertOrThrow(entry);
+            ltx.restoreFromLiveBucketList(entry->ledgerEntry(), restoredLiveUntilLedger);
         }
     }
     uint32_t ledgerVersion = ltx.loadHeader().current().ledgerVersion;

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -2850,13 +2850,13 @@ TEST_CASE_VERSIONS("archival meta", "[tx][soroban][archival]")
             "put_temporary", {makeSymbolSCVal("key"), makeU64SCVal(123)},
             client.writeKeySpec("key", ContractDataDurability::TEMPORARY));
         REQUIRE(invocation.withExactNonRefundableResourceFee().invoke());
-        auto lk = client.getContract().getDataKey(
+        auto temporaryLk = client.getContract().getDataKey(
             makeSymbolSCVal("key"), ContractDataDurability::TEMPORARY);
 
         auto expectedLiveUntilLedger =
             test.getLCLSeq() +
             test.getNetworkCfg().stateArchivalSettings().minTemporaryTTL - 1;
-        REQUIRE(test.getTTL(lk) == expectedLiveUntilLedger);
+        REQUIRE(test.getTTL(temporaryLk) == expectedLiveUntilLedger);
         auto const evictionLedger = 4097;
 
         // Close ledgers until temp entry is evicted
@@ -2865,18 +2865,18 @@ TEST_CASE_VERSIONS("archival meta", "[tx][soroban][archival]")
             closeLedgerOn(test.getApp(), i, 2, 1, 2016);
         }
 
-        REQUIRE(test.getTTL(lk) == expectedLiveUntilLedger);
+        REQUIRE(test.getTTL(temporaryLk) == expectedLiveUntilLedger);
 
         // This should be a noop
-        test.invokeExtendOp({lk}, 10'000, 0);
-        REQUIRE(test.getTTL(lk) == expectedLiveUntilLedger);
+        test.invokeExtendOp({temporaryLk}, 10'000, 0);
+        REQUIRE(test.getTTL(temporaryLk) == expectedLiveUntilLedger);
 
         // This will fail because the entry is expired
         REQUIRE(client.extend("key", ContractDataDurability::TEMPORARY, 10'000,
                               10'000) == INVOKE_HOST_FUNCTION_TRAPPED);
-        REQUIRE(test.getTTL(lk) == expectedLiveUntilLedger);
+        REQUIRE(test.getTTL(temporaryLk) == expectedLiveUntilLedger);
 
-        REQUIRE(!test.isEntryLive(lk, test.getLCLSeq()));
+        REQUIRE(!test.isEntryLive(temporaryLk, test.getLCLSeq()));
 
         SECTION("temp entry meta")
         {
@@ -2885,7 +2885,7 @@ TEST_CASE_VERSIONS("archival meta", "[tx][soroban][archival]")
 
             {
                 LedgerTxn ltx(test.getApp().getLedgerTxnRoot());
-                REQUIRE(!ltx.load(lk));
+                REQUIRE(!ltx.load(temporaryLk));
             }
 
             XDRInputFileStream in;
@@ -2900,8 +2900,8 @@ TEST_CASE_VERSIONS("archival meta", "[tx][soroban][archival]")
                     REQUIRE(lcm.v1().evictedTemporaryLedgerKeys.size() == 2);
                     auto sortedKeys = lcm.v1().evictedTemporaryLedgerKeys;
                     std::sort(sortedKeys.begin(), sortedKeys.end());
-                    REQUIRE(sortedKeys[0] == lk);
-                    REQUIRE(sortedKeys[1] == getTTLKey(lk));
+                    REQUIRE(sortedKeys[0] == temporaryLk);
+                    REQUIRE(sortedKeys[1] == getTTLKey(temporaryLk));
                     evicted = true;
                 }
                 else
@@ -2932,23 +2932,32 @@ TEST_CASE_VERSIONS("archival meta", "[tx][soroban][archival]")
                 persistentLE = ltxe.current();
             }
 
-            auto testRestore = [&]() {
-                test.invokeRestoreOp({persistentKey}, 20'048);
+            auto testRestore = [&](std::optional<uint32_t> updatedValue =
+                                       std::nullopt) {
                 auto targetRestorationLedger = test.getLCLSeq();
 
                 XDRInputFileStream in;
                 in.open(metaPath);
                 LedgerCloseMeta lcm;
                 bool restoreMeta = false;
+                bool seenUpdated = false;
+
+                // TTL Restore, Data Restore, optional Data updated
+                auto numChanges = updatedValue ? 3 : 2;
 
                 LedgerKeySet keysToRestore = {persistentKey,
                                               getTTLKey(persistentKey)};
+                LedgerKeySet updatedKeys =
+                    updatedValue ? LedgerKeySet{persistentKey} : LedgerKeySet{};
+
                 while (in.readOne(lcm))
                 {
                     REQUIRE(lcm.v() == 1);
                     if (lcm.v1().ledgerHeader.header.ledgerSeq ==
                         targetRestorationLedger)
                     {
+                        CLOG_FATAL(Bucket, "LCM {}",
+                                   stellar::xdrToCerealString(lcm, "m"));
                         REQUIRE(lcm.v1().evictedTemporaryLedgerKeys.empty());
                         REQUIRE(
                             lcm.v1().evictedPersistentLedgerEntries.empty());
@@ -2961,16 +2970,50 @@ TEST_CASE_VERSIONS("archival meta", "[tx][soroban][archival]")
 
                         auto const& changes =
                             txApplyProcessing.getLedgerEntryChangesAtOp(0);
-                        REQUIRE(changes.size() == 2);
+                        REQUIRE(changes.size() == numChanges);
                         for (auto const& change : changes)
                         {
-                            REQUIRE(
-                                change.type() ==
-                                LedgerEntryChangeType::LEDGER_ENTRY_RESTORED);
-                            auto lk = LedgerEntryKey(change.restored());
-                            REQUIRE(keysToRestore.find(lk) !=
-                                    keysToRestore.end());
-                            keysToRestore.erase(lk);
+                            if (change.type() ==
+                                LedgerEntryChangeType::LEDGER_ENTRY_RESTORED)
+                            {
+                                auto le = change.restored();
+                                auto lk = LedgerEntryKey(le);
+                                REQUIRE(keysToRestore.find(lk) !=
+                                        keysToRestore.end());
+                                keysToRestore.erase(lk);
+
+                                // If the restored value was also updated,
+                                // RESTORE meta will hold the previous value
+                                if (updatedKeys.find(lk) == updatedKeys.end())
+                                {
+                                    LedgerTxn ltx(
+                                        test.getApp().getLedgerTxnRoot());
+                                    auto ltxe = ltx.load(lk);
+                                    REQUIRE(ltxe);
+                                    REQUIRE(ltxe.current() == le);
+                                }
+                            }
+                            else if (change.type() == LedgerEntryChangeType::
+                                                          LEDGER_ENTRY_UPDATED)
+                            {
+                                auto le = change.updated();
+                                auto lk = LedgerEntryKey(le);
+                                REQUIRE(updatedKeys.find(lk) !=
+                                        updatedKeys.end());
+                                seenUpdated = true;
+
+                                LedgerTxn ltx(test.getApp().getLedgerTxnRoot());
+                                auto ltxe = ltx.load(lk);
+                                REQUIRE(ltxe);
+                                REQUIRE(ltxe.current() == le);
+                                REQUIRE(
+                                    ltxe.current().data.contractData().val ==
+                                    makeU64SCVal(*updatedValue));
+                            }
+                            else
+                            {
+                                FAIL();
+                            }
                         }
 
                         restoreMeta = true;
@@ -2979,8 +3022,12 @@ TEST_CASE_VERSIONS("archival meta", "[tx][soroban][archival]")
                 }
 
                 REQUIRE(restoreMeta);
+                REQUIRE(seenUpdated == (updatedValue.has_value()));
                 REQUIRE(keysToRestore.empty());
             };
+
+            auto persistentLk = client.getContract().getDataKey(
+                makeSymbolSCVal("key"), ContractDataDurability::PERSISTENT);
 
             // First, close ledgers until entry is expired, but not yet evicted
             auto expirationLedger =
@@ -2996,7 +3043,60 @@ TEST_CASE_VERSIONS("archival meta", "[tx][soroban][archival]")
             // identical to meta in the evicted case.
             SECTION("restore expired but not evicted")
             {
-                testRestore();
+                SECTION("manual restore")
+                {
+                    test.invokeRestoreOp({persistentKey}, 20'048);
+                    testRestore();
+                }
+
+                SECTION("autorestore")
+                {
+                    if (protocolVersionStartsFrom(
+                            cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION,
+                            LiveBucket::
+                                FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
+                    {
+                        auto spec = client.defaultSpecWithoutFootprint()
+                                        .setReadWriteFootprint({persistentKey})
+                                        .setReadOnlyFootprint(
+                                            client.getContract().getKeys())
+                                        .setReadBytes(5000)
+                                        .setWriteBytes(5000)
+                                        .setRefundableResourceFee(1'000'000);
+                        auto invocation =
+                            client.getContract().prepareInvocation(
+                                "has_persistent", {makeSymbolSCVal("key")},
+                                spec, /* addContractKeys */ false);
+                        REQUIRE(invocation.withExactNonRefundableResourceFee()
+                                    .invoke());
+                        testRestore();
+                    }
+                }
+
+                SECTION("autorestore with updated value")
+                {
+                    if (protocolVersionStartsFrom(
+                            cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION,
+                            LiveBucket::
+                                FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
+                    {
+                        auto spec = client.defaultSpecWithoutFootprint()
+                                        .setReadWriteFootprint({persistentKey})
+                                        .setReadOnlyFootprint(
+                                            client.getContract().getKeys())
+                                        .setReadBytes(5000)
+                                        .setWriteBytes(5000)
+                                        .setRefundableResourceFee(1'000'000);
+                        auto invocation =
+                            client.getContract().prepareInvocation(
+                                "put_persistent",
+                                {makeSymbolSCVal("key"), makeU64SCVal(999)},
+                                spec, /* addContractKeys */ false);
+                        REQUIRE(invocation.withExactNonRefundableResourceFee()
+                                    .invoke());
+                        testRestore(999);
+                    }
+                }
             }
 
             SECTION("entry evicted")
@@ -3093,9 +3193,59 @@ TEST_CASE_VERSIONS("archival meta", "[tx][soroban][archival]")
                     }
                 }
 
-                SECTION("Restoration Meta")
+                SECTION("manual restore")
                 {
+                    test.invokeRestoreOp({persistentKey}, 20'048);
                     testRestore();
+                }
+
+                SECTION("autorestore")
+                {
+                    if (protocolVersionStartsFrom(
+                            cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION,
+                            LiveBucket::
+                                FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
+                    {
+                        auto spec = client.defaultSpecWithoutFootprint()
+                                        .setReadWriteFootprint({persistentKey})
+                                        .setReadOnlyFootprint(
+                                            client.getContract().getKeys())
+                                        .setReadBytes(5000)
+                                        .setWriteBytes(5000)
+                                        .setRefundableResourceFee(1'000'000);
+                        auto invocation =
+                            client.getContract().prepareInvocation(
+                                "has_persistent", {makeSymbolSCVal("key")},
+                                spec, /* addContractKeys */ false);
+                        REQUIRE(invocation.withExactNonRefundableResourceFee()
+                                    .invoke());
+                        testRestore();
+                    }
+                }
+
+                SECTION("autorestore with updated value")
+                {
+                    if (protocolVersionStartsFrom(
+                            cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION,
+                            LiveBucket::
+                                FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
+                    {
+                        auto spec = client.defaultSpecWithoutFootprint()
+                                        .setReadWriteFootprint({persistentKey})
+                                        .setReadOnlyFootprint(
+                                            client.getContract().getKeys())
+                                        .setReadBytes(5000)
+                                        .setWriteBytes(5000)
+                                        .setRefundableResourceFee(1'000'000);
+                        auto invocation =
+                            client.getContract().prepareInvocation(
+                                "put_persistent",
+                                {makeSymbolSCVal("key"), makeU64SCVal(999)},
+                                spec, /* addContractKeys */ false);
+                        REQUIRE(invocation.withExactNonRefundableResourceFee()
+                                    .invoke());
+                        testRestore(999);
+                    }
                 }
             }
         }
@@ -3108,7 +3258,7 @@ TEST_CASE_VERSIONS("archival meta", "[tx][soroban][archival]")
                     INVOKE_HOST_FUNCTION_SUCCESS);
             {
                 LedgerTxn ltx(test.getApp().getLedgerTxnRoot());
-                REQUIRE(ltx.load(lk));
+                REQUIRE(ltx.load(temporaryLk));
             }
 
             // Verify that we're on the ledger where the entry would get evicted
@@ -3116,7 +3266,7 @@ TEST_CASE_VERSIONS("archival meta", "[tx][soroban][archival]")
             REQUIRE(test.getLCLSeq() == evictionLedger);
 
             // Entry is live again
-            REQUIRE(test.isEntryLive(lk, test.getLCLSeq()));
+            REQUIRE(test.isEntryLive(temporaryLk, test.getLCLSeq()));
 
             // Verify that we didn't emit an eviction
             XDRInputFileStream in;

--- a/src/transactions/test/SorobanTxTestUtils.cpp
+++ b/src/transactions/test/SorobanTxTestUtils.cpp
@@ -919,6 +919,53 @@ SorobanTest::computeFeePerIncrement(int64_t resourceVal, int64_t feeRate,
     return (num + increment - 1) / increment;
 };
 
+int64_t
+SorobanTest::getAccountBalance(TestAccount* source)
+{
+    auto& account = source ? *source : getRoot();
+    return account.getBalance();
+}
+
+void
+SorobanTest::checkRefundableFee(int64_t initialBalance,
+                                TransactionFrameBaseConstPtr tx,
+                                TransactionMetaFrame const& txm,
+                                int64_t expectedRefundableFeeCharged,
+                                size_t eventsSize)
+{
+    // Get the account balance after transaction execution
+    int64_t balanceAfterFeeCharged;
+    if (tx->getSourceID() == getRoot().getPublicKey())
+    {
+        balanceAfterFeeCharged = getRoot().getBalance();
+    }
+    else
+    {
+        LedgerTxn ltx(mApp->getLedgerTxnRoot());
+        auto account = ltx.load(accountKey(tx->getSourceID()));
+        REQUIRE(account);
+        balanceAfterFeeCharged = account.current().data.account().balance;
+    }
+
+    int64_t baseFee = 100;
+    auto changesAfter = txm.getChangesAfter();
+    REQUIRE(changesAfter.size() == 2);
+    int64_t nonRefundableResourceFee =
+        sorobanResourceFee(getApp(), tx->sorobanResources(),
+                           xdr::xdr_size(tx->getEnvelope()), eventsSize);
+    int64_t expectedFeeCharged =
+        nonRefundableResourceFee + expectedRefundableFeeCharged + baseFee;
+    int64_t actualFeeCharged = initialBalance - balanceAfterFeeCharged;
+    REQUIRE(actualFeeCharged == expectedFeeCharged);
+
+    // Meta should contain the refund in `changesAfter`.
+    int64_t chargedBeforeRefund =
+        (tx->getFullFee() - tx->getInclusionFee()) + baseFee;
+    REQUIRE(changesAfter[1].updated().data.account().balance -
+                changesAfter[0].state().data.account().balance ==
+            chargedBeforeRefund - expectedFeeCharged);
+}
+
 void
 SorobanTest::invokeArchivalOp(TransactionFrameBaseConstPtr tx,
                               int64_t expectedRefundableFeeCharged)
@@ -929,8 +976,8 @@ SorobanTest::invokeArchivalOp(TransactionFrameBaseConstPtr tx,
         result = tx->checkValid(getApp().getAppConnector(), ltx, 0, 0, 0);
     }
     REQUIRE(result->isSuccess());
-    int64_t initBalance = getRoot().getBalance();
 
+    int64_t initBalance = getAccountBalance();
     int64_t baseFee = 100;
     int64_t chargedBeforeRefund =
         (tx->getFullFee() - tx->getInclusionFee()) + baseFee;
@@ -939,21 +986,7 @@ SorobanTest::invokeArchivalOp(TransactionFrameBaseConstPtr tx,
     TransactionMetaFrame txm(getLedgerVersion(), mApp->getConfig());
     REQUIRE(isSuccessResult(invokeTx(tx, &txm)));
 
-    int64_t balanceAfterFeeCharged = getRoot().getBalance();
-
-    auto changesAfter = txm.getChangesAfter();
-    REQUIRE(changesAfter.size() == 2);
-    int64_t nonRefundableResourceFee = sorobanResourceFee(
-        getApp(), tx->sorobanResources(), xdr::xdr_size(tx->getEnvelope()), 0);
-    int64_t expectedFeeCharged =
-        nonRefundableResourceFee + expectedRefundableFeeCharged + baseFee;
-    int64_t actualFeeCharged = initBalance - balanceAfterFeeCharged;
-    REQUIRE(actualFeeCharged == expectedFeeCharged);
-
-    // Meta should contain the refund in `changesAfter`.
-    REQUIRE(changesAfter[1].updated().data.account().balance -
-                changesAfter[0].state().data.account().balance ==
-            chargedBeforeRefund - expectedFeeCharged);
+    checkRefundableFee(initBalance, tx, txm, expectedRefundableFeeCharged);
 }
 
 Hash

--- a/src/transactions/test/SorobanTxTestUtils.h
+++ b/src/transactions/test/SorobanTxTestUtils.h
@@ -335,6 +335,15 @@ class SorobanTest
                                        std::function<SCVal(uint256)> signFn);
     SorobanSigner createClassicAccountSigner(TestAccount const& account,
                                              std::vector<TestAccount*> signers);
+
+    void checkRefundableFee(int64_t initialBalance,
+                            TransactionFrameBaseConstPtr tx,
+                            TransactionMetaFrame const& txm,
+                            int64_t expectedRefundableFeeCharged,
+                            size_t eventsSize = 0);
+
+    // Defaults to root account
+    int64_t getAccountBalance(TestAccount* source = nullptr);
 };
 
 class AssetContractTestClient

--- a/src/util/ProtocolVersion.h
+++ b/src/util/ProtocolVersion.h
@@ -55,4 +55,5 @@ constexpr ProtocolVersion PARALLEL_SOROBAN_PHASE_PROTOCOL_VERSION =
     ProtocolVersion::V_23;
 constexpr ProtocolVersion REUSABLE_SOROBAN_MODULE_CACHE_PROTOCOL_VERSION =
     ProtocolVersion::V_23;
+constexpr ProtocolVersion AUTO_RESTORE_PROTOCOL_VERSION = ProtocolVersion::V_23;
 }

--- a/test-tx-meta-baseline-next/InvokeHostFunctionTests.json
+++ b/test-tx-meta-baseline-next/InvokeHostFunctionTests.json
@@ -1340,6 +1340,38 @@
 		"ggnpCOwYXac="
 	],
 	"Vm instantiation tightening" : [ "MR6BJ3xmn2c=" ],
+	"archival meta|protocol version 20" : 
+	[
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo="
+	],
+	"archival meta|protocol version 21" : 
+	[
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo="
+	],
+	"archival meta|protocol version 22" : 
+	[
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo="
+	],
+	"archival meta|protocol version 23" : 
+	[
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I="
+	],
 	"autorestore contract instance" : [ "+cR3oq2qY0I=", "+cR3oq2qY0I=" ],
 	"autorestore with storage resize" : 
 	[
@@ -1405,10 +1437,6 @@
 		"+cR3oq2qY0I="
 	],
 	"contract storage|footprint|unused readWrite key" : [ "KxHGewG2KcM=" ],
-	"entry eviction|protocol version 20" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=", "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
-	"entry eviction|protocol version 21" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=", "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
-	"entry eviction|protocol version 22" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=", "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
-	"entry eviction|protocol version 23" : [ "+cR3oq2qY0I=", "+cR3oq2qY0I=", "+cR3oq2qY0I=", "+cR3oq2qY0I=" ],
 	"failure diagnostics" : [ "+cR3oq2qY0I=" ],
 	"fee bump refund account merged|protocol version 20" : 
 	[
@@ -1491,14 +1519,7 @@
 	"refund test with closeLedger|protocol version 22" : [ "krqalR4VBqg=", "Yn/dIXLvAQU=" ],
 	"refund test with closeLedger|protocol version 23" : [ "krqalR4VBqg=", "t+MG8Dn0eQ4=" ],
 	"settings upgrade" : [ "+cR3oq2qY0I=", "+cR3oq2qY0I=" ],
-	"settings upgrade command line utils" : 
-	[
-		"bQzyJNptErg=",
-		"bQzyJNptErg=",
-		"bQzyJNptErg=",
-		"bQzyJNptErg=",
-		"bQzyJNptErg="
-	],
+	"settings upgrade command line utils" : [ "bQzyJNptErg=", "bQzyJNptErg=", "bQzyJNptErg=", "bQzyJNptErg=" ],
 	"state archival" : 
 	[
 		"+cR3oq2qY0I=",

--- a/test-tx-meta-baseline-next/InvokeHostFunctionTests.json
+++ b/test-tx-meta-baseline-next/InvokeHostFunctionTests.json
@@ -1340,6 +1340,18 @@
 		"ggnpCOwYXac="
 	],
 	"Vm instantiation tightening" : [ "MR6BJ3xmn2c=" ],
+	"autorestore contract instance" : [ "+cR3oq2qY0I=", "+cR3oq2qY0I=" ],
+	"autorestore with storage resize" : 
+	[
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I="
+	],
 	"basic contract invocation" : 
 	[
 		"+cR3oq2qY0I=",
@@ -1444,10 +1456,24 @@
 		"+cR3oq2qY0I=",
 		"+cR3oq2qY0I="
 	],
-	"persistent entry archival|eviction" : [ "+cR3oq2qY0I=", "+cR3oq2qY0I=", "+cR3oq2qY0I=" ],
-	"persistent entry archival|eviction|key accessible after restore in same ledger" : [ "x+jcrgP4L+c=" ],
-	"persistent entry archival|expiration without eviction" : [ "+cR3oq2qY0I=", "+cR3oq2qY0I=", "+cR3oq2qY0I=" ],
-	"persistent entry archival|expiration without eviction|key accessible after restore in same ledger" : [ "x+jcrgP4L+c=" ],
+	"persistent entry archival|eviction" : 
+	[
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I="
+	],
+	"persistent entry archival|eviction|key accessible after restore in same ledger" : [ "X6v/mOWiiW4=", "X6v/mOWiiW4=" ],
+	"persistent entry archival|expiration without eviction" : 
+	[
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I="
+	],
+	"persistent entry archival|expiration without eviction|key accessible after restore in same ledger" : [ "X6v/mOWiiW4=", "X6v/mOWiiW4=" ],
 	"refund account merged|protocol version 20" : [ "krqalR4VBqg=", "ibmBre1y48o=", "pbEBZ3W1weM=", "HKURUDFC4f8=" ],
 	"refund account merged|protocol version 21" : [ "krqalR4VBqg=", "ibmBre1y48o=", "pbEBZ3W1weM=", "HKURUDFC4f8=" ],
 	"refund account merged|protocol version 22" : [ "krqalR4VBqg=", "Yn/dIXLvAQU=", "sTchUemldDs=", "Be3X15PT6Gc=" ],


### PR DESCRIPTION
# Description

Implements auto restore functionality in InvokeHostFunction.

During implementation, I realized that there was some under specification of how fees should be handled by auto restore. I'll update the cap here shortly, but fees have been modified as follows:

Prior to entering the host:
- All archived entries in the rw footprint of a transaction are metered against disk read bytes based on the size of the archived entry.
- Archived entries are charged minimum rent fees based on their initial, archived size.
- At this point, archived entries are considered "restored". They are added to the Cxx buffer as if they were live with an accompanying TTL entry with the minimum `liveUntilLedgerSeq`.

After exiting the host:
- Writes fees are charged based on whatever state is returned from the host.
- Additional rent bumps (either due to extension or entry resizing) are charged by the host as is the case today.

In terms of rent fees and readBytes metering, this is identical to calling a RestoreOp, followed by an InvocationOp as if they shared a footprint such that reads were not double counted. Write fees are slightly different, as they are based only on the final size of the entry that actually gets written to disk. This means it is possible that a restore will not be charged any write fees at all if an entry is deleted by the same TX it is autorestored in. This seems reasonable from a DOS perspective, since we charge users for the bytes they actually end up writing to disk. Restoration is never free, since we charge rent and disk read bytes based on the starting size of the entry. This seems like the most fair and easiest to implement approach.

This PR should be correct and well tested wrt basic correctness and rent fees. It does not yet use in-memory vs disk based resources, and I'm waiting to rebase on Dima's PR. I also need to add some more specific meta tests. After I rebase I'll add write/read resource tests. Hopefully this doesn't conflict too much logically with the parallel apply work, although I did add a stateful helper class inside InvokeHostFunctionOp. This was helpful since we added lots of complexity to `addReads`, and any sort of function or lambda would have a very long parameter list. If it's too many LOC of conflict I can figure something out.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
