### PR TITLE
getledgerentry endpoint for RPC

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -57,7 +57,8 @@ PREFETCH_BATCH_SIZE=1000
 
 # HTTP_PORT (integer) default 11626
 # What port stellar-core listens for commands on.
-# If set to 0, disable HTTP interface entirely
+# If set to 0, disable HTTP commands interface entirely
+# (note that this does not disable HTTP query interface).
 # Must not be the same as HTTP_QUERY_PORT if not 0.
 HTTP_PORT=11626
 
@@ -80,7 +81,8 @@ COMMANDS=[
 # HTTP_QUERY_PORT (integer) default 0
 # What port stellar-core listens for query commands on,
 # such as getledgerentryraw.
-# If set to 0, disable HTTP query interface entirely.
+# If set to 0, disable HTTP query interface entirely
+# (note that this does not disable HTTP commands interface).
 # Must not be the same as HTTP_PORT if not 0.
 HTTP_QUERY_PORT=0
 

--- a/src/bucket/BucketSnapshotManager.h
+++ b/src/bucket/BucketSnapshotManager.h
@@ -89,5 +89,12 @@ class BucketSnapshotManager : NonMovableOrCopyable
     maybeCopySearchableBucketListSnapshot(SearchableSnapshotConstPtr& snapshot);
     void maybeCopySearchableHotArchiveBucketListSnapshot(
         SearchableHotArchiveSnapshotConstPtr& snapshot);
+
+    // This function is the same as snapshot refreshers above, but guarantees
+    // that both snapshots are consistent with the same lcl. This is required
+    // when querying both snapshot types as part of the same query.
+    void maybeCopyLiveAndHotArchiveSnapshots(
+        SearchableSnapshotConstPtr& liveSnapshot,
+        SearchableHotArchiveSnapshotConstPtr& hotArchiveSnapshot);
 };
 }

--- a/src/bucket/HotArchiveBucket.cpp
+++ b/src/bucket/HotArchiveBucket.cpp
@@ -6,6 +6,8 @@
 #include "bucket/BucketInputIterator.h"
 #include "bucket/BucketOutputIterator.h"
 #include "bucket/BucketUtils.h"
+#include "ledger/LedgerTypeUtils.h"
+#include "util/GlobalChecks.h"
 
 namespace stellar
 {
@@ -51,6 +53,7 @@ HotArchiveBucket::convertToBucketEntry(
         HotArchiveBucketEntry be;
         be.type(HOT_ARCHIVE_ARCHIVED);
         be.archivedEntry() = e;
+        releaseAssertOrThrow(isPersistentEntry(e.data));
         bucket.push_back(be);
     }
     for (auto const& k : restoredEntries)
@@ -58,6 +61,7 @@ HotArchiveBucket::convertToBucketEntry(
         HotArchiveBucketEntry be;
         be.type(HOT_ARCHIVE_LIVE);
         be.key() = k;
+        releaseAssertOrThrow(isPersistentEntry(k));
         bucket.push_back(be);
     }
 

--- a/src/bucket/test/BucketIndexTests.cpp
+++ b/src/bucket/test/BucketIndexTests.cpp
@@ -1060,8 +1060,8 @@ TEST_CASE("hot archive bucket lookups", "[bucket][bucketindex][archive]")
         };
 
         auto archivedEntries =
-            LedgerTestUtils::generateValidUniqueLedgerEntriesWithTypes(
-                {CONTRACT_DATA, CONTRACT_CODE}, 10);
+            LedgerTestUtils::generateUniquePersistentLedgerEntries(
+                10, keysToSearch);
         for (auto const& e : archivedEntries)
         {
             auto k = LedgerEntryKey(e);
@@ -1071,8 +1071,8 @@ TEST_CASE("hot archive bucket lookups", "[bucket][bucketindex][archive]")
 
         // Note: keys to search automatically populated by these functions
         auto restoredEntries =
-            LedgerTestUtils::generateValidUniqueLedgerKeysWithTypes(
-                {CONTRACT_DATA, CONTRACT_CODE}, 10, keysToSearch);
+            LedgerTestUtils::generateUniquePersistentLedgerKeys(10,
+                                                                keysToSearch);
         for (auto const& k : restoredEntries)
         {
             expectedRestoredEntries.emplace(k);

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -166,8 +166,6 @@ basicBucketListTest()
                     {
                         bl.addBatch(
                             *app, i, getAppLedgerVersion(app), {},
-                            LedgerTestUtils::generateValidUniqueLedgerEntries(
-                                8),
                             LedgerTestUtils::
                                 generateValidLedgerEntryKeysWithExclusions(
                                     {CONFIG_SETTING}, 5));
@@ -176,14 +174,11 @@ basicBucketListTest()
                     {
                         bl.addBatch(
                             *app, i, getAppLedgerVersion(app),
-                            stellar::LedgerTestUtils::
-                                generateValidUniqueLedgerEntriesWithTypes(
-                                    {CONTRACT_CODE, CONTRACT_DATA}, 8,
-                                    seenKeys),
-                            stellar::LedgerTestUtils::
-                                generateValidUniqueLedgerKeysWithTypes(
-                                    {CONTRACT_CODE, CONTRACT_DATA}, 5,
-                                    seenKeys));
+                            LedgerTestUtils::
+                                generateUniquePersistentLedgerEntries(8,
+                                                                      seenKeys),
+                            LedgerTestUtils::generateUniquePersistentLedgerKeys(
+                                5, seenKeys));
                     }
                 }
 
@@ -439,10 +434,8 @@ TEST_CASE_VERSIONS("hot archive bucket tombstones expire at bottom level",
         {
             bl.addBatch(
                 *app, ledger, getAppLedgerVersion(app),
-                LedgerTestUtils::generateValidUniqueLedgerEntriesWithTypes(
-                    {CONTRACT_DATA, CONTRACT_CODE}, 5, keys),
-                LedgerTestUtils::generateValidUniqueLedgerKeysWithTypes(
-                    {CONTRACT_CODE, CONTRACT_DATA}, 5, keys));
+                LedgerTestUtils::generateUniquePersistentLedgerEntries(5, keys),
+                LedgerTestUtils::generateUniquePersistentLedgerKeys(5, keys));
 
             // Once all entries merge to the bottom level, only deleted entries
             // should remain

--- a/src/ledger/test/LedgerTestUtils.cpp
+++ b/src/ledger/test/LedgerTestUtils.cpp
@@ -688,6 +688,38 @@ generateUniqueValidSorobanLedgerEntryKeys(size_t n)
         n);
 }
 
