### PR TITLE
Backfills meta with new restore LedgerEntryChange type

### DIFF
--- a/src/testdata/ledger-close-meta-enable-classic-events-v1-protocol-20-soroban.json
+++ b/src/testdata/ledger-close-meta-enable-classic-events-v1-protocol-20-soroban.json
@@ -1422,6 +1422,33 @@
                                     },
                                     "changes": [
                                         {
+                                            "type": "LEDGER_ENTRY_RESTORED",
+                                            "restored": {
+                                                "lastModifiedLedgerSeq": 10,
+                                                "data": {
+                                                    "type": "CONTRACT_DATA",
+                                                    "contractData": {
+                                                        "ext": {
+                                                            "v": 0
+                                                        },
+                                                        "contract": "CAA3QKIP2SNVXUJTB4HKOGF55JTSSMQGED3FZYNHMNSXYV3DRRMAWA3Y",
+                                                        "key": {
+                                                            "type": "SCV_SYMBOL",
+                                                            "sym": "archived"
+                                                        },
+                                                        "durability": "PERSISTENT",
+                                                        "val": {
+                                                            "type": "SCV_U64",
+                                                            "u64": 42
+                                                        }
+                                                    }
+                                                },
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        {
                                             "type": "LEDGER_ENTRY_STATE",
                                             "state": {
                                                 "lastModifiedLedgerSeq": 10,
@@ -1438,8 +1465,8 @@
                                             }
                                         },
                                         {
-                                            "type": "LEDGER_ENTRY_UPDATED",
-                                            "updated": {
+                                            "type": "LEDGER_ENTRY_RESTORED",
+                                            "restored": {
                                                 "lastModifiedLedgerSeq": 31,
                                                 "data": {
                                                     "type": "TTL",

--- a/src/testdata/ledger-close-meta-enable-classic-events-v1-protocol-21-soroban.json
+++ b/src/testdata/ledger-close-meta-enable-classic-events-v1-protocol-21-soroban.json
@@ -2220,6 +2220,33 @@
                                     },
                                     "changes": [
                                         {
+                                            "type": "LEDGER_ENTRY_RESTORED",
+                                            "restored": {
+                                                "lastModifiedLedgerSeq": 10,
+                                                "data": {
+                                                    "type": "CONTRACT_DATA",
+                                                    "contractData": {
+                                                        "ext": {
+                                                            "v": 0
+                                                        },
+                                                        "contract": "CAA3QKIP2SNVXUJTB4HKOGF55JTSSMQGED3FZYNHMNSXYV3DRRMAWA3Y",
+                                                        "key": {
+                                                            "type": "SCV_SYMBOL",
+                                                            "sym": "archived"
+                                                        },
+                                                        "durability": "PERSISTENT",
+                                                        "val": {
+                                                            "type": "SCV_U64",
+                                                            "u64": 42
+                                                        }
+                                                    }
+                                                },
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        {
                                             "type": "LEDGER_ENTRY_STATE",
                                             "state": {
                                                 "lastModifiedLedgerSeq": 10,
@@ -2236,8 +2263,8 @@
                                             }
                                         },
                                         {
-                                            "type": "LEDGER_ENTRY_UPDATED",
-                                            "updated": {
+                                            "type": "LEDGER_ENTRY_RESTORED",
+                                            "restored": {
                                                 "lastModifiedLedgerSeq": 31,
                                                 "data": {
                                                     "type": "TTL",

--- a/src/testdata/ledger-close-meta-enable-classic-events-v1-protocol-22-soroban.json
+++ b/src/testdata/ledger-close-meta-enable-classic-events-v1-protocol-22-soroban.json
@@ -1066,6 +1066,33 @@
                                     },
                                     "changes": [
                                         {
+                                            "type": "LEDGER_ENTRY_RESTORED",
+                                            "restored": {
+                                                "lastModifiedLedgerSeq": 10,
+                                                "data": {
+                                                    "type": "CONTRACT_DATA",
+                                                    "contractData": {
+                                                        "ext": {
+                                                            "v": 0
+                                                        },
+                                                        "contract": "CAA3QKIP2SNVXUJTB4HKOGF55JTSSMQGED3FZYNHMNSXYV3DRRMAWA3Y",
+                                                        "key": {
+                                                            "type": "SCV_SYMBOL",
+                                                            "sym": "archived"
+                                                        },
+                                                        "durability": "PERSISTENT",
+                                                        "val": {
+                                                            "type": "SCV_U64",
+                                                            "u64": 42
+                                                        }
+                                                    }
+                                                },
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        {
                                             "type": "LEDGER_ENTRY_STATE",
                                             "state": {
                                                 "lastModifiedLedgerSeq": 10,
@@ -1082,8 +1109,8 @@
                                             }
                                         },
                                         {
-                                            "type": "LEDGER_ENTRY_UPDATED",
-                                            "updated": {
+                                            "type": "LEDGER_ENTRY_RESTORED",
+                                            "restored": {
                                                 "lastModifiedLedgerSeq": 31,
                                                 "data": {
                                                     "type": "TTL",

--- a/src/testdata/ledger-close-meta-v1-protocol-20-soroban.json
+++ b/src/testdata/ledger-close-meta-v1-protocol-20-soroban.json
@@ -1293,6 +1293,33 @@
                                 {
                                     "changes": [
                                         {
+                                            "type": "LEDGER_ENTRY_RESTORED",
+                                            "restored": {
+                                                "lastModifiedLedgerSeq": 10,
+                                                "data": {
+                                                    "type": "CONTRACT_DATA",
+                                                    "contractData": {
+                                                        "ext": {
+                                                            "v": 0
+                                                        },
+                                                        "contract": "CAA3QKIP2SNVXUJTB4HKOGF55JTSSMQGED3FZYNHMNSXYV3DRRMAWA3Y",
+                                                        "key": {
+                                                            "type": "SCV_SYMBOL",
+                                                            "sym": "archived"
+                                                        },
+                                                        "durability": "PERSISTENT",
+                                                        "val": {
+                                                            "type": "SCV_U64",
+                                                            "u64": 42
+                                                        }
+                                                    }
+                                                },
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        {
                                             "type": "LEDGER_ENTRY_STATE",
                                             "state": {
                                                 "lastModifiedLedgerSeq": 10,
@@ -1309,8 +1336,8 @@
                                             }
                                         },
                                         {
-                                            "type": "LEDGER_ENTRY_UPDATED",
-                                            "updated": {
+                                            "type": "LEDGER_ENTRY_RESTORED",
+                                            "restored": {
                                                 "lastModifiedLedgerSeq": 31,
                                                 "data": {
                                                     "type": "TTL",

--- a/src/testdata/ledger-close-meta-v1-protocol-21-soroban.json
+++ b/src/testdata/ledger-close-meta-v1-protocol-21-soroban.json
@@ -1953,6 +1953,33 @@
                                 {
                                     "changes": [
                                         {
+                                            "type": "LEDGER_ENTRY_RESTORED",
+                                            "restored": {
+                                                "lastModifiedLedgerSeq": 10,
+                                                "data": {
+                                                    "type": "CONTRACT_DATA",
+                                                    "contractData": {
+                                                        "ext": {
+                                                            "v": 0
+                                                        },
+                                                        "contract": "CAA3QKIP2SNVXUJTB4HKOGF55JTSSMQGED3FZYNHMNSXYV3DRRMAWA3Y",
+                                                        "key": {
+                                                            "type": "SCV_SYMBOL",
+                                                            "sym": "archived"
+                                                        },
+                                                        "durability": "PERSISTENT",
+                                                        "val": {
+                                                            "type": "SCV_U64",
+                                                            "u64": 42
+                                                        }
+                                                    }
+                                                },
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        {
                                             "type": "LEDGER_ENTRY_STATE",
                                             "state": {
                                                 "lastModifiedLedgerSeq": 10,
@@ -1969,8 +1996,8 @@
                                             }
                                         },
                                         {
-                                            "type": "LEDGER_ENTRY_UPDATED",
-                                            "updated": {
+                                            "type": "LEDGER_ENTRY_RESTORED",
+                                            "restored": {
                                                 "lastModifiedLedgerSeq": 31,
                                                 "data": {
                                                     "type": "TTL",

--- a/src/testdata/ledger-close-meta-v1-protocol-22-soroban.json
+++ b/src/testdata/ledger-close-meta-v1-protocol-22-soroban.json
@@ -994,6 +994,33 @@
                                 {
                                     "changes": [
                                         {
+                                            "type": "LEDGER_ENTRY_RESTORED",
+                                            "restored": {
+                                                "lastModifiedLedgerSeq": 10,
+                                                "data": {
+                                                    "type": "CONTRACT_DATA",
+                                                    "contractData": {
+                                                        "ext": {
+                                                            "v": 0
+                                                        },
+                                                        "contract": "CAA3QKIP2SNVXUJTB4HKOGF55JTSSMQGED3FZYNHMNSXYV3DRRMAWA3Y",
+                                                        "key": {
+                                                            "type": "SCV_SYMBOL",
+                                                            "sym": "archived"
+                                                        },
+                                                        "durability": "PERSISTENT",
+                                                        "val": {
+                                                            "type": "SCV_U64",
+                                                            "u64": 42
+                                                        }
+                                                    }
+                                                },
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        {
                                             "type": "LEDGER_ENTRY_STATE",
                                             "state": {
                                                 "lastModifiedLedgerSeq": 10,
@@ -1010,8 +1037,8 @@
                                             }
                                         },
                                         {
-                                            "type": "LEDGER_ENTRY_UPDATED",
-                                            "updated": {
+                                            "type": "LEDGER_ENTRY_RESTORED",
+                                            "restored": {
                                                 "lastModifiedLedgerSeq": 31,
                                                 "data": {
                                                     "type": "TTL",

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -1806,18 +1806,7 @@ TransactionFrame::applyOperations(SignatureChecker& signatureChecker,
                 app.checkOnOperationApply(op->getOperation(), opResult, delta,
                                           opEventManager.getContractEvents());
 
-                LedgerEntryChanges changes;
-                if (protocolVersionStartsFrom(
-                        ledgerVersion,
-                        LiveBucket::
-                            FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
-                {
-                    changes = processOpLedgerEntryChanges(op, ltxOp);
-                }
-                else
-                {
-                    changes = ltxOp.getChanges();
-                }
+                auto changes = processOpLedgerEntryChanges(op, ltxOp);
                 xdr::xvector<ContractEvent> xdrContractEvents;
                 opEventManager.flushContractEvents(xdrContractEvents);
                 opMetas.push(std::move(changes), std::move(xdrContractEvents));


### PR DESCRIPTION
# Description

This change applies the new restoration meta to all protocol versions. This was originally included in the autorestore PR, but I cherry picked it so that meta diffs are easier to review.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
