### PR TITLE
Fix tmpdir-reuse crash bug of new QIC

### DIFF
--- a/src/herder/QuorumIntersectionChecker.h
+++ b/src/herder/QuorumIntersectionChecker.h
@@ -55,12 +55,8 @@ struct QuorumMapIntersectionState
         return mLastCheckLedger == mLastGoodLedger;
     }
 
-    QuorumMapIntersectionState(TmpDir&& tmpDir,
-                               medida::MetricsRegistry& metrics)
-        : mTmpDir(std::make_unique<TmpDir>(std::move(tmpDir)))
-        , mMetrics(metrics)
-    {
-    }
+    void reset(Application& app);
+    QuorumMapIntersectionState(Application& app);
 };
 
 class QuorumIntersectionChecker

--- a/src/herder/QuorumIntersectionCheckerImpl.cpp
+++ b/src/herder/QuorumIntersectionCheckerImpl.cpp
@@ -6,6 +6,7 @@
 #include "QuorumIntersectionChecker.h"
 #include "herder/HerderUtils.h"
 
+#include "main/Application.h"
 #include "util/GlobalChecks.h"
 #include "util/Logging.h"
 #include "util/Math.h"
@@ -790,6 +791,24 @@ groupString(std::optional<Config> const& cfg, std::set<NodeID> const& group)
 
 namespace stellar
 {
+
+void
+QuorumMapIntersectionState::reset(Application& app)
+{
+    // NB: this deletes any existing tmp dir before creating a new one.
+    mTmpDir =
+        std::make_unique<TmpDir>(app.getTmpDirManager().tmpDir("qic-tmp"));
+    mRecalculating = false;
+    mInterruptFlag = false;
+    mCheckingQuorumMapHash = Hash{};
+}
+
+QuorumMapIntersectionState::QuorumMapIntersectionState(Application& app)
+    : mMetrics(app.getMetrics())
+{
+    reset(app);
+}
+
 std::shared_ptr<QuorumIntersectionChecker>
 QuorumIntersectionChecker::create(
     QuorumTracker::QuorumMap const& qmap, std::optional<Config> const& cfg,

--- a/src/herder/RustQuorumCheckerAdaptor.h
+++ b/src/herder/RustQuorumCheckerAdaptor.h
@@ -79,8 +79,8 @@ QuorumCheckerStatus networkEnjoysQuorumIntersection(
 // analysis. Results are read from the output JSON file and propagated back to
 // the main process through the provided QuorumMapIntersectionState.
 void runQuorumIntersectionCheckAsync(
-    Hash const curr, uint32 ledger, std::string const& tmpDirName,
-    QuorumTracker::QuorumMap const& qmap,
+    Application& app, Hash const curr, uint32 ledger,
+    std::string const& tmpDirName, QuorumTracker::QuorumMap const& qmap,
     std::weak_ptr<QuorumMapIntersectionState> hState, ProcessManager& pm,
     uint64_t timeLimitMs, size_t memoryLimitBytes, bool analyzeCriticalGroups);
 


### PR DESCRIPTION
This is a slightly expanded version of https://github.com/stellar/stellar-core/pull/4818 with a test and a little bit of cleanup / robustness around resetting the tmpdir aggressively.

There's plenty of room for more cleanup here -- the cluster of classes is fairly fragile and un-encapsulated still -- but this ought to unblock us for the current release.