### PR TITLE
Use Soroban in-memory State

### DIFF
--- a/src/bucket/test/BucketIndexTests.cpp
+++ b/src/bucket/test/BucketIndexTests.cpp
@@ -123,6 +123,7 @@ class BucketIndexTest
 
                     // Entry should never expire
                     ttl.data.ttl().liveUntilLedgerSeq = ledger + 10'000;
+                    ttl.lastModifiedLedgerSeq = ledger;
 
                     // Add TTL key to mGeneratedKeys to maintain uniqueness
                     auto ttlKey = LedgerEntryKey(ttl);
@@ -1114,36 +1115,40 @@ TEST_CASE("soroban cache population", "[soroban][bucketindex]")
                     inMemorySorobanState.mContractCodeEntries.size());
             for (auto const& [k, v] : codeEntries)
             {
-                auto inMemoryEntry =
-                    inMemorySorobanState.getContractCodeEntry(k);
+                auto inMemoryEntry = inMemorySorobanState.get(k);
                 REQUIRE(inMemoryEntry);
 
                 auto liveEntry = snapshot->load(k);
                 REQUIRE(liveEntry);
-                REQUIRE(*liveEntry == *inMemoryEntry->ledgerEntry);
+                REQUIRE(*liveEntry == *inMemoryEntry);
 
-                auto ttlEntry = snapshot->load(getTTLKey(k));
+                auto ttlKey = getTTLKey(k);
+                auto ttlEntry = snapshot->load(ttlKey);
                 REQUIRE(ttlEntry);
-                REQUIRE(ttlEntry->data.ttl().liveUntilLedgerSeq ==
-                        inMemoryEntry->liveUntilLedgerSeq);
+
+                auto inMemoryTTL = inMemorySorobanState.get(ttlKey);
+                REQUIRE(inMemoryTTL);
+                REQUIRE(*inMemoryTTL == *ttlEntry);
             }
 
             REQUIRE(dataEntries.size() ==
                     inMemorySorobanState.mContractDataEntries.size());
             for (auto const& [k, v] : dataEntries)
             {
-                auto inMemoryEntry =
-                    inMemorySorobanState.getContractDataEntry(k);
+                auto inMemoryEntry = inMemorySorobanState.get(k);
                 REQUIRE(inMemoryEntry);
 
                 auto liveEntry = snapshot->load(k);
                 REQUIRE(liveEntry);
-                REQUIRE(*liveEntry == *inMemoryEntry->ledgerEntry);
+                REQUIRE(*liveEntry == *inMemoryEntry);
 
-                auto ttlEntry = snapshot->load(getTTLKey(k));
+                auto ttlKey = getTTLKey(k);
+                auto ttlEntry = snapshot->load(ttlKey);
                 REQUIRE(ttlEntry);
-                REQUIRE(ttlEntry->data.ttl().liveUntilLedgerSeq ==
-                        inMemoryEntry->liveUntilLedgerSeq);
+
+                auto inMemoryTTL = inMemorySorobanState.get(ttlKey);
+                REQUIRE(inMemoryTTL);
+                REQUIRE(*inMemoryTTL == *ttlEntry);
             }
         };
 

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -1022,6 +1022,7 @@ TEST_CASE_VERSIONS("eviction scan", "[bucketlist][archival]")
                 ConfigSettingID::CONFIG_SETTING_STATE_ARCHIVAL);
             sesLE.data.configSetting().stateArchivalSettings() =
                 stateArchivalSettings;
+            sesLE.lastModifiedLedgerSeq = ledgerSeq;
             result.emplace_back(sesLE);
 
             LedgerEntry iterLE;
@@ -1029,6 +1030,7 @@ TEST_CASE_VERSIONS("eviction scan", "[bucketlist][archival]")
             iterLE.data.configSetting().configSettingID(
                 ConfigSettingID::CONFIG_SETTING_EVICTION_ITERATOR);
             iterLE.data.configSetting().evictionIterator() = evictionIter;
+            iterLE.lastModifiedLedgerSeq = ledgerSeq;
             result.emplace_back(iterLE);
 
             return result;