+std::vector<LedgerEntry>
+generateUniquePersistentLedgerEntries(size_t n,
+                                      UnorderedSet<LedgerKey>& seenKeys)
+{
+    auto res = LedgerTestUtils::generateValidUniqueLedgerEntriesWithTypes(
+        {CONTRACT_DATA, CONTRACT_CODE}, n, seenKeys);
+    for (auto& le : res)
+    {
+        if (le.data.type() == CONTRACT_DATA)
+        {
+            seenKeys.erase(LedgerEntryKey(le));
+            le.data.contractData().durability = PERSISTENT;
+            seenKeys.insert(LedgerEntryKey(le));
+        }
+    }
+
+    return res;
+}
+
+std::vector<LedgerKey>
+generateUniquePersistentLedgerKeys(size_t n, UnorderedSet<LedgerKey>& seenKeys)
+{
+    auto entries = generateUniquePersistentLedgerEntries(n, seenKeys);
+    std::vector<LedgerKey> res;
+    for (auto const& le : entries)
+    {
+        res.push_back(LedgerEntryKey(le));
+    }
+
+    return res;
+}
+
 std::vector<LedgerKey>
 generateValidUniqueLedgerEntryKeysWithExclusions(
     std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n)

--- a/src/ledger/test/LedgerTestUtils.h
+++ b/src/ledger/test/LedgerTestUtils.h
@@ -51,6 +51,12 @@ std::vector<LedgerKey> generateValidUniqueLedgerKeysWithTypes(
     std::unordered_set<LedgerEntryType> const& types, size_t n,
     UnorderedSet<LedgerKey>& seenKeys);
 
