### PR TITLE
Make WIP soroban submodules conditional on vnext.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -136,7 +136,45 @@ LIBRUST_STELLAR_CORE=$(RUST_TARGET_DIR)/$(RUST_PROFILE)/librust_stellar_core.a
 stellar_core_LDADD += $(LIBRUST_STELLAR_CORE) -ldl
 
 SOROBAN_BUILD_DIR=$(abspath $(RUST_BUILD_DIR))/soroban
-ALL_SOROBAN_PROTOCOLS=$(notdir $(wildcard rust/soroban/p*))
+
+# There's some subtlety to the way the next few lines work and interact with the
+# "next protocol" flag `--enable-next-protocol-version-unsafe-for-production`.
+#
+# There are two possible and legitimate ways to interpret this flag:
+#
+#    1. If the flag is on, build the submodule named by the next protocol
+#       version, with no additional feature-flags passed to cargo. If the flag
+#       is off, don't build that submodule at all.
+#
+#    2. If the flag is on, build the submodule named by the _current_ protocol
+#       version but pass the `--features=next` flag to cargo. If the flag is
+#       off, don't pass `--features=next` to the submodule.
+#
+# Both of these interpretations are valid and have their own use cases. They
+# happen at different times during the development process and we want to allow
+# both. Interpretation #1 is useful while a protocol is in-development and we
+# want to be certain that the entire submodule isn't built or shipped by
+# accident. Interpretation #2 is useful when a protocol is in-production but we
+# still want the "next" builds to be available to experiment with protocol
+# changes in the current codebase (or at minimum: to be identical to curr, but
+# to pass CI and not spuriously fail to build or run)
+#
+# If you want interpretation #1, you should put the submodule in the variable
+# `WIP_SOROBAN_PROTOCOL`. If you want interpretation #2, you should leave that
+# variable empty (and include or exclude submodules from the list of
+# ALL_SOROBAN_PROTOCOLS as you see fit).
+
+ALL_SOROBAN_PROTOCOLS=p21 p22
+WIP_SOROBAN_PROTOCOL=p23
+
+if ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+ALL_SOROBAN_PROTOCOLS+=$(WIP_SOROBAN_PROTOCOL)
+# This means "only pass --features=next if there's no WIP submodule"
+SOROBAN_FEATURE_NEXT=$(if $(WIP_SOROBAN_PROTOCOL),,$(CARGO_FEATURE_NEXT))
+else
+SOROBAN_FEATURE_NEXT=
+endif
+
 SOROBAN_MAX_PROTOCOL=$(lastword $(sort $(ALL_SOROBAN_PROTOCOLS)))
 
 define soroban_lib_dir
@@ -246,7 +284,7 @@ $(SOROBAN_LIBS_STAMP): $(wildcard rust/soroban/p*/Cargo.lock) Makefile $(RUST_DE
 				FEATURE_FLAGS="" \
 			;; \
 			$(SOROBAN_MAX_PROTOCOL)) \
-				FEATURE_FLAGS="$(CARGO_FEATURE_TRACY) $(CARGO_FEATURE_NEXT)" \
+				FEATURE_FLAGS="$(CARGO_FEATURE_TRACY) $(SOROBAN_FEATURE_NEXT)" \
 			;; \
 			*) \
 				FEATURE_FLAGS="$(CARGO_FEATURE_TRACY)" \

--- a/src/main/CommandLine.h
+++ b/src/main/CommandLine.h
@@ -21,6 +21,7 @@ struct CommandLineArgs
 };
 
 int handleCommandLine(int argc, char* const* argv);
+int runVersion(CommandLineArgs const&);
 
 void writeWithTextFlow(std::ostream& os, std::string const& text);
 }

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -347,14 +347,25 @@ main(int argc, char* const* argv)
     initializeAllGlobalState();
     xdr::marshaling_stack_limit = 1000;
 
-    checkStellarCoreMajorVersionProtocolIdentity();
-    rust_bridge::check_sensible_soroban_config_for_protocol(
-        Config::CURRENT_LEDGER_PROTOCOL_VERSION);
+    try
+    {
 
-    // Disable XDR hash checking in vnext builds
+        checkStellarCoreMajorVersionProtocolIdentity();
+        rust_bridge::check_sensible_soroban_config_for_protocol(
+            Config::CURRENT_LEDGER_PROTOCOL_VERSION);
+
+        // Disable XDR hash checking in vnext builds
 #ifndef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-    checkXDRFileIdentity();
+        checkXDRFileIdentity();
 #endif
+    }
+    catch (...)
+    {
+        // Diagnosing version-mismatch errors is hard so we print
+        // the version information before we throw.
+        runVersion(CommandLineArgs{});
+        throw;
+    }
 
     int res = handleCommandLine(argc, argv);
     return res;

