### PR TITLE
Thread safety audit

### DIFF
--- a/.github/workflows/clang-19-static-analysis.yml
+++ b/.github/workflows/clang-19-static-analysis.yml
@@ -1,0 +1,103 @@
+name: Clang-19 Static Analysis
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches:
+      - master
+      - prod
+      - testnet
+      - acceptance-test-pass
+
+jobs:
+  clang-19-compile:
+    runs-on: ubuntu-latest
+    env:
+      CACHED_PATHS: |
+        ~/.cargo
+        target
+    strategy:
+      fail-fast: false
+      matrix:
+        protocol: ["current", "next"]
+    steps:
+      - name: Fix kernel mmap rnd bits
+        # Asan in llvm provided in ubuntu 22.04 is incompatible with
+        # high-entropy ASLR in much newer kernels that GitHub runners are
+        # using leading to random crashes: https://reviews.llvm.org/D148280
+        run: sudo sysctl vm.mmap_rnd_bits=28
+
+      - name: Probe Cache
+        id: cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.CACHED_PATHS }}
+          key: ${{ runner.os }}-clang-19-${{ matrix.protocol }}-${{ github.sha }}
+          lookup-only: true
+
+      - name: Restore Cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.CACHED_PATHS }}
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+          restore-keys: |
+            ${{ runner.os }}-clang-19-${{ matrix.protocol }}
+
+      - uses: actions/checkout@v4
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          fetch-depth: 200
+          submodules: true
+
+      - name: install core packages
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install --no-install-recommends apt-utils dialog git iproute2 procps lsb-release
+
+      - name: install clang-19
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install clang-19 llvm-19
+
+      - name: install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get -y install libc++-19-dev libc++abi-19-dev
+          sudo apt-get -y install postgresql git build-essential pkg-config autoconf automake libtool bison flex libpq-dev parallel sed perl ccache
+
+      - name: install rustup components
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: rustup component add rustfmt
+
+      - name: install cargo-cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: cargo install --locked cargo-cache --version 0.8.3
+
+      - name: install cargo-sweep
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: cargo install --locked cargo-sweep --version 0.7.0
+
+      - name: Build with ci-build.sh
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          # Set compiler environment variables for ci-build.sh
+          export CC='clang'
+          export CXX='clang++'
+          export CLANG_VERSION='19'
+
+          # Skip clang-format check since we don't have clang-format-12
+          export SKIP_FORMAT_CHECK=1
+
+          # Run ci-build.sh with tests disabled and protocol specified
+          ./ci-build.sh --disable-tests --protocol ${{ matrix.protocol }}
+
+      - uses: actions/cache/save@v4
+        if: ${{ steps.cache.outputs.cache-hit != 'true' && github.ref_name == 'master' }}
+        with:
+          path: ${{ env.CACHED_PATHS }}
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+

--- a/src/bucket/BucketSnapshotManager.cpp
+++ b/src/bucket/BucketSnapshotManager.cpp
@@ -147,12 +147,12 @@ BucketSnapshotManager::maybeCopyLiveAndHotArchiveSnapshots(
     SharedLockShared guard(mSnapshotMutex);
     if (needsUpdate(liveSnapshot, mCurrLiveSnapshot))
     {
-        liveSnapshot = copySearchableLiveBucketListSnapshot();
+        liveSnapshot = copySearchableLiveBucketListSnapshot(guard);
     }
 
     if (needsUpdate(hotArchiveSnapshot, mCurrHotArchiveSnapshot))
     {
-        hotArchiveSnapshot = copySearchableHotArchiveBucketListSnapshot();
+        hotArchiveSnapshot = copySearchableHotArchiveBucketListSnapshot(guard);
     }
 }
 

--- a/src/overlay/FlowControl.h
+++ b/src/overlay/FlowControl.h
@@ -133,13 +133,13 @@ class FlowControl
 
 #ifdef BUILD_TESTS
     FlowControlCapacity&
-    getCapacity()
+    getCapacity() NO_THREAD_SAFETY_ANALYSIS
     {
         return mFlowControlCapacity;
     }
 
     FlowControlCapacity&
-    getCapacityBytes()
+    getCapacityBytes() NO_THREAD_SAFETY_ANALYSIS
     {
         return mFlowControlBytesCapacity;
     }
@@ -152,7 +152,7 @@ class FlowControl
     }
 
     FloodQueues<QueuedOutboundMessage>&
-    getQueuesForTesting()
+    getQueuesForTesting() NO_THREAD_SAFETY_ANALYSIS
     {
         return mOutboundQueues;
     }


### PR DESCRIPTION
# Description

Resolves #4774

This fixes a few errors from clang's static thread safety analyzer. We have this enabled in CI, but it looks like clang-12 is pretty outdated and doesn't catch several classes of errors that are covered in newer versions. To help strengthen our CI, I've added a new job that just compiles core with clang-19 with static analysis enabled. We should investigate updating our clang version, but that's a much larger lift. In the meantime this should give us better coverage for static thread analysis.

I'm not an expert at CI scripts, so I've opened #4793 with just the CI change. It should fail and isn't mergable on it's own, but I want to make sure the new job actually catches the compiler errors from clang-19 that are fixed by this PR.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
