### PR TITLE
Fix restore methods in ltx

### DIFF
--- a/src/bucket/test/BucketTestUtils.cpp
+++ b/src/bucket/test/BucketTestUtils.cpp
@@ -244,7 +244,8 @@ LedgerManagerForBucketTests::sealLedgerTxnAndTransferEntriesToBucketList(
                             FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
                 {
                     std::vector<LedgerKey> restoredKeys;
-                    auto restoredKeysMap = ltx.getRestoredHotArchiveKeys();
+                    auto restoredKeysMap =
+                        ltxEvictions.getRestoredHotArchiveKeys();
                     for (auto const& [key, entry] : restoredKeysMap)
                     {
                         // Hot Archive does not track TTLs

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -2059,7 +2059,8 @@ LedgerManagerImpl::sealLedgerTxnAndTransferEntriesToBucketList(
                     LiveBucket::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
             {
                 std::vector<LedgerKey> restoredKeys;
-                auto const& restoredKeyMap = ltx.getRestoredHotArchiveKeys();
+                auto const& restoredKeyMap =
+                    ltxEvictions.getRestoredHotArchiveKeys();
                 for (auto const& [key, entry] : restoredKeyMap)
                 {
                     // TTL keys are not recorded in the hot archive BucketList

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -511,6 +511,13 @@ class AbstractLedgerTxnParent
 
     virtual SessionWrapper& getSession() const = 0;
 
+    // Returns map of TTL and corresponding contract/data keys that have been
+    // restored from the Hot Archive/Live Bucket List.
+    virtual UnorderedMap<LedgerKey, LedgerEntry>
+    getRestoredHotArchiveKeys() const = 0;
+    virtual UnorderedMap<LedgerKey, LedgerEntry>
+    getRestoredLiveBucketListKeys() const = 0;
+
 #ifdef BUILD_TESTS
     virtual void resetForFuzzer() = 0;
 #endif // BUILD_TESTS
@@ -639,12 +646,6 @@ class AbstractLedgerTxn : public AbstractLedgerTxnParent
     virtual void getAllEntries(std::vector<LedgerEntry>& initEntries,
                                std::vector<LedgerEntry>& liveEntries,
                                std::vector<LedgerKey>& deadEntries) = 0;
-    // Returns map of TTL and corresponding contract/data keys that have been
-    // restored from the Hot Archive/Live Bucket List.
-    virtual UnorderedMap<LedgerKey, LedgerEntry> const&
-    getRestoredHotArchiveKeys() const = 0;
-    virtual UnorderedMap<LedgerKey, LedgerEntry> const&
-    getRestoredLiveBucketListKeys() const = 0;
 
     // Returns all TTL keys that have been modified (create, update, and
     // delete), but does not cause the AbstractLedgerTxn or update last
@@ -784,9 +785,9 @@ class LedgerTxn : public AbstractLedgerTxn
                        std::vector<LedgerKey>& deadEntries) override;
     LedgerKeySet getAllTTLKeysWithoutSealing() const override;
 
-    UnorderedMap<LedgerKey, LedgerEntry> const&
+    UnorderedMap<LedgerKey, LedgerEntry>
     getRestoredHotArchiveKeys() const override;
-    UnorderedMap<LedgerKey, LedgerEntry> const&
+    UnorderedMap<LedgerKey, LedgerEntry>
     getRestoredLiveBucketListKeys() const override;
 
     std::shared_ptr<InternalLedgerEntry const>
@@ -911,6 +912,11 @@ class LedgerTxnRoot : public AbstractLedgerTxnParent
 
     std::shared_ptr<InternalLedgerEntry const>
     getNewestVersion(InternalLedgerKey const& key) const override;
+
+    UnorderedMap<LedgerKey, LedgerEntry>
+    getRestoredHotArchiveKeys() const override;
+    UnorderedMap<LedgerKey, LedgerEntry>
+    getRestoredLiveBucketListKeys() const override;
 
     void rollbackChild() noexcept override;
 

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -452,10 +452,8 @@ class LedgerTxn::Impl
                        std::vector<LedgerKey>& deadEntries);
     // getRestoredHotArchiveKeys and getRestoredLiveBucketListKeys
     // have the strong exception safety guarantee
-    UnorderedMap<LedgerKey, LedgerEntry> const&
-    getRestoredHotArchiveKeys() const;
-    UnorderedMap<LedgerKey, LedgerEntry> const&
-    getRestoredLiveBucketListKeys() const;
+    UnorderedMap<LedgerKey, LedgerEntry> getRestoredHotArchiveKeys() const;
+    UnorderedMap<LedgerKey, LedgerEntry> getRestoredLiveBucketListKeys() const;
 
     LedgerKeySet getAllTTLKeysWithoutSealing() const;
 
@@ -800,6 +798,11 @@ class LedgerTxnRoot::Impl
     // - the entry cache may be, but is not guaranteed to be, cleared.
     std::shared_ptr<InternalLedgerEntry const>
     getNewestVersion(InternalLedgerKey const& key) const;
+
+    // getRestoredHotArchiveKeys and getRestoredLiveBucketListKeys
+    // have the strong exception safety guarantee
+    UnorderedMap<LedgerKey, LedgerEntry> getRestoredHotArchiveKeys() const;
+    UnorderedMap<LedgerKey, LedgerEntry> getRestoredLiveBucketListKeys() const;
 
     void rollbackChild() noexcept;
 

--- a/src/ledger/test/InMemoryLedgerTxnRoot.cpp
+++ b/src/ledger/test/InMemoryLedgerTxnRoot.cpp
@@ -97,6 +97,18 @@ InMemoryLedgerTxnRoot::getNewestVersion(InternalLedgerKey const& key) const
     return nullptr;
 }
 
+UnorderedMap<LedgerKey, LedgerEntry>
+InMemoryLedgerTxnRoot::getRestoredHotArchiveKeys() const
+{
+    return {};
+}
+
+UnorderedMap<LedgerKey, LedgerEntry>
+InMemoryLedgerTxnRoot::getRestoredLiveBucketListKeys() const
+{
+    return {};
+}
+
 uint64_t
 InMemoryLedgerTxnRoot::countOffers(LedgerRange const& ledgers) const
 {

--- a/src/ledger/test/InMemoryLedgerTxnRoot.h
+++ b/src/ledger/test/InMemoryLedgerTxnRoot.h
@@ -64,6 +64,11 @@ class InMemoryLedgerTxnRoot : public AbstractLedgerTxnParent
     std::shared_ptr<InternalLedgerEntry const>
     getNewestVersion(InternalLedgerKey const& key) const override;
 
+    UnorderedMap<LedgerKey, LedgerEntry>
+    getRestoredHotArchiveKeys() const override;
+    UnorderedMap<LedgerKey, LedgerEntry>
+    getRestoredLiveBucketListKeys() const override;
+
     uint64_t countOffers(LedgerRange const& ledgers) const override;
 
     void deleteOffersModifiedOnOrAfterLedger(uint32_t ledger) const override;


### PR DESCRIPTION
# Description

1. Add invariants so the `getRestored*` functions cannot be called on a child ltx.
2. Copy the parents' `mRestoredKeys` into the child when the child is created.
3. Stop returning a reference to `mRestoredKeys` for safety. This still isn't ideal. Maybe we should refactor how `LedgerTxn` stores and propagates restored keys.  

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
