### PR TITLE
Remove prefetching for Soroban TXs

### DIFF
--- a/src/bucket/BucketListSnapshotBase.cpp
+++ b/src/bucket/BucketListSnapshotBase.cpp
@@ -132,7 +132,7 @@ template <class BucketT>
 std::optional<std::vector<typename BucketT::LoadT>>
 SearchableBucketListSnapshotBase<BucketT>::loadKeysInternal(
     std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys,
-    LedgerKeyMeter* lkMeter, std::optional<uint32_t> ledgerSeq) const
+    std::optional<uint32_t> ledgerSeq) const
 {
     ZoneScoped;
 
@@ -140,7 +140,7 @@ SearchableBucketListSnapshotBase<BucketT>::loadKeysInternal(
     auto keys = inKeys;
     std::vector<typename BucketT::LoadT> entries;
     auto loadKeysLoop = [&](auto const& b) {
-        b.loadKeys(keys, entries, lkMeter);
+        b.loadKeys(keys, entries);
         return keys.empty() ? Loop::COMPLETE : Loop::INCOMPLETE;
     };
 
@@ -169,7 +169,7 @@ SearchableBucketListSnapshotBase<BucketT>::loadKeysFromLedger(
     std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys,
     uint32_t ledgerSeq) const
 {
-    return loadKeysInternal(inKeys, /*lkMeter=*/nullptr, ledgerSeq);
+    return loadKeysInternal(inKeys, ledgerSeq);
 }
 
 template <class BucketT>

--- a/src/bucket/BucketListSnapshotBase.h
+++ b/src/bucket/BucketListSnapshotBase.h
@@ -119,7 +119,6 @@ class SearchableBucketListSnapshotBase : public NonMovableOrCopyable
 
     std::optional<std::vector<typename BucketT::LoadT>>
     loadKeysInternal(std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys,
-                     LedgerKeyMeter* lkMeter,
                      std::optional<uint32_t> ledgerSeq) const;
 
     medida::Timer& getBulkLoadTimer(std::string const& label,

--- a/src/bucket/BucketSnapshot.h
+++ b/src/bucket/BucketSnapshot.h
@@ -19,7 +19,6 @@ namespace stellar
 {
 
 struct EvictionResultEntry;
-class LedgerKeyMeter;
 class SearchableLiveBucketListSnapshot;
 
 // A lightweight wrapper around Bucket for thread safe BucketListDB lookups
@@ -63,12 +62,8 @@ template <class BucketT> class BucketSnapshotBase : public NonMovable
 
     // Loads LedgerEntry's for given keys. When a key is found, the
     // entry is added to result and the key is removed from keys.
-    // If a pointer to a LedgerKeyMeter is provided, a key will only be loaded
-    // if the meter has a transaction with sufficient read quota for the key.
-    // If Bucket is not of type LiveBucket, lkMeter is ignored.
     void loadKeys(std::set<LedgerKey, LedgerEntryIdCmp>& keys,
-                  std::vector<typename BucketT::LoadT>& result,
-                  LedgerKeyMeter* lkMeter) const;
+                  std::vector<typename BucketT::LoadT>& result) const;
 };
 
 class LiveBucketSnapshot : public BucketSnapshotBase<LiveBucket>

--- a/src/bucket/SearchableBucketList.cpp
+++ b/src/bucket/SearchableBucketList.cpp
@@ -129,7 +129,7 @@ SearchableLiveBucketListSnapshot::loadPoolShareTrustLinesByAccountAndAsset(
 
     std::vector<LedgerEntry> result;
     auto loadKeysLoop = [&](auto const& b) {
-        b.loadKeys(trustlinesToLoad, result, /*lkMeter=*/nullptr);
+        b.loadKeys(trustlinesToLoad, result);
         return trustlinesToLoad.empty() ? Loop::COMPLETE : Loop::INCOMPLETE;
     };
 
@@ -229,12 +229,12 @@ SearchableLiveBucketListSnapshot::loadInflationWinners(size_t maxWinners,
 }
 
 std::vector<LedgerEntry>
-SearchableLiveBucketListSnapshot::loadKeysWithLimits(
+SearchableLiveBucketListSnapshot::loadKeys(
     std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys,
-    std::string const& label, LedgerKeyMeter* lkMeter) const
+    std::string const& label) const
 {
     auto timer = getBulkLoadTimer(label, inKeys.size()).TimeScope();
-    auto op = loadKeysInternal(inKeys, lkMeter, std::nullopt);
+    auto op = loadKeysInternal(inKeys, std::nullopt);
     releaseAssertOrThrow(op);
     return std::move(*op);
 }
@@ -263,7 +263,7 @@ std::vector<HotArchiveBucketEntry>
 SearchableHotArchiveBucketListSnapshot::loadKeys(
     std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys) const
 {
-    auto op = loadKeysInternal(inKeys, /*lkMeter=*/nullptr, std::nullopt);
+    auto op = loadKeysInternal(inKeys, std::nullopt);
     releaseAssertOrThrow(op);
     return std::move(*op);
 }

--- a/src/bucket/SearchableBucketList.h
+++ b/src/bucket/SearchableBucketList.h
@@ -27,8 +27,8 @@ class SearchableLiveBucketListSnapshot
                                                       int64_t minBalance) const;
 
     std::vector<LedgerEntry>
-    loadKeysWithLimits(std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys,
-                       std::string const& label, LedgerKeyMeter* lkMeter) const;
+    loadKeys(std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys,
+             std::string const& label) const;
 
     std::unique_ptr<EvictionResultCandidates> scanForEviction(
         uint32_t ledgerSeq, EvictionCounters& counters, EvictionIterator iter,

--- a/src/bucket/test/BucketIndexTests.cpp
+++ b/src/bucket/test/BucketIndexTests.cpp
@@ -482,8 +482,7 @@ class BucketIndexTest
         };
 
         // Test bulk load lookup
-        auto loadResult =
-            searchableBL->loadKeysWithLimits(mKeysToSearch, "test", nullptr);
+        auto loadResult = searchableBL->loadKeys(mKeysToSearch, "test");
         validateResults(mTestEntries, loadResult);
 
         if (expectedHitRate)
@@ -532,8 +531,7 @@ class BucketIndexTest
                          mKeysToSearch.size());
 
             // Run bulk lookup again
-            auto loadResult2 = searchableBL->loadKeysWithLimits(
-                mKeysToSearch, "test", nullptr);
+            auto loadResult2 = searchableBL->loadKeys(mKeysToSearch, "test");
             validateResults(mTestEntries, loadResult2);
 
             checkHitRate(expectedHitRate, startingHitCount, startingMissCount,
@@ -578,8 +576,7 @@ class BucketIndexTest
                 searchSubset.insert(addKeys.begin(), addKeys.end());
             }
 
-            auto blLoad =
-                searchableBL->loadKeysWithLimits(searchSubset, "test", nullptr);
+            auto blLoad = searchableBL->loadKeys(searchSubset, "test");
             validateResults(testEntriesSubset, blLoad);
         }
     }
