### PR TITLE
overlay-only mode for testing

### DIFF
--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -360,7 +360,6 @@ TransactionQueue::canAdd(
         if (!mApp.getRunInOverlayOnlyMode())
 #endif
         {
-            CLOG_INFO(Tx, "Transaction is banned, not adding to queue");
             return AddResult(
                 TransactionQueue::AddResultCode::ADD_STATUS_TRY_AGAIN_LATER);
         }

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -356,8 +356,14 @@ TransactionQueue::canAdd(
     ZoneScoped;
     if (isBanned(tx->getFullHash()))
     {
-        return AddResult(
-            TransactionQueue::AddResultCode::ADD_STATUS_TRY_AGAIN_LATER);
+#ifdef BUILD_TESTS
+        if (!mApp.getRunInOverlayOnlyMode())
+#endif
+        {
+            CLOG_INFO(Tx, "Transaction is banned, not adding to queue");
+            return AddResult(
+                TransactionQueue::AddResultCode::ADD_STATUS_TRY_AGAIN_LATER);
+        }
     }
     if (isFiltered(tx))
     {
@@ -508,7 +514,7 @@ TransactionQueue::canAdd(
     // Loadgen transactions are given unlimited funds, and therefore do no need
     // to be checked for fees
 #ifdef BUILD_TESTS
-    if (!isLoadgenTx)
+    if (!isLoadgenTx && !mApp.getRunInOverlayOnlyMode())
 #endif
     {
         auto const feeSource = ls.getAccount(tx->getFeeSourceID());

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -890,6 +890,11 @@ class LedgerTxn : public AbstractLedgerTxn
     getOrderBook() const;
 
     void resetForFuzzer() override;
+    void
+    deactivateHeaderTestOnly()
+    {
+        deactivateHeader();
+    }
 #endif // BUILD_TESTS
 
 #ifdef BEST_OFFER_DEBUGGING

--- a/src/main/AppConnector.cpp
+++ b/src/main/AppConnector.cpp
@@ -183,4 +183,12 @@ AppConnector::getOverlayThreadSnapshot()
 {
     return mApp.getOverlayManager().getOverlayThreadSnapshot();
 }
+
+#ifdef BUILD_TESTS
+bool
+AppConnector::getRunInOverlayOnlyMode() const
+{
+    return mApp.getRunInOverlayOnlyMode();
+}
+#endif
 }

--- a/src/main/AppConnector.h
+++ b/src/main/AppConnector.h
@@ -75,5 +75,10 @@ class AppConnector
     // Get a snapshot of ledger state for use by the overlay thread only. Must
     // only be called from the overlay thread.
     SearchableSnapshotConstPtr& getOverlayThreadSnapshot();
+
+#ifdef BUILD_TESTS
+    // Access the runtime overlay-only mode flag for testing
+    bool getRunInOverlayOnlyMode() const;
+#endif
 };
 }

--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -296,6 +296,10 @@ class Application
     virtual Config& getMutableConfig() = 0;
 
     virtual std::shared_ptr<TestAccount> getRoot() = 0;
+
+    // Access the runtime overlay-only mode flag for testing
+    virtual bool getRunInOverlayOnlyMode() const = 0;
+    virtual void setRunInOverlayOnlyMode(bool mode) = 0;
 #endif
 
     // Execute any administrative commands written in the Config.COMMANDS

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -106,6 +106,9 @@ ApplicationImpl::ApplicationImpl(VirtualClock& clock, Config const& cfg)
     , mStopSignals(clock.getIOContext(), SIGINT)
     , mStarted(false)
     , mStopping(false)
+#ifdef BUILD_TESTS
+    , mRunInOverlayOnlyMode(false)
+#endif
     , mStoppingTimer(*this)
     , mSelfCheckTimer(*this)
     , mMetrics(
@@ -1138,6 +1141,18 @@ ApplicationImpl::getRoot()
     }
 
     return mRootAccount;
+}
+
+bool
+ApplicationImpl::getRunInOverlayOnlyMode() const
+{
+    return mRunInOverlayOnlyMode;
+}
+
+void
+ApplicationImpl::setRunInOverlayOnlyMode(bool mode)
+{
+    mRunInOverlayOnlyMode = mode;
 }
 #endif
 

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -125,6 +125,9 @@ class ApplicationImpl : public Application
     virtual Config& getMutableConfig() override;
 
     virtual std::shared_ptr<TestAccount> getRoot() override;
+
+    virtual bool getRunInOverlayOnlyMode() const override;
+    virtual void setRunInOverlayOnlyMode(bool mode) override;
 #endif
 
     virtual void applyCfgCommands() override;
@@ -235,6 +238,10 @@ class ApplicationImpl : public Application
     bool mStarted;
     std::atomic<bool> mStopping;
     bool mLedgerCloseThreadStopped{false};
+
+#ifdef BUILD_TESTS
+    bool mRunInOverlayOnlyMode;
+#endif
 
     VirtualTimer mStoppingTimer;
     VirtualTimer mSelfCheckTimer;

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -130,6 +130,7 @@ CommandHandler::CommandHandler(Application& app) : mApp(app)
     addRoute("generateload", &CommandHandler::generateLoad);
     addRoute("testacc", &CommandHandler::testAcc);
     addRoute("testtx", &CommandHandler::testTx);
+    addRoute("toggleoverlayonlymode", &CommandHandler::toggleOverlayOnlyMode);
     addRoute("getsurveyresult", &CommandHandler::getSurveyResult);
     addRoute("startsurveycollecting", &CommandHandler::startSurveyCollecting);
     addRoute("stopsurveycollecting", &CommandHandler::stopSurveyCollecting);
@@ -1434,6 +1435,20 @@ CommandHandler::testTx(std::string const& params, std::string& retStr)
         root["detail"] = "Bad HTTP GET: try something like: "
                          "testtx?from=root&to=bob&amount=1000000000";
     }
