### PR TITLE
Improve the check for the events invariant.

### DIFF
--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -1502,13 +1502,24 @@ ApplicationImpl::enableInvariantsFromConfig()
         std::find(invariants.begin(), invariants.end(),
                   "EventsAreConsistentWithEntryDiffs") != invariants.end();
 
-    if (eventsInvariantEnabled && (!mConfig.EMIT_CLASSIC_EVENTS ||
-                                   !mConfig.BACKFILL_STELLAR_ASSET_EVENTS))
+    if (eventsInvariantEnabled)
     {
-        throw std::invalid_argument(
-            "Invalid configuration: EventsAreConsistentWithEntryDiffs "
-            "invariant requires both EMIT_CLASSIC_EVENTS and "
-            "BACKFILL_STELLAR_ASSET_EVENTS config options to be enabled");
+        bool metadataEnabled = !mConfig.METADATA_OUTPUT_STREAM.empty();
+#ifdef BUILD_TESTS
+        // For tests we don't always output meta, but we always enable it,
+        // so we shouldn't check `METADATA_OUTPUT_STREAM` flag value.
+        metadataEnabled = true;
+#endif
+        bool eventsEnabled = mConfig.EMIT_CLASSIC_EVENTS &&
+                             mConfig.BACKFILL_STELLAR_ASSET_EVENTS;
+        if (!metadataEnabled || !eventsEnabled)
+        {
+            throw std::invalid_argument(
+                "Invalid configuration: EventsAreConsistentWithEntryDiffs "
+                "invariant requires METADATA_OUTPUT_STREAM to be set, as well "
+                "as both EMIT_CLASSIC_EVENTS and BACKFILL_STELLAR_ASSET_EVENTS "
+                "config options to be enabled");
+        }
     }
 }
 


### PR DESCRIPTION
# Description

Improve the check for the events invariant.

Events are not generated when meta is disabled (because there wouldn't be a way to consume them), thus the invariant check should also ensure that meta is present.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