@@ -599,8 +596,7 @@ class BucketIndexTest
         LedgerKeySet invalidKeys(keysNotInBL.begin(), keysNotInBL.end());
 
         // Test bulk load
-        REQUIRE(searchableBL->loadKeysWithLimits(invalidKeys, "test", nullptr)
-                    .size() == 0);
+        REQUIRE(searchableBL->loadKeys(invalidKeys, "test").size() == 0);
 
         // Test individual load
         for (auto const& key : invalidKeys)

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1831,7 +1831,7 @@ LedgerManagerImpl::prefetchTxSourceIds(AbstractLedgerTxnParent& ltx,
                 tx->insertKeysForFeeProcessing(keys);
             }
         }
-        ltx.prefetchClassic(keys);
+        ltx.prefetch(keys);
     }
 }
 
@@ -1843,31 +1843,15 @@ LedgerManagerImpl::prefetchTransactionData(AbstractLedgerTxnParent& ltx,
     ZoneScoped;
     if (config.PREFETCH_BATCH_SIZE > 0 && !config.allBucketsInMemory())
     {
-        UnorderedSet<LedgerKey> sorobanKeys;
-        auto lkMeter = make_unique<LedgerKeyMeter>();
-        UnorderedSet<LedgerKey> classicKeys;
+        UnorderedSet<LedgerKey> keysToPreFetch;
         for (auto const& phase : txSet.getPhases())
         {
             for (auto const& tx : phase)
             {
-                if (tx->isSoroban())
-                {
-                    tx->insertKeysForTxApply(sorobanKeys, lkMeter.get());
-                }
-                else
-                {
-                    tx->insertKeysForTxApply(classicKeys, nullptr);
-                }
+                tx->insertKeysForTxApply(keysToPreFetch);
             }
         }
-        // Prefetch classic and soroban keys separately for greater
-        // visibility into the performance of each mode.
-        if (!sorobanKeys.empty())
-        {
-            ltx.prefetchSoroban(sorobanKeys, lkMeter.get());
-        }
-
-        ltx.prefetchClassic(classicKeys);
+        ltx.prefetch(keysToPreFetch);
     }
 }
 

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -374,33 +374,6 @@ struct LedgerTxnDelta
     UnorderedMap<InternalLedgerKey, EntryDelta> entry;
     HeaderDelta header;
 };
