### PR TITLE
Soroban state cache 

### DIFF
--- a/src/bucket/test/BucketIndexTests.cpp
+++ b/src/bucket/test/BucketIndexTests.cpp
@@ -20,10 +20,12 @@
 #include "main/Config.h"
 #include "test/test.h"
 
+#include "util/GlobalChecks.h"
 #include "util/UnorderedMap.h"
 #include "util/UnorderedSet.h"
 #include "util/XDRCereal.h"
 #include "util/types.h"
+#include "xdr/Stellar-ledger-entries.h"
 
 using namespace stellar;
 using namespace BucketTestUtils;
@@ -40,6 +42,9 @@ class BucketIndexTest
     // Mapping of Key->value that BucketList should return
     UnorderedMap<LedgerKey, LedgerEntry> mTestEntries;
     UnorderedSet<LedgerKey> mGeneratedKeys;
+
+    UnorderedMap<LedgerKey, LedgerEntry> mContractCodeEntries;
+    UnorderedMap<LedgerKey, LedgerEntry> mContractDataEntries;
 
     // Set of keys to query BucketList for
     LedgerKeySet mKeysToSearch;
@@ -60,28 +65,73 @@ class BucketIndexTest
     }
 
     void
-    insertEntries(std::vector<LedgerEntry> const& entries)
-    {
-        mApp->getLedgerManager().setNextLedgerEntryBatchForBucketTesting(
-            {}, entries, {});
-        closeLedger(*mApp);
-    }
-
-    void
     buildBucketList(std::function<void(std::vector<LedgerEntry>&)> f,
-                    bool isCacheTest = false)
+                    bool isCacheTest = false, bool sorobanOnly = false)
     {
+        releaseAssertOrThrow(!(isCacheTest && sorobanOnly));
+
         uint32_t ledger = 0;
         do
         {
             ++ledger;
-            std::vector<LedgerEntry> entries =
-                isCacheTest
-                    ? LedgerTestUtils::
-                          generateValidUniqueLedgerEntriesWithTypes(
-                              {ACCOUNT}, 10, mGeneratedKeys)
-                    : LedgerTestUtils::generateValidLedgerEntriesWithExclusions(
-                          {CONFIG_SETTING}, 10);
+            std::vector<LedgerEntry> entries;
+            if (!isCacheTest && !sorobanOnly)
+            {
+                entries = LedgerTestUtils::
+                    generateValidUniqueLedgerEntriesWithExclusions(
+                        {CONFIG_SETTING, TTL}, 10, mGeneratedKeys);
+            }
+            else if (isCacheTest)
+            {
+                entries =
+                    LedgerTestUtils::generateValidUniqueLedgerEntriesWithTypes(
+                        {ACCOUNT}, 10, mGeneratedKeys);
+            }
+            else if (sorobanOnly)
+            {
+
+                entries =
+                    LedgerTestUtils::generateValidUniqueLedgerEntriesWithTypes(
+                        {CONTRACT_DATA, CONTRACT_CODE}, 10, mGeneratedKeys);
+
+                // Insert TTL for each entry
+                for (auto& e : entries)
+                {
+                    if (e.data.type() == CONTRACT_CODE)
+                    {
+                        mContractCodeEntries.emplace(LedgerEntryKey(e), e);
+                    }
+                    else if (e.data.type() == CONTRACT_DATA)
+                    {
+                        mContractDataEntries.emplace(LedgerEntryKey(e), e);
+                    }
+                }
+            }
+
+            auto entriesSize = entries.size();
+            for (size_t i = 0; i < entriesSize; ++i)
+            {
+                auto const& e = entries.at(i);
+                releaseAssertOrThrow(e.data.type() != TTL);
+
+                // Insert TTL for Soroban entries to maintain invariant
+                if (isSorobanEntry(e.data))
+                {
+                    LedgerEntry ttl;
+                    ttl.data.type(TTL);
+                    ttl.data.ttl().keyHash = getTTLKey(e).ttl().keyHash;
+
+                    // Entry should never expire
+                    ttl.data.ttl().liveUntilLedgerSeq = ledger + 10'000;
+
+                    // Add TTL key to mGeneratedKeys to maintain uniqueness
+                    auto ttlKey = LedgerEntryKey(ttl);
+                    mGeneratedKeys.insert(ttlKey);
+
+                    entries.push_back(ttl);
+                }
+            }
+
             f(entries);
             closeLedger(*mApp);
         } while (!LiveBucketList::levelShouldSpill(ledger, mLevelsToBuild - 1));
@@ -101,6 +151,24 @@ class BucketIndexTest
         return mApp->getBucketManager();
     }
 
+    Application&
+    getApp() const
+    {
+        return *mApp;
+    }
+
+    UnorderedMap<LedgerKey, LedgerEntry> const&
+    getContractCodeEntries() const
+    {
+        return mContractCodeEntries;
+    }
+
+    UnorderedMap<LedgerKey, LedgerEntry> const&
+    getContractDataEntries() const
+    {
+        return mContractDataEntries;
+    }
+
     virtual void
     buildGeneralTest(bool isCacheTest = false)
     {
@@ -118,7 +186,7 @@ class BucketIndexTest
                 }
             }
             mApp->getLedgerManager().setNextLedgerEntryBatchForBucketTesting(
-                {}, entries, {});
+                entries, {}, {});
         };
 
         buildBucketList(f, isCacheTest);
@@ -128,9 +196,11 @@ class BucketIndexTest
     runHistoricalSnapshotTest()
     {
         uint32_t ledger = 0;
+
+        // Exclude soroban types so we don't have to insert TTLs
         auto canonicalEntry =
             LedgerTestUtils::generateValidLedgerEntryWithExclusions(
-                {LedgerEntryType::CONFIG_SETTING});
+                {CONFIG_SETTING, TTL, CONTRACT_CODE, CONTRACT_DATA});
         canonicalEntry.lastModifiedLedgerSeq = 0;
 
         do
@@ -177,7 +247,7 @@ class BucketIndexTest
     }
 
     virtual void
-    buildMultiVersionTest()
+    buildMultiVersionTest(bool sorobanOnly = false)
     {
         std::vector<LedgerKey> toDestroy;
         std::vector<LedgerEntry> toUpdate;
@@ -187,18 +257,41 @@ class BucketIndexTest
             {
                 for (auto& e : toUpdate)
                 {
-                    e.data.account().balance += 1;
+                    e.lastModifiedLedgerSeq++;
                     auto iter = mTestEntries.find(LedgerEntryKey(e));
                     iter->second = e;
+
+                    if (sorobanOnly)
+                    {
+                        if (e.data.type() == CONTRACT_CODE)
+                        {
+                            mContractCodeEntries.emplace(LedgerEntryKey(e), e);
+                        }
+                        else if (e.data.type() == CONTRACT_DATA)
+                        {
+                            mContractDataEntries.emplace(LedgerEntryKey(e), e);
+                        }
+                    }
                 }
 
                 for (auto const& k : toDestroy)
                 {
                     mTestEntries.erase(k);
+                    if (sorobanOnly)
+                    {
+                        if (k.type() == CONTRACT_CODE)
+                        {
+                            mContractCodeEntries.erase(k);
+                        }
+                        else if (k.type() == CONTRACT_DATA)
+                        {
+                            mContractDataEntries.erase(k);
+                        }
+                    }
                 }
 
                 mApp->getLedgerManager()
-                    .setNextLedgerEntryBatchForBucketTesting({}, toUpdate,
+                    .setNextLedgerEntryBatchForBucketTesting(entries, toUpdate,
                                                              toDestroy);
                 toDestroy.clear();
                 toUpdate.clear();
@@ -212,30 +305,66 @@ class BucketIndexTest
                     {
                         mTestEntries.emplace(LedgerEntryKey(e), e);
                         mKeysToSearch.emplace(LedgerEntryKey(e));
-                        if (e.data.type() == ACCOUNT)
+                        if (rand_flip())
                         {
+                            if (e.data.type() == TTL)
+                            {
+                                // Make sure we don't try to update the same
+                                // entry we want to destroy
+                                auto ttlKey = LedgerEntryKey(e);
+                                auto iter = std::find(toDestroy.begin(),
+                                                      toDestroy.end(), ttlKey);
+                                if (iter != toDestroy.end())
+                                {
+                                    continue;
+                                }
+                            }
+
                             toUpdate.emplace_back(e);
                         }
-                        else
+                        // Never destroy just a TTL key to preserve invariant
+                        else if (e.data.type() != TTL)
                         {
                             toDestroy.emplace_back(LedgerEntryKey(e));
+
+                            // If we destroy a soroban entry, we also destroy
+                            // the corresponding TTL entry
+                            if (isSorobanEntry(e.data))
+                            {
+                                auto ttlKey = getTTLKey(e);
+                                toDestroy.emplace_back(ttlKey);
+
+                                // Make sure we don't try to destroy the same
+                                // entry we want to update
+                                for (auto iter = toUpdate.begin();
+                                     iter != toUpdate.end(); ++iter)
+                                {
+                                    if (LedgerEntryKey(*iter) == ttlKey)
+                                    {
+                                        toUpdate.erase(iter);
+                                        break;
+                                    }
+                                }
+                            }
                         }
                     }
                 }
 
                 mApp->getLedgerManager()
-                    .setNextLedgerEntryBatchForBucketTesting({}, entries, {});
+                    .setNextLedgerEntryBatchForBucketTesting(entries, {}, {});
             }
         };
 
