### PR TITLE
Added ledger entry type offsets to BucketIndex

### DIFF
--- a/src/bucket/BucketApplicator.cpp
+++ b/src/bucket/BucketApplicator.cpp
@@ -42,7 +42,7 @@ BucketApplicator::BucketApplicator(Application& app,
     // Only apply offers
     if (!bucket->isEmpty())
     {
-        auto offsetOp = bucket->getOfferRange();
+        auto offsetOp = bucket->getRangeForTypes({OFFER});
         if (offsetOp)
         {
             auto [lowOffset, highOffset] = *offsetOp;

--- a/src/bucket/BucketApplicator.cpp
+++ b/src/bucket/BucketApplicator.cpp
@@ -42,7 +42,7 @@ BucketApplicator::BucketApplicator(Application& app,
     // Only apply offers
     if (!bucket->isEmpty())
     {
-        auto offsetOp = bucket->getRangeForTypes({OFFER});
+        auto offsetOp = bucket->getRangeForType(OFFER);
         if (offsetOp)
         {
             auto [lowOffset, highOffset] = *offsetOp;

--- a/src/bucket/BucketSnapshot.cpp
+++ b/src/bucket/BucketSnapshot.cpp
@@ -318,10 +318,10 @@ LiveBucketSnapshot::scanForEviction(
     return Loop::INCOMPLETE;
 }
 
-// Scans entries of the specified types in the bucket.
+// Scans entries of the specified type in the bucket.
 Loop
 LiveBucketSnapshot::scanForEntriesOfType(
-    std::set<LedgerEntryType> const& types,
+    LedgerEntryType type,
     std::function<Loop(BucketEntry const&)> callback) const
 {
     ZoneScoped;
@@ -330,7 +330,7 @@ LiveBucketSnapshot::scanForEntriesOfType(
         return Loop::INCOMPLETE;
     }
 
-    auto range = mBucket->getRangeForTypes(types);
+    auto range = mBucket->getRangeForType(type);
     if (!range)
     {
         return Loop::INCOMPLETE;
@@ -345,11 +345,11 @@ LiveBucketSnapshot::scanForEntriesOfType(
         bool matchesType = false;
         if (be.type() == LIVEENTRY || be.type() == INITENTRY)
         {
-            matchesType = types.find(be.liveEntry().data.type()) != types.end();
+            matchesType = be.liveEntry().data.type() == type;
         }
         else if (be.type() == DEADENTRY)
         {
-            matchesType = types.find(be.deadEntry().type()) != types.end();
+            matchesType = be.deadEntry().type() == type;
         }
 
         if (matchesType)

--- a/src/bucket/BucketSnapshot.h
+++ b/src/bucket/BucketSnapshot.h
@@ -88,9 +88,9 @@ class LiveBucketSnapshot : public BucketSnapshotBase<LiveBucket>
                          SearchableLiveBucketListSnapshot const& bl,
                          uint32_t ledgerVers) const;
 
-    // Scans entries of the specified types in the bucket.
+    // Scans entries of the specified type in the bucket.
     Loop scanForEntriesOfType(
-        std::set<LedgerEntryType> const& types,
+        LedgerEntryType type,
         std::function<Loop(BucketEntry const&)> callback) const;
 };
 

--- a/src/bucket/BucketSnapshot.h
+++ b/src/bucket/BucketSnapshot.h
@@ -88,9 +88,10 @@ class LiveBucketSnapshot : public BucketSnapshotBase<LiveBucket>
                          SearchableLiveBucketListSnapshot const& bl,
                          uint32_t ledgerVers) const;
 
-    // Scans contract code entries in the bucket.
-    Loop
-    scanForContractCode(std::function<Loop(BucketEntry const&)> callback) const;
+    // Scans entries of the specified types in the bucket.
+    Loop scanForEntriesOfType(
+        std::set<LedgerEntryType> const& types,
+        std::function<Loop(BucketEntry const&)> callback) const;
 };
 
 class HotArchiveBucketSnapshot : public BucketSnapshotBase<HotArchiveBucket>

--- a/src/bucket/BucketUtils.cpp
+++ b/src/bucket/BucketUtils.cpp
@@ -432,39 +432,4 @@ buildTypeRangesMap(
 
     return typeRanges;
 }
-
-std::optional<std::pair<std::streamoff, std::streamoff>>
-getRangeForTypesHelper(
-    std::set<LedgerEntryType> const& types,
-    std::map<LedgerEntryType, std::pair<std::streamoff, std::streamoff>> const&
-        typeRanges)
-{
-    std::optional<std::streamoff> start = std::nullopt;
-    std::streamoff end = 0;
-
-    // Iterate types in the same order they are sorted in the BucketList
-    for (auto type : types)
-    {
-        auto it = typeRanges.find(type);
-        if (it != typeRanges.end())
-        {
-            // If start is null, this is the first and smallest type in the
-            // range we've found, so set start.
-            if (!start)
-            {
-                start = it->second.first;
-            }
-
-            // The last type we find in the loop will be our upper bound
-            end = it->second.second;
-        }
-    }
-
-    if (start)
-    {
-        return std::make_optional(std::make_pair(*start, end));
-    }
-
-    return std::nullopt;
-}
 }

--- a/src/bucket/BucketUtils.h
+++ b/src/bucket/BucketUtils.h
@@ -6,11 +6,14 @@
 
 #include "util/NonCopyable.h"
 #include "xdr/Stellar-ledger-entries.h"
+
 #include <cstdint>
 #include <list>
 #include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
+#include <set>
 
 namespace medida
 {
@@ -224,4 +227,24 @@ template <class BucketT>
 LedgerEntryTypeAndDurability
 bucketEntryToLedgerEntryAndDurabilityType(typename BucketT::EntryT const& be);
 std::string toString(LedgerEntryTypeAndDurability let);
+
+// Utility functions for tracking type boundaries during bucket index
+// construction
+void updateTypeBoundaries(
+    LedgerEntryType currentType, std::streamoff position,
+    std::map<LedgerEntryType, std::streamoff>& typeStartOffsets,
+    std::map<LedgerEntryType, std::streamoff>& typeEndOffsets,
+    std::optional<LedgerEntryType>& lastTypeSeen);
+
+std::map<LedgerEntryType, std::pair<std::streamoff, std::streamoff>>
+buildTypeRangesMap(
+    std::map<LedgerEntryType, std::streamoff> const& typeStartOffsets,
+    std::map<LedgerEntryType, std::streamoff> const& typeEndOffsets);
+
+// Helper function to compute range for multiple types from a BucketIndex type
+// ranges map
+std::optional<std::pair<std::streamoff, std::streamoff>> getRangeForTypesHelper(
+    std::set<LedgerEntryType> const& types,
+    std::map<LedgerEntryType, std::pair<std::streamoff, std::streamoff>> const&
+        typeRanges);
 }

--- a/src/bucket/BucketUtils.h
+++ b/src/bucket/BucketUtils.h
@@ -240,11 +240,4 @@ std::map<LedgerEntryType, std::pair<std::streamoff, std::streamoff>>
 buildTypeRangesMap(
     std::map<LedgerEntryType, std::streamoff> const& typeStartOffsets,
     std::map<LedgerEntryType, std::streamoff> const& typeEndOffsets);
-
-// Helper function to compute range for multiple types from a BucketIndex type
-// ranges map
-std::optional<std::pair<std::streamoff, std::streamoff>> getRangeForTypesHelper(
-    std::set<LedgerEntryType> const& types,
-    std::map<LedgerEntryType, std::pair<std::streamoff, std::streamoff>> const&
-        typeRanges);
 }

--- a/src/bucket/DiskIndex.cpp
+++ b/src/bucket/DiskIndex.cpp
@@ -118,10 +118,15 @@ DiskIndex<BucketT>::getOffsetBounds(LedgerKey const& lowerBound,
 
 template <class BucketT>
 std::optional<std::pair<std::streamoff, std::streamoff>>
-DiskIndex<BucketT>::getRangeForTypes(
-    std::set<LedgerEntryType> const& types) const
+DiskIndex<BucketT>::getRangeForType(LedgerEntryType type) const
 {
-    return getRangeForTypesHelper(types, mData.typeRanges);
+    auto it = mData.typeRanges.find(type);
+    if (it != mData.typeRanges.end())
+    {
+        return std::make_optional(it->second);
+    }
+
+    return std::nullopt;
 }
 
 template <class BucketT>

--- a/src/bucket/DiskIndex.h
+++ b/src/bucket/DiskIndex.h
@@ -82,14 +82,16 @@ template <class BucketT> class DiskIndex : public NonMovableOrCopyable
         // Note: mAssetToPoolID is null for HotArchive Bucket types
         std::unique_ptr<AssetPoolIDMap> assetToPoolID{};
         BucketEntryCounters counters{};
+        std::map<LedgerEntryType, std::pair<std::streamoff, std::streamoff>>
+            typeRanges;
 
         template <class Archive>
         void
         save(Archive& ar) const
         {
             auto version = BucketT::IndexT::BUCKET_INDEX_VERSION;
-            ar(version, pageSize, keysToOffset, filter, assetToPoolID,
-               counters);
+            ar(version, pageSize, keysToOffset, filter, assetToPoolID, counters,
+               typeRanges);
         }
 
         // Note: version and pageSize must be loaded before this
@@ -102,7 +104,7 @@ template <class BucketT> class DiskIndex : public NonMovableOrCopyable
         void
         load(Archive& ar)
         {
-            ar(keysToOffset, filter, assetToPoolID, counters);
+            ar(keysToOffset, filter, assetToPoolID, counters, typeRanges);
         }
 
     } mData;
@@ -139,6 +141,9 @@ template <class BucketT> class DiskIndex : public NonMovableOrCopyable
     std::optional<std::pair<std::streamoff, std::streamoff>>
     getOffsetBounds(LedgerKey const& lowerBound,
                     LedgerKey const& upperBound) const;
+
+    std::optional<std::pair<std::streamoff, std::streamoff>>
+    getRangeForTypes(std::set<LedgerEntryType> const& types) const;
 
     // Returns page size for index
     std::streamoff

--- a/src/bucket/DiskIndex.h
+++ b/src/bucket/DiskIndex.h
@@ -143,7 +143,7 @@ template <class BucketT> class DiskIndex : public NonMovableOrCopyable
                     LedgerKey const& upperBound) const;
 
     std::optional<std::pair<std::streamoff, std::streamoff>>
-    getRangeForTypes(std::set<LedgerEntryType> const& types) const;
+    getRangeForType(LedgerEntryType type) const;
 
     // Returns page size for index
     std::streamoff

--- a/src/bucket/InMemoryIndex.cpp
+++ b/src/bucket/InMemoryIndex.cpp
@@ -150,9 +150,15 @@ InMemoryIndex::InMemoryIndex(BucketManager const& bm,
 }
 
 std::optional<std::pair<std::streamoff, std::streamoff>>
-InMemoryIndex::getRangeForTypes(std::set<LedgerEntryType> const& types) const
+InMemoryIndex::getRangeForType(LedgerEntryType type) const
 {
-    return getRangeForTypesHelper(types, mTypeRanges);
+    auto it = mTypeRanges.find(type);
+    if (it != mTypeRanges.end())
+    {
+        return std::make_optional(it->second);
+    }
+
+    return std::nullopt;
 }
 
 #ifdef BUILD_TESTS

--- a/src/bucket/InMemoryIndex.h
+++ b/src/bucket/InMemoryIndex.h
@@ -189,8 +189,8 @@ class InMemoryIndex
     InMemoryBucketState mInMemoryState;
     AssetPoolIDMap mAssetPoolIDMap;
     BucketEntryCounters mCounters{};
-    std::optional<std::pair<std::streamoff, std::streamoff>> mOfferRange;
-    std::optional<std::pair<std::streamoff, std::streamoff>> mContractCodeRange;
+    std::map<LedgerEntryType, std::pair<std::streamoff, std::streamoff>>
+        mTypeRanges;
 
   public:
     using IterT = InMemoryBucketState::IterT;
@@ -232,16 +232,7 @@ class InMemoryIndex
     }
 
     std::optional<std::pair<std::streamoff, std::streamoff>>
-    getOfferRange() const
-    {
-        return mOfferRange;
-    }
-
-    std::optional<std::pair<std::streamoff, std::streamoff>>
-    getContractCodeRange() const
-    {
-        return mContractCodeRange;
-    }
+    getRangeForTypes(std::set<LedgerEntryType> const& types) const;
 
 #ifdef BUILD_TESTS
     bool operator==(InMemoryIndex const& in) const;

--- a/src/bucket/InMemoryIndex.h
+++ b/src/bucket/InMemoryIndex.h
@@ -232,7 +232,7 @@ class InMemoryIndex
     }
 
     std::optional<std::pair<std::streamoff, std::streamoff>>