@@ -1084,6 +1086,7 @@ TEST_CASE_VERSIONS("eviction scan", "[bucketlist][archival]")
             TTLEntry.data.type(TTL);
             TTLEntry.data.ttl().keyHash = getTTLKey(e).ttl().keyHash;
             TTLEntry.data.ttl().liveUntilLedgerSeq = ledgerSeq + 1;
+            TTLEntry.lastModifiedLedgerSeq = e.lastModifiedLedgerSeq;
 
             entries.emplace_back(e);
             entries.emplace_back(TTLEntry);
@@ -1309,6 +1312,7 @@ TEST_CASE_VERSIONS("eviction scan", "[bucketlist][archival]")
             ttlLe.data.type(TTL);
             ttlLe.data.ttl().keyHash = ttlKey.ttl().keyHash;
             ttlLe.data.ttl().liveUntilLedgerSeq = ledgerSeq + 1;
+            ttlLe.lastModifiedLedgerSeq = ledgerSeq;
 
             lm.setNextLedgerEntryBatchForBucketTesting({}, {ttlLe}, {});
             closeLedger(*app);

--- a/src/ledger/InMemorySorobanState.cpp
+++ b/src/ledger/InMemorySorobanState.cpp
@@ -295,6 +295,13 @@ InMemorySorobanState::hasTTL(LedgerKey const& ledgerKey) const
     return false;
 }
 
+bool
+InMemorySorobanState::isEmpty() const
+{
+    return mContractDataEntries.empty() && mContractCodeEntries.empty() &&
+           mPendingTTLs.empty();
+}
+
 std::shared_ptr<LedgerEntry const>
 InMemorySorobanState::getTTL(LedgerKey const& ledgerKey) const
 {
@@ -485,4 +492,15 @@ InMemorySorobanState::checkUpdateInvariants() const
     // No TTLs should be orphaned after finishing an update
     releaseAssertOrThrow(mPendingTTLs.empty());
 }
+
+#ifdef BUILD_TESTS
+void
+InMemorySorobanState::clearForTesting()
+{
+    mContractDataEntries.clear();
+    mContractCodeEntries.clear();
+    mPendingTTLs.clear();
+    mLastClosedLedgerSeq = 0;
+}
+#endif
 }

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -8,6 +8,7 @@
 #include "history/HistoryManager.h"
 #include "ledger/LedgerCloseMetaFrame.h"
 #include "ledger/NetworkConfig.h"
+#include "main/ApplicationImpl.h"
 #include "rust/RustBridge.h"
 #include "transactions/TransactionMeta.h"
 #include <memory>
