### PR TITLE
getledgerentry returns 0 TTL for archived state

### DIFF
--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -672,8 +672,9 @@ Every key queried is guaranteed to have a corresponding `state` field while the 
   - `live`: Entry is live.
   - `not-found`: Entry does not exist. Either the entry has never existed or is an expired temp entry.
   - `archived`: Entry is archived, counts towards disk resources.
-- `liveUntilLedgerSeq`: An optional value, only returned for live Soroban entries. Contains
-  a uint32 value for the entry's `liveUntilLedgerSeq`.
+- `liveUntilLedgerSeq`: An optional value, only returned for Soroban entries. For live
+  Soroban entries, contains the actual TTL value. For archived Soroban entries, contains
+  a placeholder value of 0. Not returned for classic entries.
 - `ledgerSeq`: The ledger number on which the query was performed.
 
 Classic entries will always return a state of `live` or `not-found`.

--- a/src/main/QueryServer.cpp
+++ b/src/main/QueryServer.cpp
@@ -372,6 +372,7 @@ QueryServer::getLedgerEntry(std::string const& params, std::string const& body,
             {
                 entry["entry"] = toOpaqueBase64(le);
                 entry["state"] = "archived";
+                entry["liveUntilLedgerSeq"] = 0;
             }
             // Archived temporary entries are considered "not-found"
             else
@@ -400,6 +401,9 @@ QueryServer::getLedgerEntry(std::string const& params, std::string const& body,
         Json::Value entry;
         entry["entry"] = toOpaqueBase64(le);
         entry["state"] = "archived";
+
+        // Add placeholder TTL value for archived entries
+        entry["liveUntilLedgerSeq"] = 0;
 
         responseEntries[lk] = entry;
     }

--- a/src/main/test/QueryServerTests.cpp
+++ b/src/main/test/QueryServerTests.cpp
@@ -172,15 +172,24 @@ TEST_CASE("getledgerentry", "[queryserver]")
 
                 REQUIRE(entry["state"].asString() == expectedState);
 
-                // Only live soroban entries should have a TTL
-                if (isSorobanEntry(le.data) && expectedState == "live")
+                // All soroban entries should have a TTL
+                if (isSorobanEntry(le.data))
                 {
                     REQUIRE(entry.isMember("liveUntilLedgerSeq"));
-                    REQUIRE(entry["liveUntilLedgerSeq"].asUInt() ==
-                            *expectedTTL);
+                    if (expectedState == "live")
+                    {
+                        REQUIRE(entry["liveUntilLedgerSeq"].asUInt() ==
+                                *expectedTTL);
+                    }
+                    else if (expectedState == "archived")
+                    {
+                        // Archived Soroban entries should have TTL = 0
+                        REQUIRE(entry["liveUntilLedgerSeq"].asUInt() == 0);
+                    }
                 }
                 else
                 {
+                    // Classic entries should not have TTL
                     REQUIRE(!entry.isMember("liveUntilLedgerSeq"));
                 }
 


### PR DESCRIPTION
# Description

Resolves #4766

Archived soroban state now returns a TTL of 0 when queried via `getledgerentry`

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