-    getRangeForTypes(std::set<LedgerEntryType> const& types) const;
+    getRangeForType(LedgerEntryType type) const;
 
 #ifdef BUILD_TESTS
     bool operator==(InMemoryIndex const& in) const;

--- a/src/bucket/LiveBucket.cpp
+++ b/src/bucket/LiveBucket.cpp
@@ -361,9 +361,9 @@ LiveBucket::getMaxCacheSize() const
 #endif // BUILD_TESTS
 
 std::optional<std::pair<std::streamoff, std::streamoff>>
-LiveBucket::getRangeForTypes(std::set<LedgerEntryType> const& types) const
+LiveBucket::getRangeForType(LedgerEntryType type) const
 {
-    return getIndex().getRangeForTypes(types);
+    return getIndex().getRangeForType(type);
 }
 
 std::vector<BucketEntry>

--- a/src/bucket/LiveBucket.cpp
+++ b/src/bucket/LiveBucket.cpp
@@ -361,15 +361,9 @@ LiveBucket::getMaxCacheSize() const
 #endif // BUILD_TESTS
 
 std::optional<std::pair<std::streamoff, std::streamoff>>
-LiveBucket::getOfferRange() const
+LiveBucket::getRangeForTypes(std::set<LedgerEntryType> const& types) const
 {
-    return getIndex().getOfferRange();
-}
-
-std::optional<std::pair<std::streamoff, std::streamoff>>
-LiveBucket::getContractCodeRange() const
-{
-    return getIndex().getContractCodeRange();
+    return getIndex().getRangeForTypes(types);
 }
 
 std::vector<BucketEntry>