-// An abstraction for storing and applying per-txn read bytes metering limits
-// when loading keys.
-class LedgerKeyMeter : public NonMovableOrCopyable
-{
-  public:
-    // Adds a transaction with a read quota and the keys it will read.
-    void addTxn(SorobanResources const& resources);
-    // Conumes entrySizeBytes from the read quotas of all transactions with this
-    // key.
-    void updateReadQuotasForKey(LedgerKey const& key, size_t entrySizeBytes);
-    // Returns true if a transaction with sufficient read quota exists for this
-    // key.
-    bool canLoad(LedgerKey const& key, size_t entrySizeBytes) const;
-    // Returns true if a key was not loaded due to insufficient read quota.
-    bool loadFailed(LedgerKey const& key) const;
-
-  private:
-    // Returns the maximum read quota across all transactions with this key.
-    uint32_t maxReadQuotaForKey(LedgerKey const& key) const;
-    using TxReadBytesPtr = std::shared_ptr<uint32_t>;
-    // Stores a mapping from keys to a vector of pointers to the read bytes
-    // of the transactions that will read the keys.
-    UnorderedMap<LedgerKey, std::vector<TxReadBytesPtr>>
-        mLedgerKeyToTxReadBytes{};
-    // Stores the keys that were not loaded due to insufficient read quota.
-    LedgerKeySet mNotLoadedKeys{};
-};
 
 // An abstraction for an object that is iterator-like and permits enumerating
 // the LedgerTxnEntry objects managed by an AbstractLedgerTxn. This enables
@@ -538,12 +511,9 @@ class AbstractLedgerTxnParent
     // Prefetch a set of ledger entries into memory, anticipating their use.
     // This is purely advisory and can be a no-op, or do any level of actual
     // work, while still being correct. Will throw when called on anything other
-    // than a (real or stub) root LedgerTxn.
-    virtual uint32_t prefetchClassic(UnorderedSet<LedgerKey> const& keys) = 0;
-    // Prefetch a set of ledger entries into memory, while accounting for
-    // the read byte footprint of the transactions using the keys.
-    virtual uint32_t prefetchSoroban(UnorderedSet<LedgerKey> const& keys,
-                                     LedgerKeyMeter* lkMeter) = 0;
+    // than a (real or stub) root LedgerTxn. Throws if any key is a Soroban key,
+    // as these are stored in-memory and should not be loaded from disk.
+    virtual uint32_t prefetch(UnorderedSet<LedgerKey> const& keys) = 0;
 
     // prepares to increase the capacity of pending changes by up to "s" changes
     virtual void prepareNewObjects(size_t s) = 0;
@@ -874,10 +844,7 @@ class LedgerTxn : public AbstractLedgerTxn
     void dropOffers() override;
 
     double getPrefetchHitRate() const override;
