### PR TITLE
Fix prng seed bug

### DIFF
--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -2495,7 +2495,7 @@ LedgerManagerImpl::applyTransactions(
     size_t numTxs = txSet.sizeTxTotal();
     size_t numOps = txSet.sizeOpTotal();
     releaseAssert(numTxs == mutableTxResults.size());
-    int index = 0;
+    uint32_t index = 0;
 
     // Record counts
     if (numTxs > 0)
@@ -2561,7 +2561,7 @@ void
 LedgerManagerImpl::applyParallelPhase(
     TxSetPhaseFrame const& phase, std::vector<stellar::ApplyStage>& applyStages,
     std::vector<stellar::MutableTxResultPtr> const& mutableTxResults,
-    int& index, stellar::AbstractLedgerTxn& ltx, bool enableTxMeta,
+    uint32_t& index, stellar::AbstractLedgerTxn& ltx, bool enableTxMeta,
     Hash const& sorobanBasePrngSeed)
 {
 
@@ -2618,7 +2618,7 @@ LedgerManagerImpl::applyParallelPhase(
 void
 LedgerManagerImpl::applySequentialPhase(
     TxSetPhaseFrame const& phase,
-    std::vector<MutableTxResultPtr> const& mutableTxResults, int& index,
+    std::vector<MutableTxResultPtr> const& mutableTxResults, uint32_t& index,
     AbstractLedgerTxn& ltx, bool enableTxMeta, Hash const& sorobanBasePrngSeed,
     std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta,
     TransactionResultSet& txResultSet)
@@ -2650,7 +2650,11 @@ LedgerManagerImpl::applySequentialPhase(
         {
             SHA256 subSeedSha;
             subSeedSha.add(sorobanBasePrngSeed);
-            subSeedSha.add(xdr::xdr_to_opaque(index));
+            // The index used here was originally a uint64_t, but it was removed
+            // because it was duplicated info. We need to still use a uint64_t
+            // because the type of the integer affects the prng seed, which
+            // is observable in the protocol.
+            subSeedSha.add(xdr::xdr_to_opaque(static_cast<uint64_t>(index)));
             subSeed = subSeedSha.finish();
         }
 

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -177,13 +177,13 @@ class LedgerManagerImpl : public LedgerManager
     applyParallelPhase(TxSetPhaseFrame const& phase,
                        std::vector<ApplyStage>& applyStages,
                        std::vector<MutableTxResultPtr> const& mutableTxResults,
-                       int& index, AbstractLedgerTxn& ltx, bool enableTxMeta,
-                       Hash const& sorobanBasePrngSeed);
+                       uint32_t& index, AbstractLedgerTxn& ltx,
+                       bool enableTxMeta, Hash const& sorobanBasePrngSeed);
 
     void applySequentialPhase(
         TxSetPhaseFrame const& phase,
-        std::vector<MutableTxResultPtr> const& mutableTxResults, int& index,
-        AbstractLedgerTxn& ltx, bool enableTxMeta,
+        std::vector<MutableTxResultPtr> const& mutableTxResults,
+        uint32_t& index, AbstractLedgerTxn& ltx, bool enableTxMeta,
         Hash const& sorobanBasePrngSeed,
         std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta,
         TransactionResultSet& txResultSet);


### PR DESCRIPTION
# Description

Fixes an issue that affects catchup.

Maybe we should add a test that invokes a contract that returns the prng seed for validation? Or just uses the prng seed in it's logic?

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
