### PR TITLE
Stop skipping known results for fee bumps

### DIFF
--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1645,8 +1645,14 @@ LedgerManagerImpl::processFeesSeqNums(
                                   expectedResults->results.end());
                     releaseAssert((*expectedResultsIter)->transactionHash ==
                                   tx->getContentsHash());
-                    txResults.back()->setReplayTransactionResult(
-                        (*expectedResultsIter)->result);
+
+                    // https://github.com/stellar/stellar-core/issues/4741
+                    if (tx->getEnvelope().type() != ENVELOPE_TYPE_TX_FEE_BUMP)
+                    {
+                        txResults.back()->setReplayTransactionResult(
+                            (*expectedResultsIter)->result);
+                    }
+
                     ++(*expectedResultsIter);
                 }
 #endif // BUILD_TESTS


### PR DESCRIPTION
# Description

Skipping known fee bump results doesn't work, so we're undoing the recent change to skip them. 

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
