### PR TITLE
Allow fee bump transactions to bump inner transactions with 'invalid' inner fee in p23.

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -597,6 +597,7 @@ exit /b 0
     <ClCompile Include="..\..\src\invariant\test\SponsorshipCountIsValidTests.cpp" />
     <ClCompile Include="..\..\src\ledger\CheckpointRange.cpp" />
     <ClCompile Include="..\..\src\ledger\FlushAndRotateMetaDebugWork.cpp" />
+    <ClCompile Include="..\..\src\ledger\InMemorySorobanState.cpp" />
     <ClCompile Include="..\..\src\ledger\InternalLedgerEntry.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerCloseMetaFrame.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerHeaderUtils.cpp" />
@@ -1052,6 +1053,7 @@ exit /b 0
     <ClInclude Include="..\..\src\invariant\test\InvariantTestUtils.h" />
     <ClInclude Include="..\..\src\ledger\CheckpointRange.h" />
     <ClInclude Include="..\..\src\ledger\FlushAndRotateMetaDebugWork.h" />
+    <ClInclude Include="..\..\src\ledger\InMemorySorobanState.h" />
     <ClInclude Include="..\..\src\ledger\InternalLedgerEntry.h" />
     <ClInclude Include="..\..\src\ledger\LedgerCloseMetaFrame.h" />
     <ClInclude Include="..\..\src\ledger\LedgerHashUtils.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1411,6 +1411,7 @@
     <ClCompile Include="..\..\src\transactions\ParallelApplyUtils.cpp">
       <Filter>transactions</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ledger\InMemorySorobanState.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\util\cpptoml.h">
