### PR TITLE
Restoration cleanup

### DIFF
--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -210,16 +210,12 @@ class LedgerManagerImpl : public LedgerManager
         SorobanNetworkConfig const& sorobanConfig,
         ParallelLedgerInfo const& ledgerInfo);
 
-    void addAllRestoredEntriesToLedgerTxn(
-        std::vector<std::unique_ptr<ThreadParallelApplyLedgerState>> const&
-            threadStates,
-        AbstractLedgerTxn& ltx);
     void checkAllTxBundleInvariants(AppConnector& app, ApplyStage const& stage,
                                     Config const& config,
                                     ParallelLedgerInfo const& ledgerInfo,
-                                    AbstractLedgerTxn& ltx);
+                                    LedgerHeader const& header);
 
-    void applySorobanStage(AppConnector& app, AbstractLedgerTxn& ltx,
+    void applySorobanStage(AppConnector& app, LedgerHeader const& header,
                            GlobalParallelApplyLedgerState& globalParState,
                            ApplyStage const& stage,
                            Hash const& sorobanBasePrngSeed);

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -940,15 +940,15 @@ LedgerTxn::Impl::erase(InternalLedgerKey const& key)
 }
 
 void
-LedgerTxn::addRestoredFromHotArchive(LedgerEntry const& ledgerEntry,
-                                     LedgerEntry const& ttlEntry)
+LedgerTxn::markRestoredFromHotArchive(LedgerEntry const& ledgerEntry,
+                                      LedgerEntry const& ttlEntry)
 {
-    getImpl()->addRestoredFromHotArchive(ledgerEntry, ttlEntry);
+    getImpl()->markRestoredFromHotArchive(ledgerEntry, ttlEntry);
 }
 
 void
