### PR TITLE
Clear tx queue on upgrade

### DIFF
--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -115,8 +115,11 @@ class Herder
     // restores Herder's state from disk
     virtual void start() = 0;
 
+    // If a protocol or network config setting upgrade occurred during the
+    // ledger close, `upgradeApplied` will be true.
     virtual void lastClosedLedgerIncreased(bool latest,
-                                           TxSetXDRFrameConstPtr txSet) = 0;
+                                           TxSetXDRFrameConstPtr txSet,
+                                           bool upgradeApplied) = 0;
 
     // Setup Herder's state to fully participate in consensus
     virtual void setTrackingSCPState(uint64_t index, StellarValue const& value,
@@ -229,9 +232,6 @@ class Herder
     virtual size_t getMaxQueueSizeOps() const = 0;
     virtual size_t getMaxQueueSizeSorobanOps() const = 0;
     virtual void maybeHandleUpgrade() = 0;
-
-    // Schedule transaction queue rebuild after protocol/network config upgrades
-    virtual void scheduleQueueRebuild() = 0;
 
     virtual bool isBannedTx(Hash const& hash) const = 0;
     virtual TransactionFrameBaseConstPtr getTx(Hash const& hash) const = 0;

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -230,6 +230,9 @@ class Herder
     virtual size_t getMaxQueueSizeSorobanOps() const = 0;
     virtual void maybeHandleUpgrade() = 0;
 
+    // Schedule transaction queue rebuild after protocol/network config upgrades
+    virtual void scheduleQueueRebuild() = 0;
+
     virtual bool isBannedTx(Hash const& hash) const = 0;
     virtual TransactionFrameBaseConstPtr getTx(Hash const& hash) const = 0;
 

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1165,7 +1165,8 @@ HerderImpl::safelyProcessSCPQueue(bool synchronous)
 }
 
 void
-HerderImpl::lastClosedLedgerIncreased(bool latest, TxSetXDRFrameConstPtr txSet)
+HerderImpl::lastClosedLedgerIncreased(bool latest, TxSetXDRFrameConstPtr txSet,
+                                      bool upgradeApplied)
 {
     releaseAssert(threadIsMain());
 
@@ -1176,8 +1177,9 @@ HerderImpl::lastClosedLedgerIncreased(bool latest, TxSetXDRFrameConstPtr txSet)
     maybeHandleUpgrade();
 
     // In order to update the transaction queue we need to get the
-    // applied transactions.
-    updateTransactionQueue(txSet);
+    // applied transactions. If a protocol or network config setting upgrade
+    // occurred, we will need to rebuild the queue, as limits may have changed.
+    updateTransactionQueue(txSet, upgradeApplied);
 
     // If we're in sync and there are no buffered ledgers to apply, trigger next
     // ledger
@@ -2421,7 +2423,8 @@ HerderImpl::trackingHeartBeat()
 }
 
 void
-HerderImpl::updateTransactionQueue(TxSetXDRFrameConstPtr externalizedTxSet)
+HerderImpl::updateTransactionQueue(TxSetXDRFrameConstPtr externalizedTxSet,
+                                   bool queueRebuildNeeded)
 {
     ZoneScoped;
     if (externalizedTxSet == nullptr)
@@ -2439,13 +2442,9 @@ HerderImpl::updateTransactionQueue(TxSetXDRFrameConstPtr externalizedTxSet)
         queue.removeApplied(applied);
         queue.shift();
 
-        // Check if queue rebuild was scheduled due to upgrades. Do this
-        // after removing applied transactions, but before checking for invalid
-        // TXs so we can use the most up to date limits for the validity check.
-        if (isSoroban && mQueueRebuildNeeded)
+        if (isSoroban && queueRebuildNeeded)
         {
             mSorobanTransactionQueue->resetAndRebuild();
-            mQueueRebuildNeeded = false;
         }
 
         auto txs = queue.getTransactions(lhhe.header);
@@ -2474,12 +2473,6 @@ HerderImpl::updateTransactionQueue(TxSetXDRFrameConstPtr externalizedTxSet)
                     txsPerPhase[static_cast<size_t>(TxSetPhase::SOROBAN)],
                     true);
     }
-}
-
-void
-HerderImpl::scheduleQueueRebuild()
-{
-    mQueueRebuildNeeded = true;
 }
 
 void

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -233,6 +233,7 @@ class HerderImpl : public Herder
     size_t getMaxQueueSizeOps() const override;
     size_t getMaxQueueSizeSorobanOps() const override;
     void maybeHandleUpgrade() override;
+    void scheduleQueueRebuild() override;
 
     bool isBannedTx(Hash const& hash) const override;
     TransactionFrameBaseConstPtr getTx(Hash const& hash) const override;
@@ -355,6 +356,9 @@ class HerderImpl : public Herder
     // network or not (Herder::State is used to properly track the state of
     // Herder) On startup, this variable is set to LCL
     ConsensusData mTrackingSCP;
+
+    // Flag to trigger transaction queue rebuild after upgrades
+    std::atomic<bool> mQueueRebuildNeeded{false};
 
     uint32_t mMaxTxSize{0};
 };

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -75,8 +75,8 @@ class HerderImpl : public Herder
 
     void start() override;
 
-    void lastClosedLedgerIncreased(bool latest,
-                                   TxSetXDRFrameConstPtr txSet) override;
+    void lastClosedLedgerIncreased(bool latest, TxSetXDRFrameConstPtr txSet,
+                                   bool queueRebuildNeeded) override;
 
     SCP& getSCP();
     HerderSCPDriver&
@@ -233,7 +233,6 @@ class HerderImpl : public Herder
     size_t getMaxQueueSizeOps() const override;
     size_t getMaxQueueSizeSorobanOps() const override;
     void maybeHandleUpgrade() override;
-    void scheduleQueueRebuild() override;
 
     bool isBannedTx(Hash const& hash) const override;
     TransactionFrameBaseConstPtr getTx(Hash const& hash) const override;
