### PR TITLE
Event fix

### DIFF
--- a/src/invariant/EventsAreConsistentWithEntryDiffs.cpp
+++ b/src/invariant/EventsAreConsistentWithEntryDiffs.cpp
@@ -440,6 +440,11 @@ aggregateEventDiffs(Hash const& networkID,
 
             auto amount = getAmountFromData(event.body.v0().data);
 
+            if (rust_bridge::i128_is_negative(amount))
+            {
+                return std::nullopt;
+            }
+
             // If the events are sane, we should never overflow.
             if (!res.subtractAssetBalance(fromVal.address(), asset, amount))
             {
@@ -461,6 +466,12 @@ aggregateEventDiffs(Hash const& networkID,
             auto const& toVal = topics.at(1);
 
             auto amount = getAmountFromData(event.body.v0().data);
+
+            if (rust_bridge::i128_is_negative(amount))
+            {
+                return std::nullopt;
+            }
+
             if (!res.addAssetBalance(toVal.address(), asset, amount))
             {
                 return std::nullopt;
@@ -477,6 +488,12 @@ aggregateEventDiffs(Hash const& networkID,
             auto const& fromVal = topics.at(1);
 
             auto amount = getAmountFromData(event.body.v0().data);
+
+            if (rust_bridge::i128_is_negative(amount))
+            {
+                return std::nullopt;
+            }
+
             if (!res.subtractAssetBalance(fromVal.address(), asset, amount))
             {
                 return std::nullopt;

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -2247,17 +2247,6 @@ LedgerManagerImpl::checkAllTxBundleInvariants(
             }
         }
 
-        // We only increase the internal-error metric count if the
-        // ledger is a newer version.
-        if (txBundle.getResPayload().getResultCode() == txINTERNAL_ERROR &&
-            ledgerInfo.getLedgerVersion() >=
-                config.LEDGER_PROTOCOL_MIN_VERSION_INTERNAL_ERROR_REPORT)
-        {
-            auto& internalErrorCounter = app.getMetrics().NewCounter(
-                {"ledger", "transaction", "internal-error"});
-            internalErrorCounter.inc();
-        }
-
         // We don't call processPostApply for post v23 transactions at the
         // moment because processPostApply is currently a no-op for those
         // transactions.

--- a/src/rust/src/bridge.rs
+++ b/src/rust/src/bridge.rs
@@ -269,6 +269,8 @@ pub(crate) mod rust_bridge {
 
         fn i128_from_i64(val: i64) -> Result<CxxI128>;
 
+        fn i128_is_negative(val: &CxxI128) -> Result<bool>;
+
         type SorobanModuleCache;
 
         fn new_module_cache() -> Result<Box<SorobanModuleCache>>;

--- a/src/rust/src/i128.rs
+++ b/src/rust/src/i128.rs
@@ -59,3 +59,9 @@ pub(crate) fn i128_from_i64(val: i64) -> Result<CxxI128, Box<dyn std::error::Err
         lo: i128_lo(res),
     })
 }
+
+pub(crate) fn i128_is_negative(val: &CxxI128) -> Result<bool, Box<dyn std::error::Error>> {
+    use xdr::int128_helpers::i128_from_pieces;
+    let res: i128 = i128_from_pieces(val.hi, val.lo);
+    Ok(res.is_negative())
+}

--- a/src/transactions/LumenEventReconciler.cpp
+++ b/src/transactions/LumenEventReconciler.cpp
@@ -64,24 +64,17 @@ reconcileEvents(AccountID const& txSourceAccount, Operation const& operation,
                         : txSourceAccount;
 
     Asset native(ASSET_TYPE_NATIVE);
-    if (operation.body.type() == ACCOUNT_MERGE ||
-        operation.body.type() == PAYMENT)
-    {
 
+    if (deltaBalances > 0)
+    {
         opEventManager.newMintEvent(native, makeAccountAddress(opSource),
                                     deltaBalances, false,
                                     true /*Insert mint at the beginning*/);
     }
-    else if (operation.body.type() == PATH_PAYMENT_STRICT_RECEIVE)
+    else
     {
         opEventManager.newBurnEvent(native, makeAccountAddress(opSource),
                                     std::abs(deltaBalances));
-    }
-    else
-    {
-        CLOG_ERROR(
-            Tx, "LumenEventReconciler: Unknown mint or burn. OperationType={}",
-            operation.body.type());
     }
 }
 }

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -1912,6 +1912,8 @@ TransactionFrame::parallelApply(
         return {false, {}};
     }
 
+    auto& internalErrorCounter = app.getMetrics().NewCounter(
+        {"ledger", "transaction", "internal-error"});
     bool reportInternalErrOnException = true;
     try
     {
@@ -1990,6 +1992,13 @@ TransactionFrame::parallelApply(
 
     // This is only reachable if an exception is thrown
     txResult.setInnermostError(txINTERNAL_ERROR);
+
+    // We only increase the internal-error metric count if the
+    // ledger is a newer version.
+    if (reportInternalErrOnException)
+    {
+        internalErrorCounter.inc();
+    }
     return {false, {}};
 }
 


### PR DESCRIPTION
# Description

1. Handles negative amounts in events, and fixes the `LumenEventReconciler` logic to handle the pre-protocol 8 bug more generally.
2. Moves the internal error logic back to parallel apply. It was moved out before I knew metrics were thread safe. 

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