-    uint32_t prefetchClassic(UnorderedSet<LedgerKey> const& keys) override;
-
-    uint32_t prefetchSoroban(UnorderedSet<LedgerKey> const& keys,
-                             LedgerKeyMeter* lkMeter) override;
+    uint32_t prefetch(UnorderedSet<LedgerKey> const& keys) override;
     void prepareNewObjects(size_t s) override;
     SessionWrapper& getSession() const override;
 
@@ -969,9 +936,7 @@ class LedgerTxnRoot : public AbstractLedgerTxnParent
 
     void rollbackChild() noexcept override;
 
-    uint32_t prefetchClassic(UnorderedSet<LedgerKey> const& keys) override;
-    uint32_t prefetchSoroban(UnorderedSet<LedgerKey> const& keys,
-                             LedgerKeyMeter* lkMeter) override;
+    uint32_t prefetch(UnorderedSet<LedgerKey> const& keys) override;
 
     double getPrefetchHitRate() const override;
     void prepareNewObjects(size_t s) override;

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -544,9 +544,7 @@ class LedgerTxn::Impl
     // unsealHeader has the same exception safety guarantee as f
     void unsealHeader(LedgerTxn& self, std::function<void(LedgerHeader&)> f);
 
-    uint32_t prefetchClassic(UnorderedSet<LedgerKey> const& keys);
-    uint32_t prefetchSoroban(UnorderedSet<LedgerKey> const& keys,
-                             LedgerKeyMeter* lkMeter);
+    uint32_t prefetch(UnorderedSet<LedgerKey> const& keys);
 
     double getPrefetchHitRate() const;
 
@@ -720,9 +718,6 @@ class LedgerTxnRoot::Impl
     SearchableLiveBucketListSnapshot const&
     getSearchableLiveBucketListSnapshot() const;
 