@@ -265,7 +264,8 @@ class HerderImpl : public Herder
     ClassicTransactionQueue mTransactionQueue;
     std::unique_ptr<SorobanTransactionQueue> mSorobanTransactionQueue;
 
-    void updateTransactionQueue(TxSetXDRFrameConstPtr txSet);
+    void updateTransactionQueue(TxSetXDRFrameConstPtr txSet,
+                                bool queueRebuildNeeded);
     void maybeSetupSorobanQueue(uint32_t protocolVersion);
 
     PendingEnvelopes mPendingEnvelopes;
@@ -356,9 +356,6 @@ class HerderImpl : public Herder
     // network or not (Herder::State is used to properly track the state of
     // Herder) On startup, this variable is set to LCL
     ConsensusData mTrackingSCP;
-
-    // Flag to trigger transaction queue rebuild after upgrades
-    std::atomic<bool> mQueueRebuildNeeded{false};
 
     uint32_t mMaxTxSize{0};
 };

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -292,6 +292,16 @@ class SorobanTransactionQueue : public TransactionQueue
     }
 
     size_t getMaxQueueSizeOps() const override;
+
+    /**
+     * Reset and rebuild the Soroban transaction queue with respect to new
+     * limits. This method extracts all current transactions, clears the queue
+     * state, and re-adds transactions using surge pricing logic for
+     * sorting/evictions. Should be called synchronously during protocol or
+     * network config upgrades.
+     */
+    void resetAndRebuild();
+
 #ifdef BUILD_TESTS
     void
     clearBroadcastCarryover()

