### PR TITLE
Add phase invariants to LedgerManager::ApplyState

### DIFF
--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -975,8 +975,8 @@ TEST_CASE_VERSIONS("network config snapshots Soroban state size", "[soroban]")
                                                   .header.ledgerVersion,
                                               ProtocolVersion::V_23))
                 {
-                    sizeSnapshot =
-                        app->getLedgerManager().getSorobanInMemoryStateSize();
+                    sizeSnapshot = app->getLedgerManager()
+                                       .getSorobanInMemoryStateSizeForTesting();
                 }
                 else
                 {

--- a/src/bucket/test/BucketTestUtils.cpp
+++ b/src/bucket/test/BucketTestUtils.cpp
@@ -237,7 +237,7 @@ LedgerManagerForBucketTests::sealLedgerTxnAndTransferEntriesToBucketList(
                     mApp.getBucketManager().resolveBackgroundEvictionScan(
                         ltxEvictions, lh.ledgerSeq, keys, initialLedgerVers,
                         mApp.getLedgerManager()
-                            .getSorobanNetworkConfigForApply());
+                            .getMutableSorobanNetworkConfigForApply());
                 if (protocolVersionStartsFrom(
                         initialLedgerVers,
                         LiveBucket::
@@ -277,8 +277,9 @@ LedgerManagerForBucketTests::sealLedgerTxnAndTransferEntriesToBucketList(
                 .getMutableSorobanNetworkConfigForApply()
                 .maybeSnapshotSorobanStateSize(
                     lh.ledgerSeq,
-                    mApp.getLedgerManager().getSorobanInMemoryStateSize(), ltx,
-                    mApp);
+                    mApp.getLedgerManager()
+                        .getSorobanInMemoryStateSizeForTesting(),
+                    ltx, mApp);
         }
 
         ltx.getAllEntries(init, live, dead);

--- a/src/catchup/ApplyBucketsWork.cpp
+++ b/src/catchup/ApplyBucketsWork.cpp
@@ -190,9 +190,15 @@ ApplyBucketsWork::doWork()
 {
     ZoneScoped;
 
+    // Step 0: Applying Buckets resets DB state, so we need to reset
+    // LedgerManager apply state phase to `SETTING_UP_STATE`. We'll do this with
+    // step 1 below for convience.
+
     // Step 1: index live buckets. Step 2: apply buckets. Step 3: assume state
     if (!mIndexBucketsWork)
     {
+        mApp.getLedgerManager().markApplyStateReset();
+
         // Spawn indexing work for the first time. Hot Archive buckets aren't
         // needed for apply (since we only store live state in SQL tables), so
         // for now only index the live BL. AssumeStateWork will take care of

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -4184,7 +4184,8 @@ TEST_CASE("quick restart", "[herder][quickRestart]")
             auto headerBefore =
                 app->getLedgerManager().getLastClosedLedgerHeader();
             auto configBeforeApply =
-                app->getLedgerManager().getSorobanNetworkConfigForApply();
+                app->getLedgerManager()
+                    .getMutableSorobanNetworkConfigForApply();
             auto configBefore =
                 app->getLedgerManager().getLastClosedSorobanNetworkConfig();
             auto hasBefore = app->getLedgerManager().getLastClosedLedgerHAS();
@@ -4207,7 +4208,7 @@ TEST_CASE("quick restart", "[herder][quickRestart]")
                 newListener->getLedgerManager().getLastClosedLedgerHeader());
             REQUIRE(configBeforeApply ==
                     newListener->getLedgerManager()
-                        .getSorobanNetworkConfigForApply());
+                        .getMutableSorobanNetworkConfigForApply());
             REQUIRE(configBefore == newListener->getLedgerManager()
                                         .getLastClosedSorobanNetworkConfig());
             REQUIRE(hasBefore.toString() == newListener->getLedgerManager()
@@ -4325,7 +4326,7 @@ TEST_CASE("ledger state update flow with parallel apply", "[herder][parallel]")
             for (auto const& node : sim->getNodes())
             {
                 auto& lm = node->getLedgerManager();
-                auto applyConfig = lm.getSorobanNetworkConfigForApply();
+                auto applyConfig = lm.getMutableSorobanNetworkConfigForApply();
                 auto prevConfig = lm.getLastClosedSorobanNetworkConfig();
                 REQUIRE(!(applyConfig == prevConfig));
                 REQUIRE(prevConfig == configBeforeUpgrade);
@@ -4355,7 +4356,7 @@ TEST_CASE("ledger state update flow with parallel apply", "[herder][parallel]")
             for (auto const& node : sim->getNodes())
             {
                 auto& lm = node->getLedgerManager();
-                auto applyConfig = lm.getSorobanNetworkConfigForApply();
+                auto applyConfig = lm.getMutableSorobanNetworkConfigForApply();
                 auto prevConfig = lm.getLastClosedSorobanNetworkConfig();
                 REQUIRE(applyConfig == prevConfig);
                 REQUIRE(!(prevConfig == configBeforeUpgrade));

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -1048,8 +1048,9 @@ TEST_CASE("upgrades affect in-memory Soroban state state size",
 
     std::vector<LedgerKey> addedKeys;
 
-    uint64_t lastInMemorySize =
-        test.getApp().getLedgerManager().getSorobanInMemoryStateSize();
+    uint64_t lastInMemorySize = test.getApp()
+                                    .getLedgerManager()
+                                    .getSorobanInMemoryStateSizeForTesting();
     auto ensureInMemorySizeIncreased = [&]() {
         // We only increase the state by either generating lots of
         // transactions, or by multiplicatively increasing the memory cost, so
@@ -1059,11 +1060,12 @@ TEST_CASE("upgrades affect in-memory Soroban state state size",
         int64_t diff =
             static_cast<int64_t>(test.getApp()
                                      .getLedgerManager()
-                                     .getSorobanInMemoryStateSize()) -
+                                     .getSorobanInMemoryStateSizeForTesting()) -
             static_cast<int64_t>(lastInMemorySize);
         REQUIRE(diff >= minIncrease);
-        lastInMemorySize =
-            test.getApp().getLedgerManager().getSorobanInMemoryStateSize();
+        lastInMemorySize = test.getApp()
+                               .getLedgerManager()
+                               .getSorobanInMemoryStateSizeForTesting();
     };
     auto generateTxs = [&](int untilLedger) {
         // Make sure we start on odd ledger, so that we finish generation 1
@@ -1088,7 +1090,9 @@ TEST_CASE("upgrades affect in-memory Soroban state state size",
     // We accumulate a small error in the expected state size estimation due
     // to upgrades. It's tracked in `expectedInMemorySizeDelta` variable.
     int64_t expectedInMemorySizeDelta =
-        test.getApp().getLedgerManager().getSorobanInMemoryStateSize();
+        test.getApp()
+            .getLedgerManager()
+            .getSorobanInMemoryStateSizeForTesting();
     auto getExpectedInMemorySize = [&]() {
         LedgerSnapshot ls(test.getApp());
         auto res = expectedInMemorySizeDelta;
@@ -1149,7 +1153,7 @@ TEST_CASE("upgrades affect in-memory Soroban state state size",
         int64_t diff =
             static_cast<int64_t>(test.getApp()
                                      .getLedgerManager()
-                                     .getSorobanInMemoryStateSize()) -
+                                     .getSorobanInMemoryStateSizeForTesting()) -
             static_cast<int64_t>(getExpectedInMemorySize());
         if (maxDiff >= 0)
         {
@@ -1225,8 +1229,9 @@ TEST_CASE("upgrades affect in-memory Soroban state state size",
     executeUpgrade(test.getApp(), makeProtocolVersionUpgrade(23));
     // In-memory size shouldn't have changed as it has been computed with p23
     // logic.
-    REQUIRE(test.getApp().getLedgerManager().getSorobanInMemoryStateSize() ==
-            lastInMemorySize);
+    REQUIRE(test.getApp()
+                .getLedgerManager()
+                .getSorobanInMemoryStateSizeForTesting() == lastInMemorySize);
     auto const p23MemorySize = lastInMemorySize;
     // State size window now contains only the current in-memory size.
     expectSingleValueStateSizeWindow(p23MemorySize);
@@ -1297,14 +1302,15 @@ TEST_CASE("upgrades affect in-memory Soroban state state size",
         int64_t stateSizeDecrease =
             static_cast<int64_t>(test.getApp()
                                      .getLedgerManager()
-                                     .getSorobanInMemoryStateSize()) -
+                                     .getSorobanInMemoryStateSizeForTesting()) -
             static_cast<int64_t>(lastInMemorySize);
         REQUIRE(stateSizeDecrease <= -10'000'000);
         // The state size is now smaller than expected because the upgrade
         // contract had its memory cost decreased.
         verifyExpectedInMemorySize(-300'000);
-        lastInMemorySize =
-            test.getApp().getLedgerManager().getSorobanInMemoryStateSize();
+        lastInMemorySize = test.getApp()
+                               .getLedgerManager()
+                               .getSorobanInMemoryStateSizeForTesting();
         expectSingleValueStateSizeWindow(lastInMemorySize);
         verifyAverageStateSize(lastInMemorySize, lastInMemorySize);
     }

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -260,7 +260,8 @@ class LedgerManager
 
     virtual Resource maxLedgerResources(bool isSoroban) = 0;
     virtual Resource maxSorobanTransactionResources() = 0;
-    virtual void updateSorobanNetworkConfigForApply(AbstractLedgerTxn& ltx) = 0;
+    virtual void
+    updateSorobanNetworkConfigForCommit(AbstractLedgerTxn& ltx) = 0;
     // Return the network config for Soroban.
     // The config is automatically refreshed on protocol upgrades.
     // Ledger txn here is needed for the sake of lazy load; it won't be
@@ -271,8 +272,6 @@ class LedgerManager
 
     virtual bool hasLastClosedSorobanNetworkConfig() const = 0;
     virtual std::chrono::milliseconds getExpectedLedgerCloseTime() const = 0;
-
-    virtual uint64_t getSorobanInMemoryStateSize() const = 0;
 
 #ifdef BUILD_TESTS
     virtual SorobanNetworkConfig& getMutableSorobanNetworkConfigForApply() = 0;
@@ -286,6 +285,9 @@ class LedgerManager
     virtual InMemorySorobanState const& getInMemorySorobanStateForTesting() = 0;
     virtual void
     rebuildInMemorySorobanStateForTesting(uint32_t ledgerVersion) = 0;
+    virtual ::rust::Box<rust_bridge::SorobanModuleCache>
+    getModuleCacheForTesting() = 0;
+    virtual uint64_t getSorobanInMemoryStateSizeForTesting() = 0;
 #endif
 
     // Return the (changing) number of seconds since the LCL closed.
@@ -351,6 +353,12 @@ class LedgerManager
     }
 
     virtual bool isApplying() const = 0;
+
+    // Sets apply state phase to SETTING_UP_STATE. This only changes the phase,
+    // but does not actually reset any state. This should be called when
+    // anything related to ApplyState, such as the LedgerState database, is
+    // modified outside of the regular ledgerClose path (i.e. BucketApply).
+    virtual void markApplyStateReset() = 0;
 
     // Recomputes the size of the in-memory Soroban state (specifically, the
     // unstable contract code size part of it), and fully overrides all the

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -6505,7 +6505,7 @@ makeAddTx(TestContract const& contract, int64_t instructions,
 static bool
 wasmsAreCached(Application& app, std::vector<Hash> const& wasms)
 {
-    auto moduleCache = app.getLedgerManager().getModuleCache();
+    auto moduleCache = app.getLedgerManager().getModuleCacheForTesting();
     for (auto const& wasm : wasms)
     {
         if (!moduleCache->contains_module(
@@ -6839,7 +6839,7 @@ TEST_CASE("Module cache cost with restore gaps", "[tx][soroban][modulecache]")
     {
         closeLedger(test.getApp());
     }
-    auto moduleCache = lm.getModuleCache();
+    auto moduleCache = lm.getModuleCacheForTesting();
     auto const wasmHash = sha256(wasm);
     REQUIRE(!moduleCache->contains_module(
         proto, ::rust::Slice{wasmHash.data(), wasmHash.size()}));
@@ -7859,7 +7859,7 @@ TEST_CASE("apply generated parallel tx sets", "[tx][soroban][parallelapply]")
     auto& root = test.getRoot();
     const int64_t startingBalance = lm.getLastMinBalance(50);
 
-    auto const& sorobanConfig = lm.getSorobanNetworkConfigForApply();
+    auto const& sorobanConfig = lm.getMutableSorobanNetworkConfigForApply();
     std::vector<TestAccount> accounts;
     for (size_t i = 0; i < sorobanConfig.ledgerMaxTxCount(); ++i)
     {
@@ -8204,7 +8204,9 @@ TEST_CASE("in-memory state size tracking", "[soroban]")
     // Initial network config has a higher persistent TTL, so we don't expect
     // this state to expire.
     auto const stateSizeAfterUpgrade =
-        test.getApp().getLedgerManager().getSorobanInMemoryStateSize();
+        test.getApp()
+            .getLedgerManager()
+            .getSorobanInMemoryStateSizeForTesting();
 
     std::vector<TestAccount> accounts;
 
@@ -8217,8 +8219,9 @@ TEST_CASE("in-memory state size tracking", "[soroban]")
     ContractStorageTestClient client(test);
 
     auto const initialContractsCreatedLedgerSeq = test.getLCLSeq();
-    auto baseStateSize =
-        test.getApp().getLedgerManager().getSorobanInMemoryStateSize();
+    auto baseStateSize = test.getApp()
+                             .getLedgerManager()
+                             .getSorobanInMemoryStateSizeForTesting();
 
     std::vector<std::pair<std::string, ContractDataDurability>> dataKeys;
 
@@ -8243,8 +8246,9 @@ TEST_CASE("in-memory state size tracking", "[soroban]")
                 expectedSize += xdr::xdr_size(le.current());
             }
         }
-        auto actualSize =
-            test.getApp().getLedgerManager().getSorobanInMemoryStateSize();
+        auto actualSize = test.getApp()
+                              .getLedgerManager()
+                              .getSorobanInMemoryStateSizeForTesting();
         REQUIRE(actualSize == expectedSize);
         // Make sure there actually were some live contract data entries.
         REQUIRE(actualSize > baseStateSize);
@@ -8378,8 +8382,9 @@ TEST_CASE("in-memory state size tracking", "[soroban]")
         {
             closeLedger(test.getApp());
         }
-        REQUIRE(
-            test.getApp().getLedgerManager().getSorobanInMemoryStateSize() ==
-            stateSizeAfterUpgrade);
+        REQUIRE(test.getApp()
+                    .getLedgerManager()
+                    .getSorobanInMemoryStateSizeForTesting() ==
+                stateSizeAfterUpgrade);
     }
 }


### PR DESCRIPTION
# Description

Adds additional invariant to `LedgerManager::ApplyState`. Now that there are multiple apply threads accessing `ApplyState`, sometimes the state is expected to be an immutable snapshot (i.e. during transaction execution), and other times `ApplyState` is modified by the apply thread to commit state changes and advance the ledger. This codifies these invariants. There's still some room for further hardening. For example, `getNetworkConfig` isn't protected by these invariants yet, as that's a larger overhaul that probably also requires changes to the LedgerStateSnapshot interface. 

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
