### PR TITLE
Clean up eviction scan

### DIFF
--- a/src/bucket/BucketSnapshot.h
+++ b/src/bucket/BucketSnapshot.h
@@ -9,6 +9,7 @@
 #include "bucket/LedgerCmp.h"
 #include "bucket/LiveBucket.h"
 #include "util/NonCopyable.h"
+#include "util/UnorderedSet.h"
 #include "util/XDRStream.h"
 #include "xdr/Stellar-ledger-entries.h"
 #include <list>
@@ -84,9 +85,10 @@ class LiveBucketSnapshot : public BucketSnapshotBase<LiveBucket>
 
     Loop scanForEviction(EvictionIterator& iter, uint32_t& bytesToScan,
                          uint32_t ledgerSeq,
-                         std::list<EvictionResultEntry>& evictableKeys,
+                         std::list<EvictionResultEntry>& evictableEntries,
                          SearchableLiveBucketListSnapshot const& bl,
-                         uint32_t ledgerVers) const;
+                         uint32_t ledgerVers,
+                         UnorderedSet<LedgerKey>& keysInEvictableEntries) const;
 
     // Scans contract code entries in the bucket.
     Loop


### PR DESCRIPTION
# Description

Cleans up eviction scan logic


# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