-        buildBucketList(f);
+        buildBucketList(f, /*isCacheTest=*/false, sorobanOnly);
     }
 
     void
     insertSimilarContractDataKeys()
     {
         auto templateEntry =
-            LedgerTestUtils::generateValidLedgerEntryWithTypes({CONTRACT_DATA});
+            LedgerTestUtils::generateValidUniqueLedgerEntriesWithTypes(
+                {CONTRACT_DATA}, 1, mGeneratedKeys)
+                .front();
 
         auto generateEntry = [&](ContractDataDurability t) {
             auto le = templateEntry;
@@ -247,6 +376,24 @@ class BucketIndexTest
             generateEntry(ContractDataDurability::TEMPORARY),
             generateEntry(ContractDataDurability::PERSISTENT),
         };
+
+        auto entriesSize = entries.size();
+        for (size_t i = 0; i < entriesSize; ++i)
+        {
+            auto const& e = entries.at(i);
+            LedgerEntry ttl;
+            ttl.data.type(TTL);
+            ttl.data.ttl().keyHash = getTTLKey(e).ttl().keyHash;
+            ttl.data.ttl().liveUntilLedgerSeq =
+                e.lastModifiedLedgerSeq + 10'000;
+
+            // Add TTL key to mGeneratedKeys to maintain uniqueness
+            auto ttlKey = LedgerEntryKey(ttl);
+            mGeneratedKeys.insert(ttlKey);
+
+            entries.push_back(ttl);
+        }
+
         for (auto const& e : entries)
         {
             auto k = LedgerEntryKey(e);
@@ -257,7 +404,9 @@ class BucketIndexTest
             mKeysToSearch.emplace(k);
         }
 
-        insertEntries(entries);
+        mApp->getLedgerManager().setNextLedgerEntryBatchForBucketTesting(
+            entries, {}, {});
+        closeLedger(*mApp);
     }
 
     virtual void
@@ -419,10 +568,12 @@ class BucketIndexTest
 
             if (rand_flip())
             {
-                // Add keys not in bucket list as well
+                // Add keys not in bucket list as well. Don't add soroban keys
+                // to avoid state cache
                 auto addKeys =
                     LedgerTestUtils::generateValidLedgerEntryKeysWithExclusions(
-                        {CONFIG_SETTING}, 10);
+                        {CONFIG_SETTING, TTL, CONTRACT_CODE, CONTRACT_DATA},
+                        10);
 
                 searchSubset.insert(addKeys.begin(), addKeys.end());
             }
@@ -442,8 +593,9 @@ class BucketIndexTest
 
         // Load should return empty vector for keys not in bucket list
         auto keysNotInBL =
-            LedgerTestUtils::generateValidLedgerEntryKeysWithExclusions(
-                {CONFIG_SETTING}, 10);
+            LedgerTestUtils::generateValidUniqueLedgerKeysWithTypes(
+                {ACCOUNT, TRUSTLINE, DATA, CLAIMABLE_BALANCE, LIQUIDITY_POOL},
+                10, mGeneratedKeys);
         LedgerKeySet invalidKeys(keysNotInBL.begin(), keysNotInBL.end());
 
         // Test bulk load
@@ -498,31 +650,22 @@ class BucketIndexPoolShareTest : public BucketIndexTest
     {
         auto f = [&](std::vector<LedgerEntry>& entries) {
             std::vector<LedgerEntry> poolEntries;
-            std::vector<LedgerKey> toWriteNewVersion;
+            std::vector<LedgerKey> toDelete;
+            std::vector<LedgerEntry> toUpdate;
             if (mDist(gRandomEngine) < 30)
             {
-                // Make sure we generate a unique poolID for each entry
-                LiquidityPoolEntry pool;
-                for (;;)
-                {
-                    pool = LedgerTestUtils::generateValidLiquidityPoolEntry();
-                    for (auto e : poolEntries)
-                    {
-                        if (e.data.liquidityPool().liquidityPoolID ==
-                            pool.liquidityPoolID)
-                        {
-                            continue;
-                        }
-                    }
+                auto pool =
+                    LedgerTestUtils::generateValidUniqueLedgerEntriesWithTypes(
+                        {LIQUIDITY_POOL}, 1, mGeneratedKeys)
+                        .front();
 
-                    break;
-                }
+                auto& params =
+                    pool.data.liquidityPool().body.constantProduct().params;
 
-                auto& params = pool.body.constantProduct().params;
-
-                auto trustlineToSearch =
-                    generateTrustline(mAccountToSearch, pool);
-                auto trustline2 = generateTrustline(mAccount2, pool);
+                auto trustlineToSearch = generateTrustline(
+                    mAccountToSearch, pool.data.liquidityPool());
+                auto trustline2 =
+                    generateTrustline(mAccount2, pool.data.liquidityPool());
 
                 // Include target asset
                 if (rand_flip())
@@ -548,10 +691,7 @@ class BucketIndexPoolShareTest : public BucketIndexTest
                     params.assetB = mAsset3;
                 }
 
-                LedgerEntry poolEntry;
-                poolEntry.data.type(LIQUIDITY_POOL);
-                poolEntry.data.liquidityPool() = pool;
-                poolEntries.emplace_back(poolEntry);
+                entries.emplace_back(pool);
                 entries.emplace_back(trustlineToSearch);
                 entries.emplace_back(trustline2);
             }
@@ -559,9 +699,9 @@ class BucketIndexPoolShareTest : public BucketIndexTest
             else if (shouldMultiVersion && mDist(gRandomEngine) < 10 &&
                      !mTestEntries.empty())
             {
-                // Arbitrarily pcik first entry of map
+                // Arbitrarily pick first entry of map
                 auto iter = mTestEntries.begin();
-                toWriteNewVersion.emplace_back(iter->first);
+                toDelete.emplace_back(iter->first);
                 mTestEntries.erase(iter);
             }
             // Write new version via modify
@@ -571,13 +711,17 @@ class BucketIndexPoolShareTest : public BucketIndexTest
                 // Arbitrarily pick first entry of map
                 auto iter = mTestEntries.begin();
                 iter->second.data.trustLine().balance += 10;
-                entries.emplace_back(iter->second);
+                toUpdate.emplace_back(iter->second);
             }
 
-            // We only index liquidity pool INITENTRY, so they must be inserted
-            // as INITENTRY
+            std::vector<LedgerEntry> initEntries;
+            initEntries.insert(initEntries.end(), poolEntries.begin(),
+                               poolEntries.end());
+            initEntries.insert(initEntries.end(), entries.begin(),
+                               entries.end());
+
             mApp->getLedgerManager().setNextLedgerEntryBatchForBucketTesting(
-                poolEntries, entries, toWriteNewVersion);
+                initEntries, toUpdate, toDelete);
         };
 
         BucketIndexTest::buildBucketList(f);
@@ -605,7 +749,7 @@ class BucketIndexPoolShareTest : public BucketIndexTest
     }
 
     virtual void
-    buildMultiVersionTest() override
+    buildMultiVersionTest(bool ignored = false) override
     {
         buildTest(true);
     }
@@ -948,6 +1092,76 @@ TEST_CASE("in-memory index construction", "[bucket][bucketindex]")
                 {ACCOUNT, OFFER, CONTRACT_DATA}, 100);
         test(entries);
     }
