### PR TITLE
Parallel soroban - Add tests and fix bug with loading deleted entries from global state

### DIFF
--- a/src/transactions/ParallelApplyUtils.cpp
+++ b/src/transactions/ParallelApplyUtils.cpp
@@ -596,6 +596,17 @@ ThreadParallelApplyLedgerState::collectClusterFootprintEntriesFromGlobal(
                             ParallelApplyEntry::cleanPopulated(ttlOpt.value()));
                     }
                 }
+                else
+                {
+                    mThreadEntryMap.emplace(key,
+                                            ParallelApplyEntry::cleanEmpty());
+                    if (isSorobanEntry(key))
+                    {
+                        auto ttlKey = getTTLKey(key);
+                        mThreadEntryMap.emplace(
+                            ttlKey, ParallelApplyEntry::cleanEmpty());
+                    }
+                }
             }
         }
     }

--- a/src/transactions/ParallelApplyUtils.cpp
+++ b/src/transactions/ParallelApplyUtils.cpp
@@ -497,19 +497,6 @@ GlobalParallelApplyLedgerState::getLiveEntryOpt(LedgerKey const& key) const
     return res ? std::make_optional(*res) : std::nullopt;
 }
 
-void
-GlobalParallelApplyLedgerState::upsertEntry(LedgerKey const& key,
-                                            LedgerEntry const& entry)
-{
-    mGlobalEntryMap[key] = ParallelApplyEntry::dirtyPopulated(entry);
-}
-
-void
-GlobalParallelApplyLedgerState::eraseEntry(LedgerKey const& key)
-{
-    mGlobalEntryMap[key] = ParallelApplyEntry::dirtyEmpty();
-}
-
 RestoredEntries const&
 GlobalParallelApplyLedgerState::getRestoredEntries() const
 {

--- a/src/transactions/ParallelApplyUtils.h
+++ b/src/transactions/ParallelApplyUtils.h
@@ -221,9 +221,6 @@ class GlobalParallelApplyLedgerState
                                    InMemorySorobanState const& inMemoryState);
 
     std::optional<LedgerEntry> getLiveEntryOpt(LedgerKey const& key) const;
-    void upsertEntry(LedgerKey const& key, LedgerEntry const& entry);
-    void eraseEntry(LedgerKey const& key);
-
     RestoredEntries const& getRestoredEntries() const;
 
     void commitChangesFromThreads(

--- a/test-tx-meta-baseline-current/InvokeHostFunctionTests.json
+++ b/test-tx-meta-baseline-current/InvokeHostFunctionTests.json
@@ -2184,6 +2184,10 @@
 	],
 	"ledger entry size limit enforced" : [ "+cR3oq2qY0I=", "+cR3oq2qY0I=" ],
 	"loadgen Wasm executes properly" : [ "+cR3oq2qY0I=" ],
+	"merge account then do SAC payment to the merged account|protocol version 20" : [ "bKDF6V5IzTo=", "4qTJp8JmPaQ=", "TZsMI+VIqms=", "OPJp6Z6eHjY=" ],
+	"merge account then do SAC payment to the merged account|protocol version 21" : [ "bKDF6V5IzTo=", "4qTJp8JmPaQ=", "TZsMI+VIqms=", "OPJp6Z6eHjY=" ],
+	"merge account then do SAC payment to the merged account|protocol version 22" : [ "bKDF6V5IzTo=", "nZaHaZaWjPM=", "ank7hDEdE90=", "UhTmVoE7E10=" ],
+	"merge account then do SAC payment to the merged account|protocol version 23" : [ "+cR3oq2qY0I=", "kDMMDQdWWBg=", "XgQ36O588Cw=", "AeLB0v5FV3E=" ],
 	"multiple soroban ops in a tx|protocol version 20" : [ "bKDF6V5IzTo=", "n9Sc/mMA2VA=", "bKDF6V5IzTo=", "n9Sc/mMA2VA=" ],
 	"multiple soroban ops in a tx|protocol version 20|with fee bump" : [ "nfyrGO2ZGaM=" ],
 	"multiple soroban ops in a tx|protocol version 21" : [ "bKDF6V5IzTo=", "SStJyt3nT/c=", "bKDF6V5IzTo=", "SStJyt3nT/c=" ],
@@ -2767,6 +2771,20 @@
 		"RH+UShPLOJY="
 	],
 	"persistent entry archival|expiration without eviction|key accessible after restore in same ledger|restore, delete, restore" : [ "qkHKGYYnCSI=", "bxv547+A4zA=" ],
