### PR TITLE
Fix quorum intersection checker

### DIFF
--- a/src/herder/RustQuorumCheckerAdaptor.cpp
+++ b/src/herder/RustQuorumCheckerAdaptor.cpp
@@ -478,7 +478,7 @@ runQuorumIntersectionCheckAsync(
     ZoneScoped;
 
     std::string quorumMapFile(fmt::format("{}/quorum_map.json", tmpDirName));
-    std::string qicOutFile(fmt::format("{}/out.txt", tmpDirName)); // for stdout
+
     std::string qicResultJson(
         fmt::format("{}/result.json", tmpDirName)); // for result
 
@@ -499,14 +499,14 @@ runQuorumIntersectionCheckAsync(
         "--time-limit-ms {} --memory-limit-bytes {} {}",
         exe, quorumMapFile, ll, qicResultJson, timeLimitMs, memoryLimitBytes,
         analyzeCriticalGroups ? "--analyze-critical-groups" : "");
-    auto evt = pm.runProcess(cmdline, qicOutFile).lock();
+    auto evt = pm.runProcess(cmdline, "").lock();
     if (!evt)
     {
         CLOG_ERROR(SCP, "Failed to start quorum intersection check process");
         return;
     }
 
-    evt->async_wait([numNodes, ledger, curr, qicOutFile, qicResultJson,
+    evt->async_wait([numNodes, ledger, curr, qicResultJson,
                      hState](asio::error_code ec) {
         auto hStateSP = hState.lock();
         if (hStateSP == nullptr)
@@ -526,9 +526,8 @@ runQuorumIntersectionCheckAsync(
         CLOG_DEBUG(SCP,
                    "Processing quorum intersection check result: numNodes={}, "
                    "ledger={}, "
-                   "hash={}, outFile='{}', resultJson='{}', errorCode = {}",
-                   numNodes, ledger, binToHex(curr), qicOutFile, qicResultJson,
-                   ecode);
+                   "hash={}, resultJson='{}', errorCode = {}",
+                   numNodes, ledger, binToHex(curr), qicResultJson, ecode);
 
         if (ecode == static_cast<int>(QuorumCheckerStatus::UNSAT) ||
             ecode == static_cast<int>(QuorumCheckerStatus::SAT) ||

--- a/src/herder/RustQuorumCheckerAdaptor.cpp
+++ b/src/herder/RustQuorumCheckerAdaptor.cpp
@@ -500,6 +500,11 @@ runQuorumIntersectionCheckAsync(
         exe, quorumMapFile, ll, qicResultJson, timeLimitMs, memoryLimitBytes,
         analyzeCriticalGroups ? "--analyze-critical-groups" : "");
     auto evt = pm.runProcess(cmdline, qicOutFile).lock();
+    if (!evt)
+    {
+        CLOG_ERROR(SCP, "Failed to start quorum intersection check process");
+        return;
+    }
 
     evt->async_wait([numNodes, ledger, curr, qicOutFile, qicResultJson,
                      hState](asio::error_code ec) {


### PR DESCRIPTION
# Description

There are two issues -

1. The `weak_ptr` returned by `runProcess` isn't checked before it is used. The first commit fixes this.
2. `runProcess` will fail if you pass it an output file that already exists. `runQuorumIntersectionCheckAsync` can be called multiple times, so the second call to it will fail. The second commit just passes an empty string so the output isn't captured. I am not familiar with how the QIC works or if the output is helpful, but wanted to put this out there and gather suggestions on what to do. Another option is deleting the file if it exists before calling the process manager 

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