@@ -157,6 +158,18 @@ class InMemorySorobanState;
 // thread.
 class LedgerManager
 {
+
+  protected:
+    friend void ApplicationImpl::initialize(bool createNewDB,
+                                            bool forceRebuild);
+    virtual std::unique_ptr<LedgerTxnRoot>
+    createLedgerTxnRoot(Application& app, size_t entryCacheSize,
+                        size_t prefetchBatchSize
+#ifdef BEST_OFFER_DEBUGGING
+                        ,
+                        bool bestOfferDebuggingEnabled
+#endif
+                        ) = 0;
   public:
     static const uint32_t GENESIS_LEDGER_SEQ;
     static const uint32_t GENESIS_LEDGER_VERSION;
@@ -325,8 +338,6 @@ class LedgerManager
 
     virtual SorobanMetrics& getSorobanMetrics() = 0;
     virtual ::rust::Box<rust_bridge::SorobanModuleCache> getModuleCache() = 0;
-
-    virtual InMemorySorobanState const& getInMemorySorobanState() const = 0;
 
     virtual ~LedgerManager()
     {

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -326,6 +326,8 @@ class LedgerManager
     virtual SorobanMetrics& getSorobanMetrics() = 0;
     virtual ::rust::Box<rust_bridge::SorobanModuleCache> getModuleCache() = 0;
 
+    virtual InMemorySorobanState const& getInMemorySorobanState() const = 0;
+
     virtual ~LedgerManager()
     {
     }

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -230,20 +230,19 @@ LedgerManagerImpl::ApplyState::getMetrics()
     return mMetrics;
 }
 
-void
-LedgerManagerImpl::ApplyState::setInMemorySorobanState(
-    std::unique_ptr<InMemorySorobanState> inMemorySorobanState)
-{
-    threadInvariant();
-    mInMemorySorobanState = std::move(inMemorySorobanState);
-}
-
 InMemorySorobanState const&
 LedgerManagerImpl::ApplyState::getInMemorySorobanState() const
 {
-    releaseAssert(mInMemorySorobanState);
-    return *mInMemorySorobanState;
+    return mInMemorySorobanState;
 }
+
+#ifdef BUILD_TESTS
+InMemorySorobanState&
+LedgerManagerImpl::ApplyState::getInMemorySorobanStateForTesting()
+{
+    return mInMemorySorobanState;
+}
+#endif
 
 void
 LedgerManagerImpl::ApplyState::threadInvariant() const
@@ -300,9 +299,8 @@ LedgerManagerImpl::ApplyState::updateInMemorySorobanState(
     std::vector<LedgerKey> const& deadEntries, LedgerHeader const& lh)
 {
     threadInvariant();
-    releaseAssert(mInMemorySorobanState);
-    mInMemorySorobanState->updateState(initEntries, liveEntries, deadEntries,
-                                       lh);
+    mInMemorySorobanState.updateState(initEntries, liveEntries, deadEntries,
+                                      lh);
 }
 
 void
@@ -310,8 +308,7 @@ LedgerManagerImpl::ApplyState::manuallyAdvanceLedgerHeader(
     LedgerHeader const& lh)
 {
     threadInvariant();
-    releaseAssert(mInMemorySorobanState);
-    mInMemorySorobanState->manuallyAdvanceLedgerHeader(lh);
+    mInMemorySorobanState.manuallyAdvanceLedgerHeader(lh);
 }
 
 LedgerManagerImpl::LedgerManagerImpl(Application& app)
@@ -397,11 +394,6 @@ LedgerManagerImpl::startNewLedger(LedgerHeader const& genesisLedger)
 {
     auto ledgerTime = mApplyState.getMetrics().mLedgerClose.TimeScope();
     SecretKey skey = SecretKey::fromSeed(mApp.getNetworkID());
-
-    // mInMemorySorobanState is expected to exist when we go through the ledger
-    // close flow, so initialize empty in-memory state.
-    mApplyState.mInMemorySorobanState =
-        std::make_unique<InMemorySorobanState>();
 
     LedgerTxn ltx(mApp.getLedgerTxnRoot(), false);
     auto const& cfg = mApp.getConfig();
@@ -789,12 +781,13 @@ LedgerManagerImpl::storeCurrentLedgerForTest(LedgerHeader const& header)
 InMemorySorobanState const&
 LedgerManagerImpl::getInMemorySorobanStateForTesting()
 {
-    return mApplyState.getInMemorySorobanState();
+    return mApplyState.getInMemorySorobanStateForTesting();
 }
 
 void
 LedgerManagerImpl::rebuildInMemorySorobanStateForTesting()
 {
+    mApplyState.getInMemorySorobanStateForTesting().clearForTesting();
     mApplyState.populateInMemorySorobanState(
         mLastClosedLedgerState->getBucketSnapshot());
 }
@@ -806,6 +799,25 @@ LedgerManagerImpl::getSorobanMetrics()
     return mApplyState.getMetrics().mSorobanMetrics;
 }
 
+std::unique_ptr<LedgerTxnRoot>
+LedgerManagerImpl::createLedgerTxnRoot(Application& app, size_t entryCacheSize,
+                                       size_t prefetchBatchSize
+#ifdef BEST_OFFER_DEBUGGING
+                                       ,
+                                       bool bestOfferDebuggingEnabled
+#endif
+)
+{
+    return std::make_unique<LedgerTxnRoot>(
+        app, mApplyState.getInMemorySorobanState(), entryCacheSize,
+        prefetchBatchSize
+#ifdef BEST_OFFER_DEBUGGING
+        ,
+        bestOfferDebuggingEnabled
+#endif
+    );
+}
+
 ::rust::Box<rust_bridge::SorobanModuleCache>
 LedgerManagerImpl::getModuleCache()
 {
@@ -814,13 +826,6 @@ LedgerManagerImpl::getModuleCache()
     // transactions during apply only.
     releaseAssert(!mApplyState.isCompilationRunning());
     return mApplyState.getModuleCache()->shallow_clone();
-}
-
-InMemorySorobanState const&
-LedgerManagerImpl::getInMemorySorobanState() const
-{
-    releaseAssert(mApplyState.mInMemorySorobanState);
-    return *mApplyState.mInMemorySorobanState;
 }
 
 void
@@ -853,8 +858,7 @@ LedgerManagerImpl::ApplyState::populateInMemorySorobanState(
     SearchableSnapshotConstPtr snap)
 {
     threadInvariant();
-    mInMemorySorobanState = std::make_unique<InMemorySorobanState>();
-    mInMemorySorobanState->initializeStateFromSnapshot(snap);
+    mInMemorySorobanState.initializeStateFromSnapshot(snap);
 }
 
 void
@@ -2158,7 +2162,8 @@ LedgerManagerImpl::applySorobanStages(AppConnector& app, AbstractLedgerTxn& ltx,
                                       std::vector<ApplyStage> const& stages,
                                       Hash const& sorobanBasePrngSeed)
 {
-    GlobalParallelApplyLedgerState globalParState(app, ltx, stages);
+    GlobalParallelApplyLedgerState globalParState(
+        app, ltx, stages, mApplyState.getInMemorySorobanState());
     // LedgerTxn is not passed into applySorobanStage, so there's no risk
     // of the header being updated while we apply the stages.
     auto const& header = ltx.loadHeader().current();

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -425,6 +425,7 @@ class LedgerManagerImpl : public LedgerManager
         return mCurrentlyApplyingLedger;
     }
     ::rust::Box<rust_bridge::SorobanModuleCache> getModuleCache() override;
+    InMemorySorobanState const& getInMemorySorobanState() const override;
 
 #ifdef BUILD_TESTS
     friend class BucketTestUtils::LedgerManagerForBucketTests;

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -178,6 +178,8 @@
 namespace stellar
 {
 
+class InMemorySorobanState;
+
 /* LedgerEntryPtr holds a shared_ptr to a InternalLedgerEntry along with
   information about the state of the entry (or lack thereof)
 
@@ -884,8 +886,9 @@ class LedgerTxnRoot : public AbstractLedgerTxnParent
     LedgerHeader const& getHeader() const override;
 
   public:
-    explicit LedgerTxnRoot(Application& app, size_t entryCacheSize,
-                           size_t prefetchBatchSize
+    explicit LedgerTxnRoot(Application& app,
+                           InMemorySorobanState const& inMemorySorobanState,
+                           size_t entryCacheSize, size_t prefetchBatchSize
 #ifdef BEST_OFFER_DEBUGGING
                            ,
                            bool bestOfferDebuggingEnabled

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -21,6 +21,7 @@
 namespace stellar
 {
 
+class InMemorySorobanState;
 class SearchableLiveBucketListSnapshot;
 
 class EntryIterator::AbstractImpl
@@ -641,6 +642,7 @@ class LedgerTxnRoot::Impl
     size_t const mMaxBestOffersBatchSize;
 
     Application& mApp;
+    InMemorySorobanState const& mInMemorySorobanState;
     std::unique_ptr<SessionWrapper> mSession;
 
     std::unique_ptr<LedgerHeader> mHeader;
@@ -720,7 +722,8 @@ class LedgerTxnRoot::Impl
 
   public:
     // Constructor has the strong exception safety guarantee
-    Impl(Application& app, size_t entryCacheSize, size_t prefetchBatchSize
+    Impl(Application& app, InMemorySorobanState const& inMemorySorobanState,
+         size_t entryCacheSize, size_t prefetchBatchSize
 #ifdef BEST_OFFER_DEBUGGING
          ,
          bool bestOfferDebuggingEnabled

--- a/src/ledger/test/LedgerTestUtils.cpp
+++ b/src/ledger/test/LedgerTestUtils.cpp
@@ -498,6 +498,11 @@ static auto validLedgerEntryGenerator = autocheck::map(
     [](LedgerEntry&& le, size_t s) {
         auto& led = le.data;
         le.lastModifiedLedgerSeq = le.lastModifiedLedgerSeq & INT32_MAX;
+        if (le.lastModifiedLedgerSeq == 0)
+        {
+            le.lastModifiedLedgerSeq = 1;
+        }
+
         switch (led.type())
         {
         case ACCOUNT:

--- a/src/ledger/test/LedgerTestUtils.cpp
+++ b/src/ledger/test/LedgerTestUtils.cpp
@@ -498,6 +498,8 @@ static auto validLedgerEntryGenerator = autocheck::map(
     [](LedgerEntry&& le, size_t s) {
         auto& led = le.data;
         le.lastModifiedLedgerSeq = le.lastModifiedLedgerSeq & INT32_MAX;
+
+        // InMemorySorobanState expects lastModifiedLedgerSeq to be non-zero
         if (le.lastModifiedLedgerSeq == 0)
         {
             le.lastModifiedLedgerSeq = 1;

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -35,6 +35,7 @@
 #include "invariant/SponsorshipCountIsValid.h"
 #include "ledger/LedgerHeaderUtils.h"
 #include "ledger/LedgerManager.h"
+#include "ledger/LedgerManagerImpl.h"
 #include "ledger/LedgerTxn.h"
 #include "main/AppConnector.h"
 #include "main/ApplicationUtils.h"
@@ -271,7 +272,7 @@ ApplicationImpl::initialize(bool createNewDB, bool forceRebuild)
                     "of 20000",
                     mConfig.ENTRY_CACHE_SIZE);
     }
-    mLedgerTxnRoot = std::make_unique<LedgerTxnRoot>(
+    mLedgerTxnRoot = getLedgerManager().createLedgerTxnRoot(
         *this, mConfig.ENTRY_CACHE_SIZE, mConfig.PREFETCH_BATCH_SIZE
 #ifdef BEST_OFFER_DEBUGGING
         ,

--- a/src/main/test/QueryServerTests.cpp
+++ b/src/main/test/QueryServerTests.cpp
@@ -353,6 +353,8 @@ TEST_CASE("getledgerentry", "[queryserver]")
         entryToRestoreTTL.data.ttl().keyHash =
             getTTLKey(*entryToRestore).ttl().keyHash;
         entryToRestoreTTL.data.ttl().liveUntilLedgerSeq = restoredTTL;
+        entryToRestoreTTL.lastModifiedLedgerSeq =
+            modifiedEntry.lastModifiedLedgerSeq;
 
         // Make a new TTL such that live entry becomes archived
         LedgerEntry entryToArchiveTTL;
@@ -360,6 +362,8 @@ TEST_CASE("getledgerentry", "[queryserver]")
         entryToArchiveTTL.data.ttl().keyHash =
             getTTLKey(*entryToArchive).ttl().keyHash;
         entryToArchiveTTL.data.ttl().liveUntilLedgerSeq = oldLedger - 1;
+        entryToArchiveTTL.lastModifiedLedgerSeq =
+            modifiedEntry.lastModifiedLedgerSeq;
 
         lm.setNextLedgerEntryBatchForBucketTesting(
             {newEntry}, {entryToArchiveTTL, entryToRestoreTTL, modifiedEntry},


### PR DESCRIPTION
# Description

Uses the soroban state cache in the serial and parallel apply paths.

In order to get more confidence in the new in-memory soroban state map, this PR uses the map in all protocol versions by replacing the BucketList lookup in `LedgerTxnRoot` for soroban types. Additionally, the parallel apply path uses the cache.

In the initial state map design, I tried to avoid storing the LedgerEntry for TTLs, but I didn't realize we need the lastModifiedLedgerSeq value of TTLs for meta generation. To cut down on memory overhead, I store the lastModifiedLedgerSeq and liveUntilLedgerSeq explicitly instead of the full TTL LedgerEntry and reconstruct the LedgerEntry manually when queried. This is to avoid redundantly storing the keyHash of the TTL since we already store it as the key to our map.

Rebased on https://github.com/stellar/stellar-core/pull/4807

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