+}
+
+TEST_CASE("soroban cache population", "[soroban][bucketindex]")
+{
+    auto f = [&](Config& cfg) {
+        auto test = BucketIndexTest(cfg);
+        test.buildMultiVersionTest(/*sorobanOnly=*/true);
+        test.run();
+
+        auto& lm = test.getApp().getLedgerManager();
+        auto codeEntries = test.getContractCodeEntries();
+        auto dataEntries = test.getContractDataEntries();
+
+        auto testCache = [&]() {
+            auto& inMemorySorobanState = lm.getInMemorySorobanStateForTesting();
+
+            auto snapshot = test.getBM()
+                                .getBucketSnapshotManager()
+                                .copySearchableLiveBucketListSnapshot();
+
+            // First, test that the cache is maintained correctly via `addBatch`
+            REQUIRE(codeEntries.size() ==
+                    inMemorySorobanState.mContractCodeEntries.size());
+            for (auto const& [k, v] : codeEntries)
+            {
+                auto inMemoryEntry =
+                    inMemorySorobanState.getContractCodeEntry(k);
+                REQUIRE(inMemoryEntry);
+
+                auto liveEntry = snapshot->load(k);
+                REQUIRE(liveEntry);
+                REQUIRE(*liveEntry == *inMemoryEntry->ledgerEntry);
+
+                auto ttlEntry = snapshot->load(getTTLKey(k));
+                REQUIRE(ttlEntry);
+                REQUIRE(ttlEntry->data.ttl().liveUntilLedgerSeq ==
+                        inMemoryEntry->liveUntilLedgerSeq);
+            }
+
+            REQUIRE(dataEntries.size() ==
+                    inMemorySorobanState.mContractDataEntries.size());
+            for (auto const& [k, v] : dataEntries)
+            {
+                auto inMemoryEntry =
+                    inMemorySorobanState.getContractDataEntry(k);
+                REQUIRE(inMemoryEntry);
+
+                auto liveEntry = snapshot->load(k);
+                REQUIRE(liveEntry);
+                REQUIRE(*liveEntry == *inMemoryEntry->ledgerEntry);
+
+                auto ttlEntry = snapshot->load(getTTLKey(k));
+                REQUIRE(ttlEntry);
+                REQUIRE(ttlEntry->data.ttl().liveUntilLedgerSeq ==
+                        inMemoryEntry->liveUntilLedgerSeq);
+            }
+        };
+
+        // Test that we maintain the cache properly. We initialized an empty
+        // cache on the genesis ledger and updated it with each call to close
+        // ledger.
+        testCache();
+
+        // Now wipe cache and repopulate from scratch to test initialization on
+        // a non-empty bucketlist.
+        lm.rebuildInMemorySorobanStateForTesting();
+        testCache();
+    };
+
+    testAllIndexTypes(f);
 }
 
 TEST_CASE("load from historical snapshots", "[bucket][bucketindex]")
@@ -1312,7 +1526,7 @@ TEST_CASE("getRangeForType bounds verification", "[bucket][bucketindex]")
         {
             auto entries =
                 LedgerTestUtils::generateValidUniqueLedgerEntriesWithTypes(
-                    {ACCOUNT, TRUSTLINE, CONTRACT_DATA}, 40);
+                    {ACCOUNT, TRUSTLINE, CLAIMABLE_BALANCE}, 40);
 
             app->getLedgerManager().setNextLedgerEntryBatchForBucketTesting(
                 {}, entries, {});
@@ -1323,30 +1537,8 @@ TEST_CASE("getRangeForType bounds verification", "[bucket][bucketindex]")
             verifyIndexBounds(bucket);
 
             // Non-existent type
-            auto claimableBalanceRange =
-                bucket->getRangeForType(CLAIMABLE_BALANCE);
-            REQUIRE(!claimableBalanceRange.has_value());
-        }
-
-        SECTION("Bucket contains 1 of all types")
-        {
-            std::vector<LedgerEntry> allTypeEntries;
-            for (auto type : xdr::xdr_traits<LedgerEntryType>::enum_values())
-            {
-                allTypeEntries.push_back(
-                    LedgerTestUtils::generateValidLedgerEntryOfType(
-                        static_cast<LedgerEntryType>(type)));
-            }
-
-            app->getLedgerManager().setNextLedgerEntryBatchForBucketTesting(
-                {}, allTypeEntries, {});
-            closeLedger(*app);
-
-            auto bucket = app->getBucketManager()
-                              .getLiveBucketList()
-                              .getLevel(0)
-                              .getCurr();
-            verifyIndexBounds(bucket);
+            auto contractDataRange = bucket->getRangeForType(CONTRACT_DATA);
+            REQUIRE(!contractDataRange.has_value());
         }
 
         SECTION("Bucket contains only one type, mix of live and dead")
