### PR TITLE
Check for entry in command handler

### DIFF
--- a/src/ledger/LedgerStateSnapshot.cpp
+++ b/src/ledger/LedgerStateSnapshot.cpp
@@ -40,7 +40,11 @@ LedgerEntryWrapper::current() const
     case 1:
         return std::get<1>(mEntry).current();
     case 2:
-        return *std::get<2>(mEntry);
+    {
+        auto res = std::get<2>(mEntry);
+        releaseAssertOrThrow(res);
+        return *res;
+    }
     default:
         throw std::runtime_error("Invalid LedgerEntryWrapper index");
     }

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -872,6 +872,10 @@ CommandHandler::sorobanInfo(std::string const& params, std::string& retStr)
             {
                 auto entry =
                     lsg.load(configSettingKey(static_cast<ConfigSettingID>(c)));
+                if (!entry)
+                {
+                    continue;
+                }
                 entries.emplace_back(entry.current().data.configSetting());
             }
 
@@ -891,6 +895,10 @@ CommandHandler::sorobanInfo(std::string const& params, std::string& retStr)
                     continue;
                 }
                 auto entry = lsg.load(configSettingKey(configSettingID));
+                if (!entry)
+                {
+                    continue;
+                }
                 upgradeSet.updatedEntry.emplace_back(
                     entry.current().data.configSetting());
             }


### PR DESCRIPTION
# Description

The `sorobaninfo` command will fail due to the non-existent v23 settings. This is the only non-test use case where we loop over the config setting enum values.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