--- a/src/bucket/LiveBucket.h
+++ b/src/bucket/LiveBucket.h
@@ -95,10 +95,12 @@ class LiveBucket : public BucketBase<LiveBucket, LiveBucketIndex>,
 #endif
 
     // Returns [lowerBound, upperBound) of file offsets for all entries of the
-    // given types in the bucket, or std::nullopt if no entries of these types
-    // exist
+    // given type in the bucket, or std::nullopt if no entries of this type
+    // exist. Note that if the underlying index is a page based index, this is a
+    // rough bound such that entries of another type may also be present in the
+    // range.
     std::optional<std::pair<std::streamoff, std::streamoff>>
-    getRangeForTypes(std::set<LedgerEntryType> const& types) const;
+    getRangeForType(LedgerEntryType type) const;
 
     // Create a fresh bucket from given vectors of init (created) and live
     // (updated) LedgerEntries, and dead LedgerEntryKeys. The bucket will

--- a/src/bucket/LiveBucket.h
+++ b/src/bucket/LiveBucket.h
@@ -94,15 +94,11 @@ class LiveBucket : public BucketBase<LiveBucket, LiveBucketIndex>,
     size_t getMaxCacheSize() const;
 #endif
 
-    // Returns [lowerBound, upperBound) of file offsets for all offers in the
-    // bucket, or std::nullopt if no offers exist
+    // Returns [lowerBound, upperBound) of file offsets for all entries of the
+    // given types in the bucket, or std::nullopt if no entries of these types
+    // exist
     std::optional<std::pair<std::streamoff, std::streamoff>>