@@ -1354,7 +1546,7 @@ TEST_CASE("getRangeForType bounds verification", "[bucket][bucketindex]")
             std::vector<LedgerKey> deadKeys;
             std::vector<LedgerEntry> liveEntries =
                 LedgerTestUtils::generateValidUniqueLedgerEntriesWithTypes(
-                    {CONTRACT_CODE}, 10);
+                    {TRUSTLINE}, 10);
             for (auto iter = liveEntries.begin(); iter != liveEntries.end();)
             {
                 if (rand_flip())
@@ -1378,7 +1570,7 @@ TEST_CASE("getRangeForType bounds verification", "[bucket][bucketindex]")
                               .getCurr();
 
             verifyIndexBounds(bucket);
-            auto singleRange = bucket->getRangeForType(CONTRACT_CODE);
+            auto singleRange = bucket->getRangeForType(TRUSTLINE);
             REQUIRE(singleRange.has_value());
 
             // For a single type, upper bound should be EOF
@@ -1389,15 +1581,15 @@ TEST_CASE("getRangeForType bounds verification", "[bucket][bucketindex]")
         SECTION("Scan for entries by type")
         {
             auto const numOffers = 10;
-            auto const numContractCodes = 15;
+            auto const numClaimableBalances = 15;
             auto const numTrustlines = 5;
 
             auto offerEntries =
                 LedgerTestUtils::generateValidUniqueLedgerEntriesWithTypes(
                     {OFFER}, numOffers);
-            auto contractCodeEntries =
+            auto claimableBalanceEntries =
                 LedgerTestUtils::generateValidUniqueLedgerEntriesWithTypes(
-                    {CONTRACT_CODE}, numContractCodes);
+                    {CLAIMABLE_BALANCE}, numClaimableBalances);
             auto trustlineEntries =
                 LedgerTestUtils::generateValidUniqueLedgerEntriesWithTypes(
                     {TRUSTLINE}, numTrustlines);
@@ -1405,8 +1597,8 @@ TEST_CASE("getRangeForType bounds verification", "[bucket][bucketindex]")
             std::vector<LedgerEntry> entries;
             entries.insert(entries.end(), offerEntries.begin(),
                            offerEntries.end());
-            entries.insert(entries.end(), contractCodeEntries.begin(),
-                           contractCodeEntries.end());
+            entries.insert(entries.end(), claimableBalanceEntries.begin(),
+                           claimableBalanceEntries.end());
             entries.insert(entries.end(), trustlineEntries.begin(),
                            trustlineEntries.end());
 
@@ -1452,11 +1644,11 @@ TEST_CASE("getRangeForType bounds verification", "[bucket][bucketindex]")
 
             // Verify each type
             verifyScanForType(OFFER, offerEntries);
-            verifyScanForType(CONTRACT_CODE, contractCodeEntries);
+            verifyScanForType(CLAIMABLE_BALANCE, claimableBalanceEntries);
             verifyScanForType(TRUSTLINE, trustlineEntries);
 
             // Verify that we don't call the callback for non-existent types
-            searchableBL->scanForEntriesOfType(CLAIMABLE_BALANCE,
+            searchableBL->scanForEntriesOfType(CONTRACT_CODE,
                                                [&](BucketEntry const& be) {
                                                    REQUIRE(false);
                                                    return Loop::INCOMPLETE;

--- a/src/bucket/test/BucketMergeMapTests.cpp
+++ b/src/bucket/test/BucketMergeMapTests.cpp
@@ -21,7 +21,8 @@ TEST_CASE("bucket merge map", "[bucket][bucketmergemap]")
     auto getValidBucket = [&](int numEntries = 10) {
         std::vector<LedgerEntry> live =
             LedgerTestUtils::generateValidUniqueLedgerEntriesWithExclusions(
-                {CONFIG_SETTING}, numEntries);
+                {CONFIG_SETTING, CONTRACT_DATA, CONTRACT_CODE, TTL},
+                numEntries);
         std::shared_ptr<LiveBucket> b1 = LiveBucket::fresh(
             app->getBucketManager(), BucketTestUtils::getAppLedgerVersion(app),
             {}, live, {},

--- a/src/bucket/test/BucketTestUtils.cpp
+++ b/src/bucket/test/BucketTestUtils.cpp
@@ -292,8 +292,20 @@ LedgerManagerForBucketTests::sealLedgerTxnAndTransferEntriesToBucketList(
         }
 
         // Use the testing values.
+        mApplyState.addAnyContractsToModuleCache(lh.ledgerVersion,
+                                                 mTestInitEntries);
+        mApplyState.addAnyContractsToModuleCache(lh.ledgerVersion,
+                                                 mTestLiveEntries);
         mApp.getBucketManager().addLiveBatch(
             mApp, lh, mTestInitEntries, mTestLiveEntries, mTestDeadEntries);
+
+        // Update Soroban state cache
+        if (protocolVersionStartsFrom(initialLedgerVers,
+                                      SOROBAN_PROTOCOL_VERSION))
+        {
+            mApplyState.mInMemorySorobanState->updateState(
+                mTestInitEntries, mTestLiveEntries, mTestDeadEntries);
+        }
 
         mUseTestEntries = false;
         mTestInitEntries.clear();

--- a/src/bucket/test/BucketTestUtils.cpp
+++ b/src/bucket/test/BucketTestUtils.cpp
@@ -298,14 +298,8 @@ LedgerManagerForBucketTests::sealLedgerTxnAndTransferEntriesToBucketList(
                                                  mTestLiveEntries);
         mApp.getBucketManager().addLiveBatch(
             mApp, lh, mTestInitEntries, mTestLiveEntries, mTestDeadEntries);
-
-        // Update Soroban state cache
-        if (protocolVersionStartsFrom(initialLedgerVers,
-                                      SOROBAN_PROTOCOL_VERSION))
-        {
-            mApplyState.mInMemorySorobanState->updateState(
-                mTestInitEntries, mTestLiveEntries, mTestDeadEntries);
-        }
+        mApplyState.mInMemorySorobanState->updateState(
+            mTestInitEntries, mTestLiveEntries, mTestDeadEntries, lh);
 
         mUseTestEntries = false;
         mTestInitEntries.clear();

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -1502,11 +1502,12 @@ TEST_CASE_VERSIONS(
             {
                 auto lcl = lm.getLastClosedLedgerHeader();
                 lcl.header.ledgerSeq += 1;
+                // Generate entries excluding soroban types to avoid worrying
+                // about TTL invariants
                 lm.setNextLedgerEntryBatchForBucketTesting(
-                    {},
                     LedgerTestUtils::generateValidLedgerEntriesWithExclusions(
-                        {LedgerEntryType::CONFIG_SETTING}, 8),
-                    {});
+                        {CONFIG_SETTING, TTL, CONTRACT_DATA, CONTRACT_CODE}, 8),
+                    {}, {});
                 clock.crank(true);
             }
 

--- a/src/ledger/InMemorySorobanState.cpp
+++ b/src/ledger/InMemorySorobanState.cpp
@@ -1,0 +1,405 @@
+// Copyright 2025 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "ledger/InMemorySorobanState.h"
+#include "bucket/SearchableBucketList.h"
+#include "ledger/LedgerTypeUtils.h"
+#include "util/GlobalChecks.h"
+
+namespace stellar
+{
+
+void
+InMemorySorobanState::updateContractDataTTL(
+    std::unordered_set<InternalContractDataMapEntry,
+                       InternalContractDataEntryHash>::iterator dataIt,
+    uint32_t newLiveUntilLedgerSeq)
+{
+    // Since entries are immutable, we must erase and re-insert
+    auto ledgerEntryPtr = dataIt->get().ledgerEntry;
+    mContractDataEntries.erase(dataIt);
+    mContractDataEntries.emplace(InternalContractDataMapEntry(
+        std::move(ledgerEntryPtr), newLiveUntilLedgerSeq));
+}
+
+void
+InMemorySorobanState::updateTTL(LedgerEntry const& ttlEntry)
+{
+    releaseAssertOrThrow(ttlEntry.data.type() == TTL);
+
+    auto lk = LedgerEntryKey(ttlEntry);
+    auto newLiveUntilLedgerSeq = ttlEntry.data.ttl().liveUntilLedgerSeq;
+
+    // TTL updates can apply to either ContractData or ContractCode entries.
+    // First check if this TTL belongs to a stored ContractData entry.
+    auto dataIt = mContractDataEntries.find(InternalContractDataMapEntry(lk));
+    if (dataIt != mContractDataEntries.end())
+    {
+        updateContractDataTTL(dataIt, newLiveUntilLedgerSeq);
+    }
+    else
+    {
+        // Since we're updating a TTL that exists, if we get here it must belong
+        // to a contract code entry.
+        auto codeIt = mContractCodeEntries.find(lk.ttl().keyHash);
+        releaseAssertOrThrow(codeIt != mContractCodeEntries.end());
+        codeIt->second.liveUntilLedgerSeq = newLiveUntilLedgerSeq;
+    }
+}
+
+void
+InMemorySorobanState::updateContractData(LedgerEntry const& ledgerEntry)
+{
+    releaseAssertOrThrow(ledgerEntry.data.type() == CONTRACT_DATA);
+
+    // Entry must already exist since this is an update
+    auto lk = LedgerEntryKey(ledgerEntry);
+    auto dataIt = mContractDataEntries.find(InternalContractDataMapEntry(lk));
+    releaseAssertOrThrow(dataIt != mContractDataEntries.end());
+
+    // Preserve the existing TTL while updating the data
+    auto preservedTTL = dataIt->get().liveUntilLedgerSeq;
+    mContractDataEntries.erase(dataIt);
+    mContractDataEntries.emplace(
+        InternalContractDataMapEntry(ledgerEntry, preservedTTL));
+}
+
+void
+InMemorySorobanState::createContractDataEntry(LedgerEntry const& ledgerEntry)
+{
+    releaseAssertOrThrow(ledgerEntry.data.type() == CONTRACT_DATA);
+
+    // Verify entry doesn't already exist
+    auto dataIt = mContractDataEntries.find(
+        InternalContractDataMapEntry(LedgerEntryKey(ledgerEntry)));
+    releaseAssertOrThrow(dataIt == mContractDataEntries.end());
+
+    // Check if we've already seen this entry's TTL (can happen during
+    // initialization when TTL is written before the data)
+    auto ttlKey = getTTLKey(LedgerEntryKey(ledgerEntry));
+    uint32_t liveUntilLedgerSeq = 0;
+
+    auto ttlIt = mPendingTTLs.find(ttlKey.ttl().keyHash);
+    if (ttlIt != mPendingTTLs.end())
+    {
+        // Found orphaned TTL - adopt it and remove from temporary storage
+        liveUntilLedgerSeq = ttlIt->second;
+        mPendingTTLs.erase(ttlIt);
+    }
+    // else: TTL hasn't arrived yet, initialize to 0 (will be updated later)
+
+    mContractDataEntries.emplace(
+        InternalContractDataMapEntry(ledgerEntry, liveUntilLedgerSeq));
+}
+
+void
+InMemorySorobanState::createTTL(LedgerEntry const& ttlEntry)
+{
+    releaseAssertOrThrow(ttlEntry.data.type() == TTL);
+
+    auto lk = LedgerEntryKey(ttlEntry);
+    auto newLiveUntilLedgerSeq = ttlEntry.data.ttl().liveUntilLedgerSeq;
+
+    // Check if the corresponding ContractData entry already exists
+    // (can happen during initialization when entries arrive out of order)
+    auto dataIt = mContractDataEntries.find(InternalContractDataMapEntry(lk));
+    if (dataIt != mContractDataEntries.end())
+    {
+        // ContractData exists but has no TTL yet - update it
+        // Verify TTL hasn't been set yet (should be default initialized)
+        releaseAssertOrThrow(dataIt->get().liveUntilLedgerSeq == 0);
+
+        updateContractDataTTL(dataIt, newLiveUntilLedgerSeq);
+    }
+    else
+    {
+        // Check if this TTL belongs to a ContractCode entry that hasn't arrived
+        // yet
+        auto codeIt = mContractCodeEntries.find(lk.ttl().keyHash);
+        if (codeIt != mContractCodeEntries.end())
+        {
+            // ContractCode exists but has no TTL yet - update it
+            // Verify TTL hasn't been set yet (should be default initialized)
+            releaseAssertOrThrow(codeIt->second.liveUntilLedgerSeq == 0);
+            codeIt->second.liveUntilLedgerSeq = newLiveUntilLedgerSeq;
+        }
+        else
+        {
+            // No ContractData or ContractCode yet - store TTL for later
+            auto [_, inserted] =
+                mPendingTTLs.emplace(lk.ttl().keyHash, newLiveUntilLedgerSeq);
+            releaseAssertOrThrow(inserted);
+        }
+    }
+}
+
+void
+InMemorySorobanState::deleteContractData(LedgerKey const& ledgerKey)
+{
+    releaseAssertOrThrow(ledgerKey.type() == CONTRACT_DATA);
+    releaseAssertOrThrow(mContractDataEntries.erase(
+                             InternalContractDataMapEntry(ledgerKey)) == 1);
+}
+
+std::optional<ContractDataMapEntryT>
+InMemorySorobanState::getContractDataEntry(LedgerKey const& ledgerKey) const
+{
+    releaseAssertOrThrow(ledgerKey.type() == LedgerEntryType::CONTRACT_DATA);
+
+    auto it =
+        mContractDataEntries.find(InternalContractDataMapEntry(ledgerKey));
+    if (it == mContractDataEntries.end())
+    {
+        return std::nullopt;
+    }
+
+    return it->get();
+}
+
+void
+InMemorySorobanState::createContractCodeEntry(LedgerEntry const& ledgerEntry)
+{
+    releaseAssertOrThrow(ledgerEntry.data.type() == CONTRACT_CODE);
+
+    // Get the TTL key hash
+    auto ttlKey = getTTLKey(LedgerEntryKey(ledgerEntry));
+    auto keyHash = ttlKey.ttl().keyHash;
+
+    // Verify entry doesn't already exist
+    auto codeIt = mContractCodeEntries.find(keyHash);
+    releaseAssertOrThrow(codeIt == mContractCodeEntries.end());
+
+    // Check if we've already seen this entry's TTL (can happen during
+    // initialization when TTL is written before the code)
+    uint32_t liveUntilLedgerSeq = 0;
+
+    auto ttlIt = mPendingTTLs.find(keyHash);
+    if (ttlIt != mPendingTTLs.end())
+    {
+        // Found orphaned TTL - adopt it and remove from temporary storage
+        liveUntilLedgerSeq = ttlIt->second;
+        mPendingTTLs.erase(ttlIt);
+    }
+    // else: TTL hasn't arrived yet, initialize to 0 (will be updated later)
+
+    mContractCodeEntries.emplace(
+        keyHash,
+        ContractCodeMapEntryT(std::make_shared<LedgerEntry const>(ledgerEntry),
+                              liveUntilLedgerSeq));
+}
+
+void
+InMemorySorobanState::updateContractCode(LedgerEntry const& ledgerEntry)
+{
+    releaseAssertOrThrow(ledgerEntry.data.type() == CONTRACT_CODE);
+    auto ttlKey = getTTLKey(LedgerEntryKey(ledgerEntry));
+    auto keyHash = ttlKey.ttl().keyHash;
+
+    // Entry must already exist since this is an update
+    auto codeIt = mContractCodeEntries.find(keyHash);
+    releaseAssertOrThrow(codeIt != mContractCodeEntries.end());
+
+    // Preserve the existing TTL while updating the code
+    auto ttl = codeIt->second.liveUntilLedgerSeq;
+    codeIt->second = ContractCodeMapEntryT(
+        std::make_shared<LedgerEntry const>(ledgerEntry), ttl);
+}
+
+void
+InMemorySorobanState::deleteContractCode(LedgerKey const& ledgerKey)
+{
+    releaseAssertOrThrow(ledgerKey.type() == CONTRACT_CODE);
+
+    auto ttlKey = getTTLKey(ledgerKey);
+    auto keyHash = ttlKey.ttl().keyHash;
+    releaseAssertOrThrow(mContractCodeEntries.erase(keyHash) == 1);
+}
+
+std::optional<ContractCodeMapEntryT>
+InMemorySorobanState::getContractCodeEntry(LedgerKey const& ledgerKey) const
+{
+    releaseAssertOrThrow(ledgerKey.type() == LedgerEntryType::CONTRACT_CODE);
+
+    auto ttlKey = getTTLKey(ledgerKey);
+    auto keyHash = ttlKey.ttl().keyHash;
+
+    auto it = mContractCodeEntries.find(keyHash);
+    if (it == mContractCodeEntries.end())
+    {
+        return std::nullopt;
+    }
+
+    return it->second;
+}
+
+bool
+InMemorySorobanState::hasTTL(LedgerKey const& ledgerKey) const
+{
+    releaseAssertOrThrow(ledgerKey.type() == TTL);
+
+    // Check if this is a pending TTL
+    if (mPendingTTLs.find(ledgerKey.ttl().keyHash) != mPendingTTLs.end())
+    {
+        return true;
+    }
+
+    // Check if this is a ContractData TTL (stored with the data)
+    auto dataIt =
+        mContractDataEntries.find(InternalContractDataMapEntry(ledgerKey));
+    if (dataIt != mContractDataEntries.end())
+    {
+        // Only return true if TTL has been set (non-zero)
+        // During initialization, entries may exist with TTL == 0
+        return dataIt->get().liveUntilLedgerSeq != 0;
+    }
+
+    // Check if this is a ContractCode TTL (stored with the code)
+    auto codeIt = mContractCodeEntries.find(ledgerKey.ttl().keyHash);
+    if (codeIt != mContractCodeEntries.end())
+    {
+        // Only return true if TTL has been set (non-zero)
+        // During initialization, entries may exist with TTL == 0
+        return codeIt->second.liveUntilLedgerSeq != 0;
+    }
+
+    return false;
+}
+
+void
+InMemorySorobanState::initializeStateFromSnapshot(
+    SearchableSnapshotConstPtr snap)
+{
+    releaseAssertOrThrow(mContractDataEntries.empty());
+    releaseAssertOrThrow(mContractCodeEntries.empty());
+    releaseAssertOrThrow(mPendingTTLs.empty());
+
+    // Check if entry is a DEADENTRY and add it to deletedKeys. Otherwise, check
+    // if the entry is shadowed by a DEADENTRY.
+    std::unordered_set<LedgerKey> deletedKeys;
+    auto shouldAddToMap = [&deletedKeys](BucketEntry const& be,
+                                         LedgerEntryType expectedType) {
+        if (be.type() == DEADENTRY)
+        {
+            deletedKeys.insert(be.deadEntry());
+            return false;
+        }
+
+        releaseAssertOrThrow(be.type() == LIVEENTRY || be.type() == INITENTRY);
+        auto lk = LedgerEntryKey(be.liveEntry());
+        releaseAssertOrThrow(lk.type() == expectedType);
+        return deletedKeys.find(lk) == deletedKeys.end();
+    };
+
+    auto contractDataHandler = [this, &shouldAddToMap](BucketEntry const& be) {
+        if (!shouldAddToMap(be, CONTRACT_DATA))
+        {
+            return Loop::INCOMPLETE;
+        }
+
+        auto lk = LedgerEntryKey(be.liveEntry());
+        if (!getContractDataEntry(lk))
+        {
+            createContractDataEntry(be.liveEntry());
+        }
+
+        return Loop::INCOMPLETE;
+    };
+
+    auto ttlHandler = [this, &shouldAddToMap](BucketEntry const& be) {
+        if (!shouldAddToMap(be, TTL))
+        {
+            return Loop::INCOMPLETE;
+        }
+
+        auto lk = LedgerEntryKey(be.liveEntry());
+        if (!hasTTL(lk))
+        {
+            createTTL(be.liveEntry());
+        }
+
+        return Loop::INCOMPLETE;
+    };
+
+    auto contractCodeHandler = [this, &shouldAddToMap](BucketEntry const& be) {
+        if (!shouldAddToMap(be, CONTRACT_CODE))
+        {
+            return Loop::INCOMPLETE;
+        }
+
+        auto lk = LedgerEntryKey(be.liveEntry());
+        if (!getContractCodeEntry(lk))
+        {
+            createContractCodeEntry(be.liveEntry());
+        }
+
+        return Loop::INCOMPLETE;
+    };
+
+    snap->scanForEntriesOfType(CONTRACT_DATA, contractDataHandler);
+    snap->scanForEntriesOfType(TTL, ttlHandler);
+    snap->scanForEntriesOfType(CONTRACT_CODE, contractCodeHandler);
+
+    checkUpdateInvariants();
+}
+
+void
+InMemorySorobanState::updateState(std::vector<LedgerEntry> const& initEntries,
+                                  std::vector<LedgerEntry> const& liveEntries,
+                                  std::vector<LedgerKey> const& deadEntries)
+{
+    for (auto const& entry : initEntries)
+    {
+        if (entry.data.type() == CONTRACT_DATA)
+        {
+            createContractDataEntry(entry);
+        }
+        else if (entry.data.type() == CONTRACT_CODE)
+        {
+            createContractCodeEntry(entry);
+        }
+        else if (entry.data.type() == TTL)
+        {
+            createTTL(entry);
+        }
+    }
+
+    for (auto const& entry : liveEntries)
+    {
+        if (entry.data.type() == CONTRACT_DATA)
+        {
+            updateContractData(entry);
+        }
+        else if (entry.data.type() == CONTRACT_CODE)
+        {
+            updateContractCode(entry);
+        }
+        else if (entry.data.type() == TTL)
+        {
+            updateTTL(entry);
+        }
+    }
+
+    for (auto const& key : deadEntries)
+    {
+        if (key.type() == CONTRACT_DATA)
+        {
+            deleteContractData(key);
+        }
+        else if (key.type() == CONTRACT_CODE)
+        {
+            deleteContractCode(key);
+        }
+        // No need to evict TTLs, they are stored with their associated entry
+    }
+
+    checkUpdateInvariants();
+}
+
+void
+InMemorySorobanState::checkUpdateInvariants() const
+{
+    // No TTLs should be orphaned after finishing an update
+    releaseAssertOrThrow(mPendingTTLs.empty());
+}
+}

--- a/src/ledger/InMemorySorobanState.h
+++ b/src/ledger/InMemorySorobanState.h
@@ -279,6 +279,9 @@ class InMemorySorobanState : public NonMovableOrCopyable
     // this should be empty.
     std::unordered_map<uint256, uint32_t> mPendingTTLs;
 
+    // ledgerSeq which the InMemorySorobanState currently "snapshots".
+    uint32_t mLastClosedLedgerSeq = 0;
+
     // Helper to update an existing ContractData entry's TTL without changing
     // data
     void updateContractDataTTL(
@@ -343,9 +346,14 @@ class InMemorySorobanState : public NonMovableOrCopyable
     // Initialize the map from a bucket list snapshot
     void initializeStateFromSnapshot(SearchableSnapshotConstPtr snap);
 
-    // Update the map with entries from a ledger close.
+    // Update the map with entries from a ledger close. ledgerSeq must be
+    // exactly mLastClosedLedgerSeq + 1.
     void updateState(std::vector<LedgerEntry> const& initEntries,
                      std::vector<LedgerEntry> const& liveEntries,
-                     std::vector<LedgerKey> const& deadEntries);
+                     std::vector<LedgerKey> const& deadEntries,
+                     LedgerHeader const& lh);
+
+    // Should only be called in manual ledger close paths.
+    void manuallyAdvanceLedgerHeader(LedgerHeader const& lh);
 };
 }

--- a/src/ledger/InMemorySorobanState.h
+++ b/src/ledger/InMemorySorobanState.h
@@ -1,0 +1,351 @@
+#pragma once
+
+// Copyright 2025 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "bucket/BucketSnapshotManager.h"
+#include "ledger/LedgerHashUtils.h"
+#include "ledger/LedgerTypeUtils.h"
+#include "util/HashOfHash.h"
+#include "util/NonCopyable.h"
+#include "util/types.h"
+#include "xdr/Stellar-ledger-entries.h"
+#include "xdr/Stellar-types.h"
+
+namespace stellar
+{
+
+// ContractDataMapEntryT stores a ContractData LedgerEntry and its TTL. TTL is
+// stored directly with the data to avoid an additional lookup and save memory.
+struct ContractDataMapEntryT
+{
+    std::shared_ptr<LedgerEntry const> const ledgerEntry;
+    uint32_t const liveUntilLedgerSeq;
+
+    explicit ContractDataMapEntryT(
+        std::shared_ptr<LedgerEntry const>&& ledgerEntry,
+        uint32_t liveUntilLedgerSeq)
+        : ledgerEntry(std::move(ledgerEntry))
+        , liveUntilLedgerSeq(liveUntilLedgerSeq)
+    {
+    }
+};
+
+// ContractCodeMapEntryT stores a ContractCode LedgerEntry and its TTL.
+struct ContractCodeMapEntryT
+{
+    std::shared_ptr<LedgerEntry const> ledgerEntry;
+    uint32_t liveUntilLedgerSeq;
+
+    explicit ContractCodeMapEntryT(
+        std::shared_ptr<LedgerEntry const>&& ledgerEntry,
+        uint32_t liveUntilLedgerSeq)
+        : ledgerEntry(std::move(ledgerEntry))
+        , liveUntilLedgerSeq(liveUntilLedgerSeq)
+    {
+    }
+};
+
+// InternalContractDataMapEntry provides a memory-efficient map
+// implementation.
+//
+// Soroban keys can be quite large (often dominating LedgerEntry size), so
+// storing them twice in a traditional key-value map would be wasteful. Instead,
+// we use std::unordered_set since LedgerEntry contains both key and value data.
+//
+// Since C++17's unordered_set doesn't support heterogeneous lookup (searching
+// with a different type than stored), we use polymorphism to enable key-only
+// lookups without constructing full entries. This will be simplified when we
+// upgrade to C++20.
+//
+// We index entries by their TTL key (SHA256 hash of the ContractData key)
+// rather than the full ContractData key. This lets us look up both ContractData
+// entries and their TTLs with one index.
+//
+// Logical map structure:
+//     TTLKey -> <std::shared_ptr<LedgerEntry>, liveUntilLedgerSeq>
+//
+class InternalContractDataMapEntry
+{
+  private:
+    // Abstract base class for polymorphic entry handling.
+    // This allows QueryKey and ValueEntry to be used interchangeably in the
+    // set.
+    struct AbstractEntry
+    {
+        virtual ~AbstractEntry() = default;
+
+        // Returns the TTL key (SHA256 hash) that indexes this entry.
+        // For ContractData entries, this is getTTLKey(ledgerKey).ttl().keyHash
+        // For TTL queries, this is directly the keyHash from the TTL key
+        virtual uint256 copyKey() const = 0;
+
+        // Computes hash for unordered_set storage.
+        // Note: This returns size_t for STL compatibility, not the uint256 key
+        virtual size_t hash() const = 0;
+
+        // Returns the stored data. Only valid for ValueEntry instances.
+        virtual ContractDataMapEntryT const& get() const = 0;
+
+        // Equality comparison based on TTL keys
+        virtual bool
+        operator==(AbstractEntry const& other) const
+        {
+            return copyKey() == other.copyKey();
+        }
+    };
+
+    // ValueEntry stores actual ContractData entries in the map.
+    // Contains both the LedgerEntry and its TTL information.
+    struct ValueEntry : public AbstractEntry
+    {
+      private:
+        ContractDataMapEntryT entry;
+
+      public:
+        ValueEntry(std::shared_ptr<LedgerEntry const>&& ledgerEntry,
+                   uint32_t liveUntilLedgerSeq)
+            : entry(std::move(ledgerEntry), liveUntilLedgerSeq)
+        {
+        }
+
+        uint256
+        copyKey() const override
+        {
+            auto ttlKey = getTTLKey(LedgerEntryKey(*entry.ledgerEntry));
+            return ttlKey.ttl().keyHash;
+        }
+
+        size_t
+        hash() const override
+        {
+            return std::hash<uint256>{}(copyKey());
+        }
+
+        ContractDataMapEntryT const&
+        get() const override
+        {
+            return entry;
+        }
+    };
+
+    // QueryKey is a lightweight key-only entry used for map lookups.
+    struct QueryKey : public AbstractEntry
+    {
+      private:
+        uint256 const ledgerKeyHash;
+
+      public:
+        explicit QueryKey(uint256 const& ledgerKeyHash)
+            : ledgerKeyHash(ledgerKeyHash)
+        {
+        }
+
+        uint256
+        copyKey() const override
+        {
+            return ledgerKeyHash;
+        }
+
+        size_t
+        hash() const override
+        {
+            return std::hash<uint256>{}(ledgerKeyHash);
+        }
+
+        // Should never be called - QueryKey is only for lookups
+        ContractDataMapEntryT const&
+        get() const override
+        {
+            throw std::runtime_error(
+                "QueryKey::get() called - this is a logic error");
+        }
+    };
+
+    std::unique_ptr<AbstractEntry> impl;
+
+  public:
+    // Creates a ValueEntry from a LedgerEntry (copies the entry)
+    InternalContractDataMapEntry(LedgerEntry const& ledgerEntry,
+                                 uint32_t liveUntilLedgerSeq)
+        : impl(std::make_unique<ValueEntry>(
+              std::make_shared<LedgerEntry const>(ledgerEntry),
+              liveUntilLedgerSeq))
+    {
+    }
+
+    // Creates a ValueEntry from a shared_ptr (avoids copying)
+    InternalContractDataMapEntry(
+        std::shared_ptr<LedgerEntry const>&& ledgerEntry,
+        uint32_t liveUntilLedgerSeq)
+        : impl(std::make_unique<ValueEntry>(std::move(ledgerEntry),
+                                            liveUntilLedgerSeq))
+    {
+    }
+
+    // Creates a QueryKey for lookups. Accepts both CONTRACT_DATA and TTL keys.
+    // For CONTRACT_DATA keys, converts to TTL key hash.
+    // For TTL keys, uses the hash directly.
+    explicit InternalContractDataMapEntry(LedgerKey const& ledgerKey)
+    {
+        if (ledgerKey.type() == CONTRACT_DATA)
+        {
+            auto ttlKey = getTTLKey(ledgerKey);
+            impl = std::make_unique<QueryKey>(ttlKey.ttl().keyHash);
+        }
+        else if (ledgerKey.type() == TTL)
+        {
+            impl = std::make_unique<QueryKey>(ledgerKey.ttl().keyHash);
+        }
+        else
+        {
+            throw std::runtime_error(
+                "Invalid ledger key type for contract data map entry");
+        }
+    }
+
+    size_t
+    hash() const
+    {
+        return impl->hash();
+    }
+
+    bool
+    operator==(InternalContractDataMapEntry const& other) const
+    {
+        return impl->operator==(*other.impl);
+    }
+
+    ContractDataMapEntryT const&
+    get() const
+    {
+        return impl->get();
+    }
+};
+
+struct InternalContractDataEntryHash
+{
+    size_t
+    operator()(InternalContractDataMapEntry const& entry) const
+    {
+        return entry.hash();
+    }
+};
+
+// InMemorySorobanState provides an efficient in-memory map for Soroban contract
+// state.
+//
+// This includes contract data entries, contract code entries, and their TTLs.
+//
+// This logically provides two maps:
+//   - ContractData: TTLKey -> (LedgerEntry, liveUntilLedgerSeq)
+//   - ContractCode: TTLKey -> (LedgerEntry, liveUntilLedgerSeq)
+//
+// Implementation notes:
+// - We don't store TTL entries explicitly, liveUntilLedgerSeq is
+//   stored with the ContractData/ContractCode entry
+// - During initialization, TTLs may arrive before their corresponding data
+//   entries, so mPendingTTLs temporarily holds these orphaned TTLs
+//
+// This class is NOT thread-safe and should only be accessed and populated from
+// the apply thread.
+class InMemorySorobanState : public NonMovableOrCopyable
+{
+#ifdef BUILD_TESTS
+  public:
+#endif
+
+    // Primary storage for ContractData entries with embedded TTL information.
+    // Uses unordered_set with custom entries to save memory vs traditional map.
+    std::unordered_set<InternalContractDataMapEntry,
+                       InternalContractDataEntryHash>
+        mContractDataEntries;
+
+    // Storage for ContractCode entries. Maps from TTL key hash to entry, ttl
+    // struct. Unlike ContractData, we use a map here because the key size is
+    // dominated by LedgerEntry size, so there's no real need for extra
+    // complexity.
+    std::unordered_map<uint256, ContractCodeMapEntryT> mContractCodeEntries;
+
+    // Temporary storage for orphaned TTLs that arrive before their
+    // corresponding data entries during initialization. After initialization,
+    // this should be empty.
+    std::unordered_map<uint256, uint32_t> mPendingTTLs;
+
+    // Helper to update an existing ContractData entry's TTL without changing
+    // data
+    void updateContractDataTTL(
+        std::unordered_set<InternalContractDataMapEntry,
+                           InternalContractDataEntryHash>::iterator dataIt,
+        uint32_t newLiveUntilLedgerSeq);
+
+    // Should be called after initialization/updates finish to check consistency
+    // invariants.
+    void checkUpdateInvariants() const;
+
+  public:
+    // Creates new TTL entry. Throws if a non-zero TTL value at the key already
+    // exists. LedgerEntry must be of type TTL.
+    void createTTL(LedgerEntry const& ttlEntry);
+
+    // Creates new ContractData entry. Throws if key already exists.
+    void createContractDataEntry(LedgerEntry const& ledgerEntry);
+
+    // Update the TTL of an existing ContractData or ContractCode entry. Throws
+    // if the key does not exist. LedgerEntry must be of type TTL. We don't know
+    // if a TTL maps to a ContractData or ContractCode entry, so we will check
+    // both mContractDataEntries and mContractCodeEntries.
+    void updateTTL(LedgerEntry const& ttlEntry);
+
+    // Updates an existing ContractData entry. Throws if the key does
+    // not exist. LedgerEntry must be of type CONTRACT_DATA.
+    void updateContractData(LedgerEntry const& ledgerEntry);
+
+    // Note: since we store TTLs with there associated entry, there is no
+    // explicit evictTTL function.
+
+    // Evicts a ContractData entry from the map. LedgerKey must be of type
+    // CONTRACT_DATA.
+    void deleteContractData(LedgerKey const& ledgerKey);
+
+    // Returns nullopt if the entry is not in the map. LedgerKey must be of
+    // type CONTRACT_DATA.
+    std::optional<ContractDataMapEntryT>
+    getContractDataEntry(LedgerKey const& ledgerKey) const;
+
+    // Creates new ContractCode entry. Throws if key already exists.
+    void createContractCodeEntry(LedgerEntry const& ledgerEntry);
+
+    // Updates an existing ContractCode entry. Throws if the key does
+    // not exist. LedgerEntry must be of type CONTRACT_CODE.
+    void updateContractCode(LedgerEntry const& ledgerEntry);
+
+    // Evicts a ContractCode entry from the map. LedgerKey must be of type
+    // CONTRACT_CODE.
+    void deleteContractCode(LedgerKey const& ledgerKey);
+
+    // Returns nullopt if the entry is not in the map. LedgerKey must be of
+    // type CONTRACT_CODE.
+    std::optional<ContractCodeMapEntryT>
+    getContractCodeEntry(LedgerKey const& ledgerKey) const;
+
+    // Returns true if the given TTL entry exists in the map. LedgerKey must
+    // be of type TTL.
+    bool hasTTL(LedgerKey const& ledgerKey) const;
+
+    // Initialize the map from a bucket list snapshot
+    void initializeStateFromSnapshot(SearchableSnapshotConstPtr snap);
+
+    // Update the map with entries from a ledger close.
+    void updateState(std::vector<LedgerEntry> const& initEntries,
+                     std::vector<LedgerEntry> const& liveEntries,
+                     std::vector<LedgerKey> const& deadEntries);
+};
+}

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -18,6 +18,7 @@ namespace stellar
 class LedgerCloseData;
 class Database;
 class SorobanMetrics;
+class InMemorySorobanState;
 
 // This diagram provides a schematic of the flow of (logical) ledgers coming in
 // from the SCP-and-Herder consensus complex, passing through the
@@ -265,6 +266,8 @@ class LedgerManager
     virtual std::optional<LedgerCloseMetaFrame> const&
     getLastClosedLedgerCloseMeta() = 0;
     virtual void storeCurrentLedgerForTest(LedgerHeader const& header) = 0;
+    virtual InMemorySorobanState& getInMemorySorobanStateForTesting() = 0;
+    virtual void rebuildInMemorySorobanStateForTesting() = 0;
 #endif
 
     // Return the (changing) number of seconds since the LCL closed.

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -48,6 +48,7 @@
 #include "util/ProtocolVersion.h"
 #include "util/XDRCereal.h"
 #include "util/XDRStream.h"
+#include "util/types.h"
 #include "work/WorkScheduler.h"
 #include "xdr/Stellar-ledger-entries.h"
 #include "xdrpp/printer.h"
@@ -491,9 +492,10 @@ LedgerManagerImpl::loadLastKnownLedger(bool restoreBucketlist)
     // Prime module cache with LCL state, not apply-state. This is acceptable
     // here because we just started and there is no apply-state yet and no apply
     // thread to hold such state.
-    mApplyState.compileAllContractsInLedger(
-        mLastClosedLedgerState->getBucketSnapshot(),
-        latestLedgerHeader->ledgerVersion);
+    auto const& snapshot = mLastClosedLedgerState->getBucketSnapshot();
+    mApplyState.compileAllContractsInLedger(snapshot,
+                                            latestLedgerHeader->ledgerVersion);
+    mApplyState.populateInMemorySorobanState(snapshot);
 }
 
 Database&
@@ -674,6 +676,21 @@ LedgerManagerImpl::storeCurrentLedgerForTest(LedgerHeader const& header)
 {
     storePersistentStateAndLedgerHeaderInDB(header, true);
 }
+
+InMemorySorobanState&
+LedgerManagerImpl::getInMemorySorobanStateForTesting()
+{
+    releaseAssert(mApplyState.mInMemorySorobanState);
+    return *mApplyState.mInMemorySorobanState;
+}
+
+void
+LedgerManagerImpl::rebuildInMemorySorobanStateForTesting()
+{
+    mApplyState.mInMemorySorobanState.reset();
+    mApplyState.populateInMemorySorobanState(
+        mLastClosedLedgerState->getBucketSnapshot());
+}
 #endif
 
 SorobanMetrics&
@@ -713,6 +730,14 @@ LedgerManagerImpl::ApplyState::compileAllContractsInLedger(
 {
     startCompilingAllContracts(snap, minLedgerVersion);
     finishPendingCompilation();
+}
+
+void
+LedgerManagerImpl::ApplyState::populateInMemorySorobanState(
+    SearchableSnapshotConstPtr snap)
+{
+    mInMemorySorobanState = std::make_unique<InMemorySorobanState>();
+    mInMemorySorobanState->initializeStateFromSnapshot(snap);
 }
 
 void
@@ -1423,8 +1448,9 @@ LedgerManagerImpl::setLastClosedLedger(
     // bucket state, there's no tx-apply state to snapshot, in this one
     // case we will prime the tx-apply-state's soroban module cache using
     // a snapshot _from_ the LCL state.
-    mApplyState.compileAllContractsInLedger(
-        mLastClosedLedgerState->getBucketSnapshot(), lv);
+    auto const& snapshot = mLastClosedLedgerState->getBucketSnapshot();
+    mApplyState.compileAllContractsInLedger(snapshot, lv);
+    mApplyState.populateInMemorySorobanState(snapshot);
 }
 
 void
@@ -2420,6 +2446,13 @@ LedgerManagerImpl::sealLedgerTxnAndTransferEntriesToBucketList(
     mApplyState.addAnyContractsToModuleCache(lh.ledgerVersion, liveEntries);
     mApp.getBucketManager().addLiveBatch(mApp, lh, initEntries, liveEntries,
                                          deadEntries);
+
+    // Update Soroban state cache
+    if (protocolVersionStartsFrom(initialLedgerVers, SOROBAN_PROTOCOL_VERSION))
+    {
+        mApplyState.mInMemorySorobanState->updateState(initEntries, liveEntries,
+                                                       deadEntries);
+    }
 }
 
 CompleteConstLedgerStatePtr

--- a/src/ledger/test/LedgerTestUtils.cpp
+++ b/src/ledger/test/LedgerTestUtils.cpp
@@ -750,45 +750,61 @@ generateUniquePersistentLedgerKeys(size_t n, UnorderedSet<LedgerKey>& seenKeys)
 
 std::vector<LedgerKey>
 generateValidUniqueLedgerEntryKeysWithExclusions(
-    std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n)
+    std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n,
+    UnorderedSet<LedgerKey>& seenKeys)
 {
-    UnorderedSet<LedgerKey> keys;
     std::vector<LedgerKey> res;
-    keys.reserve(n);
     res.reserve(n);
-    while (keys.size() < n)
+    while (seenKeys.size() < n)
     {
         auto entry = generateValidLedgerEntryWithExclusions(excludedTypes, n);
         auto key = LedgerEntryKey(entry);
-        if (keys.find(key) != keys.end())
+        if (seenKeys.find(key) != seenKeys.end())
         {
             continue;
         }
 
-        keys.insert(key);
+        seenKeys.insert(key);
         res.emplace_back(key);
     }
     return res;
+}
+
+std::vector<LedgerKey>
+generateValidUniqueLedgerEntryKeysWithExclusions(
+    std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n)
+{
+    UnorderedSet<LedgerKey> seenKeys;
+    return generateValidUniqueLedgerEntryKeysWithExclusions(excludedTypes, n,
+                                                            seenKeys);
 }
 
 std::vector<LedgerEntry>
 generateValidUniqueLedgerEntriesWithExclusions(
     std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n)
 {
-    UnorderedSet<LedgerKey> keys;
+    UnorderedSet<LedgerKey> seenKeys;
+    return generateValidUniqueLedgerEntriesWithExclusions(excludedTypes, n,
+                                                          seenKeys);
+}
+
+std::vector<LedgerEntry>
+generateValidUniqueLedgerEntriesWithExclusions(
+    std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n,
+    UnorderedSet<LedgerKey>& seenKeys)
+{
     std::vector<LedgerEntry> res;
-    keys.reserve(n);
     res.reserve(n);
-    while (keys.size() < n)
+    while (res.size() < n)
     {
         auto entry = generateValidLedgerEntryWithExclusions(excludedTypes, n);
         auto key = LedgerEntryKey(entry);
-        if (keys.find(key) != keys.end())
+        if (seenKeys.find(key) != seenKeys.end())
         {
             continue;
         }
 
-        keys.insert(key);
+        seenKeys.insert(key);
         res.emplace_back(entry);
     }
     return res;

--- a/src/ledger/test/LedgerTestUtils.h
+++ b/src/ledger/test/LedgerTestUtils.h
@@ -61,9 +61,15 @@ std::vector<LedgerKey> generateUniqueValidSorobanLedgerEntryKeys(size_t n);
 
 std::vector<LedgerKey> generateValidUniqueLedgerEntryKeysWithExclusions(
     std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n);
+std::vector<LedgerKey> generateValidUniqueLedgerEntryKeysWithExclusions(
+    std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n,
+    UnorderedSet<LedgerKey>& seenKeys);
 
 std::vector<LedgerEntry> generateValidUniqueLedgerEntriesWithExclusions(
     std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n);
+std::vector<LedgerEntry> generateValidUniqueLedgerEntriesWithExclusions(
+    std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n,
+    UnorderedSet<LedgerKey>& seenKeys);
 
 LedgerEntry generateValidLedgerEntryWithExclusions(
     std::unordered_set<LedgerEntryType> const& excludedTypes, size_t b = 3);

--- a/src/main/test/QueryServerTests.cpp
+++ b/src/main/test/QueryServerTests.cpp
@@ -103,7 +103,7 @@ TEST_CASE("getledgerentry", "[queryserver]")
             archivedEntryMap[LedgerEntryKey(le)] = le;
         }
 
-        lm.setNextLedgerEntryBatchForBucketTesting({}, liveEntriesToInsert, {});
+        lm.setNextLedgerEntryBatchForBucketTesting(liveEntriesToInsert, {}, {});
         lm.setNextArchiveBatchForBucketTesting(archivedEntries, {});
         closeLedger(*app);
     }
