### PR TITLE
Remove MODE_ENABLES_BUCKETLIST configuration option

### DIFF
--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -400,13 +400,9 @@ HistoryManagerImpl::queueCurrentHistory(uint32_t ledger, uint32_t ledgerVers)
 {
     ZoneScoped;
 
-    LiveBucketList bl;
-    if (mApp.getConfig().MODE_ENABLES_BUCKETLIST)
-    {
-        // Only one thread can modify the bucketlist, access BL from the _same_
-        // thread
-        bl = mApp.getBucketManager().getLiveBucketList();
-    }
+    // Only one thread can modify the bucketlist, access BL from the _same_
+    // thread
+    LiveBucketList bl = mApp.getBucketManager().getLiveBucketList();
 
     HistoryArchiveState has;
     if (protocolVersionStartsFrom(

--- a/src/ledger/NetworkConfig.cpp
+++ b/src/ledger/NetworkConfig.cpp
@@ -957,11 +957,8 @@ initialliveSorobanStateSizeWindow(Application& app)
     ConfigSettingEntry entry(CONFIG_SETTING_LIVE_SOROBAN_STATE_SIZE_WINDOW);
 
     // Populate 30 day sliding window of BucketList size snapshots with 30
-    // copies of the current BL size. If the bucketlist is disabled for
-    // testing, just fill with ones to avoid triggering asserts.
-    auto blSize = app.getConfig().MODE_ENABLES_BUCKETLIST
-                      ? app.getBucketManager().getLiveBucketList().getSize()
-                      : 1;
+    // copies of the current BL size.
+    auto blSize = app.getBucketManager().getLiveBucketList().getSize();
     for (uint64_t i = 0;
          i < InitialSorobanNetworkConfig::BUCKET_LIST_SIZE_WINDOW_SAMPLE_SIZE;
          ++i)
@@ -1873,8 +1870,7 @@ SorobanNetworkConfig::maybeSnapshotBucketListSize(uint32_t currLedger,
 
     auto ledgerVersion = ltx.loadHeader().current().ledgerVersion;
     // // Check if BucketList size window should exist
-    if (protocolVersionIsBefore(ledgerVersion, SOROBAN_PROTOCOL_VERSION) ||
-        !app.getConfig().MODE_ENABLES_BUCKETLIST)
+    if (protocolVersionIsBefore(ledgerVersion, SOROBAN_PROTOCOL_VERSION))
     {
         return;
     }

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -1531,7 +1531,6 @@ run(CommandLineArgs const& args)
                 {
                     cfg.DATABASE = SecretValue{"sqlite3://:memory:"};
                     cfg.MODE_STORES_HISTORY_MISC = false;
-                    cfg.MODE_ENABLES_BUCKETLIST = false;
                     cfg.PREFETCH_BATCH_SIZE = 0;
                 }
 

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -124,7 +124,6 @@ Config::Config() : NODE_SEED(SecretKey::random())
     // fill in defaults
 
     // non configurable
-    MODE_ENABLES_BUCKETLIST = true;
     MODE_STORES_HISTORY_MISC = true;
     MODE_DOES_CATCHUP = true;
     MODE_AUTO_STARTS_OVERLAY = true;
@@ -2409,7 +2408,7 @@ Config::getExpectedLedgerCloseTime() const
 bool
 Config::modeDoesCatchupWithBucketList() const
 {
-    return MODE_DOES_CATCHUP && MODE_ENABLES_BUCKETLIST;
+    return MODE_DOES_CATCHUP;
 }
 
 bool

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -465,10 +465,6 @@ class Config : public std::enable_shared_from_this<Config>
     // builds)
     uint32_t SOROBAN_TRANSACTION_QUEUE_SIZE_MULTIPLIER;
 
-    // A config parameter that allows a node to generate buckets. This should
-    // be set to `false` only for testing purposes.
-    bool MODE_ENABLES_BUCKETLIST;
-
     // A config parameter that can be set to true (in a captive-core
     // configuration) to delay emitting metadata by one ledger.
     bool EXPERIMENTAL_PRECAUTION_DELAY_META;


### PR DESCRIPTION
This removes the MODE_ENABLES_BUCKETLIST config flag that was previously used to conditionally enable/disable bucket list functionality. The bucket list is now always enabled as it's a core component of Stellar Core.

Changes:
- Remove MODE_ENABLES_BUCKETLIST declaration from Config.h
- Remove initialization and usage from Config.cpp
- Update BucketManager to always create bucket lists without conditional checks
- Update LedgerManagerImpl to always use bucket lists
- Update NetworkConfig to always get bucket list size
- Update HistoryManagerImpl to always get bucket list
- Remove the flag from CommandLine minimal mode configuration

🤖 Generated with [Claude Code](https://claude.ai/code)