+    retStr = root.toStyledString();
+}
+
+void
+CommandHandler::toggleOverlayOnlyMode(std::string const& params,
+                                      std::string& retStr)
+{
+    ZoneScoped;
+
+    bool currentMode = mApp.getRunInOverlayOnlyMode();
+    mApp.setRunInOverlayOnlyMode(!currentMode);
+
+    Json::Value root;
+    root["overlay_only_mode"] = !currentMode;
     retStr = root.toStyledString();
 }
 #endif

--- a/src/main/CommandHandler.h
+++ b/src/main/CommandHandler.h
@@ -81,6 +81,7 @@ class CommandHandler
     void generateLoad(std::string const& params, std::string& retStr);
     void testAcc(std::string const& params, std::string& retStr);
     void testTx(std::string const& params, std::string& retStr);
+    void toggleOverlayOnlyMode(std::string const& params, std::string& retStr);
 #endif
 };
 }

--- a/src/main/test/CommandHandlerTests.cpp
+++ b/src/main/test/CommandHandlerTests.cpp
@@ -545,3 +545,30 @@ TEST_CASE("manualclose", "[commandhandler]")
         }
     }
 }
+
+TEST_CASE("toggleoverlayonlymode", "[commandhandler]")
+{
+    VirtualClock clock;
+    auto app = createTestApplication(clock, getTestConfig());
+    auto& ch = app->getCommandHandler();
+    bool initialMode = app->getRunInOverlayOnlyMode();
+
+    for (int i = 0; i < 5; ++i)
+    {
+        std::string retStr;
+        ch.toggleOverlayOnlyMode("", retStr);
+
+        bool expectedMode = !initialMode;
+        if (i % 2 == 1)
+        {
+            expectedMode = initialMode;
+        }
+
+        REQUIRE(app->getRunInOverlayOnlyMode() == expectedMode);
+
+        Json::Value root;
+        Json::Reader reader;
+        REQUIRE(reader.parse(retStr, root));
+        REQUIRE(root["overlay_only_mode"].asBool() == expectedMode);
+    }
+}