-    getOfferRange() const;
-
-    // Returns [lowerBound, upperBound) of file offsets for all contract code
-    // entries in the bucket, or std::nullopt if no contract code exists
-    std::optional<std::pair<std::streamoff, std::streamoff>>
-    getContractCodeRange() const;
+    getRangeForTypes(std::set<LedgerEntryType> const& types) const;
 
     // Create a fresh bucket from given vectors of init (created) and live
     // (updated) LedgerEntries, and dead LedgerEntryKeys. The bucket will

--- a/src/bucket/LiveBucketIndex.cpp
+++ b/src/bucket/LiveBucketIndex.cpp
@@ -283,15 +283,15 @@ LiveBucketIndex::getPoolIDsByAsset(Asset const& asset) const
 }
 
 std::optional<std::pair<std::streamoff, std::streamoff>>
-LiveBucketIndex::getRangeForTypes(std::set<LedgerEntryType> const& types) const
+LiveBucketIndex::getRangeForType(LedgerEntryType type) const
 {
     if (mDiskIndex)
     {
-        return mDiskIndex->getRangeForTypes(types);
+        return mDiskIndex->getRangeForType(type);
     }
 
     releaseAssertOrThrow(mInMemoryIndex);
-    return mInMemoryIndex->getRangeForTypes(types);
+    return mInMemoryIndex->getRangeForType(type);
 }
 
 uint32_t