@@ -362,7 +362,7 @@ TEST_CASE("getledgerentry", "[queryserver]")
         entryToArchiveTTL.data.ttl().liveUntilLedgerSeq = oldLedger - 1;
 
         lm.setNextLedgerEntryBatchForBucketTesting(
-            {}, {newEntry, entryToArchiveTTL, entryToRestoreTTL, modifiedEntry},
+            {newEntry}, {entryToArchiveTTL, entryToRestoreTTL, modifiedEntry},
             {LedgerEntryKey(*entryToDelete)});
         closeLedger(*app);
 

--- a/src/simulation/ApplyLoad.cpp
+++ b/src/simulation/ApplyLoad.cpp
@@ -383,6 +383,7 @@ ApplyLoad::setupBucketList()
         ltx.commit();
     }
     mApp.getLedgerManager().storeCurrentLedgerForTest(lh);
+    mApp.getLedgerManager().rebuildInMemorySorobanStateForTesting();
     mApp.getHerder().forceSCPStateIntoSyncWithLastClosedLedger();
     closeLedger({}, {});
 }


### PR DESCRIPTION
# Description

Initializes and maintains a cache will all live soroban state. We do not yet use this cache. A followup PR that uses the cache instead of loading from disk will be opened after we merge https://github.com/stellar/stellar-core/pull/4715.

Rebased on https://github.com/stellar/stellar-core/pull/4750, so I'm opening as a draft for now.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