--- a/src/simulation/ApplyLoad.h
+++ b/src/simulation/ApplyLoad.h
@@ -11,10 +11,17 @@
 
 namespace stellar
 {
+
+enum class ApplyLoadMode
+{
+    SOROBAN,
+    CLASSIC
+};
+
 class ApplyLoad
 {
   public:
-    ApplyLoad(Application& app);
+    ApplyLoad(Application& app, ApplyLoadMode mode = ApplyLoadMode::SOROBAN);
 
     // Fills up a list of transactions with
     // SOROBAN_TRANSACTION_QUEUE_SIZE_MULTIPLIER * the max ledger resources
@@ -75,6 +82,8 @@ class ApplyLoad
     medida::Histogram& mWriteByteUtilization;
     medida::Histogram& mReadEntryUtilization;
     medida::Histogram& mWriteEntryUtilization;
+
+    ApplyLoadMode mMode;
 };
 
 }

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -48,7 +48,9 @@ enum class LoadGenMode
     // Blend classic and soroban transactions. Mix of pay, upload, and invoke.
     MIXED_CLASSIC_SOROBAN,
     // Submit pre-generated payment transactions from an XDR file
-    PAY_PREGENERATED
+    PAY_PREGENERATED,
+    // Submit the same type of invoke transaction as ApplyLoad
+    SOROBAN_INVOKE_APPLY_LOAD
 };
 
 struct GeneratedLoadConfig
@@ -264,6 +266,7 @@ class LoadGenerator
     // Set when load generation actually begins
     std::unique_ptr<VirtualClock::time_point> mStartTime;
 
+    uint32_t mTransactionsAppliedAtTheStart = 0;
     // Track account IDs that are currently being referenced by the transaction
     // queue (to avoid source account collisions during tx submission)
     std::unordered_set<uint64_t> mAccountsInUse;
@@ -318,7 +321,6 @@ class LoadGenerator
     bool mInitialAccountsCreated{false};
 
     uint32_t mWaitTillCompleteForLedgers{0};
-    uint32_t mSorobanWasmWaitTillLedgers{0};
 
     // Mode used for last mixed transaction in MIX_CLASSIC_SOROBAN mode
     LoadGenMode mLastMixedMode;

--- a/src/simulation/TxGenerator.cpp
+++ b/src/simulation/TxGenerator.cpp
@@ -162,7 +162,7 @@ TxGenerator::findAccount(uint64_t accountId, uint32_t ledgerNum)
         newAccountPtr =
             std::make_shared<TestAccount>(mApp, txtest::getAccount(name), sn);
 
-        if (!loadAccount(newAccountPtr))
+        if (!mApp.getRunInOverlayOnlyMode() && !loadAccount(newAccountPtr))
         {
             throw std::runtime_error(
                 fmt::format("Account {0} must exist in the DB.", accountId));

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -1664,6 +1664,13 @@ TransactionFrame::checkValid(AppConnector& app, LedgerSnapshot const& ls,
                              uint64_t upperBoundCloseTimeOffset,
                              DiagnosticEventManager& diagnosticEvents) const
 {
+#ifdef BUILD_TESTS
+    if (app.getRunInOverlayOnlyMode())
+    {
+        return MutableTransactionResult::createSuccess(*this, 0);
+    }
+#endif
+
     // Subtle: this check has to happen in `checkValid` and not
     // `checkValidWithOptionallyChargedFee` in order to not validate the
     // envelope XDR twice for the fee bump transactions (they use


### PR DESCRIPTION
A couple of changes to close some gaps in our performance testing setup: 
- Add "classic payment" mode to apply load
- Add "overlay-only" mode to loadgen to allow testing with effectively "instant" execution
- Enable simulated sleep configs for all modes in core (previously it was only used for in-memory mode, which is now deprecated)
- Add a mode in load generator to generate traffic identical to ApplyLoad. Currently, loadgen only supports a mode for invoke load traffic that isn't particularly accurate. In the future we can deprecate the legacy invoke host most completely (I didn't do it in this PR since it'd impact a bunch of tests). The new mode is meant to be used in overlay-only mode, with simulated apply time derived from apply-load results.

All the changes in this PR are test-only, so should be safe to merge and make any potential bugfixes later as we do performance simulations in ssc. 