### PR TITLE
Reset refundable fee tracker when adopting the known transaction result.

### DIFF
--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1645,13 +1645,8 @@ LedgerManagerImpl::processFeesSeqNums(
                                   expectedResults->results.end());
                     releaseAssert((*expectedResultsIter)->transactionHash ==
                                   tx->getContentsHash());
-
-                    // https://github.com/stellar/stellar-core/issues/4741
-                    if (tx->getEnvelope().type() != ENVELOPE_TYPE_TX_FEE_BUMP)
-                    {
-                        txResults.back()->setReplayTransactionResult(
-                            (*expectedResultsIter)->result);
-                    }
+                    txResults.back()->setReplayTransactionResult(
+                        (*expectedResultsIter)->result);
 
                     ++(*expectedResultsIter);
                 }

--- a/src/transactions/MutableTransactionResult.cpp
+++ b/src/transactions/MutableTransactionResult.cpp
@@ -209,6 +209,10 @@ MutableTransactionResultBase::adoptFailedReplayResult()
         return false;
     }
     mTxResult = *mReplayTransactionResult;
+    if (mRefundableFeeTracker)
+    {
+        mRefundableFeeTracker->resetConsumedFee();
+    }
     return true;
 }
 bool


### PR DESCRIPTION
# Description

Reset refundable fee tracker when adopting the known transaction result.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