--- a/src/bucket/LiveBucketIndex.cpp
+++ b/src/bucket/LiveBucketIndex.cpp
@@ -283,47 +283,15 @@ LiveBucketIndex::getPoolIDsByAsset(Asset const& asset) const
 }
 
 std::optional<std::pair<std::streamoff, std::streamoff>>
-LiveBucketIndex::getOfferRange() const
+LiveBucketIndex::getRangeForTypes(std::set<LedgerEntryType> const& types) const
 {
     if (mDiskIndex)
     {
-        // Get the smallest and largest possible offer keys
-        LedgerKey upperBound(OFFER);
-        upperBound.offer().sellerID.ed25519().fill(
-            std::numeric_limits<uint8_t>::max());
-        upperBound.offer().offerID = std::numeric_limits<int64_t>::max();
-
-        LedgerKey lowerBound(OFFER);
-        lowerBound.offer().sellerID.ed25519().fill(
-            std::numeric_limits<uint8_t>::min());
-        lowerBound.offer().offerID = std::numeric_limits<int64_t>::min();
-
-        return mDiskIndex->getOffsetBounds(lowerBound, upperBound);
+        return mDiskIndex->getRangeForTypes(types);
     }
 
     releaseAssertOrThrow(mInMemoryIndex);
-    return mInMemoryIndex->getOfferRange();
-}
-
-std::optional<std::pair<std::streamoff, std::streamoff>>
-LiveBucketIndex::getContractCodeRange() const
-{
-    if (mDiskIndex)
-    {
-        // Get the smallest and largest possible contract code keys
-        LedgerKey lowerBound(CONTRACT_CODE);
-        lowerBound.contractCode().hash.fill(
-            std::numeric_limits<uint8_t>::min());
-
-        LedgerKey upperBound(CONTRACT_CODE);
-        upperBound.contractCode().hash.fill(
-            std::numeric_limits<uint8_t>::max());
-
-        return mDiskIndex->getOffsetBounds(lowerBound, upperBound);
-    }
-
-    releaseAssertOrThrow(mInMemoryIndex);
-    return mInMemoryIndex->getContractCodeRange();
+    return mInMemoryIndex->getRangeForTypes(types);
 }
 
 uint32_t

--- a/src/bucket/LiveBucketIndex.h
+++ b/src/bucket/LiveBucketIndex.h
@@ -141,7 +141,7 @@ class LiveBucketIndex : public NonMovableOrCopyable
     void maybeAddToCache(std::shared_ptr<BucketEntry const> const& entry) const;
 
     std::optional<std::pair<std::streamoff, std::streamoff>>
-    getRangeForTypes(std::set<LedgerEntryType> const& types) const;
+    getRangeForType(LedgerEntryType type) const;
 
     BucketEntryCounters const& getBucketEntryCounters() const;
     uint32_t getPageSize() const;