+std::vector<LedgerEntry>
+generateUniquePersistentLedgerEntries(size_t n,
+                                      UnorderedSet<LedgerKey>& seenKeys);
+std::vector<LedgerKey>
+generateUniquePersistentLedgerKeys(size_t n, UnorderedSet<LedgerKey>& seenKeys);
+
 std::vector<LedgerKey> generateUniqueValidSorobanLedgerEntryKeys(size_t n);
 
 std::vector<LedgerKey> generateValidUniqueLedgerEntryKeysWithExclusions(

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -50,7 +50,7 @@ namespace stellar
 {
 CommandHandler::CommandHandler(Application& app) : mApp(app)
 {
-    if (mApp.getConfig().HTTP_PORT)
+    if (mApp.getConfig().HTTP_PORT || mApp.getConfig().HTTP_QUERY_PORT)
     {
         std::string ipStr;
         if (mApp.getConfig().PUBLIC_HTTP_PORT)
@@ -66,9 +66,12 @@ CommandHandler::CommandHandler(Application& app) : mApp(app)
 
         int httpMaxClient = mApp.getConfig().HTTP_MAX_CLIENT;
 
-        mServer = std::make_unique<http::server::server>(
-            app.getClock().getIOContext(), ipStr, mApp.getConfig().HTTP_PORT,
-            httpMaxClient);
+        if (mApp.getConfig().HTTP_PORT)
+        {
+            mServer = std::make_unique<http::server::server>(
+                app.getClock().getIOContext(), ipStr,
+                mApp.getConfig().HTTP_PORT, httpMaxClient);
+        }
 
         if (mApp.getConfig().HTTP_QUERY_PORT)
         {
@@ -78,7 +81,8 @@ CommandHandler::CommandHandler(Application& app) : mApp(app)
                 mApp.getBucketManager().getBucketSnapshotManager());
         }
     }
-    else
+
+    if (!mApp.getConfig().HTTP_PORT)
     {
         mServer = std::make_unique<http::server::server>(
             app.getClock().getIOContext());

--- a/src/main/QueryServer.cpp
+++ b/src/main/QueryServer.cpp
@@ -6,10 +6,15 @@
 #include "bucket/BucketSnapshotManager.h"
 #include "bucket/SearchableBucketList.h"
 #include "ledger/LedgerTxnImpl.h"
+#include "ledger/LedgerTypeUtils.h"
+#include "util/GlobalChecks.h"
 #include "util/Logging.h"
 #include "util/XDRStream.h" // IWYU pragma: keep
+#include "util/types.h"
+#include "xdr/Stellar-ledger-entries.h"
 #include <exception>
 #include <json/json.h>
+#include <unordered_map>
 
 using std::placeholders::_1;
 using std::placeholders::_2;
@@ -54,7 +59,12 @@ namespace stellar
 {
 QueryServer::QueryServer(const std::string& address, unsigned short port,
                          int maxClient, size_t threadPoolSize,
-                         BucketSnapshotManager& bucketSnapshotManager)
+                         BucketSnapshotManager& bucketSnapshotManager
+#ifdef BUILD_TESTS
+                         ,
+                         bool useMainThreadForTesting
+#endif
+                         )
     : mServer(address, port, maxClient, threadPoolSize)
     , mBucketSnapshotManager(bucketSnapshotManager)
 {
@@ -63,12 +73,28 @@ QueryServer::QueryServer(const std::string& address, unsigned short port,
 
     mServer.add404(std::bind(&QueryServer::notFound, this, _1, _2, _3));
     addRoute("getledgerentryraw", &QueryServer::getLedgerEntryRaw);
+    addRoute("getledgerentry", &QueryServer::getLedgerEntry);
 
-    auto workerPids = mServer.start();
-    for (auto pid : workerPids)
+#ifdef BUILD_TESTS
+    if (useMainThreadForTesting)
     {
-        mBucketListSnapshots[pid] = std::move(
-            bucketSnapshotManager.copySearchableLiveBucketListSnapshot());
+        mBucketListSnapshots[std::this_thread::get_id()] =
+            bucketSnapshotManager.copySearchableLiveBucketListSnapshot();
+        mHotArchiveBucketListSnapshots[std::this_thread::get_id()] =
+            bucketSnapshotManager.copySearchableHotArchiveBucketListSnapshot();
+    }
+    else
+#endif
+    {
+        auto workerPids = mServer.start();
+        for (auto pid : workerPids)
+        {
+            mBucketListSnapshots[pid] =
+                bucketSnapshotManager.copySearchableLiveBucketListSnapshot();
+            mHotArchiveBucketListSnapshots[pid] =
+                bucketSnapshotManager
+                    .copySearchableHotArchiveBucketListSnapshot();
+        }
     }
 }
 
@@ -128,8 +154,8 @@ QueryServer::getLedgerEntryRaw(std::string const& params,
     std::map<std::string, std::vector<std::string>> paramMap;
     httpThreaded::server::server::parsePostParams(body, paramMap);
 
-    auto keys = paramMap["key"];
-    auto snapshotLedger = parseOptionalParam<uint32_t>(paramMap, "ledgerSeq");
+    auto keys = paramMap["k"];
+    auto snapshotLedger = parseOptionalParam<uint32_t>(paramMap, "ledger");
 
     if (!keys.empty())
     {
@@ -152,7 +178,7 @@ QueryServer::getLedgerEntryRaw(std::string const& params,
         // If a snapshot ledger is specified, use it to get the ledger entry
         if (snapshotLedger)
         {
-            root["ledgerSeq"] = *snapshotLedger;
+            root["ledger"] = *snapshotLedger;
 
             auto loadedKeysOp =
                 bl.loadKeysFromLedger(orderedKeys, *snapshotLedger);
@@ -160,7 +186,7 @@ QueryServer::getLedgerEntryRaw(std::string const& params,
             // Return 404 if ledgerSeq not found
             if (!loadedKeysOp)
             {
-                retStr = "LedgerSeq not found";
+                retStr = "Ledger not found";
                 return false;
             }
 
@@ -171,7 +197,7 @@ QueryServer::getLedgerEntryRaw(std::string const& params,
         {
             loadedKeys = bl.loadKeysWithLimits(orderedKeys, "query",
                                                /*lkMeter=*/nullptr);
-            root["ledgerSeq"] = bl.getLedgerSeq();
+            root["ledger"] = bl.getLedgerSeq();
         }
 
         for (auto const& le : loadedKeys)
@@ -184,9 +210,217 @@ QueryServer::getLedgerEntryRaw(std::string const& params,
     else
     {
         throw std::invalid_argument(
-            "Must specify ledger key in POST body: key=<LedgerKey in base64 "
+            "Must specify ledger key in POST body: k=<LedgerKey in base64 "
             "XDR format>");
     }
+    retStr = Json::FastWriter().write(root);
+    return true;
+}
+
+// This query needs to load all the given ledger entries and their "state"
+// (live, archived, new). This requires loading an entry and TTL from
+// the live BucketList and then checking the Hot Archive for any keys we didn't
+// find. We do three passes:
+// 1. Load all keys from the live BucketList
+// 2. For any Soroban keys not in the live BucketList, load them from the Hot
+//    Archive
+// 3. Load TTL keys for any live Soroban entries found in 1.
+bool
+QueryServer::getLedgerEntry(std::string const& params, std::string const& body,
+                            std::string& retStr)
+{
+    ZoneScoped;
+    Json::Value root;
+
+    std::map<std::string, std::vector<std::string>> paramMap;
+    httpThreaded::server::server::parsePostParams(body, paramMap);
+
+    auto const keys = paramMap["k"];
+    auto snapshotLedger = parseOptionalParam<uint32_t>(paramMap, "ledger");
+
+    if (keys.empty())
+    {
+        retStr = "Must specify key in POST body: k=<LedgerKey in base64 "
+                 "XDR format>\n";
+        return false;
+    }
+
+    auto& liveBl = mBucketListSnapshots.at(std::this_thread::get_id());
+    auto& hotArchiveBl =
+        mHotArchiveBucketListSnapshots.at(std::this_thread::get_id());
+
+    LedgerKeySet keysToSearch;
+
+    // Keep track of keys in their original order for response ordering
+    std::vector<LedgerKey> inputOrderedKeys;
+
+    for (auto const& key : keys)
+    {
+        LedgerKey k;
+        fromOpaqueBase64(k, key);
+        if (k.type() == TTL)
+        {
+            retStr = "TTL keys are not allowed\n";
+            return false;
+        }
+
+        auto [_, inserted] = keysToSearch.emplace(k);
+        if (!inserted)
+        {
+            retStr = "Duplicate keys\n";
+            return false;
+        }
+
+        inputOrderedKeys.push_back(k);
+    }
+
+    mBucketSnapshotManager.maybeCopyLiveAndHotArchiveSnapshots(liveBl,
+                                                               hotArchiveBl);
+
+    std::vector<LedgerEntry> liveEntries;
+    std::vector<HotArchiveBucketEntry> archivedEntries;
+    uint32_t ledgerSeq =
+        snapshotLedger ? *snapshotLedger : liveBl->getLedgerSeq();
+    root["ledger"] = ledgerSeq;
+
+    auto liveEntriesOp = liveBl->loadKeysFromLedger(keysToSearch, ledgerSeq);
+
+    // Return 404 if ledgerSeq not found
+    if (!liveEntriesOp)
+    {
+        retStr = "Ledger not found\n";
+        return false;
+    }
+
+    liveEntries = std::move(*liveEntriesOp);
+    liveEntriesOp->clear();
+
+    // Remove keys found in live bucketList from subsequent searches
+    for (auto const& le : liveEntries)
+    {
+        keysToSearch.erase(LedgerEntryKey(le));
+    }
+
+    LedgerKeySet hotArchiveKeysToSearch;
+    for (auto const& lk : keysToSearch)
+    {
+        if (isSorobanEntry(lk))
+        {
+            hotArchiveKeysToSearch.emplace(lk);
+        }
+    }
+
+    // Only query archive for soroban keys we didn't find in the live bucketList
+    if (!hotArchiveKeysToSearch.empty())
+    {
+        auto archivedEntriesOp =
+            hotArchiveBl->loadKeysFromLedger(hotArchiveKeysToSearch, ledgerSeq);
+        if (!archivedEntriesOp)
+        {
+            retStr = "Ledger not found\n";
+            return false;
+        }
+        archivedEntries = std::move(*archivedEntriesOp);
+    }
+
+    // Collect TTL keys for Soroban entries in the live BucketList
+    LedgerKeySet ttlKeys;
+    for (auto const& le : liveEntries)
+    {
+        if (isSorobanEntry(le.data))
+        {
+            ttlKeys.emplace(getTTLKey(le));
+        }
+    }
+
+    std::vector<LedgerEntry> ttlEntries;
+    if (!ttlKeys.empty())
+    {
+        // We haven't updated the live snapshot so we know the have a snapshot
+        // available for ledgerSeq
+        ttlEntries =
+            std::move(liveBl->loadKeysFromLedger(ttlKeys, ledgerSeq).value());
+    }
+
+    std::unordered_map<LedgerKey, LedgerEntry> ttlMap;
+    for (auto const& ttlEntry : ttlEntries)
+    {
+        ttlMap.emplace(LedgerEntryKey(ttlEntry), ttlEntry);
+    }
+
+    // Store key -> formatted response
+    std::unordered_map<LedgerKey, Json::Value> responseEntries;
+
+    for (auto const& le : liveEntries)
+    {
+        LedgerKey lk = LedgerEntryKey(le);
+        Json::Value entry;
+        entry["e"] = toOpaqueBase64(le);
+
+        // Check TTL to set state for Soroban entries
+        if (isSorobanEntry(le.data))
+        {
+            auto ttlIter = ttlMap.find(getTTLKey(le));
+            releaseAssertOrThrow(ttlIter != ttlMap.end());
+            if (isLive(ttlIter->second, ledgerSeq))
+            {
+                entry["s"] = "live";
+                entry["t"] = ttlIter->second.data.ttl().liveUntilLedgerSeq;
+            }
+            else if (isPersistentEntry(lk))
+            {
+                entry["s"] = "archived";
+            }
+            // Archived temporary entries are considered "new"
+            else
+            {
+                entry["e"] = toOpaqueBase64(lk);
+                entry["s"] = "new";
+            }
+        }
+        else
+        {
+            entry["s"] = "live";
+        }
+
+        responseEntries[lk] = entry;
+    }
+
+    for (auto const& be : archivedEntries)
+    {
+        auto const& le = be.archivedEntry();
+        LedgerKey lk = LedgerEntryKey(le);
+
+        // At this point we've "found" the key and know it's archived, so remove
+        // it from our search set
+        keysToSearch.erase(lk);
+
+        Json::Value entry;
+        entry["e"] = toOpaqueBase64(le);
+        entry["s"] = "archived";
+
+        responseEntries[lk] = entry;
+    }
+
+    // Since we removed entries found in the live BucketList and archived
+    // entries found in the Hot Archive, any remaining keys must be new.
+    for (auto const& key : keysToSearch)
+    {
+        Json::Value entry;
+        entry["e"] = toOpaqueBase64(key);
+        entry["s"] = "new";
+
+        responseEntries[key] = entry;
+    }
+
+    // Add entries to the response in the same order as the input keys
+    for (auto const& key : inputOrderedKeys)
+    {
+        auto it = responseEntries.find(key);
+        releaseAssertOrThrow(it != responseEntries.end());
+        root["entries"].append(it->second);
+    }
+
     retStr = Json::FastWriter().write(root);
     return true;
 }

--- a/src/main/QueryServer.h
+++ b/src/main/QueryServer.h
@@ -29,6 +29,9 @@ class QueryServer
     std::unordered_map<std::thread::id, SearchableSnapshotConstPtr>
         mBucketListSnapshots;
 
+    std::unordered_map<std::thread::id, SearchableHotArchiveSnapshotConstPtr>
+        mHotArchiveBucketListSnapshots;
+
     BucketSnapshotManager& mBucketSnapshotManager;
 
     bool safeRouter(HandlerRoute route, std::string const& params,
@@ -39,14 +42,25 @@ class QueryServer
 
     void addRoute(std::string const& name, HandlerRoute route);
 
+#ifdef BUILD_TESTS
+  public:
+#endif
     // Returns raw LedgerKeys for the given keys from the Live BucketList. Does
     // not query other BucketLists or reason about archival.
     bool getLedgerEntryRaw(std::string const& params, std::string const& body,
                            std::string& retStr);
 
+    bool getLedgerEntry(std::string const& params, std::string const& body,
+                        std::string& retStr);
+
   public:
     QueryServer(const std::string& address, unsigned short port, int maxClient,
                 size_t threadPoolSize,
-                BucketSnapshotManager& bucketSnapshotManager);
+                BucketSnapshotManager& bucketSnapshotManager
+#ifdef BUILD_TESTS
+                ,
+                bool useMainThreadForTesting = false
+#endif
+    );
 };
 }

--- a/src/main/test/QueryServerTests.cpp
+++ b/src/main/test/QueryServerTests.cpp
@@ -1,0 +1,516 @@
+// Copyright 2025 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "bucket/BucketIndexUtils.h"
+#include "bucket/BucketManager.h"
+#include "bucket/test/BucketTestUtils.h"
+#include "ledger/LedgerTxnImpl.h"
+#include "ledger/LedgerTypeUtils.h"
+#include "ledger/test/LedgerTestUtils.h"
+#include "lib/catch.hpp"
+#include "main/Application.h"
+#include "main/Config.h"
+#include "main/QueryServer.h"
+#include "test/TestUtils.h"
+#include "test/test.h"
+#include "util/Math.h"
+#include "util/UnorderedSet.h"
+#include "util/types.h"
+#include "xdr/Stellar-ledger-entries.h"
+#include <json/json.h>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+using namespace stellar;
+
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+TEST_CASE("getledgerentry", "[queryserver]")
+{
+    VirtualClock clock;
+    auto cfg = getTestConfig();
+    cfg.QUERY_SNAPSHOT_LEDGERS = 5;
+
+    auto app = createTestApplication<BucketTestUtils::BucketTestApplication>(
+        clock, cfg);
+    auto& lm = app->getLedgerManager();
+
+    // Query Server is disabled by default in cfg. Instead of enabling it, we're
+    // going to manage a version here manually so we can directly call functions
+    // and avoid sending network requests.
+    auto qServer = std::make_unique<QueryServer>(
+        "127.0.0.1", 0,
+        1, // maxClient
+        2, // threadPoolSize
+        app->getBucketManager().getBucketSnapshotManager(), true);
+
+    std::unordered_map<LedgerKey, LedgerEntry> liveEntryMap;
+
+    // Map code/data lk -> ttl value
+    std::unordered_map<LedgerKey, uint32_t> liveTTLEntryMap;
+    std::unordered_map<LedgerKey, LedgerEntry> archivedEntryMap;
+
+    // Create some test entries
+    for (auto i = 0; i < 15; ++i)
+    {
+        auto lcl = app->getLedgerManager().getLastClosedLedgerNum();
+        auto liveEntries =
+            LedgerTestUtils::generateValidUniqueLedgerEntriesWithTypes(
+                {CONTRACT_DATA, CONTRACT_CODE, ACCOUNT}, 5);
+
+        std::vector<LedgerEntry> liveEntriesToInsert;
+        for (auto const& le : liveEntries)
+        {
+            if (isSorobanEntry(le.data))
+            {
+                LedgerEntry ttl;
+                ttl.data.type(TTL);
+                ttl.data.ttl().keyHash = getTTLKey(le).ttl().keyHash;
+
+                // Make half of the entries archived on the live BL
+                if (rand_flip())
+                {
+                    ttl.data.ttl().liveUntilLedgerSeq = lcl + 100;
+                }
+                else
+                {
+                    ttl.data.ttl().liveUntilLedgerSeq = 0;
+                }
+                liveTTLEntryMap[LedgerEntryKey(le)] =
+                    ttl.data.ttl().liveUntilLedgerSeq;
+                liveEntriesToInsert.push_back(ttl);
+            }
+
+            liveEntriesToInsert.push_back(le);
+            liveEntryMap[LedgerEntryKey(le)] = le;
+        }
+
+        auto archivedEntries =
+            LedgerTestUtils::generateValidUniqueLedgerEntriesWithTypes(
+                {CONTRACT_DATA, CONTRACT_CODE}, 5);
+        for (auto& le : archivedEntries)
+        {
+            // Entries in hot archive can only be persistent
+            if (!isPersistentEntry(le.data))
+            {
+                le.data.contractData().durability = PERSISTENT;
+            }
+
+            archivedEntryMap[LedgerEntryKey(le)] = le;
+        }
+
+        lm.setNextLedgerEntryBatchForBucketTesting({}, liveEntriesToInsert, {});
+        lm.setNextArchiveBatchForBucketTesting(archivedEntries, {}, {});
+        closeLedger(*app);
+    }
+
+    // Build HTTP request string body
+    auto buildRequestBody =
+        [](std::optional<uint32_t> ledgerSeq,
+           std::vector<LedgerKey> const& keys) -> std::string {
+        std::string body;
+        if (ledgerSeq)
+        {
+            body = "ledger=" + std::to_string(*ledgerSeq);
+        }
+
+        for (auto const& key : keys)
+        {
+            body += (body.empty() ? "" : "&") + std::string("k=") +
+                    toOpaqueBase64(key);
+        }
+        return body;
+    };
+
+    // Check response for entries that exist from returned JSON string
+    auto checkEntry = [](auto const& entries, LedgerEntry const& le,
+                         std::optional<uint32_t> expectedTTL,
+                         uint32_t ledgerSeq) -> bool {
+        for (auto const& entry : entries)
+        {
+            REQUIRE(entry.isMember("e"));
+            REQUIRE(entry.isMember("s"));
+            if (entry["s"].asString() == "new")
+            {
+                continue;
+            }
+
+            LedgerEntry responseLE;
+            fromOpaqueBase64(responseLE, entry["e"].asString());
+            if (responseLE == le)
+            {
+                std::string expectedState;
+                // Classic entries are always live
+                if (!isSorobanEntry(le.data))
+                {
+                    REQUIRE(!expectedTTL);
+                    expectedState = "live";
+                }
+                else
+                {
+                    if (expectedTTL)
+                    {
+                        if (ledgerSeq >= *expectedTTL)
+                        {
+                            expectedState = "archived";
+                        }
+                        else
+                        {
+                            expectedState = "live";
+                        }
+                    }
+                    else
+                    {
+                        expectedState = "archived";
+                    }
+                }
+
+                REQUIRE(entry["s"].asString() == expectedState);
+
+                // Only live soroban entries should have a TTL
+                if (isSorobanEntry(le.data) && expectedState == "live")
+                {
+                    REQUIRE(entry.isMember("t"));
+                    REQUIRE(entry["t"].asUInt() == *expectedTTL);
+                }
+                else
+                {
+                    REQUIRE(!entry.isMember("t"));
+                }
+
+                return true;
+            }
+        }
+        return false;
+    };
+
+    // Check response for entries that should not exist
+    auto checkNewEntry = [](auto const& entries, LedgerKey const& key) -> bool {
+        for (auto const& entry : entries)
+        {
+            REQUIRE(entry.isMember("e"));
+            REQUIRE(entry.isMember("s"));
+            if (entry["s"].asString() != "new")
+            {
+                continue;
+            }
+
+            LedgerKey responseKey;
+            fromOpaqueBase64(responseKey, entry["e"].asString());
+            if (responseKey == key)
+            {
+                REQUIRE(!entry.isMember("t"));
+                return true;
+            }
+        }
+        return false;
+    };
+
+    SECTION("lookup")
+    {
+        // Populate keysToSearch with new, live, and archived entries
+        UnorderedSet<LedgerKey> generatedKeys;
+        std::vector<LedgerKey> keysToSearch;
+        for (auto const& [lk, le] : liveEntryMap)
+        {
+            generatedKeys.insert(lk);
+            keysToSearch.push_back(lk);
+        }
+        for (auto const& [lk, le] : archivedEntryMap)
+        {
+            generatedKeys.insert(lk);
+            keysToSearch.push_back(lk);
+        }
+
+        std::vector<LedgerKey> newKeys =
+            LedgerTestUtils::generateValidUniqueLedgerKeysWithTypes(
+                {CONTRACT_CODE, CONTRACT_DATA, ACCOUNT}, 15, generatedKeys);
+        for (auto const& key : newKeys)
+        {
+            keysToSearch.push_back(key);
+        }
+
+        auto reqBody = buildRequestBody(std::nullopt, keysToSearch);
+        std::string retStr;
+        std::string empty;
+        REQUIRE(qServer->getLedgerEntry(empty, reqBody, retStr));
+
+        auto ledgerSeq = lm.getLastClosedLedgerNum();
+
+        Json::Value root;
+        Json::Reader reader;
+        REQUIRE(reader.parse(retStr, root));
+        REQUIRE(root.isMember("entries"));
+        REQUIRE(root.isMember("ledger"));
+        REQUIRE(root["ledger"].asUInt() == ledgerSeq);
+
+        auto const& entries = root["entries"];
+
+        for (auto const& key : newKeys)
+        {
+            REQUIRE(checkNewEntry(entries, key));
+        }
+
+        for (auto const& [lk, le] : archivedEntryMap)
+        {
+            REQUIRE(liveEntryMap.find(lk) == liveEntryMap.end());
+            REQUIRE(checkEntry(entries, le, std::nullopt, ledgerSeq));
+        }
+
+        for (auto const& [lk, le] : liveEntryMap)
+        {
+            std::optional<uint32_t> expectedTTL = std::nullopt;
+            if (isSorobanEntry(lk))
+            {
+                auto ttlIter = liveTTLEntryMap.find(lk);
+                REQUIRE(ttlIter != liveTTLEntryMap.end());
+                expectedTTL = std::make_optional(ttlIter->second);
+
+                // Expired temporary entries are considered "new"
+                if (!isPersistentEntry(lk))
+                {
+                    if (ttlIter->second < ledgerSeq)
+                    {
+                        REQUIRE(checkNewEntry(entries, lk));
+                        continue;
+                    }
+                }
+            }
+
+            REQUIRE(checkEntry(entries, le, expectedTTL, ledgerSeq));
+        }
+    }
+
+    SECTION("snapshot lookup")
+    {
+        // Close a ledger with all possible state transitions to make sure
+        // snapshots work correctly
+        std::optional<LedgerEntry> entryToModify;
+        std::optional<LedgerEntry> entryToDelete;
+        std::optional<LedgerEntry> entryToRestore;
+        std::optional<LedgerEntry> entryToArchive;
+        LedgerEntry newEntry =
+            LedgerTestUtils::generateValidLedgerEntryOfType(TRUSTLINE);
+
+        for (auto const& [lk, le] : liveEntryMap)
+        {
+            if (le.data.type() == ACCOUNT)
+            {
+                if (!entryToModify)
+                {
+                    entryToModify = le;
+                }
+                else
+                {
+                    entryToDelete = le;
+                }
+            }
+            else if (isSorobanEntry(le.data))
+            {
+                if (isPersistentEntry(le.data) &&
+                    liveTTLEntryMap[LedgerEntryKey(le)] >
+                        lm.getLastClosedLedgerNum())
+                {
+                    entryToArchive = le;
+                }
+                else
+                {
+                    entryToRestore = le;
+                }
+            }
+        }
+
+        REQUIRE(entryToModify);
+        REQUIRE(entryToDelete);
+        REQUIRE(entryToRestore);
+        REQUIRE(entryToArchive);
+
+        auto oldLedger = lm.getLastClosedLedgerNum();
+
+        LedgerEntry modifiedEntry = *entryToModify;
+        modifiedEntry.lastModifiedLedgerSeq++;
+
+        // Make a new TTL such that archived entry becomes live
+        auto restoredTTL = oldLedger + 100;
+        LedgerEntry entryToRestoreTTL;
+        entryToRestoreTTL.data.type(TTL);
+        entryToRestoreTTL.data.ttl().keyHash =
+            getTTLKey(*entryToRestore).ttl().keyHash;
+        entryToRestoreTTL.data.ttl().liveUntilLedgerSeq = restoredTTL;
+
+        // Make a new TTL such that live entry becomes archived
+        LedgerEntry entryToArchiveTTL;
+        entryToArchiveTTL.data.type(TTL);
+        entryToArchiveTTL.data.ttl().keyHash =
+            getTTLKey(*entryToArchive).ttl().keyHash;
+        entryToArchiveTTL.data.ttl().liveUntilLedgerSeq = oldLedger - 1;
+
+        lm.setNextLedgerEntryBatchForBucketTesting(
+            {}, {newEntry, entryToArchiveTTL, entryToRestoreTTL, modifiedEntry},
+            {LedgerEntryKey(*entryToDelete)});
+        closeLedger(*app);
+
+        auto newLedger = lm.getLastClosedLedgerNum();
+
+        auto keysToSearch = {
+            LedgerEntryKey(*entryToModify), LedgerEntryKey(*entryToDelete),
+            LedgerEntryKey(*entryToRestore), LedgerEntryKey(*entryToArchive),
+            LedgerEntryKey(newEntry)};
+
+        SECTION("current values")
+        {
+            auto reqBody = buildRequestBody(newLedger, keysToSearch);
+            std::string retStr;
+            std::string empty;
+            REQUIRE(qServer->getLedgerEntry(empty, reqBody, retStr));
+
+            Json::Value root;
+            Json::Reader reader;
+            REQUIRE(reader.parse(retStr, root));
+            REQUIRE(root.isMember("entries"));
+            REQUIRE(root.isMember("ledger"));
+            REQUIRE(root["ledger"].asUInt() == newLedger);
+
+            auto const& entries = root["entries"];
+
+            // Check that modified entry is modified
+            REQUIRE(
+                checkEntry(entries, modifiedEntry, std::nullopt, newLedger));
+
+            // Check that deleted entry does not exist
+            REQUIRE(checkNewEntry(entries, LedgerEntryKey(*entryToDelete)));
+
+            // Check that entry that was restored is live
+            REQUIRE(
+                checkEntry(entries, *entryToRestore, restoredTTL, newLedger));
+
+            // Check that entry that was archived is archived
+            REQUIRE(
+                checkEntry(entries, *entryToArchive, std::nullopt, newLedger));
+
+            // Check that newly created entry exists
+            REQUIRE(checkEntry(entries, newEntry, std::nullopt, newLedger));
+        }
+
+        SECTION("snapshot values")
+        {
+            auto reqBody = buildRequestBody(oldLedger, keysToSearch);
+            std::string retStr;
+            std::string empty;
+            REQUIRE(qServer->getLedgerEntry(empty, reqBody, retStr));
+
+            Json::Value root;
+            Json::Reader reader;
+            REQUIRE(reader.parse(retStr, root));
+            REQUIRE(root.isMember("entries"));
+            REQUIRE(root.isMember("ledger"));
+            REQUIRE(root["ledger"].asUInt() == oldLedger);
+
+            auto const& entries = root["entries"];
+
+            // Check modified entry original state
+            REQUIRE(
+                checkEntry(entries, *entryToModify, std::nullopt, oldLedger));
+
+            // Check that deleted entry still exists
+            REQUIRE(
+                checkEntry(entries, *entryToDelete, std::nullopt, oldLedger));
+
+            // Check that entry that was restored is archived
+            REQUIRE(
+                checkEntry(entries, *entryToRestore, std::nullopt, newLedger));
+
+            // Check that entry that was archived is live
+            REQUIRE(checkEntry(entries, *entryToArchive,
+                               liveTTLEntryMap[LedgerEntryKey(*entryToArchive)],
+                               newLedger));
+
+            // Newly created entry should not exist
+            REQUIRE(checkNewEntry(entries, LedgerEntryKey(newEntry)));
+        }
+    }
+
+    SECTION("empty keys")
+    {
+        std::string retStr;
+        std::string empty;
+        auto body = "ledger=10"; // No keys provided
+        REQUIRE(!qServer->getLedgerEntry(empty, body, retStr));
+        REQUIRE(retStr ==
+                "Must specify key in POST body: k=<LedgerKey in base64 "
+                "XDR format>\n");
+    }
+
+    SECTION("TTL key")
+    {
+        LedgerKey ttlKey = LedgerEntryKey(
+            LedgerTestUtils::generateValidLedgerEntryOfType(TTL));
+
+        auto body = buildRequestBody(std::nullopt, {ttlKey});
+        std::string retStr;
+        std::string empty;
+        REQUIRE(!qServer->getLedgerEntry(empty, body, retStr));
+        REQUIRE(retStr == "TTL keys are not allowed\n");
+    }
+
+    SECTION("ledger not found")
+    {
+        auto liveEntry = liveEntryMap.begin()->first;
+        auto currentLedger = lm.getLastClosedLedgerNum();
+        auto body = buildRequestBody(currentLedger + 1000, {liveEntry});
+        std::string retStr;
+        std::string empty;
+        REQUIRE(!qServer->getLedgerEntry(empty, body, retStr));
+        REQUIRE(retStr == "Ledger not found\n");
+    }
+
+    SECTION("duplicate keys")
+    {
+        auto liveEntry = liveEntryMap.begin()->first;
+        auto body = buildRequestBody(std::nullopt, {liveEntry, liveEntry});
+        std::string retStr;
+        std::string empty;
+        REQUIRE(!qServer->getLedgerEntry(empty, body, retStr));
+        REQUIRE(retStr == "Duplicate keys\n");
+    }
+
+    SECTION("response order matches request order")
+    {
+        UnorderedSet<LedgerKey> keySet;
+        auto randomKeys =
+            LedgerTestUtils::generateValidUniqueLedgerKeysWithTypes({TRUSTLINE},
+                                                                    2, keySet);
+        auto testKeyOrder = [&](std::vector<LedgerKey> const& keyOrder) {
+            auto reqBody = buildRequestBody(std::nullopt, keyOrder);
+            std::string retStr;
+            std::string empty;
+            REQUIRE(qServer->getLedgerEntry(empty, reqBody, retStr));
+
+            Json::Value root;
+            Json::Reader reader;
+            REQUIRE(reader.parse(retStr, root));
+            REQUIRE(root.isMember("entries"));
+
+            auto entries = root["entries"];
+            REQUIRE(entries.size() == keyOrder.size());
+
+            for (auto i = 0; i < keyOrder.size(); ++i)
+            {
+                LedgerKey responseKey;
+                fromOpaqueBase64(responseKey, entries[i]["e"].asString());
+                REQUIRE(responseKey == keyOrder[i]);
+                REQUIRE(entries[i]["s"].asString() == "new");
+            }
+        };
+
+        // Test both orderings
+        testKeyOrder({randomKeys[0], randomKeys[1]});
+        testKeyOrder({randomKeys[1], randomKeys[0]});
+    }
+}
+#endif


### PR DESCRIPTION
# Description

This PR adds an HTTP endpoint that can query ledger state and provide an entry's archival status. This can be used by RPC for preflighting TXs without needing to maintain a redundant ledger state database. The endpoint API can be found in `docs/software/commands.md`.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
