### PR TITLE
Add some snapshot ledger-number asserts to parallel apply

### DIFF
--- a/src/bucket/BucketListSnapshotBase.h
+++ b/src/bucket/BucketListSnapshotBase.h
@@ -69,10 +69,7 @@ template <class BucketT> class BucketListSnapshot : public NonMovable
 //
 // Any thread that needs to perform BucketList lookups should retrieve
 // a single SearchableBucketListSnapshot instance from
-// BucketListSnapshotManager. On each lookup, the SearchableBucketListSnapshot
-// instance will check that the current snapshot is up to date via the
-// BucketListSnapshotManager and will be refreshed accordingly. Callers can
-// assume SearchableBucketListSnapshot is always up to date.
+// BucketListSnapshotManager.
 template <class BucketT>
 class SearchableBucketListSnapshotBase : public NonMovableOrCopyable
 {

--- a/src/ledger/InMemorySorobanState.cpp
+++ b/src/ledger/InMemorySorobanState.cpp
@@ -6,6 +6,7 @@
 #include "bucket/SearchableBucketList.h"
 #include "ledger/LedgerTypeUtils.h"
 #include "util/GlobalChecks.h"
+#include <cstdint>
 
 namespace stellar
 {
@@ -300,6 +301,12 @@ InMemorySorobanState::isEmpty() const
 {
     return mContractDataEntries.empty() && mContractCodeEntries.empty() &&
            mPendingTTLs.empty();
+}
+
+uint32_t
+InMemorySorobanState::getLedgerSeq() const
+{
+    return mLastClosedLedgerSeq;
 }
 
 std::shared_ptr<LedgerEntry const>

--- a/src/ledger/InMemorySorobanState.h
+++ b/src/ledger/InMemorySorobanState.h
@@ -324,6 +324,8 @@ class InMemorySorobanState : public NonMovableOrCopyable
 
     bool isEmpty() const;
 
+    uint32_t getLedgerSeq() const;
+
     // Returns the entry for the given key, or nullptr if not found.
     std::shared_ptr<LedgerEntry const> get(LedgerKey const& ledgerKey) const;
 

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -92,7 +92,7 @@ class InMemorySorobanState;
 // therefore trivially threadsafe, but may be lagging behind the newest
 // bucketlist formed by the apply thread.
 //
-// In more precise terms, 4 points on the diagram are labeled: L, Q, A, and LCL.
+// In more precise terms, 4 points on the diagram are labeled: H, Q, A, and LCL.
 // These are points where we can identify and relate some state variables and an
 // invariant order between them:
 //

--- a/src/transactions/ExtendFootprintTTLOpFrame.cpp
+++ b/src/transactions/ExtendFootprintTTLOpFrame.cpp
@@ -241,8 +241,7 @@ class ExtendFootprintTTLParallelApplyHelper
         OperationMetaBuilder& opMeta, ExtendFootprintTTLOpFrame const& opFrame)
         : ExtendFootprintTTLApplyHelper(app, res, refundableFeeTracker, opMeta,
                                         opFrame)
-        , ParallelLedgerAccessHelper(threadState, ledgerInfo,
-                                     app.copySearchableLiveBucketListSnapshot())
+        , ParallelLedgerAccessHelper(threadState, ledgerInfo)
     {
     }
     virtual bool

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -1066,8 +1066,7 @@ class InvokeHostFunctionParallelApplyHelper
         OperationMetaBuilder& opMeta, InvokeHostFunctionOpFrame const& opFrame)
         : InvokeHostFunctionApplyHelper(app, sorobanBasePrngSeed, res,
                                         refundableFeeTracker, opMeta, opFrame)
-        , ParallelLedgerAccessHelper(threadState, ledgerInfo,
-                                     app.copySearchableLiveBucketListSnapshot())
+        , ParallelLedgerAccessHelper(threadState, ledgerInfo)
     {
         // Initialize the autorestore lookup vector
         auto const& resourceExt = mOpFrame.getResourcesExt();

--- a/src/transactions/ParallelApplyUtils.h
+++ b/src/transactions/ParallelApplyUtils.h
@@ -155,6 +155,10 @@ class ThreadParallelApplyLedgerState
 
     void commitChangesFromSuccessfulOp(ParallelTxReturnVal const& res,
                                        TxBundle const& txBundle);
+
+    // The snapshot ledger sequence number is one less than the
+    // applying ledger sequence number.
+    uint32_t getSnapshotLedgerSeq() const;
 };
 
 class GlobalParallelApplyLedgerState
@@ -230,6 +234,10 @@ class GlobalParallelApplyLedgerState
 
     void commitChangesToLedgerTxn(AbstractLedgerTxn& ltx) const;
 
+    // The snapshot ledger sequence number is one less than the
+    // applying ledger sequence number.
+    uint32_t getSnapshotLedgerSeq() const;
+
     // Constructor requires access to mInMemorySorobanState
     friend ThreadParallelApplyLedgerState::ThreadParallelApplyLedgerState(
         AppConnector& app, GlobalParallelApplyLedgerState const& global,
@@ -275,6 +283,7 @@ class OpParallelApplyLedgerState
                                   LedgerEntry const& ttlEntry);
     ParallelTxReturnVal takeSuccess();
     ParallelTxReturnVal takeFailure();
+    uint32_t getSnapshotLedgerSeq() const;
 };
 
 class LedgerAccessHelper
@@ -323,8 +332,7 @@ class ParallelLedgerAccessHelper : virtual public LedgerAccessHelper
   protected:
     ParallelLedgerAccessHelper(
         ThreadParallelApplyLedgerState const& threadState,
-        ParallelLedgerInfo const& ledgerInfo,
-        SearchableSnapshotConstPtr liveSnapshot);
+        ParallelLedgerInfo const& ledgerInfo);
 
     ParallelLedgerInfo const& mLedgerInfo;
     OpParallelApplyLedgerState mOpState;

--- a/src/transactions/RestoreFootprintOpFrame.cpp
+++ b/src/transactions/RestoreFootprintOpFrame.cpp
@@ -287,8 +287,7 @@ class RestoreFootprintParallelApplyHelper
         OperationMetaBuilder& opMeta, RestoreFootprintOpFrame const& opFrame)
         : RestoreFootprintApplyHelper(app, res, refundableFeeTracker, opMeta,
                                       opFrame)
-        , ParallelLedgerAccessHelper(threadState, ledgerInfo,
-                                     app.copySearchableLiveBucketListSnapshot())
+        , ParallelLedgerAccessHelper(threadState, ledgerInfo)
         , mHotArchive(app.copySearchableHotArchiveBucketListSnapshot())
     {
     }


### PR DESCRIPTION
This just adds a bunch of asserts that all the snapshot ledger numbers in the parallel apply subsystem are the same, and are 1 less than the ledger number we're applying.

(Also fixes a couple comments and removes an unused parameter I noticed while browsing code)