@@ -2502,6 +2503,7 @@
     <ClInclude Include="..\..\src\transactions\ParallelApplyUtils.h">
       <Filter>transactions</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\ledger\InMemorySorobanState.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\AUTHORS" />

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -989,7 +989,7 @@ TEST_CASE("SCP timing config affects consensus behavior", "[upgrades][herder]")
 
         // Upgrade SCP timing parameters
         upgradeSorobanNetworkConfig(
-            [](SorobanNetworkConfig& cfg) {
+            [&](SorobanNetworkConfig& cfg) {
                 cfg.mNominationTimeoutInitialMilliseconds =
                     nominationTimeoutInitialMilliseconds;
                 cfg.mNominationTimeoutIncrementMilliseconds =

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -644,7 +644,7 @@ HistoryManager::deletePublishedFiles(uint32_t ledgerSeq, Config const& cfg)
                           fs::exists(res.localPath_nogz_dirty()) ||
                           fs::exists(txs.localPath_nogz_dirty()) ||
                           fs::exists(headers.localPath_nogz_dirty()) ||
-                          fs::exists(snapshotFile);
+                          fs::exists(snapshotFile.string());
 
         if (!filesExist)
         {
@@ -661,7 +661,7 @@ HistoryManager::deletePublishedFiles(uint32_t ledgerSeq, Config const& cfg)
         fs::removeWithLog(res.localPath_nogz());
         fs::removeWithLog(txs.localPath_nogz());
         fs::removeWithLog(headers.localPath_nogz());
-        fs::removeWithLog(snapshotFile);
+        fs::removeWithLog(snapshotFile.string());
 
         if (currentCheckpoint < checkpointFreq)
         {

--- a/src/test/TxTests.h
+++ b/src/test/TxTests.h
@@ -294,6 +294,8 @@ ChangeTrustAsset makeChangeTrustAssetPoolShare(Asset const& assetA,
 OperationResult const& getFirstResult(TransactionTestFramePtr tx);
 OperationResultCode getFirstResultCode(TransactionTestFramePtr tx);
 
+void sign(Hash const& networkID, SecretKey key, TransactionV1Envelope& env);
+
 // methods to check results based off meta data
 void checkTx(int index, TransactionResultSet& r,
              TransactionResultCode expected);

--- a/src/transactions/TransactionMeta.cpp
+++ b/src/transactions/TransactionMeta.cpp
@@ -795,6 +795,12 @@ TransactionMetaFrame::getReturnValue() const
     }
 }
 
+bool
+TransactionMetaFrame::eventsAreSupported() const
+{
+    return mTransactionMeta.v() >= 4;
+}
+
 xdr::xvector<DiagnosticEvent> const&
 TransactionMetaFrame::getDiagnosticEvents() const
 {

--- a/src/transactions/TransactionMeta.h
+++ b/src/transactions/TransactionMeta.h
@@ -83,6 +83,7 @@ class TransactionMetaFrame
     LedgerEntryChanges getChangesBefore() const;
     LedgerEntryChanges getChangesAfter() const;
     SCVal const& getReturnValue() const;
+    bool eventsAreSupported() const;
     xdr::xvector<TransactionEvent> const& getTxEvents() const;
     xdr::xvector<DiagnosticEvent> const& getDiagnosticEvents() const;
     xdr::xvector<ContractEvent> const& getOpEventsAtOp(size_t opIdx) const;

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -2169,10 +2169,6 @@ checkVNext(uint32_t currProtocol, Config const& cfg,
            TransactionEnvelope const& envelope)
 {
     uint32_t maxProtocol = cfg.CURRENT_LEDGER_PROTOCOL_VERSION;
-    // If we could parse the XDR when ledger is using the maximum supported
-    // protocol version, then XDR has to be valid.
-    // This check also is pointless before protocol 21 as Soroban environment
-    // doesn't support XDR versions before 21.
     if (!xdr::check_xdr_depth(envelope, 500))
     {
         return false;

--- a/src/transactions/test/FeeBumpTransactionTests.cpp
+++ b/src/transactions/test/FeeBumpTransactionTests.cpp
@@ -18,13 +18,6 @@ using namespace stellar;
 using namespace stellar::txtest;
 
 static void
-sign(Hash const& networkID, SecretKey key, TransactionV1Envelope& env)
-{
-    env.signatures.emplace_back(SignatureUtils::sign(
-        key, sha256(xdr::xdr_to_opaque(networkID, ENVELOPE_TYPE_TX, env.tx))));
-}
-
-static void
 sign(Hash const& networkID, SecretKey key, FeeBumpTransactionEnvelope& env)
 {
     env.signatures.emplace_back(SignatureUtils::sign(

--- a/src/transactions/test/SorobanTxTestUtils.h
+++ b/src/transactions/test/SorobanTxTestUtils.h
@@ -65,7 +65,8 @@ void validateFeeEvent(TransactionEvent const& feeEvent,
 TransactionFrameBaseConstPtr
 makeSorobanWasmUploadTx(Application& app, TestAccount& source,
                         RustBuf const& wasm, SorobanResources& uploadResources,
-                        uint32_t inclusionFee);
+                        uint32_t inclusionFee,
+                        int64_t additionalRefundableFee = 0);
 
 struct ConstructorParams
 {
@@ -330,10 +331,8 @@ class SorobanTest
     bool isTxValid(TransactionFrameBaseConstPtr tx);
 
     TransactionResult invokeTx(TransactionFrameBaseConstPtr tx);
-    std::pair<TransactionResult, TransactionMetaFrame>
-    invokeTxAndGetTxMeta(TransactionFrameBaseConstPtr tx);
-    std::pair<TransactionResult, LedgerCloseMetaFrame>
-    invokeTxAndGetLCM(TransactionFrameBaseConstPtr tx);
+    TransactionMetaFrame const& getLastTxMeta(size_t index = 0) const;
+    LedgerCloseMetaFrame getLastLcm() const;
 
     uint32_t getTTL(LedgerKey const& k);
     bool isEntryLive(LedgerKey const& k, uint32_t ledgerSeq);
@@ -351,9 +350,8 @@ class SorobanTest
 
     void checkRefundableFee(int64_t initialBalance,
                             TransactionFrameBaseConstPtr tx,
-                            LedgerCloseMetaFrame const& lcm,
                             int64_t expectedRefundableFeeCharged,
-                            size_t eventsSize = 0);
+                            size_t eventsSize = 0, bool success = true);
 
     // Defaults to root account
     int64_t getAccountBalance(TestAccount* source = nullptr);

--- a/src/transactions/test/TxEnvelopeTests.cpp
+++ b/src/transactions/test/TxEnvelopeTests.cpp
@@ -2494,7 +2494,7 @@ TEST_CASE("soroban txs not allowed before protocol upgrade",
                                        SorobanResources(), 1000, 1'000'000);
     LedgerTxn ltx(app->getLedgerTxnRoot());
     REQUIRE(!tx->checkValidForTesting(app->getAppConnector(), ltx, 0, 0, 0));
-    REQUIRE(tx->getResult().result.code() == txMALFORMED);
+    REQUIRE(tx->getResultCode() == txMALFORMED);
 }
 
 TEST_CASE("XDR protocol 22 compatibility validation", "[tx][envelope]")
@@ -2642,7 +2642,7 @@ TEST_CASE_VERSIONS("Soroban extension for non-Soroban tx",
         {
             REQUIRE(!tx->checkValidForTesting(app->getAppConnector(), ltx, 0, 0,
                                               0));
-            REQUIRE(tx->getResult().result.code() == txMALFORMED);
+            REQUIRE(tx->getResultCode() == txMALFORMED);
         }
         else
         {
@@ -2652,358 +2652,427 @@ TEST_CASE_VERSIONS("Soroban extension for non-Soroban tx",
     });
 }
 
-TEST_CASE("soroban transaction validation", "[tx][envelope][soroban]")
+TEST_CASE_VERSIONS("soroban transaction validation", "[tx][envelope][soroban]")
 {
     VirtualClock clock;
     auto app = createTestApplication(clock, getTestConfig());
-    auto root = app->getRoot();
-    Operation op0;
-    op0.body.type(INVOKE_HOST_FUNCTION);
-    auto& ihf0 = op0.body.invokeHostFunctionOp().hostFunction;
-    ihf0.type(HOST_FUNCTION_TYPE_CREATE_CONTRACT);
+    for_versions_from(
+        static_cast<uint32>(SOROBAN_PROTOCOL_VERSION), *app, [&]() {
+            auto root = app->getRoot();
+            Operation op0;
+            op0.body.type(INVOKE_HOST_FUNCTION);
+            auto& ihf0 = op0.body.invokeHostFunctionOp().hostFunction;
+            ihf0.type(HOST_FUNCTION_TYPE_CREATE_CONTRACT);
+            auto ledgerVersion = app->getLedgerManager()
+                                     .getLastClosedLedgerHeader()
+                                     .header.ledgerVersion;
 
-    auto validateResources = [&](SorobanResources const& resources,
-                                 bool valid) {
-        auto tx = sorobanTransactionFrameFromOps(
-            app->getNetworkID(), *root, {op0}, {}, resources, 100, 3'500'000);
-        LedgerTxn ltx(app->getLedgerTxnRoot());
-        REQUIRE(tx->checkValidForTesting(app->getAppConnector(), ltx, 0, 0,
-                                         0) == valid);
-        if (!valid)
-        {
-            REQUIRE(tx->getResult().result.code() == txSOROBAN_INVALID);
-        }
-    };
+            auto validateResources = [&](SorobanResources const& resources,
+                                         bool valid) {
+                auto tx = sorobanTransactionFrameFromOps(
+                    app->getNetworkID(), *root, {op0}, {}, resources, 100,
+                    3'500'000);
+                LedgerTxn ltx(app->getLedgerTxnRoot());
+                REQUIRE(tx->checkValidForTesting(app->getAppConnector(), ltx, 0,
+                                                 0, 0) == valid);
+                if (!valid)
+                {
+                    REQUIRE(tx->getResultCode() == txSOROBAN_INVALID);
+                }
+            };
 
-    SECTION("no soroban extension")
-    {
-        auto tx =
-            transactionFrameFromOps(app->getNetworkID(), *root, {op0}, {});
-        LedgerTxn ltx(app->getLedgerTxnRoot());
-        REQUIRE(
-            !tx->checkValidForTesting(app->getAppConnector(), ltx, 0, 0, 0));
-        REQUIRE(tx->getResult().result.code() == txMALFORMED);
-    }
-    SorobanResources resources;
-    SECTION("minimal resources are valid")
-    {
-        validateResources(resources, true);
-    }
-    resources.instructions = InitialSorobanNetworkConfig::TX_MAX_INSTRUCTIONS;
-    resources.diskReadBytes = InitialSorobanNetworkConfig::TX_MAX_READ_BYTES;
-    resources.writeBytes = InitialSorobanNetworkConfig::TX_MAX_WRITE_BYTES;
+            SECTION("no soroban extension")
+            {
+                auto tx = transactionFrameFromOps(app->getNetworkID(), *root,
+                                                  {op0}, {});
+                LedgerTxn ltx(app->getLedgerTxnRoot());
+                REQUIRE(!tx->checkValidForTesting(app->getAppConnector(), ltx,
+                                                  0, 0, 0));
+                REQUIRE(tx->getResultCode() == txMALFORMED);
+            }
+            SorobanResources resources;
+            SECTION("minimal resources are valid")
+            {
+                validateResources(resources, true);
+            }
+            resources.instructions =
+                InitialSorobanNetworkConfig::TX_MAX_INSTRUCTIONS;
+            resources.diskReadBytes =
+                InitialSorobanNetworkConfig::TX_MAX_READ_BYTES;
+            resources.writeBytes =
+                InitialSorobanNetworkConfig::TX_MAX_WRITE_BYTES;
 
-    auto keys = LedgerTestUtils::generateUniqueValidSorobanLedgerEntryKeys(
-        InitialSorobanNetworkConfig::TX_MAX_READ_LEDGER_ENTRIES);
+            for (int i = 0;
+                 i < InitialSorobanNetworkConfig::TX_MAX_READ_LEDGER_ENTRIES;
+                 ++i)
+            {
+                LedgerKey key(LedgerEntryType::CONTRACT_DATA);
+                key.contractData().key.type(SCValType::SCV_I32);
+                key.contractData().key.i32() = i;
+                if (i <
+                    InitialSorobanNetworkConfig::TX_MAX_WRITE_LEDGER_ENTRIES)
+                {
 
-    resources.footprint.readWrite.assign(
-        keys.begin(),
-        keys.begin() +
-            InitialSorobanNetworkConfig::TX_MAX_WRITE_LEDGER_ENTRIES);
-    resources.footprint.readOnly.assign(
-        keys.begin() + InitialSorobanNetworkConfig::TX_MAX_WRITE_LEDGER_ENTRIES,
-        keys.end());
-    SECTION("instructions exceeded")
-    {
-        resources.instructions += 1;
-        validateResources(resources, false);
-    }
-    SECTION("read bytes exceeded")
-    {
-        resources.diskReadBytes += 1;
-        validateResources(resources, false);
-    }
-    SECTION("write bytes exceeded")
-    {
-        resources.writeBytes += 1;
-        validateResources(resources, false);
-    }
-    SECTION("max read entries exceeded")
-    {
-        resources.footprint.readOnly.emplace_back();
-        validateResources(resources, false);
-    }
-    SECTION("max write entries exceeded")
-    {
-        // Make sure that read entries limit is not exceeded.
-        resources.footprint.readOnly.pop_back();
-        resources.footprint.readWrite.emplace_back();
-        validateResources(resources, false);
-    }
-    SECTION("maximal resources are valid")
-    {
-        validateResources(resources, true);
-    }
-    SECTION("transaction size")
-    {
-        Operation op;
-        op.body.type(INVOKE_HOST_FUNCTION);
-        auto& ihf = op.body.invokeHostFunctionOp().hostFunction;
-        ihf.type(HOST_FUNCTION_TYPE_INVOKE_CONTRACT);
-        SCVal largeVal(SCV_BYTES);
-        largeVal.bytes().resize(InitialSorobanNetworkConfig::TX_MAX_SIZE_BYTES -
-                                3000);
-        ihf.invokeContract().args.push_back(largeVal);
-        SECTION("near limit")
-        {
-            auto tx =
-                sorobanTransactionFrameFromOps(app->getNetworkID(), *root, {op},
-                                               {}, resources, 100, 4'000'000);
-            LedgerTxn ltx(app->getLedgerTxnRoot());
-            REQUIRE(
-                tx->checkValidForTesting(app->getAppConnector(), ltx, 0, 0, 0));
-        }
-        SECTION("limit exceeded")
-        {
-            ihf.invokeContract().args.back().bytes().resize(
-                InitialSorobanNetworkConfig::TX_MAX_SIZE_BYTES);
-            auto tx =
-                sorobanTransactionFrameFromOps(app->getNetworkID(), *root, {op},
-                                               {}, resources, 100, 4'000'000);
-            LedgerTxn ltx(app->getLedgerTxnRoot());
-            REQUIRE(!tx->checkValidForTesting(app->getAppConnector(), ltx, 0, 0,
-                                              0));
-            REQUIRE(tx->getResult().result.code() == txSOROBAN_INVALID);
-        }
-    }
-    SECTION("fees")
-    {
-        SECTION("resource fee exceeds tx fee")
-        {
-            auto tx = sorobanTransactionFrameFromOpsWithTotalFee(
-                app->getNetworkID(), *root, {op0}, {}, resources, 1'000,
-                100'000);
-            LedgerTxn ltx(app->getLedgerTxnRoot());
-            REQUIRE(!tx->checkValidForTesting(app->getAppConnector(), ltx, 0, 0,
-                                              0));
-            REQUIRE(tx->getResult().result.code() == txSOROBAN_INVALID);
-        }
-        SECTION("inclusion fee is too low")
-        {
-            auto tx = sorobanTransactionFrameFromOpsWithTotalFee(
-                app->getNetworkID(), *root, {op0}, {}, resources, 1'000'099,
-                1'000'000);
-            LedgerTxn ltx(app->getLedgerTxnRoot());
-            REQUIRE(!tx->checkValidForTesting(app->getAppConnector(), ltx, 0, 0,
-                                              0));
-            REQUIRE(tx->getResult().result.code() == txINSUFFICIENT_FEE);
-        }
-        SECTION("required resource fee is lower than declared")
-        {
-            auto tx = sorobanTransactionFrameFromOpsWithTotalFee(
-                app->getNetworkID(), *root, {op0}, {}, resources, 1'000'000,
-                10);
-            LedgerTxn ltx(app->getLedgerTxnRoot());
-            REQUIRE(!tx->checkValidForTesting(app->getAppConnector(), ltx, 0, 0,
-                                              0));
-            REQUIRE(tx->getResult().result.code() == txSOROBAN_INVALID);
-        }
-        SECTION("resource fee is negative")
-        {
-            auto tx = sorobanTransactionFrameFromOpsWithTotalFee(
-                app->getNetworkID(), *root, {op0}, {}, resources, 1'000'000,
-                std::numeric_limits<int64_t>::min());
-            LedgerTxn ltx(app->getLedgerTxnRoot());
-            REQUIRE(!tx->checkValidForTesting(app->getAppConnector(), ltx, 0, 0,
-                                              0));
-            // Negative resource fee is handled before we get to
-            // Soroban-specific checks.
-            REQUIRE(tx->getResult().result.code() == txMALFORMED);
-        }
-        SECTION("resource fee exceeds uint32")
-        {
-            auto tx = sorobanTransactionFrameFromOpsWithTotalFee(
-                app->getNetworkID(), *root, {op0}, {}, resources,
-                std::numeric_limits<uint32_t>::max(),
-                static_cast<int64_t>(std::numeric_limits<uint32_t>::max()) + 1);
-            LedgerTxn ltx(app->getLedgerTxnRoot());
-            REQUIRE(!tx->checkValidForTesting(app->getAppConnector(), ltx, 0, 0,
-                                              0));
-            REQUIRE(tx->getResult().result.code() == txSOROBAN_INVALID);
-        }
-        SECTION("resource fee is max int64")
-        {
-            auto tx = sorobanTransactionFrameFromOpsWithTotalFee(
-                app->getNetworkID(), *root, {op0}, {}, resources,
-                std::numeric_limits<uint32_t>::max(),
-                std::numeric_limits<int64_t>::max());
-            LedgerTxn ltx(app->getLedgerTxnRoot());
-            REQUIRE(!tx->checkValidForTesting(app->getAppConnector(), ltx, 0, 0,
-                                              0));
-            REQUIRE(tx->getResult().result.code() == txMALFORMED);
-        }
-        SECTION("total fee is exactly uint32 max")
-        {
-            auto tx = sorobanTransactionFrameFromOpsWithTotalFee(
-                app->getNetworkID(), *root, {op0}, {}, resources,
-                std::numeric_limits<uint32_t>::max(),
-                static_cast<int64_t>(std::numeric_limits<uint32_t>::max()) -
-                    100);
-            LedgerTxn ltx(app->getLedgerTxnRoot());
-            REQUIRE(
-                tx->checkValidForTesting(app->getAppConnector(), ltx, 0, 0, 0));
-        }
-        SECTION("total fee exceeds uint32 after adding base fee")
-        {
-            auto tx = sorobanTransactionFrameFromOpsWithTotalFee(
-                app->getNetworkID(), *root, {op0}, {}, resources,
-                std::numeric_limits<uint32_t>::max(),
-                static_cast<int64_t>(std::numeric_limits<uint32_t>::max()) -
-                    100 + 1);
-            LedgerTxn ltx(app->getLedgerTxnRoot());
-            REQUIRE(!tx->checkValidForTesting(app->getAppConnector(), ltx, 0, 0,
-                                              0));
-            // This gets rejected due to insufficient inclusion fee, so
-            // we have the respective error code (even though the fee is
-            // insufficient due to Soroban resource fee).
-            REQUIRE(tx->getResult().result.code() == txINSUFFICIENT_FEE);
-        }
-        SECTION("resource fee exceeds uint32 with fee bump")
-        {
-            int64_t const resourceFee = 10'000'000'000LL;
-            auto innerTx = sorobanTransactionFrameFromOpsWithTotalFee(
-                app->getNetworkID(), *root, {op0}, {}, resources,
-                std::numeric_limits<uint32_t>::max(), resourceFee);
-            auto tx = feeBump(*app, *root, innerTx, resourceFee + 200,
-                              /* useInclusionAsFullFee */ true);
-            LedgerTxn ltx(app->getLedgerTxnRoot());
-            // This could work in theory (because the fee bump has enough
-            // fee to cover the inner tx), it can't work because we still
-            // consider the inner tx invalid due to negative inclusion fee.
-            REQUIRE(!tx->checkValidForTesting(app->getAppConnector(), ltx, 0, 0,
-                                              0));
-            REQUIRE(tx->getResult().result.code() == txFEE_BUMP_INNER_FAILED);
-        }
-        SECTION("resource fee is negative with fee bump")
-        {
-            auto innerTx = sorobanTransactionFrameFromOpsWithTotalFee(
-                app->getNetworkID(), *root, {op0}, {}, resources,
-                std::numeric_limits<uint32_t>::max(), -1);
-            auto tx = feeBump(*app, *root, innerTx,
-                              std::numeric_limits<int64_t>::max(),
-                              /* useInclusionAsFullFee */ true);
-            LedgerTxn ltx(app->getLedgerTxnRoot());
-            REQUIRE(!tx->checkValidForTesting(app->getAppConnector(), ltx, 0, 0,
-                                              0));
-            REQUIRE(tx->getResult().result.code() == txMALFORMED);
-        }
-        SECTION("resource fee is max int64 with fee bump")
-        {
-            auto innerTx = sorobanTransactionFrameFromOpsWithTotalFee(
-                app->getNetworkID(), *root, {op0}, {}, resources,
-                std::numeric_limits<uint32_t>::max(),
-                std::numeric_limits<int64_t>::max());
-            auto tx = feeBump(*app, *root, innerTx,
-                              std::numeric_limits<int64_t>::max(),
-                              /* useInclusionAsFullFee */ true);
-            LedgerTxn ltx(app->getLedgerTxnRoot());
-            REQUIRE(!tx->checkValidForTesting(app->getAppConnector(), ltx, 0, 0,
-                                              0));
-            REQUIRE(tx->getResult().result.code() == txMALFORMED);
-        }
-    }
+                    resources.footprint.readWrite.push_back(key);
+                }
+                else
+                {
+                    resources.footprint.readOnly.push_back(key);
+                }
+            }
 
-    SECTION("multiple ops are not allowed")
-    {
-        auto tx = sorobanTransactionFrameFromOps(app->getNetworkID(), *root,
-                                                 {op0, op0}, {}, resources, 100,
-                                                 100'000);
-        LedgerTxn ltx(app->getLedgerTxnRoot());
-        REQUIRE(
-            !tx->checkValidForTesting(app->getAppConnector(), ltx, 0, 0, 0));
-        REQUIRE(tx->getResult().result.code() == txMALFORMED);
-    }
-    SECTION("contract size")
-    {
-        Operation op;
-        op.body.type(INVOKE_HOST_FUNCTION);
-        auto& ihf = op.body.invokeHostFunctionOp().hostFunction;
-        ihf.type(HOST_FUNCTION_TYPE_UPLOAD_CONTRACT_WASM);
-        ihf.wasm().resize(InitialSorobanNetworkConfig::MAX_CONTRACT_SIZE);
-        SECTION("at limit")
-        {
-            auto tx =
-                sorobanTransactionFrameFromOps(app->getNetworkID(), *root, {op},
-                                               {}, resources, 100, 3'500'000);
-            LedgerTxn ltx(app->getLedgerTxnRoot());
-            REQUIRE(
-                tx->checkValidForTesting(app->getAppConnector(), ltx, 0, 0, 0));
-        }
-        SECTION("over limit")
-        {
-            ihf.wasm().resize(InitialSorobanNetworkConfig::MAX_CONTRACT_SIZE +
-                              1);
-            auto tx =
-                sorobanTransactionFrameFromOps(app->getNetworkID(), *root, {op},
-                                               {}, resources, 100, 3'500'000);
-            LedgerTxn ltx(app->getLedgerTxnRoot());
-            REQUIRE(!tx->checkValidForTesting(app->getAppConnector(), ltx, 0, 0,
-                                              0));
-        }
-    }
+            SECTION("instructions exceeded")
+            {
+                resources.instructions += 1;
+                validateResources(resources, false);
+            }
+            SECTION("read bytes exceeded")
+            {
+                resources.diskReadBytes += 1;
+                validateResources(resources, false);
+            }
+            SECTION("write bytes exceeded")
+            {
+                resources.writeBytes += 1;
+                validateResources(resources, false);
+            }
+            SECTION("max read entries exceeded")
+            {
+                resources.footprint.readOnly.emplace_back();
+                validateResources(resources, false);
+            }
+            SECTION("max write entries exceeded")
+            {
+                // Make sure that read entries limit is not exceeded.
+                resources.footprint.readOnly.pop_back();
+                resources.footprint.readWrite.emplace_back();
+                validateResources(resources, false);
+            }
+            SECTION("maximal resources are valid")
+            {
+                validateResources(resources, true);
+            }
+            SECTION("transaction size")
+            {
+                Operation op;
+                op.body.type(INVOKE_HOST_FUNCTION);
+                auto& ihf = op.body.invokeHostFunctionOp().hostFunction;
+                ihf.type(HOST_FUNCTION_TYPE_INVOKE_CONTRACT);
+                SCVal largeVal(SCV_BYTES);
+                largeVal.bytes().resize(
+                    InitialSorobanNetworkConfig::TX_MAX_SIZE_BYTES - 3000);
+                ihf.invokeContract().args.push_back(largeVal);
+                SECTION("near limit")
+                {
+                    auto tx = sorobanTransactionFrameFromOps(
+                        app->getNetworkID(), *root, {op}, {}, resources, 100,
+                        4'000'000);
+                    LedgerTxn ltx(app->getLedgerTxnRoot());
+                    REQUIRE(tx->checkValidForTesting(app->getAppConnector(),
+                                                     ltx, 0, 0, 0));
+                }
+                SECTION("limit exceeded")
+                {
+                    ihf.invokeContract().args.back().bytes().resize(
+                        InitialSorobanNetworkConfig::TX_MAX_SIZE_BYTES);
+                    auto tx = sorobanTransactionFrameFromOps(
+                        app->getNetworkID(), *root, {op}, {}, resources, 100,
+                        4'000'000);
+                    LedgerTxn ltx(app->getLedgerTxnRoot());
+                    REQUIRE(!tx->checkValidForTesting(app->getAppConnector(),
+                                                      ltx, 0, 0, 0));
+                    REQUIRE(tx->getResultCode() == txSOROBAN_INVALID);
+                }
+            }
+            SECTION("fees")
+            {
+                SECTION("resource fee exceeds tx fee")
+                {
+                    auto tx = sorobanTransactionFrameFromOpsWithTotalFee(
+                        app->getNetworkID(), *root, {op0}, {}, resources, 1'000,
+                        100'000);
+                    LedgerTxn ltx(app->getLedgerTxnRoot());
+                    REQUIRE(!tx->checkValidForTesting(app->getAppConnector(),
+                                                      ltx, 0, 0, 0));
+                    REQUIRE(tx->getResultCode() == txSOROBAN_INVALID);
+                }
+                SECTION("inclusion fee is too low")
+                {
+                    auto tx = sorobanTransactionFrameFromOpsWithTotalFee(
+                        app->getNetworkID(), *root, {op0}, {}, resources,
+                        1'000'099, 1'000'000);
+                    LedgerTxn ltx(app->getLedgerTxnRoot());
+                    REQUIRE(!tx->checkValidForTesting(app->getAppConnector(),
+                                                      ltx, 0, 0, 0));
+                    REQUIRE(tx->getResultCode() == txINSUFFICIENT_FEE);
+                }
+                SECTION("required resource fee is lower than declared")
+                {
+                    auto tx = sorobanTransactionFrameFromOpsWithTotalFee(
+                        app->getNetworkID(), *root, {op0}, {}, resources,
+                        1'000'000, 10);
+                    LedgerTxn ltx(app->getLedgerTxnRoot());
+                    REQUIRE(!tx->checkValidForTesting(app->getAppConnector(),
+                                                      ltx, 0, 0, 0));
+                    REQUIRE(tx->getResultCode() == txSOROBAN_INVALID);
+                }
+                SECTION("resource fee is negative")
+                {
+                    auto tx = sorobanTransactionFrameFromOpsWithTotalFee(
+                        app->getNetworkID(), *root, {op0}, {}, resources,
+                        1'000'000, std::numeric_limits<int64_t>::min());
+                    LedgerTxn ltx(app->getLedgerTxnRoot());
+                    REQUIRE(!tx->checkValidForTesting(app->getAppConnector(),
+                                                      ltx, 0, 0, 0));
+                    // Negative resource fee is handled before we get to
+                    // Soroban-specific checks.
+                    REQUIRE(tx->getResultCode() == txMALFORMED);
+                }
+                SECTION("resource fee exceeds uint32")
+                {
+                    auto tx = sorobanTransactionFrameFromOpsWithTotalFee(
+                        app->getNetworkID(), *root, {op0}, {}, resources,
+                        std::numeric_limits<uint32_t>::max(),
+                        static_cast<int64_t>(
+                            std::numeric_limits<uint32_t>::max()) +
+                            1);
+                    LedgerTxn ltx(app->getLedgerTxnRoot());
+                    REQUIRE(!tx->checkValidForTesting(app->getAppConnector(),
+                                                      ltx, 0, 0, 0));
+                    REQUIRE(tx->getResultCode() == txSOROBAN_INVALID);
+                }
+                SECTION("resource fee is max int64")
+                {
+                    auto tx = sorobanTransactionFrameFromOpsWithTotalFee(
+                        app->getNetworkID(), *root, {op0}, {}, resources,
+                        std::numeric_limits<uint32_t>::max(),
+                        std::numeric_limits<int64_t>::max());
+                    LedgerTxn ltx(app->getLedgerTxnRoot());
+                    REQUIRE(!tx->checkValidForTesting(app->getAppConnector(),
+                                                      ltx, 0, 0, 0));
+                    REQUIRE(tx->getResultCode() == txMALFORMED);
+                }
+                SECTION("total fee is exactly uint32 max")
+                {
+                    auto tx = sorobanTransactionFrameFromOpsWithTotalFee(
+                        app->getNetworkID(), *root, {op0}, {}, resources,
+                        std::numeric_limits<uint32_t>::max(),
+                        static_cast<int64_t>(
+                            std::numeric_limits<uint32_t>::max()) -
+                            100);
+                    LedgerTxn ltx(app->getLedgerTxnRoot());
+                    REQUIRE(tx->checkValidForTesting(app->getAppConnector(),
+                                                     ltx, 0, 0, 0));
+                }
+                SECTION("total fee exceeds uint32 after adding base fee")
+                {
+                    auto tx = sorobanTransactionFrameFromOpsWithTotalFee(
+                        app->getNetworkID(), *root, {op0}, {}, resources,
+                        std::numeric_limits<uint32_t>::max(),
+                        static_cast<int64_t>(
+                            std::numeric_limits<uint32_t>::max()) -
+                            100 + 1);
+                    LedgerTxn ltx(app->getLedgerTxnRoot());
+                    REQUIRE(!tx->checkValidForTesting(app->getAppConnector(),
+                                                      ltx, 0, 0, 0));
+                    // This gets rejected due to insufficient inclusion fee, so
+                    // we have the respective error code (even though the fee is
+                    // insufficient due to Soroban resource fee).
+                    REQUIRE(tx->getResultCode() == txINSUFFICIENT_FEE);
+                }
+                SECTION("fee bump with 0 inner inclusion fee")
+                {
+                    uint32_t const resourceFee = 1'000'000;
+                    auto innerTx = sorobanTransactionFrameFromOpsWithTotalFee(
+                        app->getNetworkID(), *root, {op0}, {}, resources,
+                        resourceFee, resourceFee);
+                    auto tx =
+                        feeBump(*app, *root, innerTx, 2 * 100 + resourceFee,
+                                /* useInclusionAsFullFee */ true);
+                    LedgerTxn ltx(app->getLedgerTxnRoot());
+                    REQUIRE(tx->checkValidForTesting(app->getAppConnector(),
+                                                     ltx, 0, 0, 0));
+                }
+                SECTION("resource fee exceeds uint32 with fee bump")
+                {
+                    int64_t const resourceFee = 10'000'000'000LL;
+                    auto innerTx = sorobanTransactionFrameFromOpsWithTotalFee(
+                        app->getNetworkID(), *root, {op0}, {}, resources,
+                        std::numeric_limits<uint32_t>::max(), resourceFee);
+                    auto tx = feeBump(*app, *root, innerTx, resourceFee + 200,
+                                      /* useInclusionAsFullFee */ true);
+                    LedgerTxn ltx(app->getLedgerTxnRoot());
+                    // This is allowed from protocol 23 - fee bump is sufficient
+                    // to cover the inner resource fee.
+                    if (protocolVersionStartsFrom(ledgerVersion,
+                                                  ProtocolVersion::V_23))
+                    {
+                        REQUIRE(tx->checkValidForTesting(app->getAppConnector(),
+                                                         ltx, 0, 0, 0));
+                    }
+                    else
+                    {
+                        REQUIRE(!tx->checkValidForTesting(
+                            app->getAppConnector(), ltx, 0, 0, 0));
+                        REQUIRE(tx->getResultCode() == txFEE_BUMP_INNER_FAILED);
+                    }
+                }
+                SECTION(
+                    "resource fee exceeds uint32 and is not fully covered by "
+                    "fee bump")
+                {
+                    int64_t const resourceFee = 10'000'000'000LL;
+                    auto innerTx = sorobanTransactionFrameFromOpsWithTotalFee(
+                        app->getNetworkID(), *root, {op0}, {}, resources,
+                        std::numeric_limits<uint32_t>::max(), resourceFee);
+                    auto tx =
+                        feeBump(*app, *root, innerTx, resourceFee + 200 - 1,
+                                /* useInclusionAsFullFee */ true);
+                    LedgerTxn ltx(app->getLedgerTxnRoot());
+                    REQUIRE(!tx->checkValidForTesting(app->getAppConnector(),
+                                                      ltx, 0, 0, 0));
+                    REQUIRE(tx->getResultCode() == txINSUFFICIENT_FEE);
+                }
+                SECTION("resource fee is negative with fee bump")
+                {
+                    auto innerTx = sorobanTransactionFrameFromOpsWithTotalFee(
+                        app->getNetworkID(), *root, {op0}, {}, resources,
+                        std::numeric_limits<uint32_t>::max(), -1);
+                    auto tx = feeBump(*app, *root, innerTx,
+                                      std::numeric_limits<int64_t>::max(),
+                                      /* useInclusionAsFullFee */ true);
+                    LedgerTxn ltx(app->getLedgerTxnRoot());
+                    REQUIRE(!tx->checkValidForTesting(app->getAppConnector(),
+                                                      ltx, 0, 0, 0));
+                    REQUIRE(tx->getResultCode() == txMALFORMED);
+                }
+                SECTION("resource fee is max int64 with fee bump")
+                {
+                    auto innerTx = sorobanTransactionFrameFromOpsWithTotalFee(
+                        app->getNetworkID(), *root, {op0}, {}, resources,
+                        std::numeric_limits<uint32_t>::max(),
+                        std::numeric_limits<int64_t>::max());
+                    auto tx = feeBump(*app, *root, innerTx,
+                                      std::numeric_limits<int64_t>::max(),
+                                      /* useInclusionAsFullFee */ true);
+                    LedgerTxn ltx(app->getLedgerTxnRoot());
+                    REQUIRE(!tx->checkValidForTesting(app->getAppConnector(),
+                                                      ltx, 0, 0, 0));
+                    REQUIRE(tx->getResultCode() == txMALFORMED);
+                }
+            }
 
-    auto makeBytes = [](size_t size) -> SCVal {
-        SCVal val(SCV_BYTES);
-        val.bytes().resize(size);
-        std::fill(val.bytes().begin(), val.bytes().end(), 1);
-        return val;
-    };
+            SECTION("multiple ops are not allowed")
+            {
+                auto tx = sorobanTransactionFrameFromOps(
+                    app->getNetworkID(), *root, {op0, op0}, {}, resources, 100,
+                    100'000);
+                LedgerTxn ltx(app->getLedgerTxnRoot());
+                REQUIRE(!tx->checkValidForTesting(app->getAppConnector(), ltx,
+                                                  0, 0, 0));
+                REQUIRE(tx->getResultCode() == txMALFORMED);
+            }
+            SECTION("contract size")
+            {
+                Operation op;
+                op.body.type(INVOKE_HOST_FUNCTION);
+                auto& ihf = op.body.invokeHostFunctionOp().hostFunction;
+                ihf.type(HOST_FUNCTION_TYPE_UPLOAD_CONTRACT_WASM);
+                ihf.wasm().resize(
+                    InitialSorobanNetworkConfig::MAX_CONTRACT_SIZE);
+                SECTION("at limit")
+                {
+                    auto tx = sorobanTransactionFrameFromOps(
+                        app->getNetworkID(), *root, {op}, {}, resources, 100,
+                        3'500'000);
+                    LedgerTxn ltx(app->getLedgerTxnRoot());
+                    REQUIRE(tx->checkValidForTesting(app->getAppConnector(),
+                                                     ltx, 0, 0, 0));
+                }
+                SECTION("over limit")
+                {
+                    ihf.wasm().resize(
+                        InitialSorobanNetworkConfig::MAX_CONTRACT_SIZE + 1);
+                    auto tx = sorobanTransactionFrameFromOps(
+                        app->getNetworkID(), *root, {op}, {}, resources, 100,
+                        3'500'000);
+                    LedgerTxn ltx(app->getLedgerTxnRoot());
+                    REQUIRE(!tx->checkValidForTesting(app->getAppConnector(),
+                                                      ltx, 0, 0, 0));
+                }
+            }
 
-    SECTION("footprint limit")
-    {
-        Operation op;
-        op.body.type(INVOKE_HOST_FUNCTION);
-        auto& ihf = op.body.invokeHostFunctionOp().hostFunction;
-        ihf.type(HOST_FUNCTION_TYPE_INVOKE_CONTRACT);
-        SECTION("success with default limits")
-        {
-            // Allow overhead for contractID in key
-            auto bytes = makeBytes(
-                InitialSorobanNetworkConfig::MAX_CONTRACT_DATA_KEY_SIZE_BYTES -
-                100);
-            resources.footprint.readOnly.back() = contractDataKey(
-                SCAddress{}, bytes, ContractDataDurability::PERSISTENT);
-            auto tx =
-                sorobanTransactionFrameFromOps(app->getNetworkID(), *root, {op},
-                                               {}, resources, 100, 3'500'000);
-            LedgerTxn ltx(app->getLedgerTxnRoot());
-            REQUIRE(
-                tx->checkValidForTesting(app->getAppConnector(), ltx, 0, 0, 0));
-        }
+            auto makeBytes = [](size_t size) -> SCVal {
+                SCVal val(SCV_BYTES);
+                val.bytes().resize(size);
+                std::fill(val.bytes().begin(), val.bytes().end(), 1);
+                return val;
+            };
 
-        auto keyBytes = makeBytes(
-            InitialSorobanNetworkConfig::MAX_CONTRACT_DATA_KEY_SIZE_BYTES + 1);
-        SECTION("read-only key over size limit")
-        {
-            resources.footprint.readOnly.resize(1);
-            resources.footprint.readOnly.back() = contractDataKey(
-                SCAddress{}, keyBytes, ContractDataDurability::PERSISTENT);
-            modifySorobanNetworkConfig(*app, [](SorobanNetworkConfig& cfg) {
-                cfg.mMaxContractDataKeySizeBytes = MinimumSorobanNetworkConfig::
-                    MAX_CONTRACT_DATA_KEY_SIZE_BYTES;
-            });
-            auto tx =
-                sorobanTransactionFrameFromOps(app->getNetworkID(), *root, {op},
-                                               {}, resources, 100, 3'500'000);
-            LedgerTxn ltx(app->getLedgerTxnRoot());
-            REQUIRE(!tx->checkValidForTesting(app->getAppConnector(), ltx, 0, 0,
-                                              0));
-        }
-        SECTION("read-write key over size limit")
-        {
-            resources.footprint.readWrite.resize(1);
-            resources.footprint.readWrite.back() = contractDataKey(
-                SCAddress{}, keyBytes, ContractDataDurability::PERSISTENT);
-            modifySorobanNetworkConfig(*app, [](SorobanNetworkConfig& cfg) {
-                cfg.mMaxContractDataKeySizeBytes = MinimumSorobanNetworkConfig::
-                    MAX_CONTRACT_DATA_KEY_SIZE_BYTES;
-            });
-            auto tx =
-                sorobanTransactionFrameFromOps(app->getNetworkID(), *root, {op},
-                                               {}, resources, 100, 3'500'000);
-            LedgerTxn ltx(app->getLedgerTxnRoot());
-            REQUIRE(!tx->checkValidForTesting(app->getAppConnector(), ltx, 0, 0,
-                                              0));
-        }
-    }
+            SECTION("footprint limit")
+            {
+                Operation op;
+                op.body.type(INVOKE_HOST_FUNCTION);
+                auto& ihf = op.body.invokeHostFunctionOp().hostFunction;
+                ihf.type(HOST_FUNCTION_TYPE_INVOKE_CONTRACT);
+                SECTION("success with default limits")
+                {
+                    // Allow overhead for contractID in key
+                    auto bytes =
+                        makeBytes(InitialSorobanNetworkConfig::
+                                      MAX_CONTRACT_DATA_KEY_SIZE_BYTES -
+                                  100);
+                    resources.footprint.readOnly.back() = contractDataKey(
+                        SCAddress{}, bytes, ContractDataDurability::PERSISTENT);
+                    auto tx = sorobanTransactionFrameFromOps(
+                        app->getNetworkID(), *root, {op}, {}, resources, 100,
+                        3'500'000);
+                    LedgerTxn ltx(app->getLedgerTxnRoot());
+                    REQUIRE(tx->checkValidForTesting(app->getAppConnector(),
+                                                     ltx, 0, 0, 0));
+                }
+
+                auto keyBytes = makeBytes(InitialSorobanNetworkConfig::
+                                              MAX_CONTRACT_DATA_KEY_SIZE_BYTES +
+                                          1);
+                SECTION("read-only key over size limit")
+                {
+                    resources.footprint.readOnly.resize(1);
+                    resources.footprint.readOnly.back() =
+                        contractDataKey(SCAddress{}, keyBytes,
+                                        ContractDataDurability::PERSISTENT);
+                    modifySorobanNetworkConfig(
+                        *app, [](SorobanNetworkConfig& cfg) {
+                            cfg.mMaxContractDataKeySizeBytes =
+                                MinimumSorobanNetworkConfig::
+                                    MAX_CONTRACT_DATA_KEY_SIZE_BYTES;
+                        });
+                    auto tx = sorobanTransactionFrameFromOps(
+                        app->getNetworkID(), *root, {op}, {}, resources, 100,
+                        3'500'000);
+                    LedgerTxn ltx(app->getLedgerTxnRoot());
+                    REQUIRE(!tx->checkValidForTesting(app->getAppConnector(),
+                                                      ltx, 0, 0, 0));
+                }
+                SECTION("read-write key over size limit")
+                {
+                    resources.footprint.readWrite.resize(1);
+                    resources.footprint.readWrite.back() =
+                        contractDataKey(SCAddress{}, keyBytes,
+                                        ContractDataDurability::PERSISTENT);
+                    modifySorobanNetworkConfig(
+                        *app, [](SorobanNetworkConfig& cfg) {
+                            cfg.mMaxContractDataKeySizeBytes =
+                                MinimumSorobanNetworkConfig::
+                                    MAX_CONTRACT_DATA_KEY_SIZE_BYTES;
+                        });
+                    auto tx = sorobanTransactionFrameFromOps(
+                        app->getNetworkID(), *root, {op}, {}, resources, 100,
+                        3'500'000);
+                    LedgerTxn ltx(app->getLedgerTxnRoot());
+                    REQUIRE(!tx->checkValidForTesting(app->getAppConnector(),
+                                                      ltx, 0, 0, 0));
+                }
+            }
+        });
 }

--- a/test-tx-meta-baseline-current/InvokeHostFunctionTests.json
+++ b/test-tx-meta-baseline-current/InvokeHostFunctionTests.json
@@ -2810,6 +2810,37 @@
 		"iA54BbkrMmc=",
 		"KLpBGpyr9Fg="
 	],
+	"resource fee exceeds uint32" : 
+	[
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I="
+	],
+	"resource fee exceeds uint32|other account fee bump|failure|fee bump fee is not sufficient to cover the resource fee" : [ "WBATg5AATZk=", "JxOQiPepSZ4=" ],
+	"resource fee exceeds uint32|other account fee bump|failure|fee bump fee is not sufficient to cover the resource fee with high inclusion fee" : [ "WBATg5AATZk=", "JxOQiPepSZ4=" ],
+	"resource fee exceeds uint32|other account fee bump|failure|fee bump fee is not sufficient to cover the resource fee with low resource fee" : [ "WBATg5AATZk=", "JxOQiPepSZ4=" ],
+	"resource fee exceeds uint32|other account fee bump|failure|insufficient fee bumper balance" : [ "WBATg5AATZk=", "Qi9f98GkVqg=" ],
+	"resource fee exceeds uint32|other account fee bump|success|inclusion fee and refund exceed uint32" : [ "WBATg5AATZk=", "JxOQiPepSZ4=" ],
+	"resource fee exceeds uint32|other account fee bump|success|inclusion fee exceeds uint32" : [ "WBATg5AATZk=", "JxOQiPepSZ4=" ],
+	"resource fee exceeds uint32|other account fee bump|success|low inclusion fee" : [ "WBATg5AATZk=", "JxOQiPepSZ4=" ],
+	"resource fee exceeds uint32|self fee bump|failure|fee bump fee is not sufficient to cover the resource fee" : [ "WBATg5AATZk=", "JxOQiPepSZ4=" ],
+	"resource fee exceeds uint32|self fee bump|failure|fee bump fee is not sufficient to cover the resource fee with high inclusion fee" : [ "WBATg5AATZk=", "JxOQiPepSZ4=" ],
+	"resource fee exceeds uint32|self fee bump|failure|fee bump fee is not sufficient to cover the resource fee with low resource fee" : [ "WBATg5AATZk=", "JxOQiPepSZ4=" ],
+	"resource fee exceeds uint32|self fee bump|failure|insufficient fee bumper balance" : [ "WBATg5AATZk=", "Qi9f98GkVqg=" ],
+	"resource fee exceeds uint32|self fee bump|success|inclusion fee and refund exceed uint32" : [ "WBATg5AATZk=", "JxOQiPepSZ4=" ],
+	"resource fee exceeds uint32|self fee bump|success|inclusion fee exceeds uint32" : [ "WBATg5AATZk=", "JxOQiPepSZ4=" ],
+	"resource fee exceeds uint32|self fee bump|success|low inclusion fee" : [ "WBATg5AATZk=", "JxOQiPepSZ4=" ],
 	"settings upgrade" : [ "+cR3oq2qY0I=", "+cR3oq2qY0I=" ],
 	"settings upgrade command line utils" : 
 	[

--- a/test-tx-meta-baseline-next/InvokeHostFunctionTests.json
+++ b/test-tx-meta-baseline-next/InvokeHostFunctionTests.json
@@ -2915,6 +2915,37 @@
 		"iA54BbkrMmc=",
 		"KLpBGpyr9Fg="
 	],
+	"resource fee exceeds uint32" : 
+	[
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I=",
+		"+cR3oq2qY0I="
+	],
+	"resource fee exceeds uint32|other account fee bump|failure|fee bump fee is not sufficient to cover the resource fee" : [ "WBATg5AATZk=", "JxOQiPepSZ4=" ],
+	"resource fee exceeds uint32|other account fee bump|failure|fee bump fee is not sufficient to cover the resource fee with high inclusion fee" : [ "WBATg5AATZk=", "JxOQiPepSZ4=" ],
+	"resource fee exceeds uint32|other account fee bump|failure|fee bump fee is not sufficient to cover the resource fee with low resource fee" : [ "WBATg5AATZk=", "JxOQiPepSZ4=" ],
+	"resource fee exceeds uint32|other account fee bump|failure|insufficient fee bumper balance" : [ "WBATg5AATZk=", "Qi9f98GkVqg=" ],
+	"resource fee exceeds uint32|other account fee bump|success|inclusion fee and refund exceed uint32" : [ "WBATg5AATZk=", "JxOQiPepSZ4=" ],
+	"resource fee exceeds uint32|other account fee bump|success|inclusion fee exceeds uint32" : [ "WBATg5AATZk=", "JxOQiPepSZ4=" ],
+	"resource fee exceeds uint32|other account fee bump|success|low inclusion fee" : [ "WBATg5AATZk=", "JxOQiPepSZ4=" ],
+	"resource fee exceeds uint32|self fee bump|failure|fee bump fee is not sufficient to cover the resource fee" : [ "WBATg5AATZk=", "JxOQiPepSZ4=" ],
+	"resource fee exceeds uint32|self fee bump|failure|fee bump fee is not sufficient to cover the resource fee with high inclusion fee" : [ "WBATg5AATZk=", "JxOQiPepSZ4=" ],
+	"resource fee exceeds uint32|self fee bump|failure|fee bump fee is not sufficient to cover the resource fee with low resource fee" : [ "WBATg5AATZk=", "JxOQiPepSZ4=" ],
+	"resource fee exceeds uint32|self fee bump|failure|insufficient fee bumper balance" : [ "WBATg5AATZk=", "Qi9f98GkVqg=" ],
+	"resource fee exceeds uint32|self fee bump|success|inclusion fee and refund exceed uint32" : [ "WBATg5AATZk=", "JxOQiPepSZ4=" ],
+	"resource fee exceeds uint32|self fee bump|success|inclusion fee exceeds uint32" : [ "WBATg5AATZk=", "JxOQiPepSZ4=" ],
+	"resource fee exceeds uint32|self fee bump|success|low inclusion fee" : [ "WBATg5AATZk=", "JxOQiPepSZ4=" ],
 	"settings upgrade" : [ "+cR3oq2qY0I=", "+cR3oq2qY0I=" ],
 	"settings upgrade command line utils" : 
 	[


### PR DESCRIPTION
# Description

Allow fee bump transactions to bump inner transactions with 'invalid' inner fee in p23.

This is implementation of CAP-66 change (https://github.com/stellar/stellar-protocol/pull/1753). It allows users to create transactions with Soroban resource fees that exceed uint32 limit (430+ XLM).

Note, that the inner fee validation is not actually necessary for protocol to function. It was only rejecting transactions during the validation, but it otherwise does not affect the transaction application logic.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