-LedgerTxn::Impl::addRestoredFromHotArchive(LedgerEntry const& ledgerEntry,
-                                           LedgerEntry const& ttlEntry)
+LedgerTxn::Impl::markRestoredFromHotArchive(LedgerEntry const& ledgerEntry,
+                                            LedgerEntry const& ttlEntry)
 {
     throwIfSealed();
     throwIfChild();

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -972,49 +972,6 @@ LedgerTxn::Impl::addRestoredFromHotArchive(LedgerEntry const& ledgerEntry,
 }
 
 LedgerTxnEntry
-LedgerTxn::restoreFromHotArchive(LedgerEntry const& entry, uint32_t ttl)
-{
-    return getImpl()->restoreFromHotArchive(*this, entry, ttl);
-}
-
-LedgerTxnEntry
-LedgerTxn::Impl::restoreFromHotArchive(LedgerTxn& self,
-                                       LedgerEntry const& entry, uint32_t ttl)
-{
-    throwIfSealed();
-    throwIfChild();
-
-    if (!isPersistentEntry(entry.data))
-    {
-        throw std::runtime_error("Key type not supported in Hot Archive");
-    }
-    auto ttlKey = getTTLKey(entry);
-
-    // Restore entry by creating it on the live BucketList
-    create(self, entry);
-
-    // Also create the corresponding TTL entry
-    LedgerEntry ttlEntry;
-    ttlEntry.data.type(TTL);
-    ttlEntry.data.ttl().liveUntilLedgerSeq = ttl;
-    ttlEntry.data.ttl().keyHash = ttlKey.ttl().keyHash;
-    auto ttlLtxe = create(self, ttlEntry);
-
-    // Mark the keys as restored
-    auto addEntry = [this](LedgerEntry const& entry, LedgerKey const& key) {
-        auto [_, inserted] = mRestoredEntries.hotArchive.emplace(key, entry);
-        if (!inserted)
-        {
-            throw std::runtime_error("Key already removed from hot archive");
-        }
-    };
-    addEntry(entry, LedgerEntryKey(entry));
-    addEntry(ttlLtxe.current(), ttlKey);
-
-    return ttlLtxe;
-}
-
-LedgerTxnEntry
 LedgerTxn::restoreFromLiveBucketList(LedgerEntry const& entry, uint32_t ttl)
 {
     return getImpl()->restoreFromLiveBucketList(*this, entry, ttl);

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -630,7 +630,7 @@ class AbstractLedgerTxn : public AbstractLedgerTxnParent
     //     Indicates that an entry in the live BucketList is being restored and
     //     updates the TTL entry accordingly. TTL key must exist, throws
     //     otherwise. Returns the TTL entry that was modified.
-    // - addRestoredFromHotArchive:
+    // - markRestoredFromHotArchive:
     //     Indicates that an entry in the hot archive BucketList is being
     //     restored. Used by the parallel apply path to signal to LedgerTxn
     //     that the entry and TTL should be treated as if they have been
@@ -644,8 +644,8 @@ class AbstractLedgerTxn : public AbstractLedgerTxnParent
     virtual void erase(InternalLedgerKey const& key) = 0;
     virtual LedgerTxnEntry restoreFromLiveBucketList(LedgerEntry const& entry,
                                                      uint32_t ttl) = 0;
-    virtual void addRestoredFromHotArchive(LedgerEntry const& ledgerEntry,
-                                           LedgerEntry const& ttlEntry) = 0;
+    virtual void markRestoredFromHotArchive(LedgerEntry const& ledgerEntry,
+                                            LedgerEntry const& ttlEntry) = 0;
     virtual LedgerTxnEntry load(InternalLedgerKey const& key) = 0;
     virtual ConstLedgerTxnEntry
     loadWithoutRecord(InternalLedgerKey const& key) = 0;
@@ -792,8 +792,8 @@ class LedgerTxn : public AbstractLedgerTxn
 
     LedgerTxnEntry restoreFromLiveBucketList(LedgerEntry const& entry,
                                              uint32_t ttl) override;
-    void addRestoredFromHotArchive(LedgerEntry const& ledgerEntry,
-                                   LedgerEntry const& ttlEntry) override;
+    void markRestoredFromHotArchive(LedgerEntry const& ledgerEntry,
+                                    LedgerEntry const& ttlEntry) override;
 
     UnorderedMap<LedgerKey, LedgerEntry> getAllOffers() override;
 

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -599,7 +599,7 @@ class AbstractLedgerTxn : public AbstractLedgerTxnParent
     virtual void rollback() noexcept = 0;
 
     // loadHeader, create, erase, load, loadWithoutRecord,
-    // restoreFromHotArchive, and restoreFromLiveBucketList provide the main
+    // and restoreFromLiveBucketList provide the main
     // interface to interact with data stored in the AbstractLedgerTxn. These
     // functions only allow one instance of a particular data to be active at a
     // time.
@@ -626,23 +626,22 @@ class AbstractLedgerTxn : public AbstractLedgerTxnParent
     //     then it will still be recorded after calling loadWithoutRecord.
     //     Throws if there is an active LedgerTxnEntry associated with this
     //     key.
-    // - restoreFromHotArchive:
-    //     Indicates that an entry in the Hot Archive has been restored. This
-    //     will create both data data/contract entry and
-    //     corresponding TTL entry. Prior to this call, the data/contract key
-    //     and TTL key must not exist in the live BucketList or any parent ltx,
-    //     throws otherwise. Returns the TTL entry created.
     // - restoreFromLiveBucketlist:
     //     Indicates that an entry in the live BucketList is being restored and
     //     updates the TTL entry accordingly. TTL key must exist, throws
     //     otherwise. Returns the TTL entry that was modified.
+    // - addRestoredFromHotArchive:
+    //     Indicates that an entry in the hot archive BucketList is being
+    //     restored. Used by the parallel apply path to signal to LedgerTxn
+    //     that the entry and TTL should be treated as if they have been
+    //     restored. This just adds the information to the map tracking entries
+    //     restored from the hot archive. The actual restoration of the entry is
+    //     handled separately.
     // All of these functions throw if the AbstractLedgerTxn is sealed or if
     // the AbstractLedgerTxn has a child.
     virtual LedgerTxnHeader loadHeader() = 0;
     virtual LedgerTxnEntry create(InternalLedgerEntry const& entry) = 0;
     virtual void erase(InternalLedgerKey const& key) = 0;
-    virtual LedgerTxnEntry restoreFromHotArchive(LedgerEntry const& entry,
-                                                 uint32_t ttl) = 0;
     virtual LedgerTxnEntry restoreFromLiveBucketList(LedgerEntry const& entry,
                                                      uint32_t ttl) = 0;
     virtual void addRestoredFromHotArchive(LedgerEntry const& ledgerEntry,
@@ -791,8 +790,6 @@ class LedgerTxn : public AbstractLedgerTxn
 
     void erase(InternalLedgerKey const& key) override;
 
-    LedgerTxnEntry restoreFromHotArchive(LedgerEntry const& entry,
-                                         uint32_t ttl) override;
     LedgerTxnEntry restoreFromLiveBucketList(LedgerEntry const& entry,
                                              uint32_t ttl) override;
     void addRestoredFromHotArchive(LedgerEntry const& ledgerEntry,

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -361,12 +361,12 @@ class LedgerTxn::Impl
     // - the entry cache may be, but is not guaranteed to be, cleared.
     void erase(InternalLedgerKey const& key);
 
-    // addRestoredFromHotArchive has the basic exception safety guarantee. If
+    // markRestoredFromHotArchive has the basic exception safety guarantee. If
     // it throws an exception, then
     // - the prepared statement cache may be, but is not guaranteed to be,
     //   modified
-    void addRestoredFromHotArchive(LedgerEntry const& ledgerEntry,
-                                   LedgerEntry const& ttlEntry);
+    void markRestoredFromHotArchive(LedgerEntry const& ledgerEntry,
+                                    LedgerEntry const& ttlEntry);
 
     // restoreFromLiveBucketList has the basic exception safety guarantee. If it
     // throws an exception, then

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -368,14 +368,6 @@ class LedgerTxn::Impl
     void addRestoredFromHotArchive(LedgerEntry const& ledgerEntry,
                                    LedgerEntry const& ttlEntry);
 
-    // restoreFromHotArchive has the basic exception safety guarantee. If it
-    // throws an exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
-    LedgerTxnEntry restoreFromHotArchive(LedgerTxn& self,
-                                         LedgerEntry const& entry,
-                                         uint32_t ttl);
-
     // restoreFromLiveBucketList has the basic exception safety guarantee. If it
     // throws an exception, then
     // - the prepared statement cache may be, but is not guaranteed to be,

--- a/src/ledger/test/InMemoryLedgerTxn.cpp
+++ b/src/ledger/test/InMemoryLedgerTxn.cpp
@@ -275,13 +275,6 @@ InMemoryLedgerTxn::erase(InternalLedgerKey const& key)
 }
 
 LedgerTxnEntry
-InMemoryLedgerTxn::restoreFromHotArchive(LedgerEntry const& entry, uint32_t ttl)
-{
-    throw std::runtime_error(
-        "called restoreFromHotArchive on InMemoryLedgerTxn");
-}
-
-LedgerTxnEntry
 InMemoryLedgerTxn::restoreFromLiveBucketList(LedgerEntry const& entry,
                                              uint32_t ttl)
 {

--- a/src/ledger/test/InMemoryLedgerTxn.h
+++ b/src/ledger/test/InMemoryLedgerTxn.h
@@ -112,8 +112,6 @@ class InMemoryLedgerTxn : public LedgerTxn
 
     LedgerTxnEntry create(InternalLedgerEntry const& entry) override;
     void erase(InternalLedgerKey const& key) override;
-    LedgerTxnEntry restoreFromHotArchive(LedgerEntry const& entry,
-                                         uint32_t ttl) override;
     LedgerTxnEntry restoreFromLiveBucketList(LedgerEntry const& entry,
                                              uint32_t ttl) override;
     LedgerTxnEntry load(InternalLedgerKey const& key) override;

--- a/src/ledger/test/LedgerTxnTests.cpp
+++ b/src/ledger/test/LedgerTxnTests.cpp
@@ -272,14 +272,14 @@ TEST_CASE("LedgerTxn commit into LedgerTxn", "[ledgertxn]")
                     return ttl;
                 };
 
-                ltx1.addRestoredFromHotArchive(
+                ltx1.markRestoredFromHotArchive(
                     randomEntries[0], getTTLEntry(randomEntries[0], 42));
 
                 SECTION("rollback")
                 {
                     {
                         LedgerTxn ltx2(ltx1);
-                        ltx2.addRestoredFromHotArchive(
+                        ltx2.markRestoredFromHotArchive(
                             randomEntries[1],
                             getTTLEntry(randomEntries[1], 42));
                     }
@@ -296,7 +296,7 @@ TEST_CASE("LedgerTxn commit into LedgerTxn", "[ledgertxn]")
                 {
                     {
                         LedgerTxn ltx2(ltx1);
-                        ltx2.addRestoredFromHotArchive(
+                        ltx2.markRestoredFromHotArchive(
                             randomEntries[1],
                             getTTLEntry(randomEntries[1], 42));
                         ltx2.commit();

--- a/src/ledger/test/LedgerTxnTests.cpp
+++ b/src/ledger/test/LedgerTxnTests.cpp
@@ -247,12 +247,6 @@ TEST_CASE("LedgerTxn commit into LedgerTxn", "[ledgertxn]")
                                              LedgerEntryKey(randomEntries[1])};
         LedgerTxn ltx1(app->getLedgerTxnRoot());
 
-        SECTION("hot archive restore key exists in live BL")
-        {
-            ltx1.create(randomEntries[0]);
-            REQUIRE_THROWS(ltx1.restoreFromHotArchive(randomEntries[0], 42));
-        }
-
         SECTION("live BL restore key does not exist")
         {
             REQUIRE_THROWS(
@@ -268,13 +262,26 @@ TEST_CASE("LedgerTxn commit into LedgerTxn", "[ledgertxn]")
         {
             SECTION("hot archive")
             {
-                ltx1.restoreFromHotArchive(randomEntries[0], 42);
+                auto getTTLEntry =
+                    [](LedgerEntry const& entry,
+                       uint32_t liveUntilLedgerSeq) -> LedgerEntry {
+                    LedgerEntry ttl;
+                    ttl.data.type(TTL);
+                    ttl.data.ttl().liveUntilLedgerSeq = liveUntilLedgerSeq;
+                    ttl.data.ttl().keyHash = getTTLKey(entry).ttl().keyHash;
+                    return ttl;
+                };
+
+                ltx1.addRestoredFromHotArchive(
+                    randomEntries[0], getTTLEntry(randomEntries[0], 42));
 
                 SECTION("rollback")
                 {
                     {
                         LedgerTxn ltx2(ltx1);
-                        ltx2.restoreFromHotArchive(randomEntries[1], 42);
+                        ltx2.addRestoredFromHotArchive(
+                            randomEntries[1],
+                            getTTLEntry(randomEntries[1], 42));
                     }
 
                     REQUIRE(ltx1.getRestoredLiveBucketListKeys().empty());
@@ -289,7 +296,9 @@ TEST_CASE("LedgerTxn commit into LedgerTxn", "[ledgertxn]")
                 {
                     {
                         LedgerTxn ltx2(ltx1);
-                        ltx2.restoreFromHotArchive(randomEntries[1], 42);
+                        ltx2.addRestoredFromHotArchive(
+                            randomEntries[1],
+                            getTTLEntry(randomEntries[1], 42));
                         ltx2.commit();
                     }
 

--- a/src/transactions/ParallelApplyUtils.cpp
+++ b/src/transactions/ParallelApplyUtils.cpp
@@ -630,6 +630,22 @@ GlobalParallelApplyLedgerState::commitChangesToLedgerTxn(
             }
         }
     }
+
+    // We don't need to add the live bucket list restoration keys
+    // because they're only needed for meta generation, which has already
+    // happened.
+    for (auto const& kvp : mGlobalRestoredEntries.hotArchive)
+    {
+        // We will search for the ttl key in the hot archive when the entry
+        // is seen
+        if (kvp.first.type() != TTL)
+        {
+            auto it =
+                mGlobalRestoredEntries.hotArchive.find(getTTLKey(kvp.first));
+            releaseAssert(it != mGlobalRestoredEntries.hotArchive.end());
+            ltxInner.addRestoredFromHotArchive(kvp.second, it->second);
+        }
+    }
     ltxInner.commit();
 }
 

--- a/src/transactions/ParallelApplyUtils.cpp
+++ b/src/transactions/ParallelApplyUtils.cpp
@@ -631,9 +631,9 @@ GlobalParallelApplyLedgerState::commitChangesToLedgerTxn(
         }
     }
 
-    // We don't need to add the live bucket list restoration keys
-    // because they're only needed for meta generation, which has already
-    // happened.
+    // While the final state of a restored key that will be written to the
+    // Live BucketList is already handled in mGlobalEntryMap, we need to
+    // let the ltx know what keys need to be removed from the Hot Archive.
     for (auto const& kvp : mGlobalRestoredEntries.hotArchive)
     {
         // We will search for the ttl key in the hot archive when the entry
@@ -643,7 +643,7 @@ GlobalParallelApplyLedgerState::commitChangesToLedgerTxn(
             auto it =
                 mGlobalRestoredEntries.hotArchive.find(getTTLKey(kvp.first));
             releaseAssert(it != mGlobalRestoredEntries.hotArchive.end());
-            ltxInner.addRestoredFromHotArchive(kvp.second, it->second);
+            ltxInner.markRestoredFromHotArchive(kvp.second, it->second);
         }
     }
     ltxInner.commit();


### PR DESCRIPTION
# Description

1. Remove `restoreFromHotArchive`.
2. Update `LedgerTxn`'s `RestoredEntries` when we're updating the entries at the end. I was considering keeping the `restoreFromHotArchive` method and attempting to use that so `LedgerTxn`'s entry map and `RestoredEntries` is updated in a single call, allowing us to get rid of `addRestoredFromHotArchive`, but we would need to add additional logic to handle restored entries that are updated. This PR seems like the better option.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
