### PR TITLE
Exclude CONFIG_SETTING from getledgerentry test

### DIFF
--- a/src/main/test/QueryServerTests.cpp
+++ b/src/main/test/QueryServerTests.cpp
@@ -485,8 +485,8 @@ TEST_CASE("getledgerentry", "[queryserver]")
     {
         UnorderedSet<LedgerKey> keySet;
         auto newKey =
-            LedgerTestUtils::generateValidLedgerEntryKeysWithExclusions({TTL},
-                                                                        1)
+            LedgerTestUtils::generateValidLedgerEntryKeysWithExclusions(
+                {TTL, CONFIG_SETTING}, 1)
                 .front();
         LedgerKey liveKey;
         for (auto const& [lk, le] : liveEntryMap)

--- a/src/overlay/test/TCPPeerTests.cpp
+++ b/src/overlay/test/TCPPeerTests.cpp
@@ -361,7 +361,7 @@ TEST_CASE("Queue purging after asio writes completion",
         tcpPeer->scheduleReadForTesting();
     }
 
-    s->crankForAtLeast(std::chrono::seconds(30), false);
+    s->crankForAtLeast(std::chrono::seconds(90), false);
 
     if (shouldDrop)
     {


### PR DESCRIPTION
This fixes a small flaky test that is currently breaking CI: it fails periodically (when the RNG seed is on specific values) because it generates a CONFIG_SETTING as a test LE that the test wants to be "new" and not-exist in the database it's serving, whereas most CONFIG_SETTINGs _do_ exist in the database, just by nature of .. being config settings. So generating a "new" one collides, it's not new.