--- a/src/bucket/LiveBucketIndex.h
+++ b/src/bucket/LiveBucketIndex.h
@@ -95,7 +95,7 @@ class LiveBucketIndex : public NonMovableOrCopyable
 
   public:
     inline static const std::string DB_BACKEND_STATE = "bl";
-    inline static const uint32_t BUCKET_INDEX_VERSION = 5;
+    inline static const uint32_t BUCKET_INDEX_VERSION = 6;
 
     // Constructor for creating new index from Bucketfile
     // Note: Constructor does not initialize the cache
@@ -138,13 +138,10 @@ class LiveBucketIndex : public NonMovableOrCopyable
 
     std::vector<PoolID> const& getPoolIDsByAsset(Asset const& asset) const;
 
-    std::optional<std::pair<std::streamoff, std::streamoff>>
-    getOfferRange() const;
-
     void maybeAddToCache(std::shared_ptr<BucketEntry const> const& entry) const;
 
     std::optional<std::pair<std::streamoff, std::streamoff>>
-    getContractCodeRange() const;
+    getRangeForTypes(std::set<LedgerEntryType> const& types) const;
 
     BucketEntryCounters const& getBucketEntryCounters() const;
     uint32_t getPageSize() const;

--- a/src/bucket/SearchableBucketList.cpp
+++ b/src/bucket/SearchableBucketList.cpp
@@ -66,13 +66,13 @@ SearchableLiveBucketListSnapshot::scanForEviction(
 
 void
 SearchableLiveBucketListSnapshot::scanForEntriesOfType(
-    std::set<LedgerEntryType> const& types,
+    LedgerEntryType type,
     std::function<Loop(BucketEntry const&)> callback) const
 {
     ZoneScoped;
     releaseAssert(mSnapshot);
-    auto f = [&types, &callback](auto const& b) {
-        return b.scanForEntriesOfType(types, callback);
+    auto f = [type, &callback](auto const& b) {
+        return b.scanForEntriesOfType(type, callback);
     };
     loopAllBuckets(f, *mSnapshot);
 }

--- a/src/bucket/SearchableBucketList.cpp
+++ b/src/bucket/SearchableBucketList.cpp
@@ -65,13 +65,14 @@ SearchableLiveBucketListSnapshot::scanForEviction(
 }
 
 void
-SearchableLiveBucketListSnapshot::scanForContractCode(
+SearchableLiveBucketListSnapshot::scanForEntriesOfType(
+    std::set<LedgerEntryType> const& types,
     std::function<Loop(BucketEntry const&)> callback) const
 {
     ZoneScoped;
     releaseAssert(mSnapshot);
-    auto f = [&callback](auto const& b) {
-        return b.scanForContractCode(callback);
+    auto f = [&types, &callback](auto const& b) {
+        return b.scanForEntriesOfType(types, callback);
     };
     loopAllBuckets(f, *mSnapshot);
 }

--- a/src/bucket/SearchableBucketList.h
+++ b/src/bucket/SearchableBucketList.h
@@ -35,8 +35,9 @@ class SearchableLiveBucketListSnapshot
         std::shared_ptr<EvictionStatistics> stats,
         StateArchivalSettings const& sas, uint32_t ledgerVers) const;
 
-    void
-    scanForContractCode(std::function<Loop(BucketEntry const&)> callback) const;
+    void scanForEntriesOfType(
+        std::set<LedgerEntryType> const& types,
+        std::function<Loop(BucketEntry const&)> callback) const;
 
     friend SearchableSnapshotConstPtr
     BucketSnapshotManager::copySearchableLiveBucketListSnapshot(

--- a/src/bucket/SearchableBucketList.h
+++ b/src/bucket/SearchableBucketList.h
@@ -36,7 +36,7 @@ class SearchableLiveBucketListSnapshot
         StateArchivalSettings const& sas, uint32_t ledgerVers) const;
 
     void scanForEntriesOfType(
-        std::set<LedgerEntryType> const& types,
+        LedgerEntryType type,
         std::function<Loop(BucketEntry const&)> callback) const;
 
     friend SearchableSnapshotConstPtr

--- a/src/ledger/SharedModuleCacheCompiler.cpp
+++ b/src/ledger/SharedModuleCacheCompiler.cpp
@@ -146,7 +146,7 @@ SharedModuleCacheCompiler::start()
         ZoneScopedN("load wasm contracts");
         std::unordered_set<Hash> seenContracts;
         this->mSnap->scanForEntriesOfType(
-            {CONTRACT_CODE}, [&](BucketEntry const& entry) {
+            CONTRACT_CODE, [&](BucketEntry const& entry) {
                 Hash h;
                 switch (entry.type())
                 {

--- a/src/ledger/SharedModuleCacheCompiler.cpp
+++ b/src/ledger/SharedModuleCacheCompiler.cpp
@@ -145,27 +145,29 @@ SharedModuleCacheCompiler::start()
     mThreads.emplace_back(std::thread([this]() {
         ZoneScopedN("load wasm contracts");
         std::unordered_set<Hash> seenContracts;
-        this->mSnap->scanForContractCode([&](BucketEntry const& entry) {
-            Hash h;
-            switch (entry.type())
-            {
-            case INITENTRY:
-            case LIVEENTRY:
-                h = entry.liveEntry().data.contractCode().hash;
-                if (seenContracts.find(h) == seenContracts.end())
+        this->mSnap->scanForEntriesOfType(
+            {CONTRACT_CODE}, [&](BucketEntry const& entry) {
+                Hash h;
+                switch (entry.type())
                 {
-                    this->pushWasm(entry.liveEntry().data.contractCode().code);
+                case INITENTRY:
+                case LIVEENTRY:
+                    h = entry.liveEntry().data.contractCode().hash;
+                    if (seenContracts.find(h) == seenContracts.end())
+                    {
+                        this->pushWasm(
+                            entry.liveEntry().data.contractCode().code);
+                    }
+                    break;
+                case DEADENTRY:
+                    h = entry.deadEntry().contractCode().hash;
+                    break;
+                default:
+                    break;
                 }
-                break;
-            case DEADENTRY:
-                h = entry.deadEntry().contractCode().hash;
-                break;
-            default:
-                break;
-            }
-            seenContracts.insert(h);
-            return Loop::INCOMPLETE;
-        });
+                seenContracts.insert(h);
+                return Loop::INCOMPLETE;
+            });
         this->setFinishedLoading(seenContracts.size());
     }));
 

--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -710,7 +710,7 @@ dumpWasmBlob(Config cfg, std::string const& hash, std::string const& dir)
     if (hash == "ALL")
     {
         snap->scanForEntriesOfType(
-            {CONTRACT_CODE}, [&](const BucketEntry& entry) {
+            CONTRACT_CODE, [&](const BucketEntry& entry) {
                 if (entry.type() == INITENTRY || entry.type() == LIVEENTRY)
                 {
                     auto const& codeEntry =

--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -709,14 +709,16 @@ dumpWasmBlob(Config cfg, std::string const& hash, std::string const& dir)
                     .copySearchableLiveBucketListSnapshot();
     if (hash == "ALL")
     {
-        snap->scanForContractCode([&](const BucketEntry& entry) {
-            if (entry.type() == INITENTRY || entry.type() == LIVEENTRY)
-            {
-                auto const& codeEntry = entry.liveEntry().data.contractCode();
-                writeBlob(codeEntry);
-            }
-            return Loop::INCOMPLETE;
-        });
+        snap->scanForEntriesOfType(
+            {CONTRACT_CODE}, [&](const BucketEntry& entry) {
+                if (entry.type() == INITENTRY || entry.type() == LIVEENTRY)
+                {
+                    auto const& codeEntry =
+                        entry.liveEntry().data.contractCode();
+                    writeBlob(codeEntry);
+                }
+                return Loop::INCOMPLETE;
+            });
     }
     else
     {


### PR DESCRIPTION
# Description

This adds a mapping of file offsets -> LedgerEntryType to BucketIndex. This is a small refactor to make the incoming soroban state cache PR a lot cleaner. It does introduce a small functionality change to Bucket Indexes to store this map, and does require re indexing on startup.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