--- a/src/herder/TxQueueLimiter.cpp
+++ b/src/herder/TxQueueLimiter.cpp
@@ -60,8 +60,8 @@ TxQueueLimiter::size() const
 Resource
 TxQueueLimiter::maxScaledLedgerResources(bool isSoroban) const
 {
-    return multiplyByDouble(mLedgerManager.maxLedgerResources(isSoroban),
-                            mPoolLedgerMultiplier);
+    return saturatedMultiplyByDouble(
+        mLedgerManager.maxLedgerResources(isSoroban), mPoolLedgerMultiplier);
 }
 
 void

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -995,8 +995,8 @@ TEST_CASE("tx set hits overlay byte limit during construction",
 
     modifySorobanNetworkConfig(*app, [max](SorobanNetworkConfig& cfg) {
         cfg.mLedgerMaxTxCount = max;
-        cfg.mledgerMaxDiskReadEntries = max;
-        cfg.mledgerMaxDiskReadBytes = max;
+        cfg.mLedgerMaxDiskReadEntries = max;
+        cfg.mLedgerMaxDiskReadBytes = max;
         cfg.mLedgerMaxWriteLedgerEntries = max;
         cfg.mLedgerMaxWriteBytes = max;
         cfg.mLedgerMaxTransactionsSizeBytes = max;
@@ -3072,8 +3072,8 @@ TEST_CASE("soroban txs each parameter surge priced", "[soroban][herder]")
                     cfg.mLedgerMaxTxCount = mx;
                     cfg.mLedgerMaxInstructions = mx;
                     cfg.mLedgerMaxTransactionsSizeBytes = mx;
-                    cfg.mledgerMaxDiskReadEntries = mx;
-                    cfg.mledgerMaxDiskReadBytes = mx;
+                    cfg.mLedgerMaxDiskReadEntries = mx;
+                    cfg.mLedgerMaxDiskReadBytes = mx;
                     cfg.mLedgerMaxWriteLedgerEntries = mx;
                     cfg.mLedgerMaxWriteBytes = mx;
                     tweakSorobanConfig(cfg);
@@ -3223,7 +3223,7 @@ TEST_CASE("soroban txs each parameter surge priced", "[soroban][herder]")
     // SECTION("read entries")
     // {
     //     auto tweakSorobanConfig = [&](SorobanNetworkConfig& cfg) {
-    //         cfg.mledgerMaxDiskReadEntries = static_cast<uint32>(
+    //         cfg.mLedgerMaxDiskReadEntries = static_cast<uint32>(
     //             baseTxRate * Herder::EXP_LEDGER_TIMESPAN_SECONDS.count() *
     //             cfg.mTxMaxDiskReadEntries);
     //     };
@@ -3248,7 +3248,7 @@ TEST_CASE("soroban txs each parameter surge priced", "[soroban][herder]")
         uint32_t constexpr txMaxDiskReadBytes = 100 * 1024;
         auto tweakSorobanConfig = [&](SorobanNetworkConfig& cfg) {
             cfg.mTxMaxDiskReadBytes = txMaxDiskReadBytes;
-            cfg.mledgerMaxDiskReadBytes =
+            cfg.mLedgerMaxDiskReadBytes =
                 static_cast<uint32>(desiredTxRate * cfg.mTxMaxDiskReadBytes);
         };
         test(tweakSorobanConfig, idTweakAppConfig);
@@ -4629,8 +4629,8 @@ TEST_CASE("do not flood too many soroban transactions",
             setSorobanNetworkConfigForTest(cfg);
             // Update read entries to allow flooding at most 1 tx per broadcast
             // interval.
-            cfg.mledgerMaxDiskReadEntries = 40;
-            cfg.mledgerMaxDiskReadBytes = cfg.mTxMaxDiskReadBytes;
+            cfg.mLedgerMaxDiskReadEntries = 40;
+            cfg.mLedgerMaxDiskReadBytes = cfg.mTxMaxDiskReadBytes;
         },
         simulation);
 

--- a/src/herder/test/TransactionQueueTests.cpp
+++ b/src/herder/test/TransactionQueueTests.cpp
@@ -3037,3 +3037,197 @@ TEST_CASE("arbitrage tx identification benchmark",
     LOG_INFO(DEFAULT_LOG, "executed 100 loop-checks of 600-op tx loop in {}",
              ch::duration_cast<ch::milliseconds>(end - start));
 }
+
+TEST_CASE("TransactionQueue reset and rebuild on upgrades",
+          "[herder][transactionqueue][upgrades]")
+{
+    VirtualClock clock;
+    auto app = createTestApplication(clock, getTestConfig());
+    auto& herder = static_cast<HerderImpl&>(app->getHerder());
+    auto& lm = app->getLedgerManager();
+    auto& sorobanQueue = herder.getSorobanTransactionQueue();
+
+    // Create test accounts
+    auto root = app->getRoot();
+    std::vector<TestAccount> accounts;
+    for (size_t i = 0; i < 10; ++i)
+    {
+        accounts.emplace_back(root->create(std::to_string(i), 1000000000));
+    }
+
+    modifySorobanNetworkConfig(*app, [](SorobanNetworkConfig& cfg) {
+        cfg.mLedgerMaxTxCount = 10;
+
+        cfg.mTxMaxInstructions = 10'000'000;
+        cfg.mTxMaxDiskReadBytes = 10000;
+        cfg.mTxMaxWriteBytes = 10000;
+        cfg.mTxMaxDiskReadEntries = 10;
+        cfg.mTxMaxWriteLedgerEntries = 10;
+        cfg.mTxMaxFootprintEntries = 40;
+        cfg.mTxMaxSizeBytes = 10000;
+
+        cfg.mLedgerMaxDiskReadBytes = cfg.mTxMaxDiskReadBytes * 10;
+        cfg.mLedgerMaxWriteBytes = cfg.mTxMaxWriteBytes * 10;
+        cfg.mLedgerMaxDiskReadEntries = cfg.mTxMaxDiskReadEntries * 10;
+        cfg.mLedgerMaxWriteLedgerEntries = cfg.mTxMaxWriteLedgerEntries * 10;
+
+        cfg.mLedgerMaxInstructions = cfg.mTxMaxInstructions * 10;
+        cfg.mLedgerMaxTransactionsSizeBytes = cfg.mTxMaxSizeBytes * 10;
+    });
+
+    auto wasm = rust_bridge::get_test_wasm_add_i32();
+    auto defaultUploadWasmResources =
+        txtest::defaultUploadWasmResourcesWithoutFootprint(
+            rust_bridge::get_test_wasm_add_i32(),
+            lm.getLastClosedLedgerHeader().header.ledgerVersion);
+
+    // Make 9 small TXs, one large TX
+    std::vector<TransactionFrameBasePtr> smallTxs;
+    for (auto i = 0; i < 9; ++i)
+    {
+        auto& acc = accounts[i];
+        auto tx = txtest::makeSorobanWasmUploadTx(
+            *app, acc, wasm, defaultUploadWasmResources, 100 + i);
+        smallTxs.push_back(tx);
+    }
+
+    // Create a TX with much larger instruction resources, right at the limit
+    auto largeResources = defaultUploadWasmResources;
+    largeResources.instructions = 10'000'000;
+    auto largeTx = txtest::makeSorobanWasmUploadTx(*app, accounts[9], wasm,
+                                                   largeResources, 1000);
+
+    auto populateQueue = [&]() {
+        for (auto& tx : smallTxs)
+        {
+            REQUIRE(herder.recvTransaction(tx, false).code ==
+                    TransactionQueue::AddResultCode::ADD_STATUS_PENDING);
+        }
+
+        REQUIRE(herder.recvTransaction(largeTx, false).code ==
+                TransactionQueue::AddResultCode::ADD_STATUS_PENDING);
+        REQUIRE(sorobanQueue.getQueueSizeOps() == 10);
+    };
+
+    auto executeUpgrade = [&](auto const& upgradeCfg, auto const& upgrade) {
+        auto lclHeader = lm.getLastClosedLedgerHeader();
+        TimePoint closeTime = lclHeader.header.scpValue.closeTime + 1;
+
+        app->getHerder().externalizeValue(TxSetXDRFrame::makeEmpty(lclHeader),
+                                          lclHeader.header.ledgerSeq + 1,
+                                          closeTime, {upgrade});
+        app->getRoot()->loadSequenceNumber();
+
+        // Check that the upgrade was actually applied.
+        auto postUpgradeCfg = lm.getLastClosedSorobanNetworkConfig();
+        releaseAssertOrThrow(postUpgradeCfg == upgradeCfg);
+    };
+
+    SECTION("TX size decreases")
+    {
+        // We need to prepare the upgrade first before adding to the TX queue,
+        // since this takes a few ledgers and our queue would get stale or
+        // included. After writing and arming the upgrade, we populate the queue
+        // then execute the upgrade.
+        auto [upgradeCfg, upgrade] = prepareSorobanNetworkConfigUpgrade(
+            *app, [](SorobanNetworkConfig& cfg) { cfg.mLedgerMaxTxCount = 4; });
+        populateQueue();
+        executeUpgrade(upgradeCfg, upgrade);
+
+        // 2 TXs should be dropped since we only keep up to 2 ledgers worth of
+        // TXs
+        REQUIRE(sorobanQueue.getQueueSizeOps() == 8);
+    }
+
+    SECTION("Soroban limit decreases")
+    {
+        auto [upgradeCfg, upgrade] = prepareSorobanNetworkConfigUpgrade(
+            *app, [](SorobanNetworkConfig& cfg) {
+                cfg.mTxMaxInstructions = 9'000'000;
+            });
+        populateQueue();
+        executeUpgrade(upgradeCfg, upgrade);
+
+        // Large TX should be dropped since it exceeds instruction limit
+        REQUIRE(sorobanQueue.getQueueSizeOps() == 9);
+        REQUIRE(!sorobanQueue.getTx(largeTx->getFullHash()));
+        for (auto& tx : smallTxs)
+        {
+            REQUIRE(sorobanQueue.getTx(tx->getFullHash()));
+        }
+    }
+
+    SECTION("Increasing limits does not drop TXs")
+    {
+        auto [upgradeCfg, upgrade] = prepareSorobanNetworkConfigUpgrade(
+            *app, [](SorobanNetworkConfig& cfg) {
+                cfg.mLedgerMaxTxCount = 11;
+                cfg.mTxMaxInstructions = 11'000'000;
+            });
+        populateQueue();
+        executeUpgrade(upgradeCfg, upgrade);
+
+        // All TXs should be kept since we increased the limits
+        REQUIRE(sorobanQueue.getQueueSizeOps() == 10);
+    }
+}
+
+// Sanity check that no TXs are invalidated on protocol 23 upgrade, since
+// limits aren't decreasing
+TEST_CASE("TXs not evicted from queue on protocol 23 upgrade",
+          "[herder][transactionqueue][upgrades]")
+{
+    VirtualClock clock;
+    auto cfg = getTestConfig();
+    cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION = 22;
+    auto app = createTestApplication(clock, cfg);
+    auto& herder = static_cast<HerderImpl&>(app->getHerder());
+    auto& lm = app->getLedgerManager();
+    auto& sorobanQueue = herder.getSorobanTransactionQueue();
+
+    overrideSorobanNetworkConfigForTest(*app);
+    REQUIRE(lm.getLastClosedLedgerHeader().header.ledgerVersion == 22);
+
+    auto root = app->getRoot();
+    std::vector<TestAccount> accounts;
+    for (size_t i = 0; i < 10; ++i)
+    {
+        accounts.emplace_back(root->create(std::to_string(i), 1000000000));
+    }
+
+    auto wasm = rust_bridge::get_test_wasm_add_i32();
+    auto defaultUploadWasmResources =
+        txtest::defaultUploadWasmResourcesWithoutFootprint(
+            wasm, lm.getLastClosedLedgerHeader().header.ledgerVersion);
+
+    std::vector<TransactionFrameBasePtr> txs;
+    for (auto i = 0; i < 10; ++i)
+    {
+        auto& acc = accounts[i];
+        auto tx = txtest::makeSorobanWasmUploadTx(
+            *app, acc, wasm, defaultUploadWasmResources, 100 + i);
+        txs.push_back(tx);
+    }
+
+    for (auto& tx : txs)
+    {
+        REQUIRE(herder.recvTransaction(tx, false).code ==
+                TransactionQueue::AddResultCode::ADD_STATUS_PENDING);
+    }
+
+    // Verify queue has all transactions before upgrade
+    REQUIRE(sorobanQueue.getQueueSizeOps() == 10);
+
+    // Execute the protocol upgrade
+    LedgerUpgrade protocolUpgrade{LEDGER_UPGRADE_VERSION};
+    protocolUpgrade.newLedgerVersion() = 23;
+    ::executeUpgrade(*app, protocolUpgrade);
+    REQUIRE(lm.getLastClosedLedgerHeader().header.ledgerVersion == 23);
+
+    // Verify queue still has all transactions after protocol upgrade
+    REQUIRE(sorobanQueue.getQueueSizeOps() == 10);
+    for (auto& tx : txs)
+    {
+        REQUIRE(sorobanQueue.getTx(tx->getFullHash()));
+    }
+}

--- a/src/herder/test/TxSetTests.cpp
+++ b/src/herder/test/TxSetTests.cpp
@@ -1176,7 +1176,7 @@ TEST_CASE("applicable txset validation - Soroban resources", "[txset][soroban]")
                         txCount * sorobanCfg.mTxMaxInstructions;
 
                     sorobanCfg.mTxMaxDiskReadBytes = 5000;
-                    sorobanCfg.mledgerMaxDiskReadBytes =
+                    sorobanCfg.mLedgerMaxDiskReadBytes =
                         txCount * sorobanCfg.mTxMaxDiskReadBytes;
 
                     sorobanCfg.mTxMaxWriteBytes =
@@ -1185,7 +1185,7 @@ TEST_CASE("applicable txset validation - Soroban resources", "[txset][soroban]")
                         txCount * sorobanCfg.mTxMaxWriteBytes;
 
                     sorobanCfg.mTxMaxDiskReadEntries = 10;
-                    sorobanCfg.mledgerMaxDiskReadEntries =
+                    sorobanCfg.mLedgerMaxDiskReadEntries =
                         txCount * sorobanCfg.mTxMaxDiskReadEntries;
 
                     sorobanCfg.mTxMaxWriteLedgerEntries = 2;
@@ -1277,7 +1277,7 @@ TEST_CASE("applicable txset validation - Soroban resources", "[txset][soroban]")
             {
                 modifySorobanNetworkConfig(
                     *app, [&](SorobanNetworkConfig& sorobanCfg) {
-                        sorobanCfg.mledgerMaxDiskReadBytes -= 1;
+                        sorobanCfg.mLedgerMaxDiskReadBytes -= 1;
                     });
                 REQUIRE(!buildAndValidate());
             }
@@ -1293,7 +1293,7 @@ TEST_CASE("applicable txset validation - Soroban resources", "[txset][soroban]")
             {
                 modifySorobanNetworkConfig(
                     *app, [&](SorobanNetworkConfig& sorobanCfg) {
-                        sorobanCfg.mledgerMaxDiskReadEntries -= 1;
+                        sorobanCfg.mLedgerMaxDiskReadEntries -= 1;
                     });
                 bool useClassic = protocolVersionStartsFrom(
                     protocolVersion, ProtocolVersion::V_23);
@@ -1358,11 +1358,11 @@ TEST_CASE("applicable txset validation - Soroban resources", "[txset][soroban]")
                     *app, [&](SorobanNetworkConfig& sorobanCfg) {
                         sorobanCfg.mLedgerMaxInstructions =
                             std::numeric_limits<int64_t>::max();
-                        sorobanCfg.mledgerMaxDiskReadBytes =
+                        sorobanCfg.mLedgerMaxDiskReadBytes =
                             std::numeric_limits<uint32_t>::max();
                         sorobanCfg.mLedgerMaxWriteBytes =
                             std::numeric_limits<uint32_t>::max();
-                        sorobanCfg.mledgerMaxDiskReadEntries =
+                        sorobanCfg.mLedgerMaxDiskReadEntries =
                             std::numeric_limits<uint32_t>::max();
                         sorobanCfg.mLedgerMaxWriteLedgerEntries =
                             std::numeric_limits<uint32_t>::max();
@@ -1834,15 +1834,15 @@ TEST_CASE("txset nomination", "[txset]")
                     static_cast<int64_t>(cfg.mLedgerMaxWriteLedgerEntries) *
                     100 / txToLedgerRatioPercentDistr(rng);
 
-                cfg.mledgerMaxDiskReadEntries =
+                cfg.mLedgerMaxDiskReadEntries =
                     cfg.mLedgerMaxWriteLedgerEntries + ledgerEntriesDistr(rng);
                 cfg.mTxMaxDiskReadEntries =
-                    static_cast<int64_t>(cfg.mledgerMaxDiskReadEntries) * 100 /
+                    static_cast<int64_t>(cfg.mLedgerMaxDiskReadEntries) * 100 /
                     txToLedgerRatioPercentDistr(rng);
 
-                cfg.mledgerMaxDiskReadBytes = ledgerBytesDistr(rng);
+                cfg.mLedgerMaxDiskReadBytes = ledgerBytesDistr(rng);
                 cfg.mTxMaxDiskReadBytes =
-                    static_cast<int64_t>(cfg.mledgerMaxDiskReadBytes) * 100 /
+                    static_cast<int64_t>(cfg.mLedgerMaxDiskReadBytes) * 100 /
                     txToLedgerRatioPercentDistr(rng);
 
                 cfg.mLedgerMaxWriteBytes = ledgerBytesDistr(rng);
@@ -2171,12 +2171,12 @@ runParallelTxSetBuildingTest(bool variableStageCount)
         sorobanCfg.mLedgerMaxInstructions = 400'000'000;
         sorobanCfg.mTxMaxDiskReadEntries = 3000;
         sorobanCfg.mTxMaxFootprintEntries = sorobanCfg.mTxMaxDiskReadEntries;
-        sorobanCfg.mledgerMaxDiskReadEntries = 3000;
+        sorobanCfg.mLedgerMaxDiskReadEntries = 3000;
         sorobanCfg.mTxMaxWriteLedgerEntries = 2000;
         sorobanCfg.mTxMaxWriteLedgerEntries = 2000;
         sorobanCfg.mLedgerMaxWriteLedgerEntries = 2000;
         sorobanCfg.mTxMaxDiskReadBytes = 1'000'000;
-        sorobanCfg.mledgerMaxDiskReadBytes = 1'000'000;
+        sorobanCfg.mLedgerMaxDiskReadBytes = 1'000'000;
         sorobanCfg.mTxMaxWriteBytes = 100'000;
         sorobanCfg.mLedgerMaxWriteBytes = 100'000;
         sorobanCfg.mLedgerMaxTxCount = 1000;
@@ -2398,7 +2398,7 @@ runParallelTxSetBuildingTest(bool variableStageCount)
             modifySorobanNetworkConfig(
                 *app, [&](SorobanNetworkConfig& sorobanCfg) {
                     sorobanCfg.mTxMaxDiskReadEntries = 4 * 10 + 3;
-                    sorobanCfg.mledgerMaxDiskReadEntries = 4 * 10 + 3;
+                    sorobanCfg.mLedgerMaxDiskReadEntries = 4 * 10 + 3;
                 });
             std::vector<TransactionFrameBaseConstPtr> sorobanTxs;
             for (int i = 0; i < STAGE_COUNT * CLUSTER_COUNT; ++i)
@@ -2836,9 +2836,9 @@ TEST_CASE("parallel tx set building benchmark",
     sorobanCfg.mLedgerMaxInstructions =
         static_cast<int64_t>(MEAN_INSTRUCTIONS_PER_TX) *
         MEAN_INCLUDED_TX_COUNT / CLUSTER_COUNT;
-    sorobanCfg.mledgerMaxDiskReadEntries =
+    sorobanCfg.mLedgerMaxDiskReadEntries =
         MEAN_INCLUDED_TX_COUNT * (MEAN_READS_PER_TX + MEAN_WRITES_PER_TX);
-    sorobanCfg.mledgerMaxDiskReadBytes =
+    sorobanCfg.mLedgerMaxDiskReadBytes =
         MEAN_INCLUDED_TX_COUNT * MEAN_READ_BYTES_PER_TX;
     sorobanCfg.mLedgerMaxWriteLedgerEntries =
         MEAN_INCLUDED_TX_COUNT * MEAN_WRITES_PER_TX;

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -306,10 +306,14 @@ class LedgerManager
     // `calledViaExternalize` false in this case).
     virtual void applyLedger(LedgerCloseData const& ledgerData,
                              bool calledViaExternalize) = 0;
-    virtual void advanceLedgerStateAndPublish(
-        uint32_t ledgerSeq, bool calledViaExternalize,
-        LedgerCloseData const& ledgerData,
-        CompleteConstLedgerStatePtr newLedgerState) = 0;
+
+    // upgradeApplied should be true if a protocol or network config setting
+    // upgrade occurred during the ledger close.
+    virtual void
+    advanceLedgerStateAndPublish(uint32_t ledgerSeq, bool calledViaExternalize,
+                                 LedgerCloseData const& ledgerData,
+                                 CompleteConstLedgerStatePtr newLedgerState,
+                                 bool upgradeApplied) = 0;
 #ifdef BUILD_TESTS
     void
     applyLedger(LedgerCloseData const& ledgerData)

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1015,7 +1015,8 @@ getMetaIOContext(Application& app)
 
 void
 LedgerManagerImpl::ledgerCloseComplete(uint32_t lcl, bool calledViaExternalize,
-                                       LedgerCloseData const& ledgerData)
+                                       LedgerCloseData const& ledgerData,
+                                       bool upgradeApplied)
 {
     // We just finished applying `lcl`, maybe change LM's state
     // Also notify Herder so it can trigger next ledger.
@@ -1053,8 +1054,8 @@ LedgerManagerImpl::ledgerCloseComplete(uint32_t lcl, bool calledViaExternalize,
     if (calledViaExternalize)
     {
         // New ledger(s) got closed, notify Herder
-        mApp.getHerder().lastClosedLedgerIncreased(appliedLatest,
-                                                   ledgerData.getTxSet());
+        mApp.getHerder().lastClosedLedgerIncreased(
+            appliedLatest, ledgerData.getTxSet(), upgradeApplied);
     }
 }
 
@@ -1062,7 +1063,7 @@ void
 LedgerManagerImpl::advanceLedgerStateAndPublish(
     uint32_t ledgerSeq, bool calledViaExternalize,
     LedgerCloseData const& ledgerData,
-    CompleteConstLedgerStatePtr newLedgerState)
+    CompleteConstLedgerStatePtr newLedgerState, bool upgradeApplied)
 {
 #ifdef BUILD_TESTS
     if (mAdvanceLedgerStateAndPublishOverride)
@@ -1093,7 +1094,8 @@ LedgerManagerImpl::advanceLedgerStateAndPublish(
 
     // Maybe set LedgerManager into synced state, maybe let
     // Herder trigger next ledger
-    ledgerCloseComplete(ledgerSeq, calledViaExternalize, ledgerData);
+    ledgerCloseComplete(ledgerSeq, calledViaExternalize, ledgerData,
+                        upgradeApplied);
     CLOG_INFO(Ledger, "Ledger close complete: {}", ledgerSeq);
 }
 
@@ -1343,14 +1345,6 @@ LedgerManagerImpl::applyLedger(LedgerCloseData const& ledgerData,
         }
     }
 
-    // Schedule transaction queue rebuild if any upgrades were applied. Note
-    // that the actual upgrade must occur on synchronously on the main thread to
-    // avoid races with incoming TXs added to the queue.
-    if (upgradeApplied)
-    {
-        mApp.getHerder().scheduleQueueRebuild();
-    }
-
     auto maybeNewVersion = ltx.loadHeader().current().ledgerVersion;
     auto ledgerSeq = ltx.loadHeader().current().ledgerSeq;
     if (protocolVersionStartsFrom(maybeNewVersion, SOROBAN_PROTOCOL_VERSION))
@@ -1445,16 +1439,17 @@ LedgerManagerImpl::applyLedger(LedgerCloseData const& ledgerData,
     if (threadIsMain())
     {
         advanceLedgerStateAndPublish(ledgerSeq, calledViaExternalize,
-                                     ledgerData, std::move(appliedLedgerState));
+                                     ledgerData, std::move(appliedLedgerState),
+                                     upgradeApplied);
     }
     else
     {
         auto cb = [this, ledgerSeq, calledViaExternalize, ledgerData,
-                   appliedLedgerState =
-                       std::move(appliedLedgerState)]() mutable {
-            advanceLedgerStateAndPublish(ledgerSeq, calledViaExternalize,
-                                         ledgerData,
-                                         std::move(appliedLedgerState));
+                   appliedLedgerState = std::move(appliedLedgerState),
+                   upgradeApplied]() mutable {
+            advanceLedgerStateAndPublish(
+                ledgerSeq, calledViaExternalize, ledgerData,
+                std::move(appliedLedgerState), upgradeApplied);
         };
         mApp.postOnMainThread(std::move(cb), "advanceLedgerStateAndPublish");
     }

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -366,12 +366,14 @@ class LedgerManagerImpl : public LedgerManager
 
     void applyLedger(LedgerCloseData const& ledgerData,
                      bool calledViaExternalize) override;
-    void advanceLedgerStateAndPublish(
-        uint32_t ledgerSeq, bool calledViaExternalize,
-        LedgerCloseData const& ledgerData,
-        CompleteConstLedgerStatePtr newLedgerState) override;
+    void
+    advanceLedgerStateAndPublish(uint32_t ledgerSeq, bool calledViaExternalize,
+                                 LedgerCloseData const& ledgerData,
+                                 CompleteConstLedgerStatePtr newLedgerState,
+                                 bool queueRebuildNeeded) override;
     void ledgerCloseComplete(uint32_t lcl, bool calledViaExternalize,
-                             LedgerCloseData const& ledgerData);
+                             LedgerCloseData const& ledgerData,
+                             bool queueRebuildNeeded);
     void
     setLastClosedLedger(LedgerHeaderHistoryEntry const& lastClosed) override;
 

--- a/src/ledger/NetworkConfig.cpp
+++ b/src/ledger/NetworkConfig.cpp
@@ -1431,15 +1431,15 @@ SorobanNetworkConfig::loadLedgerAccessSettings(AbstractLedgerTxn& ltx)
         ConfigSettingID::CONFIG_SETTING_CONTRACT_LEDGER_COST_V0;
     auto le = ltx.loadWithoutRecord(key).current();
     auto const& configSetting = le.data.configSetting().contractLedgerCost();
-    mledgerMaxDiskReadEntries = configSetting.ledgerMaxDiskReadEntries;
-    mledgerMaxDiskReadBytes = configSetting.ledgerMaxDiskReadBytes;
+    mLedgerMaxDiskReadEntries = configSetting.ledgerMaxDiskReadEntries;
+    mLedgerMaxDiskReadBytes = configSetting.ledgerMaxDiskReadBytes;
     mLedgerMaxWriteLedgerEntries = configSetting.ledgerMaxWriteLedgerEntries;
     mLedgerMaxWriteBytes = configSetting.ledgerMaxWriteBytes;
     mTxMaxDiskReadEntries = configSetting.txMaxDiskReadEntries;
     mTxMaxDiskReadBytes = configSetting.txMaxDiskReadBytes;
     mTxMaxWriteLedgerEntries = configSetting.txMaxWriteLedgerEntries;
     mTxMaxWriteBytes = configSetting.txMaxWriteBytes;
-    mfeeDiskReadLedgerEntry = configSetting.feeDiskReadLedgerEntry;
+    mFeeDiskReadLedgerEntry = configSetting.feeDiskReadLedgerEntry;
     mFeeWriteLedgerEntry = configSetting.feeWriteLedgerEntry;
     mFeeDiskRead1KB = configSetting.feeDiskRead1KB;
     mSorobanStateTargetSizeBytes = configSetting.sorobanStateTargetSizeBytes;
@@ -1730,13 +1730,13 @@ SorobanNetworkConfig::txMemoryLimit() const
 uint32_t
 SorobanNetworkConfig::ledgerMaxDiskReadEntries() const
 {
-    return mledgerMaxDiskReadEntries;
+    return mLedgerMaxDiskReadEntries;
 }
 
 uint32_t
 SorobanNetworkConfig::ledgerMaxDiskReadBytes() const
 {
-    return mledgerMaxDiskReadBytes;
+    return mLedgerMaxDiskReadBytes;
 }
 
 uint32_t
@@ -1778,7 +1778,7 @@ SorobanNetworkConfig::txMaxWriteBytes() const
 int64_t
 SorobanNetworkConfig::feeDiskReadLedgerEntry() const
 {
-    return mfeeDiskReadLedgerEntry;
+    return mFeeDiskReadLedgerEntry;
 }
 
 int64_t
@@ -2288,8 +2288,8 @@ SorobanNetworkConfig::operator==(SorobanNetworkConfig const& other) const
                other.feeRatePerInstructionsIncrement() &&
            mTxMemoryLimit == other.txMemoryLimit() &&
 
-           mledgerMaxDiskReadEntries == other.ledgerMaxDiskReadEntries() &&
-           mledgerMaxDiskReadBytes == other.ledgerMaxDiskReadBytes() &&
+           mLedgerMaxDiskReadEntries == other.ledgerMaxDiskReadEntries() &&
+           mLedgerMaxDiskReadBytes == other.ledgerMaxDiskReadBytes() &&
            mLedgerMaxWriteLedgerEntries ==
                other.ledgerMaxWriteLedgerEntries() &&
            mLedgerMaxWriteBytes == other.ledgerMaxWriteBytes() &&
@@ -2300,7 +2300,7 @@ SorobanNetworkConfig::operator==(SorobanNetworkConfig const& other) const
            mTxMaxDiskReadBytes == other.txMaxDiskReadBytes() &&
            mTxMaxWriteLedgerEntries == other.txMaxWriteLedgerEntries() &&
            mTxMaxWriteBytes == other.txMaxWriteBytes() &&
-           mfeeDiskReadLedgerEntry == other.feeDiskReadLedgerEntry() &&
+           mFeeDiskReadLedgerEntry == other.feeDiskReadLedgerEntry() &&
            mFeeWriteLedgerEntry == other.feeWriteLedgerEntry() &&
            mFeeDiskRead1KB == other.feeDiskRead1KB() &&
            mFeeFlatRateWrite1KB == other.feeFlatRateWrite1KB() &&

--- a/src/ledger/NetworkConfig.h
+++ b/src/ledger/NetworkConfig.h
@@ -479,8 +479,8 @@ class SorobanNetworkConfig
     uint32_t mTxMemoryLimit{};
 
     // Ledger access settings for contracts.
-    uint32_t mledgerMaxDiskReadEntries{};
-    uint32_t mledgerMaxDiskReadBytes{};
+    uint32_t mLedgerMaxDiskReadEntries{};
+    uint32_t mLedgerMaxDiskReadBytes{};
     uint32_t mLedgerMaxWriteLedgerEntries{};
     uint32_t mLedgerMaxWriteBytes{};
     uint32_t mLedgerMaxTxCount{};
@@ -488,7 +488,7 @@ class SorobanNetworkConfig
     uint32_t mTxMaxDiskReadBytes{};
     uint32_t mTxMaxWriteLedgerEntries{};
     uint32_t mTxMaxWriteBytes{};
-    int64_t mfeeDiskReadLedgerEntry{};
+    int64_t mFeeDiskReadLedgerEntry{};
     int64_t mFeeWriteLedgerEntry{};
     int64_t mFeeDiskRead1KB{};
     int64_t mFeeRent1KB{};

--- a/src/simulation/test/LoadGeneratorTests.cpp
+++ b/src/simulation/test/LoadGeneratorTests.cpp
@@ -622,9 +622,9 @@ TEST_CASE("generate soroban load", "[loadgen][soroban]")
             // Allow every TX to have the maximum TX resources
             cfg.mLedgerMaxInstructions =
                 cfg.mTxMaxInstructions * cfg.mLedgerMaxTxCount;
-            cfg.mledgerMaxDiskReadEntries =
+            cfg.mLedgerMaxDiskReadEntries =
                 cfg.mTxMaxDiskReadEntries * cfg.mLedgerMaxTxCount;
-            cfg.mledgerMaxDiskReadBytes =
+            cfg.mLedgerMaxDiskReadBytes =
                 cfg.mTxMaxDiskReadBytes * cfg.mLedgerMaxTxCount;
             cfg.mLedgerMaxWriteLedgerEntries =
                 cfg.mTxMaxWriteLedgerEntries * cfg.mLedgerMaxTxCount;

--- a/src/simulation/test/LoadGeneratorTests.cpp
+++ b/src/simulation/test/LoadGeneratorTests.cpp
@@ -54,8 +54,8 @@ TEST_CASE("loadgen in overlay-only mode", "[loadgen]")
             cfg.mLedgerMaxTxCount = mx;
             cfg.mLedgerMaxInstructions = mx;
             cfg.mLedgerMaxTransactionsSizeBytes = mx;
-            cfg.mledgerMaxDiskReadEntries = mx;
-            cfg.mledgerMaxDiskReadBytes = mx;
+            cfg.mLedgerMaxDiskReadEntries = mx;
+            cfg.mLedgerMaxDiskReadBytes = mx;
             cfg.mLedgerMaxWriteLedgerEntries = mx;
             cfg.mLedgerMaxWriteBytes = mx;
         },

--- a/src/test/TestUtils.cpp
+++ b/src/test/TestUtils.cpp
@@ -435,8 +435,8 @@ setSorobanNetworkConfigForTest(SorobanNetworkConfig& cfg,
     cfg.mTxMaxWriteLedgerEntries = 20;
     cfg.mTxMaxWriteBytes = 100 * 1024;
 
-    cfg.mledgerMaxDiskReadEntries = cfg.mTxMaxDiskReadEntries * 10;
-    cfg.mledgerMaxDiskReadBytes = cfg.mTxMaxDiskReadBytes * 10;
+    cfg.mLedgerMaxDiskReadEntries = cfg.mTxMaxDiskReadEntries * 10;
+    cfg.mLedgerMaxDiskReadBytes = cfg.mTxMaxDiskReadBytes * 10;
     cfg.mLedgerMaxWriteLedgerEntries = cfg.mTxMaxWriteLedgerEntries * 10;
     cfg.mLedgerMaxWriteBytes = cfg.mTxMaxWriteBytes * 10;
 

--- a/src/test/TestUtils.h
+++ b/src/test/TestUtils.h
@@ -126,6 +126,8 @@ void
 upgradeSorobanNetworkConfig(std::function<void(SorobanNetworkConfig&)> modifyFn,
                             std::shared_ptr<Simulation> simulation,
                             bool applyUpgrade = true);
+std::pair<SorobanNetworkConfig, UpgradeType> prepareSorobanNetworkConfigUpgrade(
+    Application& app, std::function<void(SorobanNetworkConfig&)> modifyFn);
 void
 modifySorobanNetworkConfig(Application& app,
                            std::function<void(SorobanNetworkConfig&)> modifyFn);

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -1426,7 +1426,7 @@ TEST_CASE_VERSIONS("Soroban non-refundable resource fees are stable",
     for_versions_from(20, *app, [&] {
         auto cfgModifyFn = [&](SorobanNetworkConfig& cfg) {
             cfg.mFeeRatePerInstructionsIncrement = 1000;
-            cfg.mfeeDiskReadLedgerEntry = 2000;
+            cfg.mFeeDiskReadLedgerEntry = 2000;
             cfg.mFeeWriteLedgerEntry = 3000;
             cfg.mFeeDiskRead1KB = 4000;
             cfg.mFeeHistorical1KB = 6000;
@@ -4891,7 +4891,7 @@ TEST_CASE("settings upgrade command line utils", "[tx][soroban][upgrades]")
         cfg.mStateArchivalSettings.liveSorobanStateSizeWindowSamplePeriod = 1;
         // These are required to allow for an upgrade of all settings at once.
         cfg.mMaxContractDataEntrySizeBytes = 5000;
-        cfg.mledgerMaxDiskReadBytes = 5000;
+        cfg.mLedgerMaxDiskReadBytes = 5000;
         cfg.mLedgerMaxWriteBytes = 5000;
         cfg.mTxMaxDiskReadBytes = 5000;
         cfg.mTxMaxWriteBytes = 5000;

--- a/src/util/TxResource.cpp
+++ b/src/util/TxResource.cpp
@@ -44,6 +44,7 @@ anyLessThan(Resource const& lhs, Resource const& rhs)
     return false;
 }
 
+// Throws if multiplication result overflows int64_t
 Resource
 multiplyByDouble(Resource const& res, double m)
 {
@@ -55,6 +56,29 @@ multiplyByDouble(Resource const& res, double m)
         releaseAssertOrThrow(tempResultDbl >= 0.0);
         releaseAssertOrThrow(isRepresentableAsInt64(tempResultDbl));
         resource = static_cast<int64_t>(tempResultDbl);
+    }
+
+    return newRes;
+}
+
+// Saturating multiply: cap at int64_t::max if result would overflow
+Resource
+saturatedMultiplyByDouble(Resource const& res, double m)
+{
+    auto newRes = res;
+    for (auto& resource : newRes.mResources)
+    {
+        auto tempResultDbl = resource * m;
+        releaseAssertOrThrow(tempResultDbl >= 0.0);
+
+        if (isRepresentableAsInt64(tempResultDbl))
+        {
+            resource = static_cast<int64_t>(tempResultDbl);
+        }
+        else
+        {
+            resource = std::numeric_limits<int64_t>::max();
+        }
     }
 
     return newRes;

--- a/src/util/TxResource.h
+++ b/src/util/TxResource.h
@@ -134,6 +134,7 @@ class Resource
     bool canAdd(Resource const& other) const;
 
     friend Resource multiplyByDouble(Resource const& res, double m);
+    friend Resource saturatedMultiplyByDouble(Resource const& res, double m);
     friend Resource bigDivideOrThrow(Resource const& res, int64_t B, int64_t C,
                                      Rounding rounding);
     friend Resource operator+(Resource const& lhs, Resource const& rhs);


### PR DESCRIPTION
# Description

Resolves #4740

This change clears and rebuilds the Soroban TX queue whenever a protocol upgrade and network config upgrade occurs, as the queue may no longer be valid with the updated values. I also spotted a minor bug where some valid network config upgrade values would cause an overflow and core to throw. This isn't a vulnerability, since tier 1 would need to vote on very large network config values, but it occurred in a test, so I've added an explicit check.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
