### PR TITLE
Fix settings upgrade utils read and write byte limits

### DIFF
--- a/src/main/SettingsUpgradeUtils.cpp
+++ b/src/main/SettingsUpgradeUtils.cpp
@@ -267,8 +267,9 @@ getInvokeTx(PublicKey const& publicKey, LedgerKey const& contractCodeLedgerKey,
                                           contractCodeLedgerKey};
     invokeResources.footprint.readWrite = {upgrade};
     invokeResources.instructions = 2'000'000;
-    invokeResources.diskReadBytes = 5000;
-    invokeResources.writeBytes = 5000;
+    invokeResources.diskReadBytes =
+        rust_bridge::get_write_bytes().data.size() + 100;
+    invokeResources.writeBytes = upgradeSetBytes.size() + 200;
 
     tx.ext.v(1);
     tx.ext.sorobanData().resources = invokeResources;


### PR DESCRIPTION
Using hardcoded values is unnecessary here, and in this case, is higher than the initial limits on a fresh network. I'll also look to see if the tests can be updated to catch this.