### PR TITLE
More parallel-apply refactoring

### DIFF
--- a/src/transactions/ExtendFootprintTTLOpFrame.cpp
+++ b/src/transactions/ExtendFootprintTTLOpFrame.cpp
@@ -72,8 +72,6 @@ class ExtendFootprintTTLApplyHelper : virtual public LedgerAccessHelper
     SorobanNetworkConfig const& mSorobanConfig;
     Config const& mAppConfig;
 
-    rust::Vec<CxxBuf> mLedgerEntryCxxBufs;
-    rust::Vec<CxxBuf> mTtlEntryCxxBufs;
     ExtendFootprintTTLMetrics mMetrics;
     DiagnosticEventManager& mDiagnosticEvents;
 

--- a/src/transactions/ParallelApplyUtils.cpp
+++ b/src/transactions/ParallelApplyUtils.cpp
@@ -20,6 +20,82 @@ namespace
 {
 using namespace stellar;
 
+// Notes on parallelism and TTL bumps
+// ==================================
+//
+// We say two soroban txs "conflict" if the RW footprint of either tx intersects
+// with the RO _or_ RW footprints of the other. Put another way: if either might
+// be able to observe whether it ran before or after the other.
+//
+// The `ParallelTxSetBuilder` partitions a txset into stages and each stage into
+// _clusters_ such that there are no conflicts between the clusters of a stage.
+// Within a cluster, any two txs may or may not conflict. But between clusters
+// they definitely do not.
+//
+//
+// Read-only TTL bumps
+// -------------------
+//
+// We special-case one action that we expect to be quite common: when a tx bumps
+// the TTL of an LE that is otherwise _not written_ by the tx. For example
+// bumping the TTL of a popular contract instance when executing it. We call
+// this action `RoTTLBump(LE)`, and it is treated as a pseudo-write that can
+// potentially commute with all other RoTTLBump(LE) actions. Specifically it
+// causes LE to only go in the tx's RO footprint, not its RW footprint.
+//
+// This is enough to cause the following:
+//
+//   - If no txs in a stage do write(LE), the RoTTLBump(LE)-containing txs are
+//     free to run in parallel, do not effect clustering. We merge the bumps
+//     performed by each cluster using std::max() when committing it back to the
+//     global state (see GlobalParallelApplyLedgerState::maybeMergeRoTTLBumps)
+//
+//   - If _any_ tx in a stage does write(LE) it will have LE in its RW
+//     footprint, and so conflict with all txs doing RoTTLBump(LE). All of them
+//     will get clustered together, no bumps can happen in parallel. This is
+//     correct since the order of bumping and writing is observable both ways:
+//
+//       1. An RoTTLBump(LE) will cost a different fee if it happens before or
+//          after write(LE) since the write(LE) can change LE's size.
+//
+//       2. a write(LE) will cost a different fee if it happens before or after
+//          an RoTTLBump(LE) since the RoTTLBump(LE) can change LE's TTL.
+//
+//
+// Deferred read-only TTL bumps
+// ----------------------------
+//
+// We want to retain the ability for future versions of stellar-core to run txs
+// within a cluster in "as much parallelism as is legal", by further analyzing
+// the conflict relationships that exist _inside_ each cluster and scheduling
+// non-conflicting txs in parallel. But any given write(LE) in a cluster
+// essentially represents a synchronization barrier for all RoTTLBump(LE)
+// operations: those RoTTLBump(LE)s that run before the write(LE) don't conflict
+// with one another, but they _do_ conflict with the write(LE) and so a future
+// scheduler will have to commit to at least a partial order between _groups_ of
+// RoTTLBump(LE)s and individual write(LE)s.
+//
+// In absence of such a fancy future scheduler, we run each cluster in
+// sequential order, using the (somewhat incidental) total order that the
+// cluster is given to us as "the schedule", and we do our best not to constrain
+// future stellar-cores to replay in exactly this order. Specifically we defer
+// the effects of each RoTTLBump(LE) by merging them into a separate map
+// (mRoTTLBumps) that we only flush back to the ledger at each write(LE), as
+// well as the end of the cluster. This bakes-in to the history the execution
+// order of groups of RoTTLBump(LE)s and write(LE)s -- as it must! -- but not
+// the order of execution within each group of RoTTLBump(LE)s before or after
+// each write(LE). In other words we wind up constraining the future scheduler
+// by a partial order, not the total order.
+//
+// Note: by deferring the visibility of RoTTLBump(LE) effects this way it is
+// possible that slightly higher fees are charged. For example if we had
+// transactions A, B and C in the total order and A and B both do the same
+// RoTTLBump(LE) then C does write(LE), A's bump will be deferred until C, and
+// so B will pay to do the same bump again. Whereas if we were to commit to a
+// total order, B could save this fee, but we would lose the ability to run A
+// and B in parallel in the future. CAP 0063 explicitly chose this tradeoff.
+
+
 std::unordered_set<LedgerKey>
 getReadWriteKeysForStage(ApplyStage const& stage)
 {

--- a/src/transactions/ParallelApplyUtils.cpp
+++ b/src/transactions/ParallelApplyUtils.cpp
@@ -16,8 +16,9 @@
 #include <fmt/std.h>
 #include <thread>
 
-namespace stellar
+namespace
 {
+using namespace stellar;
 
 std::unordered_set<LedgerKey>
 getReadWriteKeysForStage(ApplyStage const& stage)
@@ -38,6 +39,36 @@ getReadWriteKeysForStage(ApplyStage const& stage)
     }
     return res;
 }
+
+bool
+maybeMergeRoTTLBumps(LedgerKey const& key, ParallelApplyEntry const& newEntry,
+                     ParallelApplyEntry& oldEntry,
+                     std::unordered_set<LedgerKey> const& readWriteSet)
+{
+    if (newEntry.mLedgerEntry && oldEntry.mLedgerEntry)
+    {
+        auto const& newLe = newEntry.mLedgerEntry.value();
+        auto& oldLe = oldEntry.mLedgerEntry.value();
+        if (key.type() == TTL)
+        {
+            releaseAssertOrThrow(newLe.data.type() == TTL);
+            releaseAssertOrThrow(oldLe.data.type() == TTL);
+            if (readWriteSet.find(key) == readWriteSet.end())
+            {
+                auto const& newTTL = newLe.data.ttl().liveUntilLedgerSeq;
+                auto& oldTTL = oldLe.data.ttl().liveUntilLedgerSeq;
+                oldTTL = std::max(oldTTL, newTTL);
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+}
+
+namespace stellar
+{
 
 void
 preParallelApplyAndCollectModifiedClassicEntries(
@@ -99,89 +130,6 @@ preParallelApplyAndCollectModifiedClassicEntries(
             fetchInMemoryClassicEntries(footprint.readWrite);
             fetchInMemoryClassicEntries(footprint.readOnly);
         }
-    }
-}
-
-void
-writeDirtyThreadEntryMapEntriesToGlobalEntryMap(
-    ParallelApplyEntryMap const& threadEntryMap,
-    ParallelApplyEntryMap& globalEntryMap,
-    std::unordered_set<LedgerKey> const& isInReadWriteSet)
-{
-    for (auto const& entry : threadEntryMap)
-    {
-        // Only update if dirty bit is set
-        if (!entry.second.mIsDirty)
-        {
-            continue;
-        }
-
-        if (entry.second.mLedgerEntry)
-        {
-            auto const& updatedEntry = *entry.second.mLedgerEntry;
-
-            auto it = globalEntryMap.find(entry.first);
-            if (it != globalEntryMap.end() && it->second.mLedgerEntry)
-            {
-                auto const& currentEntry = *it->second.mLedgerEntry;
-                if (currentEntry.data.type() == TTL)
-                {
-                    auto currLiveUntil =
-                        currentEntry.data.ttl().liveUntilLedgerSeq;
-                    auto newLiveUntil =
-                        updatedEntry.data.ttl().liveUntilLedgerSeq;
-
-                    // The only scenario where we accept a reduction in TTL
-                    // is one where an entry was deleted, and then
-                    // recreated. This can only happen if the key was in the
-                    // readWrite set, so if it's not then this is just a
-                    // parallel readOnly bump that we can ignore here.
-                    if (newLiveUntil <= currLiveUntil &&
-                        isInReadWriteSet.count(entry.first) == 0)
-                    {
-                        continue;
-                    }
-                }
-                it->second = entry.second;
-            }
-            else
-            {
-                if (it != globalEntryMap.end())
-                {
-                    it->second = entry.second;
-                }
-                else
-                {
-                    globalEntryMap.emplace(
-                        entry.first,
-                        ParallelApplyEntry::dirtyLive(updatedEntry));
-                }
-            }
-        }
-        else
-        {
-            auto dead = ParallelApplyEntry::dirtyDead();
-            auto [it, inserted] = globalEntryMap.emplace(entry.first, dead);
-            if (!inserted)
-            {
-                it->second = dead;
-            }
-        }
-    }
-}
-
-void
-writeDirtyMapEntriesToGlobalEntryMap(
-    std::vector<std::unique_ptr<ParallelApplyEntryMap>> const&
-        entryMapsByCluster,
-    ParallelApplyEntryMap& globalEntryMap,
-    std::unordered_set<LedgerKey> const& isInReadWriteSet)
-{
-    // merge entryMaps into globalEntryMap
-    for (auto const& map : entryMapsByCluster)
-    {
-        writeDirtyThreadEntryMapEntriesToGlobalEntryMap(*map, globalEntryMap,
-                                                        isInReadWriteSet);
     }
 }
 
@@ -668,7 +616,7 @@ void
 GlobalParallelApplyLedgerState::upsertEntry(LedgerKey const& key,
                                             LedgerEntry const& entry)
 {
-    auto e = ParallelApplyEntry::dirtyLive(entry);
+    auto e = ParallelApplyEntry::dirtyPopulated(entry);
     auto [it, inserted] = mGlobalEntryMap.emplace(key, e);
     if (!inserted)
     {
@@ -679,7 +627,7 @@ GlobalParallelApplyLedgerState::upsertEntry(LedgerKey const& key,
 void
 GlobalParallelApplyLedgerState::eraseEntry(LedgerKey const& key)
 {
-    auto e = ParallelApplyEntry::dirtyDead();
+    auto e = ParallelApplyEntry::dirtyEmpty();
     auto [it, inserted] = mGlobalEntryMap.emplace(key, e);
     if (!inserted)
     {
@@ -694,6 +642,25 @@ GlobalParallelApplyLedgerState::getRestoredEntries() const
 }
 
 void
+GlobalParallelApplyLedgerState::commitChangeFromThread(
+    LedgerKey const& key, ParallelApplyEntry const& parEntry,
+    std::unordered_set<LedgerKey> const& readWriteSet)
+{
+    if (!parEntry.mIsDirty)
+    {
+        return;
+    }
+    auto [it, inserted] = mGlobalEntryMap.emplace(key, parEntry);
+    if (!inserted)
+    {
+        if (!maybeMergeRoTTLBumps(key, parEntry, it->second, readWriteSet))
+        {
+            it->second = parEntry;
+        }
+    }
+}
+
+void
 GlobalParallelApplyLedgerState::commitChangesFromThread(
     AppConnector& app, ThreadParallelApplyLedgerState const& thread,
     ApplyStage const& stage)
@@ -701,8 +668,10 @@ GlobalParallelApplyLedgerState::commitChangesFromThread(
     releaseAssert(threadIsMain() ||
                   app.threadIsType(Application::ThreadType::APPLY));
     auto readWriteSet = getReadWriteKeysForStage(stage);
-    writeDirtyThreadEntryMapEntriesToGlobalEntryMap(
-        thread.getEntryMap(), mGlobalEntryMap, readWriteSet);
+    for (auto const& [key, entry] : thread.getEntryMap())
+    {
+        commitChangeFromThread(key, entry, readWriteSet);
+    }
     mGlobalRestoredEntries.addRestoresFrom(thread.getRestoredEntries());
 }
 
@@ -754,7 +723,7 @@ ThreadParallelApplyLedgerState::collectClusterFootprintEntriesFromGlobal(
                 if (opt)
                 {
                     mThreadEntryMap.emplace(
-                        key, ParallelApplyEntry::cleanLive(opt.value()));
+                        key, ParallelApplyEntry::cleanPopulated(opt.value()));
                     if (isSorobanEntry(key))
                     {
                         auto ttlKey = getTTLKey(key);
@@ -762,7 +731,7 @@ ThreadParallelApplyLedgerState::collectClusterFootprintEntriesFromGlobal(
                         releaseAssertOrThrow(ttlOpt);
                         mThreadEntryMap.emplace(
                             ttlKey,
-                            ParallelApplyEntry::cleanLive(ttlOpt.value()));
+                            ParallelApplyEntry::cleanPopulated(ttlOpt.value()));
                     }
                 }
             }

--- a/src/transactions/ParallelApplyUtils.cpp
+++ b/src/transactions/ParallelApplyUtils.cpp
@@ -65,11 +65,6 @@ maybeMergeRoTTLBumps(LedgerKey const& key, ParallelApplyEntry const& newEntry,
     return false;
 }
 
-}
-
-namespace stellar
-{
-
 void
 preParallelApplyAndCollectModifiedClassicEntries(
     AppConnector& app, AbstractLedgerTxn& ltx,
@@ -258,13 +253,12 @@ flushResidualRoTTLBumps(SearchableSnapshotConstPtr liveSnapshot,
     }
 }
 
-// Construct a map of all the TTL keys associated with all soroban
-// (code-or-data) keys named in the footprint of the `txBundle`, along with a
-// boolean indicating whether they're RO TTL keys. When false, they're RW.
-UnorderedMap<LedgerKey, bool>
-buildRoTTLMap(TxBundle const& txBundle)
+// Construct a set of all the TTL keys associated with all RO soroban
+// (code-or-data) keys named in the footprint of the `txBundle`.
+UnorderedSet<LedgerKey>
+buildRoTTLSet(TxBundle const& txBundle)
 {
-    UnorderedMap<LedgerKey, bool> isReadOnlyTTLMap;
+    UnorderedSet<LedgerKey> isReadOnlyTTLSet;
     for (auto const& ro :
          txBundle.getTx()->sorobanResources().footprint.readOnly)
     {
@@ -272,7 +266,7 @@ buildRoTTLMap(TxBundle const& txBundle)
         {
             continue;
         }
-        isReadOnlyTTLMap.emplace(getTTLKey(ro), true);
+        isReadOnlyTTLSet.emplace(getTTLKey(ro));
     }
     for (auto const& rw :
          txBundle.getTx()->sorobanResources().footprint.readWrite)
@@ -281,20 +275,9 @@ buildRoTTLMap(TxBundle const& txBundle)
         {
             continue;
         }
-        isReadOnlyTTLMap.emplace(getTTLKey(rw), false);
+        isReadOnlyTTLSet.erase(getTTLKey(rw));
     }
-
-    return isReadOnlyTTLMap;
-}
-
-// Look up a key in the RO TTL map built above. If the key is either not a TTL,
-// or not RO, return false.
-bool
-isRoTTLKey(UnorderedMap<LedgerKey, bool> const& rmap, LedgerKey const& lk)
-{
-    auto it = rmap.find(lk);
-    releaseAssert(lk.type() == TTL || it == rmap.end());
-    return lk.type() == TTL && it->second;
+    return isReadOnlyTTLSet;
 }
 
 // Accumulate into the buffer of `roTTLBumps` the max of any existing entry and
@@ -311,45 +294,10 @@ updateMaxOfRoTTLBump(UnorderedMap<LedgerKey, uint32_t>& roTTLBumps,
     }
 }
 
-// Writes the entries in `res` back to the `entryMap`, `roTTLBumps` and
-// `threadRestoredEntries` variables that are accumulating the state of
-// the transaction cluster.
-void
-recordModifiedAndRestoredEntries(SearchableSnapshotConstPtr liveSnapshot,
-                                 ParallelApplyEntryMap& entryMap,
-                                 UnorderedMap<LedgerKey, uint32_t>& roTTLBumps,
-                                 RestoredEntries& threadRestoredEntries,
-                                 TxBundle const& txBundle,
-                                 ParallelTxReturnVal const& res)
-{
-    releaseAssert(res.getSuccess());
-    auto rmap = buildRoTTLMap(txBundle);
-
-    // now apply the entry changes to entryMap
-    for (auto const& [lk, updatedLe] : res.getModifiedEntryMap())
-    {
-        auto oldEntryOpt = getLiveEntry(lk, liveSnapshot, entryMap);
-
-        if (isRoTTLKey(rmap, lk) && oldEntryOpt && updatedLe)
-        {
-            // Accumulate RO bumps instead of writing them to the entryMap.
-            releaseAssert(ttl(updatedLe) >= ttl(oldEntryOpt));
-            updateMaxOfRoTTLBump(roTTLBumps, lk, updatedLe);
-        }
-        else
-        {
-            // A entry deletion will be marked by a nullopt le.
-            // Set the dirty bit so it'll be written to ltx later.
-            auto e = ParallelApplyEntry{updatedLe, true};
-            auto [it, inserted] = entryMap.emplace(lk, e);
-            if (!inserted)
-            {
-                it->second = e;
-            }
-        }
-    }
-    threadRestoredEntries.addRestoresFrom(res.getRestoredEntries());
 }
+
+namespace stellar
+{
 
 void
 setDelta(SearchableSnapshotConstPtr liveSnapshot,
@@ -806,13 +754,60 @@ ThreadParallelApplyLedgerState::getLiveEntryOpt(LedgerKey const& key) const
 }
 
 void
+ThreadParallelApplyLedgerState::upsertEntry(LedgerKey const& key,
+                                            LedgerEntry const& entry)
+{
+    auto e = ParallelApplyEntry::dirtyPopulated(entry);
+    auto [it, inserted] = mThreadEntryMap.emplace(key, e);
+    if (!inserted)
+    {
+        it->second = e;
+    }
+}
+void
+ThreadParallelApplyLedgerState::eraseEntry(LedgerKey const& key)
+{
+    auto e = ParallelApplyEntry::dirtyEmpty();
+    auto [it, inserted] = mThreadEntryMap.emplace(key, e);
+    if (!inserted)
+    {
+        it->second = e;
+    }
+}
+
+void
+ThreadParallelApplyLedgerState::commitChangeFromSuccessfulOp(
+    LedgerKey const& key, std::optional<LedgerEntry> const& entryOpt,
+    UnorderedSet<LedgerKey> const& roTTLSet)
+{
+    auto oldEntryOpt = getLiveEntryOpt(key);
+    if (entryOpt && oldEntryOpt && roTTLSet.find(key) != roTTLSet.end())
+    {
+        // Accumulate RO bumps instead of writing them to the entryMap.
+        releaseAssert(ttl(entryOpt) >= ttl(oldEntryOpt));
+        updateMaxOfRoTTLBump(mRoTTLBumps, key, entryOpt);
+    }
+    else if (entryOpt)
+    {
+        upsertEntry(key, entryOpt.value());
+    }
+    else
+    {
+        eraseEntry(key);
+    }
+}
+
+void
 ThreadParallelApplyLedgerState::commitChangesFromSuccessfulOp(
     ParallelTxReturnVal const& res, TxBundle const& txBundle)
 {
     releaseAssert(res.getSuccess());
-    recordModifiedAndRestoredEntries(mLiveSnapshot, mThreadEntryMap,
-                                     mRoTTLBumps, mThreadRestoredEntries,
-                                     txBundle, res);
+    auto roTTLSet = buildRoTTLSet(txBundle);
+    for (auto const& [key, entryOpt] : res.getModifiedEntryMap())
+    {
+        commitChangeFromSuccessfulOp(key, entryOpt, roTTLSet);
+    }
+    mThreadRestoredEntries.addRestoresFrom(res.getRestoredEntries());
 }
 
 bool

--- a/src/transactions/ParallelApplyUtils.h
+++ b/src/transactions/ParallelApplyUtils.h
@@ -68,27 +68,6 @@ void setDelta(SearchableSnapshotConstPtr liveSnapshot,
               UnorderedMap<LedgerKey, LedgerEntry> const& hotArchiveRestores,
               ParallelLedgerInfo const& ledgerInfo, TxEffects& effects);
 
-void preParallelApplyAndCollectModifiedClassicEntries(
-    AppConnector& app, AbstractLedgerTxn& ltx,
-    std::vector<ApplyStage> const& stages,
-    ParallelApplyEntryMap& globalEntryMap);
-
-void flushRoTTLBumpsRequiredByTx(SearchableSnapshotConstPtr liveSnapshot,
-                                 ParallelApplyEntryMap& entryMap,
-                                 UnorderedMap<LedgerKey, uint32_t>& roTTLBumps,
-                                 TxBundle const& txBundle);
-
-void
-flushResidualRoTTLBumps(SearchableSnapshotConstPtr liveSnapshot,
-                        ParallelApplyEntryMap& entryMap,
-                        UnorderedMap<LedgerKey, uint32_t> const& roTTLBumps);
-
-void recordModifiedAndRestoredEntries(
-    SearchableSnapshotConstPtr liveSnapshot, ParallelApplyEntryMap& entryMap,
-    UnorderedMap<LedgerKey, uint32_t>& roTTLBumps,
-    RestoredEntries& threadRestoredEntries, TxBundle const& txBundle,
-    ParallelTxReturnVal const& res);
-
 std::optional<LedgerEntry> getLiveEntry(LedgerKey const& lk,
                                         SearchableSnapshotConstPtr liveSnapshot,
                                         ParallelApplyEntryMap const& entryMap);
@@ -193,6 +172,13 @@ class ThreadParallelApplyLedgerState
     void collectClusterFootprintEntriesFromGlobal(
         AppConnector& app, GlobalParallelApplyLedgerState const& global,
         Cluster const& cluster);
+
+    void upsertEntry(LedgerKey const& key, LedgerEntry const& entry);
+    void eraseEntry(LedgerKey const& key);
+    void
+    commitChangeFromSuccessfulOp(LedgerKey const& key,
+                                 std::optional<LedgerEntry> const& entryOpt,
+                                 UnorderedSet<LedgerKey> const& roTTLSet);
 
   public:
     ThreadParallelApplyLedgerState(AppConnector& app,

--- a/src/transactions/ParallelApplyUtils.h
+++ b/src/transactions/ParallelApplyUtils.h
@@ -61,8 +61,6 @@ class ParallelLedgerInfo
     Hash networkID;
 };
 
-std::unordered_set<LedgerKey> getReadWriteKeysForStage(ApplyStage const& stage);
-
 // sets LedgerTxnDelta within effects
 void setDelta(SearchableSnapshotConstPtr liveSnapshot,
               ParallelApplyEntryMap const& entryMap,
@@ -74,12 +72,6 @@ void preParallelApplyAndCollectModifiedClassicEntries(
     AppConnector& app, AbstractLedgerTxn& ltx,
     std::vector<ApplyStage> const& stages,
     ParallelApplyEntryMap& globalEntryMap);
-
-void writeDirtyMapEntriesToGlobalEntryMap(
-    std::vector<std::unique_ptr<ParallelApplyEntryMap>> const&
-        entryMapsByCluster,
-    ParallelApplyEntryMap& globalEntryMap,
-    std::unordered_set<LedgerKey> const& isInReadWriteSet);
 
 void flushRoTTLBumpsRequiredByTx(SearchableSnapshotConstPtr liveSnapshot,
                                  ParallelApplyEntryMap& entryMap,
@@ -138,6 +130,11 @@ class GlobalParallelApplyLedgerState
     //    -- split into disjoint per-thread maps during execution and merged
     //    after -- as well as written back to the ltx at the phase's end.
     ParallelApplyEntryMap mGlobalEntryMap;
+
+    void
+    commitChangeFromThread(LedgerKey const& key,
+                           ParallelApplyEntry const& parEntry,
+                           std::unordered_set<LedgerKey> const& readWriteSet);
 
     void commitChangesFromThread(AppConnector& app,
                                  ThreadParallelApplyLedgerState const& thread,

--- a/src/transactions/RestoreFootprintOpFrame.cpp
+++ b/src/transactions/RestoreFootprintOpFrame.cpp
@@ -4,6 +4,7 @@
 
 #include "transactions/RestoreFootprintOpFrame.h"
 #include "TransactionUtils.h"
+#include "bucket/BucketUtils.h"
 #include "bucket/HotArchiveBucket.h"
 #include "ledger/LedgerManagerImpl.h"
 #include "ledger/LedgerTypeUtils.h"
@@ -16,6 +17,12 @@
 
 namespace stellar
 {
+
+static RestoreFootprintResult&
+innerResult(OperationResult& res)
+{
+    return res.tr().restoreFootprintResult();
+}
 
 struct RestoreFootprintMetrics
 {
@@ -47,6 +54,321 @@ RestoreFootprintOpFrame::RestoreFootprintOpFrame(
 {
 }
 
+class RestoreFootprintApplyHelper : virtual public LedgerAccessHelper
+{
+
+  protected:
+    AppConnector& mApp;
+    OperationResult& mRes;
+    std::optional<RefundableFeeTracker>& mRefundableFeeTracker;
+    OperationMetaBuilder& mOpMeta;
+    RestoreFootprintOpFrame const& mOpFrame;
+
+    SorobanResources const& mResources;
+    SorobanNetworkConfig const& mSorobanConfig;
+    Config const& mAppConfig;
+
+    RestoreFootprintMetrics mMetrics;
+    DiagnosticEventManager& mDiagnosticEvents;
+
+  public:
+    RestoreFootprintApplyHelper(
+        AppConnector& app, OperationResult& res,
+        std::optional<RefundableFeeTracker>& refundableFeeTracker,
+        OperationMetaBuilder& opMeta, RestoreFootprintOpFrame const& opFrame)
+        : mApp(app)
+        , mRes(res)
+        , mRefundableFeeTracker(refundableFeeTracker)
+        , mOpMeta(opMeta)
+        , mOpFrame(opFrame)
+        , mResources(mOpFrame.mParentTx.sorobanResources())
+        , mSorobanConfig(app.getSorobanNetworkConfigForApply())
+        , mAppConfig(app.getConfig())
+        , mMetrics(app.getSorobanMetrics())
+        , mDiagnosticEvents(mOpMeta.getDiagnosticEventManager())
+    {
+    }
+
+    virtual std::optional<LedgerEntry>
+    getHotArchiveEntry(LedgerKey const& key) = 0;
+    virtual bool entryWasRestored(LedgerKey const& key) = 0;
+    virtual void restoreEntry(LedgerKey const& lk, LedgerEntry const& entry,
+                              LedgerKey const& ttlKey,
+                              std::optional<LedgerEntry> const& ttlEntryOpt,
+                              uint32_t restoredLiveUntilLedger) = 0;
+
+    virtual bool
+    apply()
+    {
+        ZoneNamedN(applyZone, "RestoreFootprintOpFrame apply", true);
+        auto timeScope = mMetrics.getExecTimer();
+
+        auto const& resources = mOpFrame.mParentTx.sorobanResources();
+        auto const& footprint = resources.footprint;
+        auto ledgerSeq = getLedgerSeq();
+        auto const& archivalSettings = mSorobanConfig.stateArchivalSettings();
+        rust::Vec<CxxLedgerEntryRentChange> rustEntryRentChanges;
+        // Extend the TTL on the restored entry to minimum TTL, including
+        // the current ledger.
+        uint32_t restoredLiveUntilLedger =
+            ledgerSeq + archivalSettings.minPersistentTTL - 1;
+        uint32_t ledgerVersion = getLedgerVersion();
+        rustEntryRentChanges.reserve(footprint.readWrite.size());
+        auto& diagnosticEvents = mOpMeta.getDiagnosticEventManager();
+
+        for (auto const& lk : footprint.readWrite)
+        {
+            std::optional<LedgerEntry> hotArchiveEntryOpt = std::nullopt;
+            auto ttlKey = getTTLKey(lk);
+            auto ttlLeOpt = getLedgerEntryOpt(ttlKey);
+            if (!ttlLeOpt)
+            {
+                // This entry has already been restored and then deleted.
+                if (entryWasRestored(lk))
+                {
+                    continue;
+                }
+                hotArchiveEntryOpt = getHotArchiveEntry(lk);
+                if (!hotArchiveEntryOpt)
+                {
+                    // Neither live nor hot entry exists, skip.
+                    // (note: hot entry never exists in pre-23)
+                    continue;
+                }
+            }
+            else if (isLive(ttlLeOpt.value(), ledgerSeq))
+            {
+                // Skip entry if it's already live.
+                continue;
+            }
+
+            // We should _either_ have an entry to restore from hot or live BL.
+            releaseAssertOrThrow(hotArchiveEntryOpt || ttlLeOpt);
+
+            // We must load the ContractCode/ContractData entry for fee
+            // purposes, as restore is considered a write
+            uint32_t entrySize = 0;
+            LedgerEntry entry;
+            if (hotArchiveEntryOpt)
+            {
+                entry = hotArchiveEntryOpt.value();
+
+                // Update last modified ledger seq to the current ledger seq
+                // since we're rewriting this entry. ltx will update this for
+                // us, but we need to process the meta before ltx has a chance
+                // for the update.
+                entry.lastModifiedLedgerSeq = ledgerSeq;
+                entrySize = static_cast<uint32>(xdr::xdr_size(entry));
+            }
+            else
+            {
+                auto entryLeOpt = getLedgerEntryOpt(lk);
+
+                // We checked for TTLEntry existence above
+                releaseAssertOrThrow(entryLeOpt);
+
+                entry = *entryLeOpt;
+                entrySize = static_cast<uint32>(xdr::xdr_size(entry));
+            }
+
+            mMetrics.mLedgerReadByte += entrySize;
+            if (resources.diskReadBytes < mMetrics.mLedgerReadByte)
+            {
+                diagnosticEvents.pushError(
+                    SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
+                    "operation byte-read resources exceeds amount specified",
+                    {makeU64SCVal(mMetrics.mLedgerReadByte),
+                     makeU64SCVal(resources.diskReadBytes)});
+                innerResult(mRes).code(
+                    RESTORE_FOOTPRINT_RESOURCE_LIMIT_EXCEEDED);
+                return false;
+            }
+
+            // To maintain consistency with InvokeHostFunction, TTLEntry
+            // writes come out of refundable fee, so only add entrySize
+            mMetrics.mLedgerWriteByte += entrySize;
+            if (!validateContractLedgerEntry(lk, entrySize, mSorobanConfig,
+                                             mAppConfig, mOpFrame.mParentTx,
+                                             diagnosticEvents))
+            {
+                innerResult(mRes).code(
+                    RESTORE_FOOTPRINT_RESOURCE_LIMIT_EXCEEDED);
+                return false;
+            }
+
+            if (resources.writeBytes < mMetrics.mLedgerWriteByte)
+            {
+                diagnosticEvents.pushError(
+                    SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
+                    "operation byte-write resources exceeds amount specified",
+                    {makeU64SCVal(mMetrics.mLedgerWriteByte),
+                     makeU64SCVal(resources.writeBytes)});
+                innerResult(mRes).code(
+                    RESTORE_FOOTPRINT_RESOURCE_LIMIT_EXCEEDED);
+                return false;
+            }
+
+            rustEntryRentChanges.emplace_back(
+                createEntryRentChangeWithoutModification(
+                    entry, entrySize,
+                    /*entryLiveUntilLedger=*/std::nullopt,
+                    /*newLiveUntilLedger=*/restoredLiveUntilLedger,
+                    ledgerVersion, mAppConfig, mSorobanConfig));
+
+            restoreEntry(lk, entry, ttlKey, ttlLeOpt, restoredLiveUntilLedger);
+        }
+
+        int64_t rentFee = rust_bridge::compute_rent_fee(
+            mAppConfig.CURRENT_LEDGER_PROTOCOL_VERSION, ledgerVersion,
+            rustEntryRentChanges,
+            mSorobanConfig.rustBridgeRentFeeConfiguration(), ledgerSeq);
+        if (!mRefundableFeeTracker->consumeRefundableSorobanResources(
+                0, rentFee, getLedgerVersion(), mSorobanConfig, mAppConfig,
+                mOpFrame.mParentTx, mDiagnosticEvents))
+        {
+            innerResult(mRes).code(
+                RESTORE_FOOTPRINT_INSUFFICIENT_REFUNDABLE_FEE);
+            return false;
+        }
+        innerResult(mRes).code(RESTORE_FOOTPRINT_SUCCESS);
+        return true;
+    }
+};
+
+class RestoreFootprintPreV23ApplyHelper
+    : virtual public RestoreFootprintApplyHelper,
+      virtual public PreV23LedgerAccessHelper
+{
+  public:
+    RestoreFootprintPreV23ApplyHelper(
+        AppConnector& app, AbstractLedgerTxn& ltx, OperationResult& res,
+        std::optional<RefundableFeeTracker>& refundableFeeTracker,
+        OperationMetaBuilder& opMeta, RestoreFootprintOpFrame const& opFrame)
+        : RestoreFootprintApplyHelper(app, res, refundableFeeTracker, opMeta,
+                                      opFrame)
+        , PreV23LedgerAccessHelper(ltx)
+    {
+    }
+
+    std::optional<LedgerEntry>
+    getHotArchiveEntry(LedgerKey const& key) override
+    {
+        // There is no hot archive pre-23.
+        return std::nullopt;
+    }
+    bool
+    entryWasRestored(LedgerKey const& key) override
+    {
+        // NB: even though pre-23 can answer this question precisely, the code
+        // in pre-23 wasn't sensitive to it, so we preserve that functionality.
+        return false;
+    }
+    void
+    restoreEntry(LedgerKey const& lk, LedgerEntry const& entry_,
+                 LedgerKey const& ttlKey,
+                 std::optional<LedgerEntry> const& ttlEntryOpt,
+                 uint32_t restoredLiveUntilLedger) override
+    {
+        // Entry exists in the live BucketList if we get to this point due to
+        // the constTTLLtxe loadWithoutRecord logic above. Get the actual ledger
+        // entry (since we know it exists already at this point)
+        //
+        // NB: this method is given a parameter (entry_) that is the result of
+        // loadWithoutRecord, which is apparently not quite good enough: we do
+        // _exactly_ what the old code did here and make an additional call to
+        // mLtx->getNewestVersion, presumably to actually activate the restored
+        // entry in the current ltx (uncertain, it might just have been a quirk
+        // in the original code).
+        auto entry = mLtx.getNewestVersion(lk);
+        releaseAssertOrThrow(entry);
+        mLtx.restoreFromLiveBucketList(entry->ledgerEntry(),
+                                       restoredLiveUntilLedger);
+    }
+};
+
+class RestoreFootprintParallelApplyHelper
+    : virtual public RestoreFootprintApplyHelper,
+      virtual public ParallelLedgerAccessHelper
+{
+    SearchableHotArchiveSnapshotConstPtr mHotArchive;
+
+  public:
+    RestoreFootprintParallelApplyHelper(
+        AppConnector& app, ThreadParallelApplyLedgerState const& threadState,
+        ParallelLedgerInfo const& ledgerInfo, OperationResult& res,
+        std::optional<RefundableFeeTracker>& refundableFeeTracker,
+        OperationMetaBuilder& opMeta, RestoreFootprintOpFrame const& opFrame)
+        : RestoreFootprintApplyHelper(app, res, refundableFeeTracker, opMeta,
+                                      opFrame)
+        , ParallelLedgerAccessHelper(threadState, ledgerInfo,
+                                     app.copySearchableLiveBucketListSnapshot())
+        , mHotArchive(app.copySearchableHotArchiveBucketListSnapshot())
+    {
+    }
+
+    std::optional<LedgerEntry>
+    getHotArchiveEntry(LedgerKey const& key) override
+    {
+        auto ptr = mHotArchive->load(key);
+        if (ptr)
+        {
+            return ptr->archivedEntry();
+        }
+        else
+        {
+            return std::nullopt;
+        }
+    }
+
+    bool
+    entryWasRestored(LedgerKey const& key) override
+    {
+        return mOpState.entryWasRestored(key);
+    }
+
+    void
+    restoreEntry(LedgerKey const& lk, LedgerEntry const& entry,
+                 LedgerKey const& ttlKey,
+                 std::optional<LedgerEntry> const& ttlEntryOpt,
+                 uint32_t restoredLiveUntilLedger) override
+    {
+        if (!ttlEntryOpt)
+        {
+            // No TTL entry opt
+            //   => we are _not_ doing a live restore
+            //   => we _are_ doing a hot archive restore
+            mOpState.upsertEntry(lk, entry);
+            LedgerEntry ttlEntry =
+                getTTLEntryForTTLKey(ttlKey, restoredLiveUntilLedger);
+            mOpState.upsertEntry(ttlKey, ttlEntry);
+            mOpState.addHotArchiveRestore(lk, entry, ttlKey, ttlEntry);
+        }
+        else
+        {
+            // TTL entry opt
+            //   => a live restore
+            //   => just upsert the updated TTL
+            LedgerEntry ttlEntry = ttlEntryOpt.value();
+            ttlEntry.data.ttl().liveUntilLedgerSeq = restoredLiveUntilLedger;
+            mOpState.upsertEntry(ttlKey, ttlEntry);
+            mOpState.addLiveBucketlistRestore(lk, entry, ttlKey, ttlEntry);
+        }
+    }
+
+    ParallelTxReturnVal
+    takeResults(bool applySucceeded)
+    {
+        if (applySucceeded)
+        {
+            return mOpState.takeSuccess();
+        }
+        else
+        {
+            return mOpState.takeFailure();
+        }
+    }
+};
+
 bool
 RestoreFootprintOpFrame::isOpSupported(LedgerHeader const& header) const
 {
@@ -63,164 +385,15 @@ RestoreFootprintOpFrame::doParallelApply(
     std::optional<RefundableFeeTracker>& refundableFeeTracker,
     OperationMetaBuilder& opMeta) const
 {
-    ZoneNamedN(applyZone, "RestoreFootprintOpFrame apply", true);
+
     releaseAssertOrThrow(
         protocolVersionStartsFrom(ledgerInfo.getLedgerVersion(),
                                   PARALLEL_SOROBAN_PHASE_PROTOCOL_VERSION));
     releaseAssertOrThrow(refundableFeeTracker);
-
-    RestoreFootprintMetrics metrics(sorobanMetrics);
-    auto timeScope = metrics.getExecTimer();
-
-    auto liveSnapshot = app.copySearchableLiveBucketListSnapshot();
-
-    auto const& resources = mParentTx.sorobanResources();
-    auto const& footprint = resources.footprint;
-    auto ledgerSeq = ledgerInfo.getLedgerSeq();
-    auto hotArchive = app.copySearchableHotArchiveBucketListSnapshot();
-
-    // Keep track of LedgerEntry updates we need to make
-    OpModifiedEntryMap opEntryMap;
-
-    RestoredEntries restoredEntries;
-
-    auto const& archivalSettings = sorobanConfig.stateArchivalSettings();
-    rust::Vec<CxxLedgerEntryRentChange> rustEntryRentChanges;
-    // Extend the TTL on the restored entry to minimum TTL, including
-    // the current ledger.
-    uint32_t restoredLiveUntilLedger =
-        ledgerSeq + archivalSettings.minPersistentTTL - 1;
-    rustEntryRentChanges.reserve(footprint.readWrite.size());
-    auto& diagnosticEvents = opMeta.getDiagnosticEventManager();
-    for (auto const& lk : footprint.readWrite)
-    {
-        std::shared_ptr<HotArchiveBucketEntry const> hotArchiveEntry{nullptr};
-        auto ttlKey = getTTLKey(lk);
-        {
-            // First check the live BucketList
-            auto ttlLeOpt =
-                getLiveEntry(ttlKey, liveSnapshot, threadState.getEntryMap());
-            if (!ttlLeOpt)
-            {
-                // this entry has already been restored and then deleted
-                if (threadState.entryWasRestored(lk))
-                {
-                    continue;
-                }
-                hotArchiveEntry = hotArchive->load(lk);
-                if (!hotArchiveEntry)
-                {
-                    // Entry doesn't exist, skip
-                    continue;
-                }
-            }
-            // Skip entry if it's already live.
-            else if (isLive(*ttlLeOpt, ledgerSeq))
-            {
-                continue;
-            }
-        }
-
-        // We must load the ContractCode/ContractData entry for fee purposes, as
-        // restore is considered a write
-        uint32_t entrySize = 0;
-        LedgerEntry entry;
-        if (hotArchiveEntry)
-        {
-            entry = hotArchiveEntry->archivedEntry();
-
-            // Update last modified ledger seq to the current ledger seq since
-            // we're rewriting this entry. ltx will update this for us, but we
-            // need to process the meta before ltx has a chance for the update.
-            entry.lastModifiedLedgerSeq = ledgerSeq;
-            entrySize = static_cast<uint32>(xdr::xdr_size(entry));
-        }
-        else
-        {
-            auto entryLeOpt =
-                getLiveEntry(lk, liveSnapshot, threadState.getEntryMap());
-
-            // We checked for TTLEntry existence above
-            releaseAssertOrThrow(entryLeOpt);
-
-            entry = *entryLeOpt;
-            entrySize = static_cast<uint32>(xdr::xdr_size(entry));
-        }
-
-        metrics.mLedgerReadByte += entrySize;
-        if (resources.diskReadBytes < metrics.mLedgerReadByte)
-        {
-            diagnosticEvents.pushError(
-                SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
-                "operation byte-read resources exceeds amount specified",
-                {makeU64SCVal(metrics.mLedgerReadByte),
-                 makeU64SCVal(resources.diskReadBytes)});
-            innerResult(res).code(RESTORE_FOOTPRINT_RESOURCE_LIMIT_EXCEEDED);
-            return {false, {}};
-        }
-
-        // To maintain consistency with InvokeHostFunction, TTLEntry
-        // writes come out of refundable fee, so only add entrySize
-        metrics.mLedgerWriteByte += entrySize;
-        if (!validateContractLedgerEntry(lk, entrySize, sorobanConfig,
-                                         appConfig, mParentTx,
-                                         diagnosticEvents))
-        {
-            innerResult(res).code(RESTORE_FOOTPRINT_RESOURCE_LIMIT_EXCEEDED);
-            return {false, {}};
-        }
-
-        if (resources.writeBytes < metrics.mLedgerWriteByte)
-        {
-            diagnosticEvents.pushError(
-                SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
-                "operation byte-write resources exceeds amount specified",
-                {makeU64SCVal(metrics.mLedgerWriteByte),
-                 makeU64SCVal(resources.writeBytes)});
-            innerResult(res).code(RESTORE_FOOTPRINT_RESOURCE_LIMIT_EXCEEDED);
-            return {false, {}};
-        }
-
-        rustEntryRentChanges.emplace_back(
-            createEntryRentChangeWithoutModification(
-                entry, entrySize,
-                /*entryLiveUntilLedger=*/std::nullopt,
-                /*newLiveUntilLedger=*/restoredLiveUntilLedger,
-                ledgerInfo.getLedgerVersion(), app.getConfig(), sorobanConfig));
-
-        if (hotArchiveEntry)
-        {
-            opEntryMap.emplace(lk, entry);
-            LedgerEntry ttlEntry =
-                getTTLEntryForTTLKey(ttlKey, restoredLiveUntilLedger);
-            opEntryMap.emplace(ttlKey, ttlEntry);
-            restoredEntries.addHotArchiveRestore(lk, entry, ttlKey, ttlEntry);
-        }
-        else
-        {
-            auto ttlLeOpt =
-                getLiveEntry(ttlKey, liveSnapshot, threadState.getEntryMap());
-            releaseAssertOrThrow(ttlLeOpt);
-            LedgerEntry ttlEntry = *ttlLeOpt;
-            ttlEntry.data.ttl().liveUntilLedgerSeq = restoredLiveUntilLedger;
-            opEntryMap.emplace(ttlKey, ttlEntry);
-            restoredEntries.addLiveBucketlistRestore(lk, entry, ttlKey,
-                                                     ttlEntry);
-        }
-    }
-    int64_t rentFee = rust_bridge::compute_rent_fee(
-        app.getConfig().CURRENT_LEDGER_PROTOCOL_VERSION,
-        ledgerInfo.getLedgerVersion(), rustEntryRentChanges,
-        sorobanConfig.rustBridgeRentFeeConfiguration(), ledgerSeq);
-    if (!refundableFeeTracker->consumeRefundableSorobanResources(
-            0, rentFee, ledgerInfo.getLedgerVersion(), sorobanConfig,
-            app.getConfig(), mParentTx, diagnosticEvents))
-    {
-        innerResult(res).code(RESTORE_FOOTPRINT_INSUFFICIENT_REFUNDABLE_FEE);
-        return {false, {}};
-    }
-    innerResult(res).code(RESTORE_FOOTPRINT_SUCCESS);
-    return {true, std::move(opEntryMap), std::move(restoredEntries)};
+    RestoreFootprintParallelApplyHelper helper(
+        app, threadState, ledgerInfo, res, refundableFeeTracker, opMeta, *this);
+    bool success = helper.apply();
+    return helper.takeResults(success);
 }
 
 bool
@@ -230,118 +403,13 @@ RestoreFootprintOpFrame::doApply(
     std::optional<RefundableFeeTracker>& refundableFeeTracker,
     OperationMetaBuilder& opMeta) const
 {
-    ZoneNamedN(applyZone, "RestoreFootprintOpFrame apply", true);
-    releaseAssertOrThrow(refundableFeeTracker);
     releaseAssertOrThrow(
         protocolVersionIsBefore(ltx.loadHeader().current().ledgerVersion,
                                 PARALLEL_SOROBAN_PHASE_PROTOCOL_VERSION));
-
-    RestoreFootprintMetrics metrics(app.getSorobanMetrics());
-    auto timeScope = metrics.getExecTimer();
-
-    auto const& resources = mParentTx.sorobanResources();
-    auto const& footprint = resources.footprint;
-    auto ledgerSeq = ltx.loadHeader().current().ledgerSeq;
-    auto const& sorobanConfig = app.getSorobanNetworkConfigForApply();
-    auto const& appConfig = app.getConfig();
-
-    auto const& archivalSettings = sorobanConfig.stateArchivalSettings();
-    rust::Vec<CxxLedgerEntryRentChange> rustEntryRentChanges;
-    // Extend the TTL on the restored entry to minimum TTL, including
-    // the current ledger.
-    uint32_t restoredLiveUntilLedger =
-        ledgerSeq + archivalSettings.minPersistentTTL - 1;
-    uint32_t ledgerVersion = ltx.loadHeader().current().ledgerVersion;
-    rustEntryRentChanges.reserve(footprint.readWrite.size());
-    auto& diagnosticEvents = opMeta.getDiagnosticEventManager();
-    for (auto const& lk : footprint.readWrite)
-    {
-        auto ttlKey = getTTLKey(lk);
-        {
-            // First check the live BucketList
-            auto constTTLLtxe = ltx.loadWithoutRecord(ttlKey);
-            if (!constTTLLtxe)
-            {
-                // Entry doesn't exist, skip
-                continue;
-            }
-            // Skip entry if it's already live.
-            else if (isLive(constTTLLtxe.current(), ledgerSeq))
-            {
-                continue;
-            }
-        }
-
-        // We must load the ContractCode/ContractData entry for fee purposes, as
-        // restore is considered a write
-        auto constEntryLtxe = ltx.loadWithoutRecord(lk);
-        releaseAssertOrThrow(constEntryLtxe);
-        LedgerEntry constEntry = constEntryLtxe.current();
-        uint32_t entrySize = static_cast<uint32>(xdr::xdr_size(constEntry));
-
-        metrics.mLedgerReadByte += entrySize;
-        if (resources.diskReadBytes < metrics.mLedgerReadByte)
-        {
-            diagnosticEvents.pushError(
-                SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
-                "operation byte-read resources exceeds amount specified",
-                {makeU64SCVal(metrics.mLedgerReadByte),
-                 makeU64SCVal(resources.diskReadBytes)});
-            innerResult(res).code(RESTORE_FOOTPRINT_RESOURCE_LIMIT_EXCEEDED);
-            return false;
-        }
-
-        // To maintain consistency with InvokeHostFunction, TTLEntry
-        // writes come out of refundable fee, so only add entrySize
-        metrics.mLedgerWriteByte += entrySize;
-        if (!validateContractLedgerEntry(lk, entrySize, sorobanConfig,
-                                         appConfig, mParentTx,
-                                         diagnosticEvents))
-        {
-            innerResult(res).code(RESTORE_FOOTPRINT_RESOURCE_LIMIT_EXCEEDED);
-            return false;
-        }
-
-        if (resources.writeBytes < metrics.mLedgerWriteByte)
-        {
-            diagnosticEvents.pushError(
-                SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
-                "operation byte-write resources exceeds amount specified",
-                {makeU64SCVal(metrics.mLedgerWriteByte),
-                 makeU64SCVal(resources.writeBytes)});
-            innerResult(res).code(RESTORE_FOOTPRINT_RESOURCE_LIMIT_EXCEEDED);
-            return false;
-        }
-
-        rustEntryRentChanges.emplace_back(
-            createEntryRentChangeWithoutModification(
-                constEntry, entrySize,
-                /*entryLiveUntilLedger=*/std::nullopt,
-                /*newLiveUntilLedger=*/restoredLiveUntilLedger, ledgerVersion,
-                app.getConfig(), sorobanConfig));
-
-        // Entry exists in the live BucketList if we get to this point due
-        // to the constTTLLtxe loadWithoutRecord logic above.
-        // Get the actual ledger entry (since we know it exists already at
-        // this point)
-        auto entry = ltx.getNewestVersion(lk);
-        releaseAssertOrThrow(entry);
-        ltx.restoreFromLiveBucketList(entry->ledgerEntry(),
-                                      restoredLiveUntilLedger);
-    }
-    int64_t rentFee = rust_bridge::compute_rent_fee(
-        app.getConfig().CURRENT_LEDGER_PROTOCOL_VERSION, ledgerVersion,
-        rustEntryRentChanges, sorobanConfig.rustBridgeRentFeeConfiguration(),
-        ledgerSeq);
-    if (!refundableFeeTracker->consumeRefundableSorobanResources(
-            0, rentFee, ledgerVersion, sorobanConfig, app.getConfig(),
-            mParentTx, diagnosticEvents))
-    {
-        innerResult(res).code(RESTORE_FOOTPRINT_INSUFFICIENT_REFUNDABLE_FEE);
-        return false;
-    }
-    innerResult(res).code(RESTORE_FOOTPRINT_SUCCESS);
-    return true;
+    releaseAssertOrThrow(refundableFeeTracker);
+    RestoreFootprintPreV23ApplyHelper helper(
+        app, ltx, res, refundableFeeTracker, opMeta, *this);
+    return helper.apply();
 }
 
 bool

--- a/src/transactions/RestoreFootprintOpFrame.h
+++ b/src/transactions/RestoreFootprintOpFrame.h
@@ -14,12 +14,6 @@ class MutableTransactionResultBase;
 
 class RestoreFootprintOpFrame : public OperationFrame
 {
-    RestoreFootprintResult&
-    innerResult(OperationResult& res) const
-    {
-        return res.tr().restoreFootprintResult();
-    }
-
     RestoreFootprintOp const& mRestoreFootprintOp;
 
   public:
@@ -59,5 +53,8 @@ class RestoreFootprintOpFrame : public OperationFrame
     virtual bool isSoroban() const override;
 
     ThresholdLevel getThresholdLevel() const override;
+    friend class RestoreFootprintApplyHelper;
+    friend class RestoreFootprintPreV23ApplyHelper;
+    friend class RestoreFootprintParallelApplyHelper;
 };
 }

--- a/src/transactions/TransactionFrameBase.h
+++ b/src/transactions/TransactionFrameBase.h
@@ -57,22 +57,22 @@ struct ParallelApplyEntry
     std::optional<LedgerEntry> mLedgerEntry;
     bool mIsDirty;
     static ParallelApplyEntry
-    cleanLive(LedgerEntry const& e)
+    cleanPopulated(LedgerEntry const& e)
     {
         return ParallelApplyEntry{e, false};
     }
     static ParallelApplyEntry
-    dirtyLive(LedgerEntry const& e)
+    dirtyPopulated(LedgerEntry const& e)
     {
         return ParallelApplyEntry{e, true};
     }
     static ParallelApplyEntry
-    cleanDead()
+    cleanEmpty()
     {
         return ParallelApplyEntry{std::nullopt, false};
     }
     static ParallelApplyEntry
-    dirtyDead()
+    dirtyEmpty()
     {
         return ParallelApplyEntry{std::nullopt, true};
     }


### PR DESCRIPTION
4th round of refactors on parallel apply. A mix of should-be-no-op cleanups, visibility reduction, code simplification, de-duplication (of the 2 RestoreFootprintOp apply paths) and a big comment to explain what's going on with RoTTLBumps (which we almost thought was wrong, but are now I think all convinced is not-wrong). 