--- a/src/rust/src/soroban_proto_all.rs
+++ b/src/rust/src/soroban_proto_all.rs
@@ -33,6 +33,7 @@ use crate::RustBuf;
 // that's just always supposed to use the latest.
 pub(crate) use p22 as soroban_curr;
 
+#[cfg(feature = "next")]
 #[path = "."]
 pub(crate) mod p23 {
     pub(crate) extern crate soroban_env_host_p23;
@@ -57,10 +58,8 @@ pub(crate) mod p23 {
         v.interface.pre_release
     }
 
-    pub(crate) const fn get_version_protocol(_v: &soroban_env_host::Version) -> u32 {
-        // Temporarily hardcode the protocol version until we actually bump it
-        // in the host library.
-        23
+    pub(crate) const fn get_version_protocol(v: &soroban_env_host::Version) -> u32 {
+        v.interface.protocol
     }
 
     pub fn invoke_host_function_with_trace_hook_and_module_cache<
@@ -413,6 +412,7 @@ macro_rules! proto_versioned_functions_for_module {
 const HOST_MODULES: &'static [HostModule] = &[
     proto_versioned_functions_for_module!(p21),
     proto_versioned_functions_for_module!(p22),
+    #[cfg(feature = "next")]
     proto_versioned_functions_for_module!(p23),
 ];
 
@@ -453,6 +453,6 @@ fn protocol_dispatches_as_expected() {
     let last_proto = HOST_MODULES.last().unwrap().max_proto;
     assert!(get_host_module_for_protocol(last_proto + 1, last_proto + 1).is_err());
 
-    // No ledger protocol has to be less than config max.
+    // Ledger protocol has to be less than config max.
     assert!(get_host_module_for_protocol(20, 21).is_err());
 }


### PR DESCRIPTION
This tightens up a condition in the way we manage vnext builds. It currently breaks the build.

Previously (on master today) we always include the newest soroban submodule, even if it is a work-in-progress we _really_ ought to to exclude from non-vnext builds to avoid it leaking into the public and accidentally being used somehow (eg. if we were still doing p22 point releases off master while working on p23)

With this change, we _don't even compile_ such a submodule unless we're doing a vnext build.

Additionally, this change alters the conditions in which we propagate `--features=next` to soroban.

Previously we'd always pass it to the newest soroban module (even if it's WIP).

With this change, we only propagage `--features=next` to a soroban submodule that's _not_ descriped as WIP. In other words: if we're using the vnext-ness of a build to _enable a WIP submodule_ (eg. turning on p23) then we _don't_ also tell it turn turn on p24 inside of itself. We just enable the p23 submodule. If no submodule is marked as WIP, then we assume all submodules are production-ready and we continue to do what we do today, propagating `--features=next` in a vnext-build so that it continues to work (just by emulation).

Unfortunate this PR currently breaks the build. In fact this PR is motivated by the observation by @dmkozh and @sisuresh that the non-vnext build probably _should_ be broken today, because core's XDR is on 4920abbbdd05bc9b8b908143ac55c95c70f35c70 whereas the p22 soroban submodule's XDR is months behind, on 529d5176f24c73eeccfa5eba481d4e89c19b1181 (from sept 12 2024).

In theory both of these "ought to be compatible" in the sense that one is a protocol-compatible extension of the other, but there's a startup check that the versions are _identical_ and that check is currently failing (it's disabled in a vnext build but not a normal build).

So .. I don't exactly know what to do about this. Some options:

  1. Try to make the _existence_ of a WIP submodule also disable the startup XDR identity check, even in a non-vnext build. The idea here would be that the _presence_ of a WIP submodule implies "we're a ways along the development cycle of vnext" so we should relax our checking and assume any mismatch is "a compatible extension". This makes me _very_ nervous, and actually wouldn't have _worked_ for the history here -- we advanced core's XDR multiple times in the meantime, including in november before there even was a WIP p23 submodule.
  2. Do a point release of soroban 22 that pulls in newer curr-branch XDR changes. I think this might be easiest? It's some busy-work of course (all this version-skew stuff is) but it seems most likely to preserve correctness. Soroban has seen "version 22" point releases repeatedly over the 22 lifecycle (as recently as last week 22.1.4 was released) but they have all stuck with the same XDR that went out with 22.0.0 -- 529d5176f24c73eeccfa5eba481d4e89c19b1181 -- so while we _can_ bump the p22 submodule to 22.1.4, that alone doesn't help. We'd need to make a soroban 22.1.5 that bumps its own XDR to 4920abbbdd05bc9b8b908143ac55c95c70f35c70, then bump core's p22 submodule to that 22.1.5.
  3. Something else? I'm open to suggestions.