### PR TITLE
Revert unintentional rename of sorobaninfo fields.

### DIFF
--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -783,13 +783,12 @@ CommandHandler::sorobanInfo(std::string const& params, std::string& retStr)
             // Ledger access settings
             res["ledger"]["max_read_ledger_entries"] =
                 conf.ledgerMaxDiskReadEntries();
-            res["ledger"]["max_disk_read_bytes"] =
-                conf.ledgerMaxDiskReadBytes();
+            res["ledger"]["max_read_bytes"] = conf.ledgerMaxDiskReadBytes();
             res["ledger"]["max_write_ledger_entries"] =
                 conf.ledgerMaxWriteLedgerEntries();
             res["ledger"]["max_write_bytes"] = conf.ledgerMaxWriteBytes();
             res["tx"]["max_read_ledger_entries"] = conf.txMaxDiskReadEntries();
-            res["tx"]["max_disk_read_bytes"] = conf.txMaxDiskReadBytes();
+            res["tx"]["max_read_bytes"] = conf.txMaxDiskReadBytes();
             res["tx"]["max_write_ledger_entries"] =
                 conf.txMaxWriteLedgerEntries();
             res["tx"]["max_write_bytes"] = conf.txMaxWriteBytes();


### PR DESCRIPTION
# Description

Revert unintentional rename of sorobaninfo fields.

We still need to rename these, but in a more systematic fashion, and then update supercluster to consume this as well (https://github.com/stellar/supercluster/issues/282)

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