-    uint32_t prefetchInternal(UnorderedSet<LedgerKey> const& keys,
-                              LedgerKeyMeter* lkMeter = nullptr);
-
   public:
     // Constructor has the strong exception safety guarantee
     Impl(Application& app, size_t entryCacheSize, size_t prefetchBatchSize
@@ -815,10 +810,8 @@ class LedgerTxnRoot::Impl
 
     // Prefetch some or all of given keys in batches. Note that no prefetching
     // could occur if the cache is at its fill ratio. Returns number of keys
-    // prefetched.
-    uint32_t prefetchClassic(UnorderedSet<LedgerKey> const& keys);
-    uint32_t prefetchSoroban(UnorderedSet<LedgerKey> const& keys,
-                             LedgerKeyMeter* lkMeter);
+    // prefetched. Throws if any key is a Soroban key.
+    uint32_t prefetch(UnorderedSet<LedgerKey> const& keys);
 
     double getPrefetchHitRate() const;
 

--- a/src/ledger/LedgerTypeUtils.h
+++ b/src/ledger/LedgerTypeUtils.h
@@ -14,7 +14,6 @@
 
 namespace stellar
 {
-class LedgerKeyMeter;
 bool isLive(LedgerEntry const& e, uint32_t cutoffLedger);
 
 LedgerKey getTTLKey(LedgerEntry const& e);
@@ -26,8 +25,7 @@ LedgerEntry getTTLEntryForTTLKey(LedgerKey const& ttlKey, uint32_t ttl);
 template <typename KeySetT>
 UnorderedMap<LedgerKey, std::shared_ptr<LedgerEntry const>>
 populateLoadedEntries(KeySetT const& keys,
-                      std::vector<LedgerEntry> const& entries,
-                      LedgerKeyMeter* lkMeter = nullptr)
+                      std::vector<LedgerEntry> const& entries)
 {
     UnorderedMap<LedgerKey, std::shared_ptr<LedgerEntry const>> res;
 
@@ -47,10 +45,9 @@ populateLoadedEntries(KeySetT const& keys,
 
     for (auto const& key : keys)
     {
-        // If the key was not loaded (but not due to metering), we should put
-        // a nullptr entry in the result.
-        if (res.find(key) == res.end() &&
-            (!lkMeter || !lkMeter->loadFailed(key)))
+        // If the key was not loaded, we should put a nullptr entry in the
+        // result.
+        if (res.find(key) == res.end())
         {
             res.emplace(key, nullptr);
         }

--- a/src/ledger/test/InMemoryLedgerTxnRoot.cpp
+++ b/src/ledger/test/InMemoryLedgerTxnRoot.cpp
@@ -140,15 +140,7 @@ InMemoryLedgerTxnRoot::getPrefetchHitRate() const
 }
 
 uint32_t
-InMemoryLedgerTxnRoot::prefetchClassic(UnorderedSet<LedgerKey> const&)
-{
-    return 0;
-}
-
-uint32_t
-InMemoryLedgerTxnRoot::prefetchSoroban(UnorderedSet<LedgerKey> const&,
-                                       LedgerKeyMeter*)
-
+InMemoryLedgerTxnRoot::prefetch(UnorderedSet<LedgerKey> const&)
 {
     return 0;
 }

--- a/src/ledger/test/InMemoryLedgerTxnRoot.h
+++ b/src/ledger/test/InMemoryLedgerTxnRoot.h
@@ -78,9 +78,7 @@ class InMemoryLedgerTxnRoot : public AbstractLedgerTxnParent
 
     void dropOffers() override;
     double getPrefetchHitRate() const override;
-    uint32_t prefetchClassic(UnorderedSet<LedgerKey> const& keys) override;
-    uint32_t prefetchSoroban(UnorderedSet<LedgerKey> const& keys,
-                             LedgerKeyMeter* lkMeter) override;
+    uint32_t prefetch(UnorderedSet<LedgerKey> const& keys) override;
 
     void prepareNewObjects(size_t s) override;
     SessionWrapper& getSession() const override;

--- a/src/main/QueryServer.cpp
+++ b/src/main/QueryServer.cpp
@@ -195,8 +195,7 @@ QueryServer::getLedgerEntryRaw(std::string const& params,
         // Otherwise default to current ledger
         else
         {
-            loadedKeys = bl.loadKeysWithLimits(orderedKeys, "query",
-                                               /*lkMeter=*/nullptr);
+            loadedKeys = bl.loadKeys(orderedKeys, "query");
             root["ledgerSeq"] = bl.getLedgerSeq();
         }
 

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -584,10 +584,10 @@ FeeBumpTransactionFrame::insertKeysForFeeProcessing(
 }
 
 void
-FeeBumpTransactionFrame::insertKeysForTxApply(UnorderedSet<LedgerKey>& keys,
-                                              LedgerKeyMeter* lkMeter) const
+FeeBumpTransactionFrame::insertKeysForTxApply(
+    UnorderedSet<LedgerKey>& keys) const
 {
-    mInnerTx->insertKeysForTxApply(keys, lkMeter);
+    mInnerTx->insertKeysForTxApply(keys);
 }
 
 MutableTxResultPtr

--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -143,8 +143,7 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
 
     void
     insertKeysForFeeProcessing(UnorderedSet<LedgerKey>& keys) const override;
-    void insertKeysForTxApply(UnorderedSet<LedgerKey>& keys,
-                              LedgerKeyMeter* lkMeter) const override;
+    void insertKeysForTxApply(UnorderedSet<LedgerKey>& keys) const override;
 
     MutableTxResultPtr
     processFeeSeqNum(AbstractLedgerTxn& ltx,

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -1700,8 +1700,7 @@ TransactionFrame::insertKeysForFeeProcessing(
 }
 
 void
-TransactionFrame::insertKeysForTxApply(UnorderedSet<LedgerKey>& keys,
-                                       LedgerKeyMeter* lkMeter) const
+TransactionFrame::insertKeysForTxApply(UnorderedSet<LedgerKey>& keys) const
 {
     for (auto const& op : mOperations)
     {
@@ -1710,27 +1709,6 @@ TransactionFrame::insertKeysForTxApply(UnorderedSet<LedgerKey>& keys,
             keys.emplace(accountKey(op->getSourceID()));
         }
         op->insertLedgerKeysToPrefetch(keys);
-    }
-
-    if (lkMeter)
-    {
-        auto const& resources = sorobanResources();
-        keys.insert(resources.footprint.readOnly.begin(),
-                    resources.footprint.readOnly.end());
-        keys.insert(resources.footprint.readWrite.begin(),
-                    resources.footprint.readWrite.end());
-        auto insertTTLKey = [&](LedgerKey const& lk) {
-            if (lk.type() == CONTRACT_DATA || lk.type() == CONTRACT_CODE)
-            {
-                keys.insert(getTTLKey(lk));
-            }
-        };
-        // TTL keys must be prefetched for soroban entries.
-        std::for_each(resources.footprint.readOnly.begin(),
-                      resources.footprint.readOnly.end(), insertTTLKey);
-        std::for_each(resources.footprint.readWrite.begin(),
-                      resources.footprint.readWrite.end(), insertTTLKey);
-        lkMeter->addTxn(resources);
     }
 }
 

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -241,8 +241,7 @@ class TransactionFrame : public TransactionFrameBase
 
     void
     insertKeysForFeeProcessing(UnorderedSet<LedgerKey>& keys) const override;
-    void insertKeysForTxApply(UnorderedSet<LedgerKey>& keys,
-                              LedgerKeyMeter* lkMeter) const override;
+    void insertKeysForTxApply(UnorderedSet<LedgerKey>& keys) const override;
 
     // collect fee, consume sequence number
     MutableTxResultPtr

--- a/src/transactions/TransactionFrameBase.h
+++ b/src/transactions/TransactionFrameBase.h
@@ -210,8 +210,7 @@ class TransactionFrameBase
 
     virtual void
     insertKeysForFeeProcessing(UnorderedSet<LedgerKey>& keys) const = 0;
-    virtual void insertKeysForTxApply(UnorderedSet<LedgerKey>& keys,
-                                      LedgerKeyMeter* lkMeter) const = 0;
+    virtual void insertKeysForTxApply(UnorderedSet<LedgerKey>& keys) const = 0;
 
     virtual MutableTxResultPtr
     processFeeSeqNum(AbstractLedgerTxn& ltx,

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -1410,7 +1410,7 @@ prefetchForRevokeFromPoolShareTrustLines(
             keys.emplace(accountKey(sponsor));
         }
     }
-    ltx.prefetchClassic(keys);
+    ltx.prefetch(keys);
 
     // now prefetch the asset trustlines
     keys.clear();
@@ -1436,7 +1436,7 @@ prefetchForRevokeFromPoolShareTrustLines(
             keys.emplace(trustlineKey(accountID, params.assetB));
         }
     }
-    ltx.prefetchClassic(keys);
+    ltx.prefetch(keys);
 }
 
 static ClaimableBalanceID

--- a/src/transactions/test/TransactionTestFrame.cpp
+++ b/src/transactions/test/TransactionTestFrame.cpp
@@ -301,10 +301,9 @@ TransactionTestFrame::insertKeysForFeeProcessing(
 }
 
 void
-TransactionTestFrame::insertKeysForTxApply(UnorderedSet<LedgerKey>& keys,
-                                           LedgerKeyMeter* lkMeter) const
+TransactionTestFrame::insertKeysForTxApply(UnorderedSet<LedgerKey>& keys) const
 {
-    mTransactionFrame->insertKeysForTxApply(keys, lkMeter);
+    mTransactionFrame->insertKeysForTxApply(keys);
 }
 
 void

--- a/src/transactions/test/TransactionTestFrame.h
+++ b/src/transactions/test/TransactionTestFrame.h
@@ -124,8 +124,7 @@ class TransactionTestFrame : public TransactionFrameBase
 
     void
     insertKeysForFeeProcessing(UnorderedSet<LedgerKey>& keys) const override;
-    void insertKeysForTxApply(UnorderedSet<LedgerKey>& keys,
-                              LedgerKeyMeter* lkMeter) const override;
+    void insertKeysForTxApply(UnorderedSet<LedgerKey>& keys) const override;
 
     void preParallelApply(AppConnector& app, AbstractLedgerTxn& ltx,
                           TransactionMetaBuilder& meta,


### PR DESCRIPTION
# Description

Resolves #4658

Removes prefetching of Soroban TXs, as these transactions no longer use LTX and most state is in-memory anyway. We still prefetch source ID's for Soroban TXs, since source account fees are still handled via ltx. 

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
