### PR TITLE
Drop experimental background overlay flag

### DIFF
--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -1082,14 +1082,6 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                  [&]() { DISABLE_XDR_FSYNC = readBool(item); }},
                 {"METADATA_OUTPUT_STREAM",
                  [&]() { METADATA_OUTPUT_STREAM = readString(item); }},
-                {"EXPERIMENTAL_BACKGROUND_OVERLAY_PROCESSING",
-                 [&]() {
-                     CLOG_WARNING(Overlay,
-                                  "EXPERIMENTAL_BACKGROUND_OVERLAY_PROCESSING "
-                                  "is deprecated. Use "
-                                  "BACKGROUND_OVERLAY_PROCESSING instead");
-                     BACKGROUND_OVERLAY_PROCESSING = readBool(item);
-                 }},
                 {"BACKGROUND_OVERLAY_PROCESSING",
                  [&]() { BACKGROUND_OVERLAY_PROCESSING = readBool(item); }},
                 {"EXPERIMENTAL_PARALLEL_LEDGER_APPLY",


### PR DESCRIPTION
Dropping `EXPERIMENTAL_BACKGROUND_OVERLAY_PROCESSING` in favor of `BACKGROUND_OVERLAY_PROCESSING`. Let's ship this breaking change in p23 to avoid unexpected downstream breakages.