### PR TITLE
Parallel-apply refactor round 5

### DIFF
--- a/src/crypto/SHA.cpp
+++ b/src/crypto/SHA.cpp
@@ -26,6 +26,15 @@ sha256(ByteSlice const& bin)
     return out;
 }
 
+Hash
+subSha256(ByteSlice const& seed, uint64_t counter)
+{
+    SHA256 sha;
+    sha.add(seed);
+    sha.add(xdr::xdr_to_opaque(counter));
+    return sha.finish();
+}
+
 SHA256::SHA256()
 {
     reset();

--- a/src/crypto/SHA.h
+++ b/src/crypto/SHA.h
@@ -16,6 +16,10 @@ namespace stellar
 // Plain SHA256
 uint256 sha256(ByteSlice const& bin);
 
+// SHA256 of existing seed and a counter, used for
+// sub-seeding per-transaction PRNGs in soroban.
+Hash subSha256(ByteSlice const& seed, uint64_t counter);
+
 // SHA256 in incremental mode, for large inputs.
 class SHA256
 {

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -2027,10 +2027,7 @@ TransactionFrame::applyOperations(SignatureChecker& signatureChecker,
             // If op can use the seed, we need to compute a sub-seed for it.
             if (op->isSoroban())
             {
-                SHA256 subSeedSha;
-                subSeedSha.add(sorobanBasePrngSeed);
-                subSeedSha.add(xdr::xdr_to_opaque(opNum));
-                subSeed = subSeedSha.finish();
+                subSeed = subSha256(sorobanBasePrngSeed, opNum);
             }
             ++opNum;
             auto& opMeta = outerMeta.getOperationMetaBuilderAt(i);

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -1930,16 +1930,10 @@ TransactionFrame::parallelApply(
 
         if (res.getSuccess())
         {
-            auto hotArchive = res.getRestoredEntries().hotArchive;
-            setDelta(liveSnapshot, threadState.getEntryMap(),
-                     res.getModifiedEntryMap(), hotArchive, ledgerInfo,
-                     effects);
-
-            opMeta.setLedgerChangesFromEntryMaps(
-                liveSnapshot, threadState.getEntryMap(),
-                res.getModifiedEntryMap(), hotArchive,
-                res.getRestoredEntries().liveBucketList,
-                ledgerInfo.getLedgerSeq());
+            threadState.setEffectsDeltaFromSuccessfulOp(res, ledgerInfo,
+                                                        effects);
+            opMeta.setLedgerChangesFromSuccessfulOp(threadState, res,
+                                                    ledgerInfo.getLedgerSeq());
         }
         else
         {

--- a/src/transactions/TransactionMeta.h
+++ b/src/transactions/TransactionMeta.h
@@ -22,15 +22,11 @@ class OperationMetaBuilder
     // ledger transaction used for this operation.
     void setLedgerChanges(AbstractLedgerTxn& opLtx, uint32_t ledgerSeq);
 
-    // Similar to the above function, but used during parallel apply,
-    // which uses maps to track entry changes.
-    void setLedgerChangesFromEntryMaps(
-        SearchableSnapshotConstPtr liveSnapshot,
-        ParallelApplyEntryMap const& entryMap,
-        OpModifiedEntryMap const& opModifiedEntryMap,
-        UnorderedMap<LedgerKey, LedgerEntry> const& hotArchiveRestores,
-        UnorderedMap<LedgerKey, LedgerEntry> const& liveRestores,
-        uint32_t ledgerSeq);
+    // Similar to the above function, but used during parallel apply, which uses
+    // thread state and return value maps to track entry changes.
+    void setLedgerChangesFromSuccessfulOp(
+        ThreadParallelApplyLedgerState const& threadState,
+        ParallelTxReturnVal const& res, uint32_t ledgerSeq);
 
     // Sets the return value for a Soroban operation.
     void setSorobanReturnValue(SCVal const& val);


### PR DESCRIPTION
This is just more refactoring of the parallel apply path

(It is an extension of https://github.com/stellar/stellar-core/pull/4805 which is still in the merge queue, just look at the last 2 changes here)

- sinking more free functions into members of the thread helper and removing use of `getLiveEntry` entirely
- factoring out the repeated and slightly error-prone PRNG sub-seeding sequence