### PR TITLE
Rename RestoredKeys => RestoredEntries

### DIFF
--- a/src/bucket/test/BucketTestUtils.cpp
+++ b/src/bucket/test/BucketTestUtils.cpp
@@ -244,9 +244,9 @@ LedgerManagerForBucketTests::sealLedgerTxnAndTransferEntriesToBucketList(
                             FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
                 {
                     std::vector<LedgerKey> restoredKeys;
-                    auto restoredKeysMap =
+                    auto restoredEntriesMap =
                         ltxEvictions.getRestoredHotArchiveKeys();
-                    for (auto const& [key, entry] : restoredKeysMap)
+                    for (auto const& [key, entry] : restoredEntriesMap)
                     {
                         // Hot Archive does not track TTLs
                         if (key.type() == CONTRACT_DATA ||

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -194,7 +194,7 @@ class LedgerManagerImpl : public LedgerManager
         std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta,
         TransactionResultSet& txResultSet);
 
-    std::pair<RestoredKeys, std::unique_ptr<ThreadEntryMap>> applyThread(
+    std::pair<RestoredEntries, std::unique_ptr<ThreadEntryMap>> applyThread(
         AppConnector& app, std::unique_ptr<ThreadEntryMap> entryMap,
 
         UnorderedMap<LedgerKey, LedgerEntry> previouslyRestoredHotEntries,
@@ -202,7 +202,7 @@ class LedgerManagerImpl : public LedgerManager
         SorobanNetworkConfig const& sorobanConfig,
         ParallelLedgerInfo ledgerInfo, Hash sorobanBasePrngSeed);
 
-    std::pair<std::vector<RestoredKeys>,
+    std::pair<std::vector<RestoredEntries>,
               std::vector<std::unique_ptr<ThreadEntryMap>>>
     applySorobanStageClustersInParallel(
         AppConnector& app, ApplyStage const& stage,
@@ -213,8 +213,8 @@ class LedgerManagerImpl : public LedgerManager
         SorobanNetworkConfig const& sorobanConfig,
         ParallelLedgerInfo const& ledgerInfo);
 
-    void addAllRestoredKeysToLedgerTxn(
-        std::vector<RestoredKeys> const& threadRestoredKeys,
+    void addAllRestoredEntriesToLedgerTxn(
+        std::vector<RestoredEntries> const& threadRestoredEntries,
         AbstractLedgerTxn& ltx);
     void checkAllTxBundleInvariants(AppConnector& app, ApplyStage const& stage,
                                     Config const& config,

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -96,7 +96,7 @@ class LedgerTxn::Impl
     std::shared_ptr<LedgerTxnHeader::Impl> mActiveHeader;
     EntryMap mEntry;
 
-    RestoredKeys mRestoredKeys;
+    RestoredEntries mRestoredEntries;
     UnorderedMap<InternalLedgerKey, std::shared_ptr<EntryImplBase>> mActive;
     bool const mShouldUpdateLastModified;
     bool mIsSealed;
@@ -338,7 +338,7 @@ class LedgerTxn::Impl
 
     void commit() noexcept;
 
-    void commitChild(EntryIterator iter, RestoredKeys const& restoredKeys,
+    void commitChild(EntryIterator iter, RestoredEntries const& restoredEntries,
                      LedgerTxnConsistency cons) noexcept;
 
     // create has the basic exception safety guarantee. If it throws an
@@ -745,7 +745,7 @@ class LedgerTxnRoot::Impl
     // addChild has the strong exception safety guarantee.
     void addChild(AbstractLedgerTxn& child, TransactionMode mode);
 
-    void commitChild(EntryIterator iter, RestoredKeys const& restoredKeys,
+    void commitChild(EntryIterator iter, RestoredEntries const& restoredEntries,
                      LedgerTxnConsistency cons) noexcept;
 
     // countOffers has the strong exception safety guarantee.

--- a/src/ledger/test/InMemoryLedgerTxn.cpp
+++ b/src/ledger/test/InMemoryLedgerTxn.cpp
@@ -188,7 +188,7 @@ InMemoryLedgerTxn::getFilteredEntryIterator(EntryIterator const& iter)
 
 void
 InMemoryLedgerTxn::commitChild(EntryIterator iter,
-                               RestoredKeys const& restoredKeys,
+                               RestoredEntries const& restoredEntries,
                                LedgerTxnConsistency cons) noexcept
 {
     if (!mTransaction)
@@ -200,7 +200,7 @@ InMemoryLedgerTxn::commitChild(EntryIterator iter,
         auto filteredIter = getFilteredEntryIterator(iter);
         updateLedgerKeyMap(filteredIter);
 
-        LedgerTxn::commitChild(filteredIter, restoredKeys, cons);
+        LedgerTxn::commitChild(filteredIter, restoredEntries, cons);
         mTransaction->commit();
         mTransaction.reset();
     }

--- a/src/ledger/test/InMemoryLedgerTxn.h
+++ b/src/ledger/test/InMemoryLedgerTxn.h
@@ -102,7 +102,7 @@ class InMemoryLedgerTxn : public LedgerTxn
     virtual ~InMemoryLedgerTxn();
 
     void addChild(AbstractLedgerTxn& child, TransactionMode mode) override;
-    void commitChild(EntryIterator iter, RestoredKeys const& restoredKeys,
+    void commitChild(EntryIterator iter, RestoredEntries const& restoredEntries,
                      LedgerTxnConsistency cons) noexcept override;
     void rollbackChild() noexcept override;
 

--- a/src/ledger/test/InMemoryLedgerTxnRoot.cpp
+++ b/src/ledger/test/InMemoryLedgerTxnRoot.cpp
@@ -34,7 +34,7 @@ InMemoryLedgerTxnRoot::addChild(AbstractLedgerTxn& child, TransactionMode mode)
 
 void
 InMemoryLedgerTxnRoot::commitChild(EntryIterator iter,
-                                   RestoredKeys const& restoredKeys,
+                                   RestoredEntries const& restoredEntries,
                                    LedgerTxnConsistency cons) noexcept
 {
     printErrorAndAbort("committing to stub InMemoryLedgerTxnRoot");

--- a/src/ledger/test/InMemoryLedgerTxnRoot.h
+++ b/src/ledger/test/InMemoryLedgerTxnRoot.h
@@ -38,7 +38,7 @@ class InMemoryLedgerTxnRoot : public AbstractLedgerTxnParent
 #endif
     );
     void addChild(AbstractLedgerTxn& child, TransactionMode mode) override;
-    void commitChild(EntryIterator iter, RestoredKeys const& restoredKeys,
+    void commitChild(EntryIterator iter, RestoredEntries const& restoredEntries,
                      LedgerTxnConsistency cons) noexcept override;
     void rollbackChild() noexcept override;
 

--- a/src/transactions/RestoreFootprintOpFrame.cpp
+++ b/src/transactions/RestoreFootprintOpFrame.cpp
@@ -82,7 +82,7 @@ RestoreFootprintOpFrame::doParallelApply(
     // Keep track of LedgerEntry updates we need to make
     OpModifiedEntryMap opEntryMap;
 
-    RestoredKeys restoredKeys;
+    RestoredEntries restoredEntries;
 
     auto const& archivalSettings = sorobanConfig.stateArchivalSettings();
     rust::Vec<CxxLedgerEntryRentChange> rustEntryRentChanges;
@@ -209,8 +209,8 @@ RestoreFootprintOpFrame::doParallelApply(
 
             opEntryMap.emplace(ttlKey, ttlEntry);
 
-            restoredKeys.hotArchive.emplace(lk, entry);
-            restoredKeys.hotArchive.emplace(ttlKey, ttlEntry);
+            restoredEntries.hotArchive.emplace(lk, entry);
+            restoredEntries.hotArchive.emplace(ttlKey, ttlEntry);
         }
         else
         {
@@ -221,8 +221,8 @@ RestoreFootprintOpFrame::doParallelApply(
             ttlEntry.data.ttl().liveUntilLedgerSeq = restoredLiveUntilLedger;
             opEntryMap.emplace(ttlKey, ttlEntry);
 
-            restoredKeys.liveBucketList.emplace(lk, entry);
-            restoredKeys.liveBucketList.emplace(ttlKey, ttlEntry);
+            restoredEntries.liveBucketList.emplace(lk, entry);
+            restoredEntries.liveBucketList.emplace(ttlKey, ttlEntry);
         }
     }
     int64_t rentFee = rust_bridge::compute_rent_fee(
@@ -237,7 +237,7 @@ RestoreFootprintOpFrame::doParallelApply(
         return {false, {}};
     }
     innerResult(res).code(RESTORE_FOOTPRINT_SUCCESS);
-    return {true, std::move(opEntryMap), std::move(restoredKeys)};
+    return {true, std::move(opEntryMap), std::move(restoredEntries)};
 }
 
 bool

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -1943,13 +1943,13 @@ TransactionFrame::parallelApply(
 
         if (res.getSuccess())
         {
-            auto hotArchive = res.getRestoredKeys().hotArchive;
+            auto hotArchive = res.getRestoredEntries().hotArchive;
             setDelta(liveSnapshot, entryMap, res.getModifiedEntryMap(),
                      hotArchive, ledgerInfo, effects);
 
             opMeta.setLedgerChangesFromEntryMaps(
                 liveSnapshot, entryMap, res.getModifiedEntryMap(), hotArchive,
-                res.getRestoredKeys().liveBucketList,
+                res.getRestoredEntries().liveBucketList,
                 ledgerInfo.getLedgerSeq());
         }
         else

--- a/src/transactions/TransactionFrameBase.h
+++ b/src/transactions/TransactionFrameBase.h
@@ -77,10 +77,10 @@ class ParallelTxReturnVal
     }
     ParallelTxReturnVal(bool success,
                         OpModifiedEntryMap const&& modifiedEntryMap,
-                        RestoredKeys const&& restoredKeys)
+                        RestoredEntries const&& restoredEntries)
         : mSuccess(success)
         , mModifiedEntryMap(std::move(modifiedEntryMap))
-        , mRestoredKeys(std::move(restoredKeys))
+        , mRestoredEntries(std::move(restoredEntries))
     {
     }
 
@@ -94,17 +94,17 @@ class ParallelTxReturnVal
     {
         return mModifiedEntryMap;
     }
-    RestoredKeys const&
-    getRestoredKeys() const
+    RestoredEntries const&
+    getRestoredEntries() const
     {
-        return mRestoredKeys;
+        return mRestoredEntries;
     }
 
   private:
     bool mSuccess;
     // This will contain a key for every entry modified by a transaction
     OpModifiedEntryMap mModifiedEntryMap;
-    RestoredKeys mRestoredKeys;
+    RestoredEntries mRestoredEntries;
 };
 
 class TransactionFrameBase


### PR DESCRIPTION
This is mostly just a rename of `RestoredKeys` to `RestoredEntries` -- this struct has been full entry maps (which are semantically meaningful!) for quite a while, they just didn't get renamed when they got expanded to this form. The current name is now somewhat misleading when thinking about data consistency scenarios.

There are also a couple small comment additions, one in RestoredEntries and another in InvokeHostFunctionParallelApplyHelper::handleArchivedEntry.