+	"read-only bumps across threads" : 
+	[
+		"+cR3oq2qY0I=",
+		"hFmIG0TZzKk=",
+		"07gXFzPdYd8=",
+		"qLimGbOITx8=",
+		"Ailk5Wavd1Y=",
+		"DhlYrpLW8OY=",
+		"T9nnMuwBnIo=",
+		"ewn8a2qomCo=",
+		"q008p8qGHIs=",
+		"+M8i+OyobEE=",
+		"RD4SbL+fpW4="
+	],
 	"refund account merged|protocol version 20" : [ "NTGGdj1offM=", "4gCiTRsvvQQ=", "lDIOdHQWnno=", "l3luGRqcBNU=" ],
 	"refund account merged|protocol version 21" : [ "NTGGdj1offM=", "4gCiTRsvvQQ=", "lDIOdHQWnno=", "l3luGRqcBNU=" ],
 	"refund account merged|protocol version 22" : [ "NTGGdj1offM=", "g3gHe/+0R0s=", "51g/NdOY708=", "qBAN8h2uYsI=" ],

--- a/test-tx-meta-baseline-next/InvokeHostFunctionTests.json
+++ b/test-tx-meta-baseline-next/InvokeHostFunctionTests.json
@@ -2275,6 +2275,11 @@
 	],
 	"ledger entry size limit enforced" : [ "+cR3oq2qY0I=", "+cR3oq2qY0I=" ],
 	"loadgen Wasm executes properly" : [ "+cR3oq2qY0I=" ],
+	"merge account then do SAC payment to the merged account|protocol version 20" : [ "bKDF6V5IzTo=", "4qTJp8JmPaQ=", "TZsMI+VIqms=", "OPJp6Z6eHjY=" ],
+	"merge account then do SAC payment to the merged account|protocol version 21" : [ "bKDF6V5IzTo=", "4qTJp8JmPaQ=", "TZsMI+VIqms=", "OPJp6Z6eHjY=" ],
+	"merge account then do SAC payment to the merged account|protocol version 22" : [ "bKDF6V5IzTo=", "nZaHaZaWjPM=", "ank7hDEdE90=", "UhTmVoE7E10=" ],
+	"merge account then do SAC payment to the merged account|protocol version 23" : [ "+cR3oq2qY0I=", "kDMMDQdWWBg=", "XgQ36O588Cw=", "AeLB0v5FV3E=" ],
+	"merge account then do SAC payment to the merged account|protocol version 24" : [ "+cR3oq2qY0I=", "kDMMDQdWWBg=", "XgQ36O588Cw=", "AeLB0v5FV3E=" ],
 	"multiple soroban ops in a tx|protocol version 20" : [ "bKDF6V5IzTo=", "n9Sc/mMA2VA=", "bKDF6V5IzTo=", "n9Sc/mMA2VA=" ],
 	"multiple soroban ops in a tx|protocol version 20|with fee bump" : [ "nfyrGO2ZGaM=" ],
 	"multiple soroban ops in a tx|protocol version 21" : [ "bKDF6V5IzTo=", "SStJyt3nT/c=", "bKDF6V5IzTo=", "SStJyt3nT/c=" ],
@@ -2861,6 +2866,20 @@
 		"RH+UShPLOJY="
 	],
 	"persistent entry archival|expiration without eviction|key accessible after restore in same ledger|restore, delete, restore" : [ "qkHKGYYnCSI=", "bxv547+A4zA=" ],
+	"read-only bumps across threads" : 
+	[
+		"+cR3oq2qY0I=",
+		"hFmIG0TZzKk=",
+		"07gXFzPdYd8=",
+		"qLimGbOITx8=",
+		"Ailk5Wavd1Y=",
+		"DhlYrpLW8OY=",
+		"T9nnMuwBnIo=",
+		"ewn8a2qomCo=",
+		"q008p8qGHIs=",
+		"+M8i+OyobEE=",
+		"RD4SbL+fpW4="
+	],
 	"refund account merged|protocol version 20" : [ "NTGGdj1offM=", "4gCiTRsvvQQ=", "lDIOdHQWnno=", "l3luGRqcBNU=" ],
 	"refund account merged|protocol version 21" : [ "NTGGdj1offM=", "4gCiTRsvvQQ=", "lDIOdHQWnno=", "l3luGRqcBNU=" ],
 	"refund account merged|protocol version 22" : [ "NTGGdj1offM=", "g3gHe/+0R0s=", "51g/NdOY708=", "qBAN8h2uYsI=" ],


### PR DESCRIPTION
# Description

Fix a bug with loading deleted entries from global state with parallel soroban.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
