### PR TITLE
Incorporate clang thread-safety static analysis into core

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -127,6 +127,14 @@ AS_IF([test "x$enable_threadsanitizer" = "xyes"], [
   sanitizeopts="thread"
 ])
 
+AC_ARG_ENABLE([threadsafety],
+  AS_HELP_STRING([--enable-threadsafety],
+        [build with thread safety static analysis instrumentation (Clang only)]))
+AS_IF([test "x$enable_threadsafety" = "xyes"], [
+  AC_MSG_NOTICE([enabling thread safety static analysis, see https://clang.llvm.org/docs/ThreadSafetyAnalysis.html])
+  CXXFLAGS="$CXXFLAGS -Wthread-safety -Werror=thread-safety"
+])
+
 AC_ARG_ENABLE([memcheck],
   AS_HELP_STRING([--enable-memcheck],
         [build with memcheck (memory-sanitizer) instrumentation]))

--- a/src/bucket/BucketSnapshotManager.cpp
+++ b/src/bucket/BucketSnapshotManager.cpp
@@ -55,7 +55,7 @@ BucketSnapshotManager::BucketSnapshotManager(
 SearchableSnapshotConstPtr
 BucketSnapshotManager::copySearchableLiveBucketListSnapshot() const
 {
-    std::shared_lock<std::shared_mutex> lock(mSnapshotMutex);
+    // SharedLockShared guard(mSnapshotMutex);
     // Can't use std::make_shared due to private constructor
     return std::shared_ptr<SearchableLiveBucketListSnapshot>(
         new SearchableLiveBucketListSnapshot(
@@ -68,7 +68,7 @@ BucketSnapshotManager::copySearchableLiveBucketListSnapshot() const
 SearchableHotArchiveSnapshotConstPtr
 BucketSnapshotManager::copySearchableHotArchiveBucketListSnapshot() const
 {
-    std::shared_lock<std::shared_mutex> lock(mSnapshotMutex);
+    // SharedLockShared guard(mSnapshotMutex);
     releaseAssert(mCurrHotArchiveSnapshot);
     // Can't use std::make_shared due to private constructor
     return std::shared_ptr<SearchableHotArchiveBucketListSnapshot>(
@@ -86,8 +86,7 @@ BucketSnapshotManager::maybeCopySearchableBucketListSnapshot(
     // The canonical snapshot held by the BucketSnapshotManager is not being
     // modified. Rather, a thread is checking it's copy against the canonical
     // snapshot, so use a shared lock.
-    std::shared_lock<std::shared_mutex> lock(mSnapshotMutex);
-
+    SharedLockShared guard(mSnapshotMutex);
     if (!snapshot ||
         snapshot->getLedgerSeq() < mCurrLiveSnapshot->getLedgerSeq())
     {
@@ -102,7 +101,7 @@ BucketSnapshotManager::maybeCopySearchableHotArchiveBucketListSnapshot(
     // The canonical snapshot held by the BucketSnapshotManager is not being
     // modified. Rather, a thread is checking it's copy against the canonical
     // snapshot, so use a shared lock.
-    std::shared_lock<std::shared_mutex> lock(mSnapshotMutex);
+    SharedLockShared guard(mSnapshotMutex);
 
     if (!snapshot ||
         snapshot->getLedgerSeq() < mCurrHotArchiveSnapshot->getLedgerSeq())
@@ -142,7 +141,7 @@ BucketSnapshotManager::updateCurrentSnapshot(
 
     // Updating the BucketSnapshotManager canonical snapshot, must lock
     // exclusively for write access.
-    std::unique_lock<std::shared_mutex> lock(mSnapshotMutex);
+    SharedLockExclusive guard(mSnapshotMutex);
     updateSnapshot(mCurrLiveSnapshot, mLiveHistoricalSnapshots, liveSnapshot);
     updateSnapshot(mCurrHotArchiveSnapshot, mHotArchiveHistoricalSnapshots,
                    hotArchiveSnapshot);

--- a/src/bucket/BucketSnapshotManager.cpp
+++ b/src/bucket/BucketSnapshotManager.cpp
@@ -55,7 +55,24 @@ BucketSnapshotManager::BucketSnapshotManager(
 SearchableSnapshotConstPtr
 BucketSnapshotManager::copySearchableLiveBucketListSnapshot() const
 {
-    // SharedLockShared guard(mSnapshotMutex);
+    SharedLockShared guard(mSnapshotMutex);
+    // Can't use std::make_shared due to private constructor
+    return copySearchableLiveBucketListSnapshot(guard);
+}
+
+SearchableHotArchiveSnapshotConstPtr
+BucketSnapshotManager::copySearchableHotArchiveBucketListSnapshot() const
+{
+    SharedLockShared guard(mSnapshotMutex);
+    releaseAssert(mCurrHotArchiveSnapshot);
+    // Can't use std::make_shared due to private constructor
+    return copySearchableHotArchiveBucketListSnapshot(guard);
+}
+
+SearchableSnapshotConstPtr
+BucketSnapshotManager::copySearchableLiveBucketListSnapshot(
+    SharedLockShared const& guard) const
+{
     // Can't use std::make_shared due to private constructor
     return std::shared_ptr<SearchableLiveBucketListSnapshot>(
         new SearchableLiveBucketListSnapshot(
@@ -66,9 +83,9 @@ BucketSnapshotManager::copySearchableLiveBucketListSnapshot() const
 }
 
 SearchableHotArchiveSnapshotConstPtr
-BucketSnapshotManager::copySearchableHotArchiveBucketListSnapshot() const
+BucketSnapshotManager::copySearchableHotArchiveBucketListSnapshot(
+    SharedLockShared const& guard) const
 {
-    // SharedLockShared guard(mSnapshotMutex);
     releaseAssert(mCurrHotArchiveSnapshot);
     // Can't use std::make_shared due to private constructor
     return std::shared_ptr<SearchableHotArchiveBucketListSnapshot>(
@@ -90,7 +107,7 @@ BucketSnapshotManager::maybeCopySearchableBucketListSnapshot(
     if (!snapshot ||
         snapshot->getLedgerSeq() < mCurrLiveSnapshot->getLedgerSeq())
     {
-        snapshot = copySearchableLiveBucketListSnapshot();
+        snapshot = copySearchableLiveBucketListSnapshot(guard);
     }
 }
 
@@ -106,7 +123,7 @@ BucketSnapshotManager::maybeCopySearchableHotArchiveBucketListSnapshot(
     if (!snapshot ||
         snapshot->getLedgerSeq() < mCurrHotArchiveSnapshot->getLedgerSeq())
     {
-        snapshot = copySearchableHotArchiveBucketListSnapshot();
+        snapshot = copySearchableHotArchiveBucketListSnapshot(guard);
     }
 }
 

--- a/src/bucket/BucketSnapshotManager.h
+++ b/src/bucket/BucketSnapshotManager.h
@@ -88,6 +88,18 @@ class BucketSnapshotManager : NonMovableOrCopyable
     copySearchableHotArchiveBucketListSnapshot() const
         LOCKS_EXCLUDED(mSnapshotMutex);
 
+    // Copy the most recent snapshot for the live bucket list, while holding the
+    // lock
+    SearchableSnapshotConstPtr
+    copySearchableLiveBucketListSnapshot(SharedLockShared const& guard) const
+        REQUIRES_SHARED(mSnapshotMutex);
+
+    // Copy the most recent snapshot for the hot archive bucket list, while
+    // holding the lock
+    SearchableHotArchiveSnapshotConstPtr
+    copySearchableHotArchiveBucketListSnapshot(
+        SharedLockShared const& guard) const REQUIRES_SHARED(mSnapshotMutex);
+
     // `maybeCopy` interface refreshes `snapshot` if a newer snapshot is
     // available. It's a no-op otherwise. This is useful to avoid unnecessary
     // copying.

--- a/src/bucket/BucketSnapshotManager.h
+++ b/src/bucket/BucketSnapshotManager.h
@@ -9,6 +9,7 @@
 #include "bucket/LiveBucket.h"
 #include "main/AppConnector.h"
 #include "util/NonCopyable.h"
+#include "util/ThreadAnnotations.h"
 
 #include <map>
 #include <memory>
@@ -45,28 +46,31 @@ class BucketSnapshotManager : NonMovableOrCopyable
   private:
     AppConnector mAppConnector;
 
+    // Lock must be held when accessing any member variables holding snapshots
+    mutable SharedMutex mSnapshotMutex;
+
     // Snapshot that is maintained and periodically updated by BucketManager on
     // the main thread. When background threads need to generate or refresh a
     // snapshot, they will copy this snapshot.
-    SnapshotPtrT<LiveBucket> mCurrLiveSnapshot{};
-    SnapshotPtrT<HotArchiveBucket> mCurrHotArchiveSnapshot{};
+    SnapshotPtrT<LiveBucket> mCurrLiveSnapshot GUARDED_BY(mSnapshotMutex){};
+    SnapshotPtrT<HotArchiveBucket>
+        mCurrHotArchiveSnapshot GUARDED_BY(mSnapshotMutex){};
 
     // ledgerSeq that the snapshot is based on -> snapshot
-    std::map<uint32_t, SnapshotPtrT<LiveBucket>> mLiveHistoricalSnapshots;
+    std::map<uint32_t, SnapshotPtrT<LiveBucket>>
+        mLiveHistoricalSnapshots GUARDED_BY(mSnapshotMutex);
     std::map<uint32_t, SnapshotPtrT<HotArchiveBucket>>
-        mHotArchiveHistoricalSnapshots;
+        mHotArchiveHistoricalSnapshots GUARDED_BY(mSnapshotMutex);
 
     uint32_t const mNumHistoricalSnapshots;
-
-    // Lock must be held when accessing any member variables holding snapshots
-    mutable std::shared_mutex mSnapshotMutex;
 
   public:
     // Called by main thread to update snapshots whenever the BucketList
     // is updated
     void
     updateCurrentSnapshot(SnapshotPtrT<LiveBucket>&& liveSnapshot,
-                          SnapshotPtrT<HotArchiveBucket>&& hotArchiveSnapshot);
+                          SnapshotPtrT<HotArchiveBucket>&& hotArchiveSnapshot)
+        LOCKS_EXCLUDED(mSnapshotMutex);
 
     // numHistoricalLedgers is the number of historical snapshots that the
     // snapshot manager will maintain. If numHistoricalLedgers is 5, snapshots
@@ -76,18 +80,22 @@ class BucketSnapshotManager : NonMovableOrCopyable
                           uint32_t numHistoricalLedgers);
 
     // Copy the most recent snapshot for the live bucket list
-    SearchableSnapshotConstPtr copySearchableLiveBucketListSnapshot() const;
+    SearchableSnapshotConstPtr copySearchableLiveBucketListSnapshot() const
+        LOCKS_EXCLUDED(mSnapshotMutex);
 
     // Copy the most recent snapshot for the hot archive bucket list
     SearchableHotArchiveSnapshotConstPtr
-    copySearchableHotArchiveBucketListSnapshot() const;
+    copySearchableHotArchiveBucketListSnapshot() const
+        LOCKS_EXCLUDED(mSnapshotMutex);
 
     // `maybeCopy` interface refreshes `snapshot` if a newer snapshot is
     // available. It's a no-op otherwise. This is useful to avoid unnecessary
     // copying.
     void
-    maybeCopySearchableBucketListSnapshot(SearchableSnapshotConstPtr& snapshot);
+    maybeCopySearchableBucketListSnapshot(SearchableSnapshotConstPtr& snapshot)
+        LOCKS_EXCLUDED(mSnapshotMutex);
     void maybeCopySearchableHotArchiveBucketListSnapshot(
-        SearchableHotArchiveSnapshotConstPtr& snapshot);
+        SearchableHotArchiveSnapshotConstPtr& snapshot)
+        LOCKS_EXCLUDED(mSnapshotMutex);
 };
 }

--- a/src/bucket/SearchableBucketList.h
+++ b/src/bucket/SearchableBucketList.h
@@ -36,7 +36,8 @@ class SearchableLiveBucketListSnapshot
         StateArchivalSettings const& sas, uint32_t ledgerVers) const;
 
     friend SearchableSnapshotConstPtr
-    BucketSnapshotManager::copySearchableLiveBucketListSnapshot() const;
+    BucketSnapshotManager::copySearchableLiveBucketListSnapshot(
+        SharedLockShared const& guard) const;
 };
 
 class SearchableHotArchiveBucketListSnapshot
@@ -54,6 +55,7 @@ class SearchableHotArchiveBucketListSnapshot
     loadKeys(std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys) const;
 
     friend SearchableHotArchiveSnapshotConstPtr
-    BucketSnapshotManager::copySearchableHotArchiveBucketListSnapshot() const;
+    BucketSnapshotManager::copySearchableHotArchiveBucketListSnapshot(
+        SharedLockShared const& guard) const;
 };
 }

--- a/src/overlay/FlowControl.cpp
+++ b/src/overlay/FlowControl.cpp
@@ -16,8 +16,7 @@ namespace stellar
 {
 
 size_t
-FlowControl::getOutboundQueueByteLimit(
-    std::lock_guard<std::mutex>& lockGuard) const
+FlowControl::getOutboundQueueByteLimit(MutexLocker& lockGuard) const
 {
 #ifdef BUILD_TESTS
     if (mOutboundQueueLimit)
@@ -44,7 +43,7 @@ FlowControl::FlowControl(AppConnector& connector, bool useBackgroundThread)
 
 bool
 FlowControl::hasOutboundCapacity(StellarMessage const& msg,
-                                 std::lock_guard<std::mutex>& lockGuard) const
+                                 MutexLocker& lockGuard) const
 {
     releaseAssert(!threadIsMain() || !mUseBackgroundThread);
     return mFlowControlCapacity.hasOutboundCapacity(msg) &&
@@ -55,7 +54,7 @@ bool
 FlowControl::noOutboundCapacityTimeout(VirtualClock::time_point now,
                                        std::chrono::seconds timeout) const
 {
-    std::lock_guard<std::mutex> guard(mFlowControlMutex);
+    MutexLocker guard(mFlowControlMutex);
     return mNoOutboundCapacity && now - *mNoOutboundCapacity >= timeout;
 }
 
@@ -63,7 +62,7 @@ void
 FlowControl::setPeerID(NodeID const& peerID)
 {
     releaseAssert(threadIsMain());
-    std::lock_guard<std::mutex> guard(mFlowControlMutex);
+    MutexLocker guard(mFlowControlMutex);
     mNodeID = peerID;
 }
 
@@ -72,7 +71,7 @@ FlowControl::maybeReleaseCapacity(StellarMessage const& msg)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
-    std::lock_guard<std::mutex> guard(mFlowControlMutex);
+    MutexLocker guard(mFlowControlMutex);
 
     if (msg.type() == SEND_MORE_EXTENDED)
     {
@@ -103,7 +102,7 @@ FlowControl::processSentMessages(
     ZoneScoped;
     releaseAssert(!threadIsMain() || !mUseBackgroundThread);
 
-    std::lock_guard<std::mutex> guard(mFlowControlMutex);
+    MutexLocker guard(mFlowControlMutex);
     for (int i = 0; i < sentMessages.size(); i++)
     {
         auto const& sentMsgs = sentMessages[i];
@@ -162,7 +161,7 @@ FlowControl::getNextBatchToSend()
     ZoneScoped;
     releaseAssert(!threadIsMain() || !mUseBackgroundThread);
 
-    std::lock_guard<std::mutex> guard(mFlowControlMutex);
+    MutexLocker guard(mFlowControlMutex);
     std::vector<QueuedOutboundMessage> batchToSend;
 
     int sent = 0;
@@ -217,7 +216,7 @@ FlowControl::updateMsgMetrics(std::shared_ptr<StellarMessage const> msg,
 {
     // The lock isn't strictly needed here, but is added for consistency and
     // future-proofing this function
-    std::lock_guard<std::mutex> guard(mFlowControlMutex);
+    MutexLocker guard(mFlowControlMutex);
     auto diff = mAppConnector.now() - timePlaced;
 
     auto updateQueueDelay = [&](auto& queue, auto& metrics) {
@@ -258,7 +257,7 @@ FlowControl::handleTxSizeIncrease(uint32_t increase)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
-    std::lock_guard<std::mutex> guard(mFlowControlMutex);
+    MutexLocker guard(mFlowControlMutex);
     releaseAssert(increase > 0);
     // Bump flood capacity to accommodate the upgrade
     mFlowControlBytesCapacity.handleTxSizeIncrease(increase);
@@ -269,7 +268,7 @@ FlowControl::beginMessageProcessing(StellarMessage const& msg)
 {
     ZoneScoped;
     releaseAssert(!threadIsMain() || !mUseBackgroundThread);
-    std::lock_guard<std::mutex> guard(mFlowControlMutex);
+    MutexLocker guard(mFlowControlMutex);
 
     return mFlowControlCapacity.lockLocalCapacity(msg) &&
            mFlowControlBytesCapacity.lockLocalCapacity(msg);
@@ -279,7 +278,7 @@ SendMoreCapacity
 FlowControl::endMessageProcessing(StellarMessage const& msg)
 {
     ZoneScoped;
-    std::lock_guard<std::mutex> guard(mFlowControlMutex);
+    MutexLocker guard(mFlowControlMutex);
 
     mFloodDataProcessed += mFlowControlCapacity.releaseLocalCapacity(msg);
     mFloodDataProcessedBytes +=
@@ -318,7 +317,7 @@ FlowControl::endMessageProcessing(StellarMessage const& msg)
 }
 
 bool
-FlowControl::canRead(std::lock_guard<std::mutex> const& guard) const
+FlowControl::canRead(MutexLocker const& guard) const
 {
     return mFlowControlBytesCapacity.canRead() &&
            mFlowControlCapacity.canRead();
@@ -327,7 +326,7 @@ FlowControl::canRead(std::lock_guard<std::mutex> const& guard) const
 bool
 FlowControl::canRead() const
 {
-    std::lock_guard<std::mutex> guard(mFlowControlMutex);
+    MutexLocker guard(mFlowControlMutex);
     return canRead(guard);
 }
 
@@ -365,7 +364,7 @@ FlowControl::isSendMoreValid(StellarMessage const& msg,
                              std::string& errorMsg) const
 {
     releaseAssert(threadIsMain());
-    std::lock_guard<std::mutex> guard(mFlowControlMutex);
+    MutexLocker guard(mFlowControlMutex);
 
     if (msg.type() != SEND_MORE_EXTENDED)
     {
@@ -404,7 +403,7 @@ FlowControl::addMsgAndMaybeTrimQueue(std::shared_ptr<StellarMessage const> msg)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
-    std::lock_guard<std::mutex> guard(mFlowControlMutex);
+    MutexLocker guard(mFlowControlMutex);
     releaseAssert(msg);
     auto type = msg->type();
     size_t msgQInd = 0;
@@ -559,7 +558,7 @@ Json::Value
 FlowControl::getFlowControlJsonInfo(bool compact) const
 {
     releaseAssert(threadIsMain());
-    std::lock_guard<std::mutex> guard(mFlowControlMutex);
+    MutexLocker guard(mFlowControlMutex);
 
     Json::Value res;
     if (mFlowControlCapacity.getCapacity().mTotalCapacity)
@@ -601,7 +600,7 @@ FlowControl::getFlowControlJsonInfo(bool compact) const
 bool
 FlowControl::maybeThrottleRead()
 {
-    std::lock_guard<std::mutex> guard(mFlowControlMutex);
+    MutexLocker guard(mFlowControlMutex);
     if (!canRead(guard))
     {
         CLOG_DEBUG(Overlay, "Throttle reading from peer {}",
@@ -615,7 +614,7 @@ FlowControl::maybeThrottleRead()
 void
 FlowControl::stopThrottling()
 {
-    std::lock_guard<std::mutex> guard(mFlowControlMutex);
+    MutexLocker guard(mFlowControlMutex);
     releaseAssert(mLastThrottle);
     CLOG_DEBUG(Overlay, "Stop throttling reading from peer {}",
                mAppConnector.getConfig().toShortString(mNodeID));
@@ -627,7 +626,7 @@ FlowControl::stopThrottling()
 bool
 FlowControl::isThrottled() const
 {
-    std::lock_guard<std::mutex> guard(mFlowControlMutex);
+    MutexLocker guard(mFlowControlMutex);
     return static_cast<bool>(mLastThrottle);
 }
 

--- a/src/overlay/FlowControl.cpp
+++ b/src/overlay/FlowControl.cpp
@@ -460,16 +460,12 @@ FlowControl::addMsgAndMaybeTrimQueue(std::shared_ptr<StellarMessage const> msg)
     auto& om = mOverlayMetrics;
     if (type == TRANSACTION)
     {
-        auto isOverLimit = [&](auto const& queue) {
-            bool overLimit =
-                queue.size() > limit ||
-                mTxQueueByteCount > getOutboundQueueByteLimit(guard);
-            return overLimit;
-        };
+        bool isOverLimit = queue.size() > limit ||
+                           mTxQueueByteCount > getOutboundQueueByteLimit(guard);
 
         // If we are at limit, we're probably really behind, so drop the entire
         // queue
-        if (isOverLimit(queue))
+        if (isOverLimit)
         {
             dropped = queue.size();
             mTxQueueByteCount = 0;

--- a/src/overlay/FlowControl.h
+++ b/src/overlay/FlowControl.h
@@ -146,6 +146,7 @@ class FlowControl
 
     void
     addToQueueAndMaybeTrimForTesting(std::shared_ptr<StellarMessage const> msg)
+        LOCKS_EXCLUDED(mFlowControlMutex)
     {
         addMsgAndMaybeTrimQueue(msg);
     }
@@ -157,18 +158,20 @@ class FlowControl
     }
 
     size_t
-    getTxQueueByteCountForTesting() const
+    getTxQueueByteCountForTesting() const LOCKS_EXCLUDED(mFlowControlMutex)
     {
+        MutexLocker lockGuard(mFlowControlMutex);
         return mTxQueueByteCount;
     }
     std::optional<size_t> mOutboundQueueLimit GUARDED_BY(mFlowControlMutex);
     void
-    setOutboundQueueLimit(size_t bytes)
+    setOutboundQueueLimit(size_t bytes) LOCKS_EXCLUDED(mFlowControlMutex)
     {
+        MutexLocker lockGuard(mFlowControlMutex);
         mOutboundQueueLimit = std::make_optional<size_t>(bytes);
     }
     size_t
-    getOutboundQueueByteLimit() const
+    getOutboundQueueByteLimit() const LOCKS_EXCLUDED(mFlowControlMutex)
     {
         MutexLocker lockGuard(mFlowControlMutex);
         return getOutboundQueueByteLimit(lockGuard);

--- a/src/overlay/FlowControl.h
+++ b/src/overlay/FlowControl.h
@@ -7,6 +7,7 @@
 #include "lib/json/json.h"
 #include "medida/timer.h"
 #include "overlay/FlowControlCapacity.h"
+#include "util/ThreadAnnotations.h"
 #include "util/Timer.h"
 #include <optional>
 
@@ -61,18 +62,21 @@ class FlowControl
 
     // How many _hashes_ in total are queued?
     // NB: Each advert & demand contains a _vector_ of tx hashes.
-    size_t mAdvertQueueTxHashCount{0};
-    size_t mDemandQueueTxHashCount{0};
-    size_t mTxQueueByteCount{0};
+    size_t mAdvertQueueTxHashCount GUARDED_BY(mFlowControlMutex){0};
+    size_t mDemandQueueTxHashCount GUARDED_BY(mFlowControlMutex){0};
+    size_t mTxQueueByteCount GUARDED_BY(mFlowControlMutex){0};
 
     // Mutex to synchronize flow control state
-    std::mutex mutable mFlowControlMutex;
+    Mutex mutable mFlowControlMutex;
     // Is this peer currently throttled due to lack of capacity
-    std::optional<VirtualClock::time_point> mLastThrottle;
+    std::optional<VirtualClock::time_point>
+        mLastThrottle GUARDED_BY(mFlowControlMutex);
 
-    NodeID mNodeID;
-    FlowControlMessageCapacity mFlowControlCapacity;
-    FlowControlByteCapacity mFlowControlBytesCapacity;
+    NodeID mNodeID GUARDED_BY(mFlowControlMutex);
+    FlowControlMessageCapacity
+        mFlowControlCapacity GUARDED_BY(mFlowControlMutex);
+    FlowControlByteCapacity
+        mFlowControlBytesCapacity GUARDED_BY(mFlowControlMutex);
 
     OverlayMetrics& mOverlayMetrics;
     AppConnector& mAppConnector;
@@ -83,40 +87,49 @@ class FlowControl
     // Priority 1 - transactions
     // Priority 2 - flood demands
     // Priority 3 - flood adverts
-    FloodQueues<QueuedOutboundMessage> mOutboundQueues;
+    FloodQueues<QueuedOutboundMessage>
+        mOutboundQueues GUARDED_BY(mFlowControlMutex);
 
     // How many flood messages we received and processed since sending
     // SEND_MORE to this peer
-    uint64_t mFloodDataProcessed{0};
+    uint64_t mFloodDataProcessed GUARDED_BY(mFlowControlMutex){0};
     // How many bytes we received and processed since sending
     // SEND_MORE to this peer
-    uint64_t mFloodDataProcessedBytes{0};
+    uint64_t mFloodDataProcessedBytes GUARDED_BY(mFlowControlMutex){0};
     // How many total messages we received and processed so far (used to track
     // throttling)
-    uint64_t mTotalMsgsProcessed{0};
-    std::optional<VirtualClock::time_point> mNoOutboundCapacity;
-    FlowControlMetrics mMetrics;
+    uint64_t mTotalMsgsProcessed GUARDED_BY(mFlowControlMutex){0};
+    std::optional<VirtualClock::time_point>
+        mNoOutboundCapacity GUARDED_BY(mFlowControlMutex);
+    FlowControlMetrics mMetrics GUARDED_BY(mFlowControlMutex);
 
     bool hasOutboundCapacity(StellarMessage const& msg,
-                             std::lock_guard<std::mutex>& lockGuard) const;
-    virtual size_t
-    getOutboundQueueByteLimit(std::lock_guard<std::mutex>& lockGuard) const;
-    bool canRead(std::lock_guard<std::mutex> const& lockGuard) const;
+                             MutexLocker& lockGuard) const
+        REQUIRES(mFlowControlMutex);
+    virtual size_t getOutboundQueueByteLimit(MutexLocker& lockGuard) const
+        REQUIRES(mFlowControlMutex);
+    bool canRead(MutexLocker const& lockGuard) const
+        REQUIRES(mFlowControlMutex);
 
   public:
     FlowControl(AppConnector& connector, bool useBackgoundThread);
     virtual ~FlowControl() = default;
 
-    void maybeReleaseCapacity(StellarMessage const& msg);
-    void handleTxSizeIncrease(uint32_t increase);
+    void maybeReleaseCapacity(StellarMessage const& msg)
+        LOCKS_EXCLUDED(mFlowControlMutex);
+    void handleTxSizeIncrease(uint32_t increase)
+        LOCKS_EXCLUDED(mFlowControlMutex);
     // This method adds a new message to the outbound queue, while shedding
     // obsolete load
-    void addMsgAndMaybeTrimQueue(std::shared_ptr<StellarMessage const> msg);
+    void addMsgAndMaybeTrimQueue(std::shared_ptr<StellarMessage const> msg)
+        LOCKS_EXCLUDED(mFlowControlMutex);
     // Return next batch of messages to send
     // NOTE: this method consumes outbound capacity of the receiving peer
-    std::vector<QueuedOutboundMessage> getNextBatchToSend();
+    std::vector<QueuedOutboundMessage> getNextBatchToSend()
+        LOCKS_EXCLUDED(mFlowControlMutex);
     void updateMsgMetrics(std::shared_ptr<StellarMessage const> msg,
-                          VirtualClock::time_point const& timePlaced);
+                          VirtualClock::time_point const& timePlaced)
+        LOCKS_EXCLUDED(mFlowControlMutex);
 
 #ifdef BUILD_TESTS
     FlowControlCapacity&
@@ -148,7 +161,7 @@ class FlowControl
     {
         return mTxQueueByteCount;
     }
-    std::optional<size_t> mOutboundQueueLimit;
+    std::optional<size_t> mOutboundQueueLimit GUARDED_BY(mFlowControlMutex);
     void
     setOutboundQueueLimit(size_t bytes)
     {
@@ -157,49 +170,54 @@ class FlowControl
     size_t
     getOutboundQueueByteLimit() const
     {
-        std::lock_guard<std::mutex> lockGuard(mFlowControlMutex);
+        MutexLocker lockGuard(mFlowControlMutex);
         return getOutboundQueueByteLimit(lockGuard);
     }
 #endif
 
     static uint32_t getNumMessages(StellarMessage const& msg);
     static uint32_t getMessagePriority(StellarMessage const& msg);
-    bool isSendMoreValid(StellarMessage const& msg,
-                         std::string& errorMsg) const;
+    bool isSendMoreValid(StellarMessage const& msg, std::string& errorMsg) const
+        LOCKS_EXCLUDED(mFlowControlMutex);
 
     // This method ensures local capacity is locked now that we've received a
     // new message
-    bool beginMessageProcessing(StellarMessage const& msg);
+    bool beginMessageProcessing(StellarMessage const& msg)
+        LOCKS_EXCLUDED(mFlowControlMutex);
 
     // This method ensures local capacity is released now that we've finished
     // processing the message. It returns available capacity that can now be
     // requested from the peer.
-    SendMoreCapacity endMessageProcessing(StellarMessage const& msg);
-    bool canRead() const;
+    SendMoreCapacity endMessageProcessing(StellarMessage const& msg)
+        LOCKS_EXCLUDED(mFlowControlMutex);
+    bool canRead() const LOCKS_EXCLUDED(mFlowControlMutex);
 
     // This method checks whether a peer has not requested new data within a
     // `timeout` (useful to diagnose if the connection is stuck for any reason)
     bool noOutboundCapacityTimeout(VirtualClock::time_point now,
-                                   std::chrono::seconds timeout) const;
+                                   std::chrono::seconds timeout) const
+        LOCKS_EXCLUDED(mFlowControlMutex);
 
-    Json::Value getFlowControlJsonInfo(bool compact) const;
+    Json::Value getFlowControlJsonInfo(bool compact) const
+        LOCKS_EXCLUDED(mFlowControlMutex);
 
     // Stores `peerID` to produce more useful log messages.
-    void setPeerID(NodeID const& peerID);
+    void setPeerID(NodeID const& peerID) LOCKS_EXCLUDED(mFlowControlMutex);
 
     // Stop reading from this peer until capacity is released
-    bool maybeThrottleRead();
+    bool maybeThrottleRead() LOCKS_EXCLUDED(mFlowControlMutex);
     // After releasing capacity, check if throttling was applied, and if so,
     // reset it. Returns true if peer was throttled, and false otherwise
-    void stopThrottling();
-    bool isThrottled() const;
+    void stopThrottling() LOCKS_EXCLUDED(mFlowControlMutex);
+    bool isThrottled() const LOCKS_EXCLUDED(mFlowControlMutex);
 
     // A function to be called once a batch of messages is sent (typically, this
     // is called once async_write completes and invokes a handler that calls
     // this function). This function will appropriatly trim outbound queues and
     // release capacity used by the messages that were sent.
-    void processSentMessages(
-        FloodQueues<ConstStellarMessagePtr> const& sentMessages);
+    void
+    processSentMessages(FloodQueues<ConstStellarMessagePtr> const& sentMessages)
+        LOCKS_EXCLUDED(mFlowControlMutex);
 };
 
 }

--- a/src/overlay/Hmac.h
+++ b/src/overlay/Hmac.h
@@ -5,16 +5,16 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "Tracy.hpp"
+#include "util/ThreadAnnotations.h"
 #include "xdr/Stellar-overlay.h"
 #include "xdr/Stellar-types.h"
-#include <mutex>
 
 using namespace stellar;
 
 class Hmac
 {
 #ifndef USE_TRACY
-    std::mutex mMutex;
+    Mutex mMutex;
 #else
     TracyLockable(std::mutex, mMutex);
 #endif

--- a/src/overlay/test/LoopbackPeer.h
+++ b/src/overlay/test/LoopbackPeer.h
@@ -22,6 +22,8 @@ namespace stellar
 // pair of them wrapped in a LoopbackPeerConnection that explicitly manages the
 // lifecycle of the connection.
 
+// This class is not thread-safe and is not meant to utilize multi-threading. It
+// is only safe to call its methods from the main thread.
 class LoopbackPeer : public Peer
 {
   private:
@@ -57,7 +59,7 @@ class LoopbackPeer : public Peer
                      std::shared_ptr<StellarMessage const> msg) override;
     AuthCert getAuthCert() override;
 
-    void processInQueue();
+    void processInQueue() NO_THREAD_SAFETY_ANALYSIS;
     void recvMessage(xdr::msg_ptr const& xdrBytes);
 
   public:
@@ -70,11 +72,12 @@ class LoopbackPeer : public Peer
 
     static std::pair<std::shared_ptr<LoopbackPeer>,
                      std::shared_ptr<LoopbackPeer>>
-    initiate(Application& app, Application& otherApp);
+    initiate(Application& app, Application& otherApp) NO_THREAD_SAFETY_ANALYSIS;
 
-    void drop(std::string const& reason, DropDirection dropDirection) override;
+    void drop(std::string const& reason,
+              DropDirection dropDirection) NO_THREAD_SAFETY_ANALYSIS override;
 
-    void deliverOne();
+    void deliverOne() NO_THREAD_SAFETY_ANALYSIS;
     void deliverAll();
     void dropAll();
     size_t getBytesQueued() const;

--- a/src/overlay/test/TCPPeerTests.cpp
+++ b/src/overlay/test/TCPPeerTests.cpp
@@ -330,8 +330,6 @@ TEST_CASE("Queue purging after asio writes completion",
     auto tcpPeer = std::static_pointer_cast<TCPPeer>(p1);
     tcpPeer->mStopReadingForTesting = true;
 
-    auto initialQueueSize =
-        p0->getFlowControl()->getQueuesForTesting()[1].size();
     auto initialQueueDrops =
         n0->getMetrics()
             .NewMeter({"overlay", "outbound-queue", "drop-tx"}, "message")
@@ -347,10 +345,6 @@ TEST_CASE("Queue purging after asio writes completion",
     auto finalQueueDrops =
         n0->getMetrics()
             .NewMeter({"overlay", "outbound-queue", "drop-tx"}, "message")
-            .count();
-    auto initialMsgCount =
-        n1->getMetrics()
-            .NewCounter({"overlay", "recv-transaction", "count"})
             .count();
 
     REQUIRE(finalQueueDrops > initialQueueDrops);

--- a/src/simulation/test/LoadGeneratorTests.cpp
+++ b/src/simulation/test/LoadGeneratorTests.cpp
@@ -663,11 +663,6 @@ TEST_CASE("generate soroban load", "[loadgen][soroban]")
             mixLoadCfg.setMinSorobanPercentSuccess(100);
 
             loadGen.generateLoad(mixLoadCfg);
-            auto numSuccessBefore = getSuccessfulTxCount();
-            auto numFailedBefore =
-                app.getMetrics()
-                    .NewCounter({"ledger", "apply-soroban", "failure"})
-                    .count();
             completeCount = complete.count();
             simulation->crankUntil(
                 [&]() { return complete.count() == completeCount + 1; },

--- a/src/util/GlobalChecks.h
+++ b/src/util/GlobalChecks.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "util/ThreadAnnotations.h"
 #include <Tracy.hpp>
 #include <mutex>
 
@@ -46,8 +47,8 @@ void dbgAbort();
 #endif
 
 #ifndef USE_TRACY
-using RecursiveLockGuard = std::lock_guard<std::recursive_mutex>;
-using LockGuard = std::lock_guard<std::mutex>;
+using RecursiveLockGuard = RecursiveMutexLocker;
+using LockGuard = MutexLocker;
 #else
 using RecursiveLockGuard = std::lock_guard<LockableBase(std::recursive_mutex)>;
 using LockGuard = std::lock_guard<LockableBase(std::mutex)>;

--- a/src/util/ThreadAnnotations.h
+++ b/src/util/ThreadAnnotations.h
@@ -1,0 +1,175 @@
+#pragma once
+
+// Copyright 2025 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+// Thread safety annotation macros for use with Clang's thread safety analysis
+// feature. These annotations allow the compiler to warn about potential thread
+// safety issues at compile time.
+//
+// Documentation for the annotations is available at:
+// https://clang.llvm.org/docs/ThreadSafetyAnalysis.html
+
+#ifndef THREAD_ANNOTATIONS_H_
+#define THREAD_ANNOTATIONS_H_
+
+#include <mutex>
+
+#if defined(__clang__) && (!defined(SWIG))
+#define THREAD_ANNOTATION_ATTRIBUTE__(x) __attribute__((x))
+#else
+#define THREAD_ANNOTATION_ATTRIBUTE__(x) // no-op
+#endif
+
+// Declares that a class member (or all members of a class) is protected by
+// the given capability.
+#define GUARDED_BY(x) THREAD_ANNOTATION_ATTRIBUTE__(guarded_by(x))
+
+// Declares that a class member (or all members of a class) is protected by
+// the given capability, but only when the class instance is accessed through
+// a pointer.
+#define PT_GUARDED_BY(x) THREAD_ANNOTATION_ATTRIBUTE__(pt_guarded_by(x))
+
+// Declares that a capability is a mutex, or a reader-writer lock.
+#define CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE__(capability(x))
+
+// Declares that a capability must be acquired before this one.
+#define ACQUIRED_BEFORE(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(acquired_before(__VA_ARGS__))
+
+// Declares that a capability must be acquired after this one.
+#define ACQUIRED_AFTER(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(acquired_after(__VA_ARGS__))
+
+// Declares that a function requires certain capabilities to be held by the
+// caller.
+#define REQUIRES(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(requires_capability(__VA_ARGS__))
+
+// Declares that a function requires shared access to certain capabilities to
+// be held by the caller.
+#define REQUIRES_SHARED(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(requires_shared_capability(__VA_ARGS__))
+
+// Declares that a function acquires a capability.
+#define ACQUIRE(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(acquire_capability(__VA_ARGS__))
+
+// Declares that a function acquires shared access to a capability.
+#define ACQUIRE_SHARED(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(acquire_shared_capability(__VA_ARGS__))
+
+// Declares that a function releases a capability.
+#define RELEASE(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(release_capability(__VA_ARGS__))
+
+// Declares that a function releases shared access to a capability.
+#define RELEASE_SHARED(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(release_shared_capability(__VA_ARGS__))
+
+// Tries to acquire a capability, returning true on success.
+#define TRY_ACQUIRE(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(try_acquire_capability(__VA_ARGS__))
+
+// Tries to acquire shared access to a capability, returning true on success.
+#define TRY_ACQUIRE_SHARED(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(try_acquire_shared_capability(__VA_ARGS__))
+
+// Asserts that a capability is held when entering the function.
+#define ASSERT_CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE__(assert_capability(x))
+
+// Asserts that shared access to a capability is held when entering the
+// function.
+#define ASSERT_SHARED_CAPABILITY(x) \
+    THREAD_ANNOTATION_ATTRIBUTE__(assert_shared_capability(x))
+
+// Return value represents a capability that is acquired.
+#define RETURN_CAPABILITY(x) THREAD_ANNOTATION_ATTRIBUTE__(lock_returned(x))
+
+// Skip thread safety analysis on this function.
+#define NO_THREAD_SAFETY_ANALYSIS \
+    THREAD_ANNOTATION_ATTRIBUTE__(no_thread_safety_analysis)
+
+// Declares that a function acquires a mutex exclusively.
+#define EXCLUSIVE_LOCK_FUNCTION(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(exclusive_lock_function(__VA_ARGS__))
+
+// Declares that a function acquires a mutex for shared (read) access.
+#define SHARED_LOCK_FUNCTION(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(shared_lock_function(__VA_ARGS__))
+
+// Declares that a function tries to acquire a mutex exclusively, returning true
+// on success.
+#define EXCLUSIVE_TRYLOCK_FUNCTION(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(exclusive_trylock_function(__VA_ARGS__))
+
+// Declares that a function tries to acquire a mutex for shared access,
+// returning true on success.
+#define SHARED_TRYLOCK_FUNCTION(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(shared_trylock_function(__VA_ARGS__))
+
+// Declares that a function releases a mutex.
+#define UNLOCK_FUNCTION(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(unlock_function(__VA_ARGS__))
+
+// Declares that a function requires the specified locks not to be held when the
+// function is called.
+#define LOCKS_EXCLUDED(...) \
+    THREAD_ANNOTATION_ATTRIBUTE__(locks_excluded(__VA_ARGS__))
+
+// Declares that a function returns a value representing a mutex.
+#define LOCK_RETURNED(x) THREAD_ANNOTATION_ATTRIBUTE__(lock_returned(x))
+
+// Declares that a class is a lockable type (such as the Mutex class).
+#define LOCKABLE THREAD_ANNOTATION_ATTRIBUTE__(lockable)
+
+// Declares that a class is a scoped lockable type (such as the MutexLocker
+// class).
+#define SCOPED_LOCKABLE THREAD_ANNOTATION_ATTRIBUTE__(scoped_lockable)
+
+// Defines an annotated interface for mutexes.
+// These methods can be implemented to use any internal mutex implementation.
+class LOCKABLE Mutex
+{
+  private:
+    std::mutex mMutex;
+
+  public:
+    // Acquire/lock this mutex exclusively.  Only one thread can have exclusive
+    // access at any one time.  Write operations to guarded data require an
+    // exclusive lock.
+    void
+    Lock() EXCLUSIVE_LOCK_FUNCTION()
+    {
+        mMutex.lock();
+    }
+
+    // Release/unlock the mutex, regardless of whether it is exclusive or
+    // shared.
+    void
+    Unlock() UNLOCK_FUNCTION()
+    {
+        mMutex.unlock();
+    }
+};
+
+// MutexLocker is an RAII class that acquires a mutex in its constructor, and
+// releases it in its destructor.
+class SCOPED_LOCKABLE MutexLocker
+{
+  private:
+    Mutex& mut;
+
+  public:
+    MutexLocker(Mutex& mu) EXCLUSIVE_LOCK_FUNCTION(mu) : mut(mu)
+    {
+        mu.Lock();
+    }
+    ~MutexLocker() UNLOCK_FUNCTION()
+    {
+        mut.Unlock();
+    }
+};
+
+#endif // THREAD_ANNOTATIONS_H_


### PR DESCRIPTION
Introduce clang thread safety analysis https://clang.llvm.org/docs/ThreadSafetyAnalysis.html, and perform it when building core with thread sanitizer. 

- For now, I've only annotated `FlowControl` and `BucketSnapshotManager` classes, but we should make it a standard for all classes doing concurrency.
- This is useful to identify data races and deadlocks at compile time. This change was able to identify two unprotected shared data bugs we had in the past: https://github.com/stellar/stellar-core/pull/4702 and https://github.com/stellar/stellar-core/pull/4458
- It also identified undefined behavior, where [shared_mutex](https://en.cppreference.com/w/cpp/thread/shared_mutex/lock_shared) is locked twice by the same thread. This PR includes a fix as well.
