### PR TITLE
Remove loadgen account creation mode, simplify upgrade path in tests

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -87,7 +87,6 @@ ledger.operation.count                    | histogram | number of operations per
 ledger.transaction.apply                  | timer     | time to apply one transaction
 ledger.transaction.count                  | histogram | number of transactions per ledger
 ledger.transaction.internal-error         | counter   | number of internal errors since start
-loadgen.account.created                   | meter     | loadgenerator: account created
 loadgen.payment.native                    | meter     | loadgenerator: native payment submitted
 loadgen.pretend.submitted                 | meter     | loadgenerator: pretend ops submitted
 loadgen.run.complete                      | meter     | loadgenerator: run complete

--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -450,11 +450,14 @@ this survey mechanism, just set `SURVEYOR_KEYS` to `$self` or a bogus key
 
 ### The following HTTP commands are exposed on test instances
 * **generateload** `generateload[?mode=
-    (create|pay|pretend|mixed_classic|soroban_upload|soroban_invoke_setup|soroban_invoke|upgrade_setup|create_upgrade|mixed_classic_soroban|pay_pregenerated|stop)&accounts=N&offset=K&txs=M&txrate=R&spikesize=S&spikeinterval=I&maxfeerate=F&skiplowfeetxs=(0|1)&dextxpercent=D&minpercentsuccess=S&instances=Y&wasms=Z&payweight=P&sorobanuploadweight=Q&sorobaninvokeweight=R&file=F]`
+    (pay|pretend|mixed_classic|soroban_upload|soroban_invoke_setup|soroban_invoke|upgrade_setup|create_upgrade|mixed_classic_soroban|pay_pregenerated|stop)&accounts=N&offset=K&txs=M&txrate=R&spikesize=S&spikeinterval=I&maxfeerate=F&skiplowfeetxs=(0|1)&dextxpercent=D&minpercentsuccess=S&instances=Y&wasms=Z&payweight=P&sorobanuploadweight=Q&sorobaninvokeweight=R&file=F]`
 
     Artificially generate load for testing; must be used with
     `ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING` set to true.
-  * `create` mode creates new accounts. Batches 100 creation operations per transaction.
+
+    **Note**: The `create` mode has been deprecated and removed. To create test accounts,
+    use the `GENESIS_TEST_ACCOUNT_COUNT` configuration parameter which creates accounts
+    at genesis when initializing a test network.
   * `pay` mode generates `PaymentOp` transactions on accounts specified
     (where the number of accounts can be offset).
   * `pay_pregenerated` mode submits pre-generated payment transactions from an XDR file.
@@ -519,7 +522,7 @@ this survey mechanism, just set `SURVEYOR_KEYS` to `$self` or a bogus key
     weight divided by the sum of all weights.
   * `stop` mode stops any existing load generation run and marks it as "failed".
 
-  Non-`create` load generation makes use of the additional parameters:
+  Load generation makes use of the additional parameters:
   * when a nonzero `spikeinterval` is given, a spike will occur every
     `spikeinterval` seconds injecting `spikesize` transactions on top of
     `txrate`

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -1184,12 +1184,21 @@ CommandHandler::generateLoad(std::string const& params, std::string& retStr)
         std::map<std::string, std::string> map;
         http::server::server::parseParams(params, map);
         auto modeStr =
-            parseOptionalParamOrDefault<std::string>(map, "mode", "create");
+            parseOptionalParamOrDefault<std::string>(map, "mode", "pay");
         // First check if a current run needs to be stopped
         if (modeStr == "stop")
         {
             mApp.getLoadGenerator().stop();
             retStr = "Stopped load generation";
+            return;
+        }
+
+        // Check for deprecated CREATE mode
+        if (modeStr == "create")
+        {
+            retStr = "DEPRECATED: CREATE mode has been removed. "
+                     "Use GENESIS_TEST_ACCOUNT_COUNT configuration parameter "
+                     "to create test accounts at genesis instead.";
             return;
         }
 

--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -377,7 +377,11 @@ TEST_CASE(
 {
     Hash networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
     Simulation::pointer simulation =
-        Topologies::pair(Simulation::OVER_LOOPBACK, networkID);
+        Topologies::pair(Simulation::OVER_LOOPBACK, networkID, [](int i) {
+            auto cfg = getTestConfig(i);
+            cfg.GENESIS_TEST_ACCOUNT_COUNT = 3;
+            return cfg;
+        });
 
     simulation->startAllNodes();
     simulation->crankUntil(
@@ -388,9 +392,6 @@ TEST_CASE(
     auto& app = *nodes[0]; // pick a node to generate load
 
     auto& loadGen = app.getLoadGenerator();
-    loadGen.generateLoad(GeneratedLoadConfig::createAccountsLoad(
-        /* nAccounts */ 3,
-        /* txRate */ 10));
     try
     {
         simulation->crankUntil(
@@ -399,7 +400,7 @@ TEST_CASE(
                 // to the second node in time and the second node gets the
                 // nomination
                 return simulation->haveAllExternalized(5, 2) &&
-                       loadGen.checkAccountSynced(app, true).empty();
+                       loadGen.checkAccountSynced(app).empty();
             },
             15 * simulation->getExpectedLedgerCloseTime(), false);
 
@@ -408,13 +409,13 @@ TEST_CASE(
         simulation->crankUntil(
             [&]() {
                 return simulation->haveAllExternalized(8, 2) &&
-                       loadGen.checkAccountSynced(app, false).empty();
+                       loadGen.checkAccountSynced(app).empty();
             },
             10 * simulation->getExpectedLedgerCloseTime(), true);
     }
     catch (...)
     {
-        auto problems = loadGen.checkAccountSynced(app, false);
+        auto problems = loadGen.checkAccountSynced(app);
         REQUIRE(problems.empty());
     }
 
@@ -422,7 +423,7 @@ TEST_CASE(
 }
 
 Application::pointer
-newLoadTestApp(VirtualClock& clock)
+newLoadTestApp(VirtualClock& clock, uint32_t accountCount = 0)
 {
     Config cfg =
 #ifdef USE_POSTGRES
@@ -434,6 +435,10 @@ newLoadTestApp(VirtualClock& clock)
     // ledger close
     cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE = 10000;
     cfg.USE_CONFIG_FOR_GENESIS = true;
+    if (accountCount > 0)
+    {
+        cfg.GENESIS_TEST_ACCOUNT_COUNT = accountCount;
+    }
     Application::pointer appPtr = Application::create(clock, cfg);
     appPtr->start();
     return appPtr;
@@ -509,27 +514,17 @@ TEST_CASE("Accounts vs latency", "[scalability][!hide]")
                      "latency50", "latency95", "latency99"});
 
     VirtualClock clock;
-    auto appPtr = newLoadTestApp(clock);
+    auto appPtr = newLoadTestApp(clock, 10); // Create 10 accounts at genesis
     auto& app = *appPtr;
 
     auto& loadGen = app.getLoadGenerator();
     auto& txtime = app.getMetrics().NewTimer({"ledger", "operation", "apply"});
     uint32_t numItems = 500000;
 
-    // Create accounts
-    loadGen.generateLoad(GeneratedLoadConfig::createAccountsLoad(
-        /* nAccounts */ 10,
-        /* txRate */ 10));
-
     auto& complete =
         appPtr->getMetrics().NewMeter({"loadgen", "run", "complete"}, "run");
 
     auto& io = clock.getIOContext();
-    asio::io_context::work mainWork(io);
-    while (!io.stopped() && complete.count() == 0)
-    {
-        clock.crank();
-    }
 
     txtime.Clear();
 
@@ -568,21 +563,6 @@ netTopologyTest(std::string const& name,
         assert(!nodes.empty());
         auto& app = *nodes[0];
 
-        auto& loadGen = app.getLoadGenerator();
-        loadGen.generateLoad(GeneratedLoadConfig::createAccountsLoad(
-            /* nAccounts */ 50,
-            /* txRate */ 10));
-        auto& complete =
-            app.getMetrics().NewMeter({"loadgen", "run", "complete"}, "run");
-
-        sim->crankUntil(
-            [&]() {
-                return sim->haveAllExternalized(8, 2) &&
-                       loadGen.checkAccountSynced(app, true).empty() &&
-                       complete.count() == 1;
-            },
-            10 * sim->getExpectedLedgerCloseTime(), true);
-
         app.reportCfgMetrics();
 
         auto& inmsg = app.getMetrics().NewMeter({"overlay", "message", "read"},
@@ -616,6 +596,7 @@ TEST_CASE("Mesh nodes vs network traffic", "[scalability][!hide]")
                 res.ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING = true;
                 res.TARGET_PEER_CONNECTIONS = 1000;
                 res.MAX_ADDITIONAL_PEER_CONNECTIONS = 1000;
+                res.GENESIS_TEST_ACCOUNT_COUNT = 50;
                 return res;
             });
     });
@@ -632,6 +613,7 @@ TEST_CASE("Cycle nodes vs network traffic", "[scalability][!hide]")
                 res.ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING = true;
                 res.TARGET_PEER_CONNECTIONS = 1000;
                 res.MAX_ADDITIONAL_PEER_CONNECTIONS = 1000;
+                res.GENESIS_TEST_ACCOUNT_COUNT = 50;
                 return res;
             });
     });
@@ -648,6 +630,7 @@ TEST_CASE("Branched cycle nodes vs network traffic", "[scalability][!hide]")
                 res.ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING = true;
                 res.TARGET_PEER_CONNECTIONS = 1000;
                 res.MAX_ADDITIONAL_PEER_CONNECTIONS = 1000;
+                res.GENESIS_TEST_ACCOUNT_COUNT = 50;
                 return res;
             });
     });

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -125,11 +125,7 @@ LoadGenerator::LoadGenerator(Application& app)
 LoadGenMode
 LoadGenerator::getMode(std::string const& mode)
 {
-    if (mode == "create")
-    {
-        return LoadGenMode::CREATE;
-    }
-    else if (mode == "pay")
+    if (mode == "pay")
     {
         return LoadGenMode::PAY;
     }
@@ -226,21 +222,6 @@ LoadGenerator::cleanupAccounts()
 {
     ZoneScoped;
 
-    // Check if creation source accounts have been created
-    for (auto it = mCreationSourceAccounts.begin();
-         it != mCreationSourceAccounts.end();)
-    {
-        if (mTxGenerator.loadAccount(it->second))
-        {
-            mAccountsAvailable.insert(it->first);
-            it = mCreationSourceAccounts.erase(it);
-        }
-        else
-        {
-            ++it;
-        }
-    }
-
     // "Free" any accounts that aren't used by the tx queue anymore
     for (auto it = mAccountsInUse.begin(); it != mAccountsInUse.end();)
     {
@@ -268,7 +249,7 @@ LoadGenerator::reset()
     mTxGenerator.reset();
     mAccountsInUse.clear();
     mAccountsAvailable.clear();
-    mCreationSourceAccounts.clear();
+
     mContractInstances.clear();
     mLoadTimer.reset();
     mStartTime.reset();
@@ -276,7 +257,7 @@ LoadGenerator::reset()
     mWaitTillCompleteForLedgers = 0;
     mFailed = false;
     mStarted = false;
-    mInitialAccountsCreated = false;
+
     mPreLoadgenApplySorobanSuccess = 0;
     mPreLoadgenApplySorobanFailure = 0;
     mTransactionsAppliedAtTheStart = 0;
@@ -494,10 +475,9 @@ LoadGenerator::scheduleLoadGeneration(GeneratedLoadConfig cfg)
     // a buffer) to accommodate the desired tx rate.
     auto closeTimeSeconds = std::chrono::duration_cast<std::chrono::seconds>(
         mApp.getLedgerManager().getExpectedLedgerCloseTime());
-    if (cfg.mode != LoadGenMode::CREATE && cfg.nTxs > cfg.nAccounts &&
-        (cfg.txRate * closeTimeSeconds.count()) *
-                MIN_UNIQUE_ACCOUNT_MULTIPLIER >
-            cfg.nAccounts)
+    if (cfg.nTxs > cfg.nAccounts && (cfg.txRate * closeTimeSeconds.count()) *
+                                            MIN_UNIQUE_ACCOUNT_MULTIPLIER >
+                                        cfg.nAccounts)
     {
         errorMsg = fmt::format(
             "Tx rate is too high, there are not enough unique accounts. Make "
@@ -536,13 +516,6 @@ LoadGenerator::scheduleLoadGeneration(GeneratedLoadConfig cfg)
         {
             errorMsg = "must run SOROBAN_UPGRADE_SETUP";
         }
-    }
-
-    if (cfg.mode == LoadGenMode::CREATE &&
-        mApp.getConfig().GENESIS_TEST_ACCOUNT_COUNT)
-    {
-        errorMsg =
-            "Cannot create accounts when GENESIS_TEST_ACCOUNT_COUNT is set";
     }
 
     if (cfg.mode == LoadGenMode::PAY_PREGENERATED)
@@ -594,14 +567,14 @@ LoadGenerator::scheduleLoadGeneration(GeneratedLoadConfig cfg)
 bool
 GeneratedLoadConfig::isDone() const
 {
-    return (isCreate() && nAccounts == 0) || (isLoad() && nTxs == 0) ||
+    return (isLoad() && nTxs == 0) ||
            (isSorobanSetup() && getSorobanConfig().nInstances == 0);
 }
 
 bool
 GeneratedLoadConfig::areTxsRemaining() const
 {
-    return (isCreate() && nAccounts != 0) || (!isCreate() && nTxs != 0);
+    return nTxs != 0;
 }
 
 Json::Value
@@ -611,9 +584,6 @@ GeneratedLoadConfig::getStatus() const
     std::string modeStr;
     switch (mode)
     {
-    case LoadGenMode::CREATE:
-        modeStr = "create";
-        break;
     case LoadGenMode::PAY:
         modeStr = "pay";
         break;
@@ -651,11 +621,7 @@ GeneratedLoadConfig::getStatus() const
 
     ret["mode"] = modeStr;
 
-    if (isCreate())
-    {
-        ret["accounts_remaining"] = nAccounts;
-    }
-    else if (isSorobanSetup())
+    if (isSorobanSetup())
     {
         ret["wasms_remaining"] = getSorobanConfig().nWasms;
         ret["instances_remaining"] = getSorobanConfig().nInstances;
@@ -707,7 +673,7 @@ LoadGenerator::generateLoad(GeneratedLoadConfig cfg)
     if (!cfg.areTxsRemaining())
     {
         // Done submitting the load, now ensure it propagates to the DB.
-        if (!cfg.isCreate() && cfg.skipLowFeeTxs)
+        if (cfg.skipLowFeeTxs)
         {
             // skipLowFeeTxs allows triggering tx queue limiter, which
             // makes it hard to track the final seq nums. Hence just
@@ -722,15 +688,6 @@ LoadGenerator::generateLoad(GeneratedLoadConfig cfg)
     }
 
     auto txPerStep = getTxPerStep(cfg.txRate, cfg.spikeInterval, cfg.spikeSize);
-    if (cfg.mode == LoadGenMode::CREATE)
-    {
-        // Limit creation to the number of accounts we have. This is only the
-        // case at the very beginning, when only root account is available for
-        // account creation
-        size_t expectedSize =
-            mInitialAccountsCreated ? mAccountsAvailable.size() : 1;
-        txPerStep = std::min<int64_t>(txPerStep, expectedSize);
-    }
     auto submitScope = mStepTimer.TimeScope();
 
     uint64_t now = mApp.timeNow();
@@ -745,178 +702,162 @@ LoadGenerator::generateLoad(GeneratedLoadConfig cfg)
     uint32_t count = 0;
     for (int64_t i = 0; i < txPerStep; ++i)
     {
-        if (cfg.mode == LoadGenMode::CREATE)
+        if (mAccountsAvailable.empty() &&
+            cfg.mode != LoadGenMode::PAY_PREGENERATED)
         {
-            cfg.nAccounts =
-                submitCreationTx(cfg.nAccounts, cfg.offset, ledgerNum);
+            CLOG_WARNING(LoadGen,
+                         "Load generation failed: no more accounts available");
+            mLoadgenFail.Mark();
+            reset();
+            return;
         }
-        else
+
+        uint64_t sourceAccountId = 0;
+        if (cfg.mode != LoadGenMode::PAY_PREGENERATED)
         {
-            if (mAccountsAvailable.empty() &&
-                cfg.mode != LoadGenMode::PAY_PREGENERATED)
-            {
-                CLOG_WARNING(
-                    LoadGen,
-                    "Load generation failed: no more accounts available");
-                mLoadgenFail.Mark();
-                reset();
-                return;
-            }
+            sourceAccountId = getNextAvailableAccount(ledgerNum);
+        }
 
-            uint64_t sourceAccountId = 0;
-            if (cfg.mode != LoadGenMode::PAY_PREGENERATED)
-            {
-                sourceAccountId = getNextAvailableAccount(ledgerNum);
-            }
+        std::function<std::pair<TxGenerator::TestAccountPtr,
+                                TransactionFrameBaseConstPtr>()>
+            generateTx;
 
-            std::function<std::pair<TxGenerator::TestAccountPtr,
-                                    TransactionFrameBaseConstPtr>()>
-                generateTx;
-
-            switch (cfg.mode)
-            {
-            case LoadGenMode::CREATE:
-                releaseAssert(false);
-                break;
-            case LoadGenMode::PAY:
-                generateTx = [&]() {
+        switch (cfg.mode)
+        {
+        case LoadGenMode::PAY:
+            generateTx = [&]() {
+                return mTxGenerator.paymentTransaction(
+                    cfg.nAccounts, cfg.offset, ledgerNum, sourceAccountId, 1,
+                    cfg.maxGeneratedFeeRate);
+            };
+            break;
+        case LoadGenMode::PRETEND:
+        {
+            auto opCount = chooseOpCount(mApp.getConfig());
+            generateTx = [&, opCount]() {
+                return mTxGenerator.pretendTransaction(
+                    cfg.nAccounts, cfg.offset, ledgerNum, sourceAccountId,
+                    opCount, cfg.maxGeneratedFeeRate);
+            };
+        }
+        break;
+        case LoadGenMode::MIXED_CLASSIC:
+        {
+            auto opCount = chooseOpCount(mApp.getConfig());
+            bool isDex =
+                rand_uniform<uint32_t>(1, 100) <= cfg.getDexTxPercent();
+            generateTx = [&, opCount, isDex]() {
+                if (isDex)
+                {
+                    return mTxGenerator.manageOfferTransaction(
+                        ledgerNum, sourceAccountId, opCount,
+                        cfg.maxGeneratedFeeRate);
+                }
+                else
+                {
                     return mTxGenerator.paymentTransaction(
                         cfg.nAccounts, cfg.offset, ledgerNum, sourceAccountId,
-                        1, cfg.maxGeneratedFeeRate);
-                };
-                break;
-            case LoadGenMode::PRETEND:
-            {
-                auto opCount = chooseOpCount(mApp.getConfig());
-                generateTx = [&, opCount]() {
-                    return mTxGenerator.pretendTransaction(
-                        cfg.nAccounts, cfg.offset, ledgerNum, sourceAccountId,
                         opCount, cfg.maxGeneratedFeeRate);
-                };
-            }
-            break;
-            case LoadGenMode::MIXED_CLASSIC:
-            {
-                auto opCount = chooseOpCount(mApp.getConfig());
-                bool isDex =
-                    rand_uniform<uint32_t>(1, 100) <= cfg.getDexTxPercent();
-                generateTx = [&, opCount, isDex]() {
-                    if (isDex)
-                    {
-                        return mTxGenerator.manageOfferTransaction(
-                            ledgerNum, sourceAccountId, opCount,
-                            cfg.maxGeneratedFeeRate);
-                    }
-                    else
-                    {
-                        return mTxGenerator.paymentTransaction(
-                            cfg.nAccounts, cfg.offset, ledgerNum,
-                            sourceAccountId, opCount, cfg.maxGeneratedFeeRate);
-                    }
-                };
-            }
-            break;
-            case LoadGenMode::SOROBAN_UPLOAD:
-            {
-                generateTx = [&]() {
-                    return mTxGenerator.sorobanRandomWasmTransaction(
-                        ledgerNum, sourceAccountId,
-                        mTxGenerator.generateFee(cfg.maxGeneratedFeeRate,
-                                                 /* opsCnt */ 1));
-                };
-            }
-            break;
-            case LoadGenMode::SOROBAN_INVOKE_SETUP:
-            case LoadGenMode::SOROBAN_UPGRADE_SETUP:
-                generateTx = [&] {
-                    auto& sorobanCfg = cfg.getMutSorobanConfig();
-                    if (sorobanCfg.nWasms != 0)
-                    {
-                        --sorobanCfg.nWasms;
-                        return createUploadWasmTransaction(cfg, ledgerNum,
-                                                           sourceAccountId);
-                    }
-                    else
-                    {
-                        --sorobanCfg.nInstances;
-                        return createInstanceTransaction(cfg, ledgerNum,
-                                                         sourceAccountId);
-                    }
-                };
-                break;
-            case LoadGenMode::SOROBAN_INVOKE:
-                generateTx = [&]() {
-                    auto instanceIter =
-                        mContractInstances.find(sourceAccountId);
-                    releaseAssert(instanceIter != mContractInstances.end());
-                    auto const& instance = instanceIter->second;
-                    return mTxGenerator.invokeSorobanLoadTransaction(
-                        ledgerNum, sourceAccountId, instance,
-                        mContactOverheadBytes, cfg.maxGeneratedFeeRate);
-                };
-                break;
-            case LoadGenMode::SOROBAN_CREATE_UPGRADE:
-                generateTx = [&]() {
-                    releaseAssert(mCodeKey);
-                    releaseAssert(mContractInstanceKeys.size() == 1);
-
-                    auto upgradeBytes =
-                        mTxGenerator.getConfigUpgradeSetFromLoadConfig(
-                            cfg.getSorobanUpgradeConfig());
-                    return mTxGenerator.invokeSorobanCreateUpgradeTransaction(
-                        ledgerNum, sourceAccountId, upgradeBytes, *mCodeKey,
-                        *mContractInstanceKeys.begin(),
-                        cfg.maxGeneratedFeeRate);
-                };
-                break;
-            case LoadGenMode::MIXED_CLASSIC_SOROBAN:
-                generateTx = [&]() {
-                    return createMixedClassicSorobanTransaction(
-                        ledgerNum, sourceAccountId, cfg);
-                };
-                break;
-            case LoadGenMode::PAY_PREGENERATED:
-                generateTx = [&]() { return readTransactionFromFile(cfg); };
-                break;
-            case LoadGenMode::SOROBAN_INVOKE_APPLY_LOAD:
-                generateTx = [&]() {
-                    auto instanceIter =
-                        mContractInstances.find(sourceAccountId);
-                    releaseAssert(instanceIter != mContractInstances.end());
-                    auto const& instance = instanceIter->second;
-                    auto const& appCfg = mApp.getConfig();
-                    uint64_t dataEntryCount =
-                        appCfg.APPLY_LOAD_BL_BATCH_SIZE *
-                        appCfg.APPLY_LOAD_BL_SIMULATED_LEDGERS;
-                    size_t dataEntrySize =
-                        appCfg.APPLY_LOAD_DATA_ENTRY_SIZE_FOR_TESTING;
-
-                    return mTxGenerator.invokeSorobanLoadTransactionV2(
-                        ledgerNum, sourceAccountId, instance, dataEntryCount,
-                        dataEntrySize, cfg.maxGeneratedFeeRate);
-                };
-                break;
-            }
-
-            try
-            {
-                if (submitTx(cfg, generateTx))
-                {
-                    --cfg.nTxs;
                 }
-            }
-            catch (std::runtime_error const& e)
-            {
-                CLOG_ERROR(LoadGen, "Exception while submitting tx: {}",
-                           e.what());
-                mFailed = true;
-                break;
-            }
+            };
+        }
+        break;
+        case LoadGenMode::SOROBAN_UPLOAD:
+        {
+            generateTx = [&]() {
+                return mTxGenerator.sorobanRandomWasmTransaction(
+                    ledgerNum, sourceAccountId,
+                    mTxGenerator.generateFee(cfg.maxGeneratedFeeRate,
+                                             /* opsCnt */ 1));
+            };
+        }
+        break;
+        case LoadGenMode::SOROBAN_INVOKE_SETUP:
+        case LoadGenMode::SOROBAN_UPGRADE_SETUP:
+            generateTx = [&] {
+                auto& sorobanCfg = cfg.getMutSorobanConfig();
+                if (sorobanCfg.nWasms != 0)
+                {
+                    --sorobanCfg.nWasms;
+                    return createUploadWasmTransaction(cfg, ledgerNum,
+                                                       sourceAccountId);
+                }
+                else
+                {
+                    --sorobanCfg.nInstances;
+                    return createInstanceTransaction(cfg, ledgerNum,
+                                                     sourceAccountId);
+                }
+            };
+            break;
+        case LoadGenMode::SOROBAN_INVOKE:
+            generateTx = [&]() {
+                auto instanceIter = mContractInstances.find(sourceAccountId);
+                releaseAssert(instanceIter != mContractInstances.end());
+                auto const& instance = instanceIter->second;
+                return mTxGenerator.invokeSorobanLoadTransaction(
+                    ledgerNum, sourceAccountId, instance, mContactOverheadBytes,
+                    cfg.maxGeneratedFeeRate);
+            };
+            break;
+        case LoadGenMode::SOROBAN_CREATE_UPGRADE:
+            generateTx = [&]() {
+                releaseAssert(mCodeKey);
+                releaseAssert(mContractInstanceKeys.size() == 1);
 
-            if (mFailed)
+                auto upgradeBytes =
+                    mTxGenerator.getConfigUpgradeSetFromLoadConfig(
+                        cfg.getSorobanUpgradeConfig());
+                return mTxGenerator.invokeSorobanCreateUpgradeTransaction(
+                    ledgerNum, sourceAccountId, upgradeBytes, *mCodeKey,
+                    *mContractInstanceKeys.begin(), cfg.maxGeneratedFeeRate);
+            };
+            break;
+        case LoadGenMode::MIXED_CLASSIC_SOROBAN:
+            generateTx = [&]() {
+                return createMixedClassicSorobanTransaction(
+                    ledgerNum, sourceAccountId, cfg);
+            };
+            break;
+        case LoadGenMode::PAY_PREGENERATED:
+            generateTx = [&]() { return readTransactionFromFile(cfg); };
+            break;
+        case LoadGenMode::SOROBAN_INVOKE_APPLY_LOAD:
+            generateTx = [&]() {
+                auto instanceIter = mContractInstances.find(sourceAccountId);
+                releaseAssert(instanceIter != mContractInstances.end());
+                auto const& instance = instanceIter->second;
+                auto const& appCfg = mApp.getConfig();
+                uint64_t dataEntryCount =
+                    appCfg.APPLY_LOAD_BL_BATCH_SIZE *
+                    appCfg.APPLY_LOAD_BL_SIMULATED_LEDGERS;
+                size_t dataEntrySize =
+                    appCfg.APPLY_LOAD_DATA_ENTRY_SIZE_FOR_TESTING;
+
+                return mTxGenerator.invokeSorobanLoadTransactionV2(
+                    ledgerNum, sourceAccountId, instance, dataEntryCount,
+                    dataEntrySize, cfg.maxGeneratedFeeRate);
+            };
+            break;
+        }
+
+        try
+        {
+            if (submitTx(cfg, generateTx))
             {
-                break;
+                --cfg.nTxs;
             }
+        }
+        catch (std::runtime_error const& e)
+        {
+            CLOG_ERROR(LoadGen, "Exception while submitting tx: {}", e.what());
+            mFailed = true;
+            break;
+        }
+
+        if (mFailed)
+        {
+            break;
         }
         ++count;
         if (cfg.nAccounts == 0 || !cfg.areTxsRemaining())
@@ -939,49 +880,6 @@ LoadGenerator::generateLoad(GeneratedLoadConfig cfg)
     mLastSecond = now;
     mTotalSubmitted += count;
     scheduleLoadGeneration(cfg);
-}
-
-uint32_t
-LoadGenerator::submitCreationTx(uint32_t nAccounts, uint32_t offset,
-                                uint32_t ledgerNum)
-{
-    uint32_t numToProcess =
-        nAccounts < MAX_OPS_PER_TX ? nAccounts : MAX_OPS_PER_TX;
-    auto [from, tx] = creationTransaction(
-        mTxGenerator.getAccounts().size() + offset, numToProcess, ledgerNum);
-    TransactionResultCode code;
-    TransactionQueue::AddResultCode status;
-    bool createDuplicate = false;
-    uint32_t numTries = 0;
-
-    while ((status = execute(tx, LoadGenMode::CREATE, code)) !=
-           TransactionQueue::AddResultCode::ADD_STATUS_PENDING)
-    {
-        // Ignore duplicate transactions, simply continue generating load
-        if (status == TransactionQueue::AddResultCode::ADD_STATUS_DUPLICATE)
-        {
-            createDuplicate = true;
-            break;
-        }
-
-        if (++numTries >= TX_SUBMIT_MAX_TRIES ||
-            status != TransactionQueue::AddResultCode::ADD_STATUS_ERROR)
-        {
-            // Failed to submit the step of load
-            mFailed = true;
-            return 0;
-        }
-
-        // In case of bad seqnum, attempt refreshing it from the DB
-        maybeHandleFailedTx(tx, from, status, code);
-    }
-
-    if (!createDuplicate)
-    {
-        nAccounts -= numToProcess;
-    }
-
-    return nAccounts;
 }
 
 bool
@@ -1092,11 +990,7 @@ LoadGenerator::logProgress(std::chrono::nanoseconds submitTimer,
     auto submitSteps = duration_cast<milliseconds>(submitTimer).count();
 
     auto remainingTxCount = 0;
-    if (cfg.mode == LoadGenMode::CREATE)
-    {
-        remainingTxCount = cfg.nAccounts / MAX_OPS_PER_TX;
-    }
-    else if (cfg.isSorobanSetup())
+    if (cfg.isSorobanSetup())
     {
         remainingTxCount =
             cfg.getSorobanConfig().nWasms + cfg.getSorobanConfig().nInstances;
@@ -1120,15 +1014,6 @@ LoadGenerator::logProgress(std::chrono::nanoseconds submitTimer,
                   cfg.txRate, applyTx.one_minute_rate(), remainingTxCount,
                   etaHours, etaMins);
     }
-    else if (cfg.mode == LoadGenMode::CREATE)
-    {
-        CLOG_INFO(LoadGen,
-                  "Tx/s: {} target, {}tx/{}op actual (1m EWMA). Pending: {} "
-                  "accounts, {} txs. ETA: {}h{}m",
-                  cfg.txRate, applyTx.one_minute_rate(),
-                  applyOp.one_minute_rate(), cfg.nAccounts, remainingTxCount,
-                  etaHours, etaMins);
-    }
     else
     {
         CLOG_INFO(LoadGen,
@@ -1142,31 +1027,6 @@ LoadGenerator::logProgress(std::chrono::nanoseconds submitTimer,
     CLOG_DEBUG(LoadGen, "Step timing: {}ms submit.", submitSteps);
 
     mTxMetrics.report();
-}
-
-std::pair<TxGenerator::TestAccountPtr, TransactionFrameBaseConstPtr>
-LoadGenerator::creationTransaction(uint64_t startAccount, uint64_t numItems,
-                                   uint32_t ledgerNum)
-{
-    TxGenerator::TestAccountPtr sourceAcc =
-        mInitialAccountsCreated
-            ? mTxGenerator.findAccount(getNextAvailableAccount(ledgerNum),
-                                       ledgerNum)
-            : mRoot;
-    vector<Operation> creationOps = mTxGenerator.createAccounts(
-        startAccount, numItems, ledgerNum, !mInitialAccountsCreated);
-    if (!mInitialAccountsCreated)
-    {
-        auto const& initialAccounts = mTxGenerator.getAccounts();
-        for (auto const& kvp : initialAccounts)
-        {
-            mCreationSourceAccounts.emplace(kvp.first, kvp.second);
-        }
-    }
-    mInitialAccountsCreated = true;
-    return std::make_pair(sourceAcc,
-                          mTxGenerator.createTransactionFramePtr(
-                              sourceAcc, creationOps, false, std::nullopt));
 }
 
 std::pair<TxGenerator::TestAccountPtr, TransactionFrameBaseConstPtr>
@@ -1318,7 +1178,7 @@ LoadGenerator::checkSorobanStateSynced(Application& app,
 }
 
 std::vector<TxGenerator::TestAccountPtr>
-LoadGenerator::checkAccountSynced(Application& app, bool isCreate)
+LoadGenerator::checkAccountSynced(Application& app)
 {
     std::vector<TxGenerator::TestAccountPtr> result;
     for (auto const& acc : mTxGenerator.getAccounts())
@@ -1327,26 +1187,9 @@ LoadGenerator::checkAccountSynced(Application& app, bool isCreate)
         auto accountFromDB = *account;
 
         auto reloadRes = mTxGenerator.loadAccount(accountFromDB);
-        // For account creation, reload accounts from the DB
-        // For payments, ensure that the sequence number matches expected
+        // Ensure that the sequence number matches expected
         // seqnum. Timeout after 20 ledgers.
-        if (isCreate)
-        {
-            if (!reloadRes)
-            {
-                CLOG_TRACE(LoadGen, "Account {} is not created yet!",
-                           account->getAccountId());
-                result.push_back(account);
-            }
-            else if (app.getHerder().sourceAccountPending(
-                         account->getPublicKey()))
-            {
-                CLOG_TRACE(LoadGen, "Account {} is pending!",
-                           account->getAccountId());
-                result.push_back(account);
-            }
-        }
-        else if (!reloadRes)
+        if (!reloadRes)
         {
             auto msg =
                 fmt::format("Account {} used to submit payment tx could not "
@@ -1416,7 +1259,7 @@ LoadGenerator::waitTillComplete(GeneratedLoadConfig cfg)
     }
     else
     {
-        classicIsDone = checkAccountSynced(mApp, cfg.isCreate()).empty();
+        classicIsDone = checkAccountSynced(mApp).empty();
         sorobanIsDone = checkSorobanStateSynced(mApp, cfg).empty();
     }
 
@@ -1493,7 +1336,7 @@ LoadGenerator::waitTillCompleteWithoutChecks()
     }
     if (++mWaitTillCompleteForLedgers == COMPLETION_TIMEOUT_WITHOUT_CHECKS)
     {
-        auto inconsistencies = checkAccountSynced(mApp, /* isCreate */ false);
+        auto inconsistencies = checkAccountSynced(mApp);
         CLOG_INFO(LoadGen, "Load generation complete.");
         if (!inconsistencies.empty())
         {
@@ -1514,8 +1357,7 @@ LoadGenerator::waitTillCompleteWithoutChecks()
 }
 
 LoadGenerator::TxMetrics::TxMetrics(medida::MetricsRegistry& m)
-    : mAccountCreated(m.NewMeter({"loadgen", "account", "created"}, "account"))
-    , mNativePayment(m.NewMeter({"loadgen", "payment", "submitted"}, "op"))
+    : mNativePayment(m.NewMeter({"loadgen", "payment", "submitted"}, "op"))
     , mManageOfferOps(m.NewMeter({"loadgen", "manageoffer", "submitted"}, "op"))
     , mPretendOps(m.NewMeter({"loadgen", "pretend", "submitted"}, "op"))
     , mSorobanUploadTxs(m.NewMeter({"loadgen", "soroban", "upload"}, "txn"))
@@ -1536,22 +1378,20 @@ void
 LoadGenerator::TxMetrics::report()
 {
     CLOG_DEBUG(LoadGen,
-               "Counts: {} tx, {} rj, {} by, {} ac, {} na, {} pr, {} dex, {} "
+               "Counts: {} tx, {} rj, {} by, {} na, {} pr, {} dex, {} "
                "su, {} ssi, {} ssu, {} si, {} scu",
                mTxnAttempted.count(), mTxnRejected.count(), mTxnBytes.count(),
-               mAccountCreated.count(), mNativePayment.count(),
-               mPretendOps.count(), mManageOfferOps.count(),
-               mSorobanUploadTxs.count(), mSorobanSetupInvokeTxs.count(),
-               mSorobanSetupUpgradeTxs.count(), mSorobanInvokeTxs.count(),
-               mSorobanCreateUpgradeTxs.count());
+               mNativePayment.count(), mPretendOps.count(),
+               mManageOfferOps.count(), mSorobanUploadTxs.count(),
+               mSorobanSetupInvokeTxs.count(), mSorobanSetupUpgradeTxs.count(),
+               mSorobanInvokeTxs.count(), mSorobanCreateUpgradeTxs.count());
 
     CLOG_DEBUG(LoadGen,
-               "Rates/sec (1m EWMA): {} tx, {} rj, {} by, {} ac, {} na, {} pr, "
+               "Rates/sec (1m EWMA): {} tx, {} rj, {} by, {} na, {} pr, "
                "{} dex, {} su, {} ssi, {} ssu, {} si, {} scu",
                mTxnAttempted.one_minute_rate(), mTxnRejected.one_minute_rate(),
-               mTxnBytes.one_minute_rate(), mAccountCreated.one_minute_rate(),
-               mNativePayment.one_minute_rate(), mPretendOps.one_minute_rate(),
-               mManageOfferOps.one_minute_rate(),
+               mTxnBytes.one_minute_rate(), mNativePayment.one_minute_rate(),
+               mPretendOps.one_minute_rate(), mManageOfferOps.one_minute_rate(),
                mSorobanUploadTxs.one_minute_rate(),
                mSorobanSetupInvokeTxs.one_minute_rate(),
                mSorobanSetupUpgradeTxs.one_minute_rate(),
@@ -1568,9 +1408,6 @@ LoadGenerator::execute(TransactionFrameBasePtr txf, LoadGenMode mode,
     // Record tx metrics.
     switch (mode)
     {
-    case LoadGenMode::CREATE:
-        txm.mAccountCreated.Mark(txf->getNumOperations());
-        break;
     case LoadGenMode::PAY:
     case LoadGenMode::PAY_PREGENERATED:
         txm.mNativePayment.Mark(txf->getNumOperations());
@@ -1768,16 +1605,6 @@ GeneratedLoadConfig::copySorobanNetworkConfigToUpgradeConfig(
 }
 
 GeneratedLoadConfig
-GeneratedLoadConfig::createAccountsLoad(uint32_t nAccounts, uint32_t txRate)
-{
-    GeneratedLoadConfig cfg;
-    cfg.mode = LoadGenMode::CREATE;
-    cfg.nAccounts = nAccounts;
-    cfg.txRate = txRate;
-    return cfg;
-}
-
-GeneratedLoadConfig
 GeneratedLoadConfig::createSorobanInvokeSetupLoad(uint32_t nAccounts,
                                                   uint32_t nInstances,
                                                   uint32_t txRate)
@@ -1904,12 +1731,6 @@ GeneratedLoadConfig::setMinSorobanPercentSuccess(uint32_t percent)
         throw std::invalid_argument("percent must be <= 100");
     }
     mMinSorobanPercentSuccess = percent;
-}
-
-bool
-GeneratedLoadConfig::isCreate() const
-{
-    return mode == LoadGenMode::CREATE;
 }
 
 bool

--- a/src/simulation/test/LoadGeneratorTests.cpp
+++ b/src/simulation/test/LoadGeneratorTests.cpp
@@ -34,6 +34,7 @@ TEST_CASE("loadgen in overlay-only mode", "[loadgen]")
             cfg.ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING = true;
             cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION =
                 Config::CURRENT_LEDGER_PROTOCOL_VERSION;
+            cfg.GENESIS_TEST_ACCOUNT_COUNT = 1000;
             return cfg;
         });
 
@@ -289,6 +290,7 @@ TEST_CASE("generate soroban load", "[loadgen][soroban]")
             cfg.USE_CONFIG_FOR_GENESIS = false;
             cfg.ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING = true;
             cfg.UPDATE_SOROBAN_COSTS_DURING_PROTOCOL_UPGRADE_FOR_TESTING = true;
+            cfg.GENESIS_TEST_ACCOUNT_COUNT = 20;
             //  Use tight bounds to we can verify storage works properly
             cfg.LOADGEN_NUM_DATA_ENTRIES_FOR_TESTING = {numDataEntries};
             cfg.LOADGEN_NUM_DATA_ENTRIES_DISTRIBUTION_FOR_TESTING = {1};
@@ -334,15 +336,10 @@ TEST_CASE("generate soroban load", "[loadgen][soroban]")
     };
 
     auto nAccounts = 20;
-    loadGen.generateLoad(GeneratedLoadConfig::createAccountsLoad(
-        /* nAccounts */ nAccounts,
-        /* txRate */ 1));
+    // Accounts are created via GENESIS_TEST_ACCOUNT_COUNT
     auto& complete =
         app.getMetrics().NewMeter({"loadgen", "run", "complete"}, "run");
     auto completeCount = complete.count();
-    simulation->crankUntil(
-        [&]() { return complete.count() == completeCount + 1; },
-        100 * simulation->getExpectedLedgerCloseTime(), false);
 
     // Before creating any contracts, test that loadgen correctly
     // reports an error when trying to run a soroban invoke setup.
@@ -775,6 +772,7 @@ TEST_CASE("Multi-op pretend transactions are valid", "[loadgen]")
             // and 50% of transactions contain 3 ops.
             cfg.LOADGEN_OP_COUNT_FOR_TESTING = {2, 3};
             cfg.LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING = {1, 1};
+            cfg.GENESIS_TEST_ACCOUNT_COUNT = 5;
             return cfg;
         });
 
@@ -790,19 +788,8 @@ TEST_CASE("Multi-op pretend transactions are valid", "[loadgen]")
     uint32_t nAccounts = 5;
     uint32_t txRate = 5;
 
-    loadGen.generateLoad(GeneratedLoadConfig::createAccountsLoad(
-        /* nAccounts */ nAccounts,
-        /* txRate */ txRate));
     try
     {
-        simulation->crankUntil(
-            [&]() {
-                return app.getMetrics()
-                           .NewMeter({"loadgen", "run", "complete"}, "run")
-                           .count() == 1;
-            },
-            3 * simulation->getExpectedLedgerCloseTime(), false);
-
         loadGen.generateLoad(GeneratedLoadConfig::txLoad(LoadGenMode::PRETEND,
                                                          nAccounts, 5, txRate));
 
@@ -810,22 +797,19 @@ TEST_CASE("Multi-op pretend transactions are valid", "[loadgen]")
             [&]() {
                 return app.getMetrics()
                            .NewMeter({"loadgen", "run", "complete"}, "run")
-                           .count() == 2;
+                           .count() == 1;
             },
             2 * simulation->getExpectedLedgerCloseTime(), false);
     }
     catch (...)
     {
-        auto problems = loadGen.checkAccountSynced(app, false);
+        auto problems = loadGen.checkAccountSynced(app);
         REQUIRE(problems.empty());
     }
 
     REQUIRE(app.getMetrics()
                 .NewMeter({"loadgen", "txn", "rejected"}, "txn")
                 .count() == 0);
-    REQUIRE(app.getMetrics()
-                .NewMeter({"loadgen", "account", "created"}, "account")
-                .count() == nAccounts);
     REQUIRE(app.getMetrics()
                 .NewMeter({"loadgen", "payment", "submitted"}, "op")
                 .count() == 0);
@@ -846,6 +830,7 @@ TEST_CASE("Multi-op mixed transactions are valid", "[loadgen]")
             cfg.LOADGEN_OP_COUNT_FOR_TESTING = {3};
             cfg.LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING = {1};
             cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE = 1000;
+            cfg.GENESIS_TEST_ACCOUNT_COUNT = 100;
             return cfg;
         });
 
@@ -858,49 +843,31 @@ TEST_CASE("Multi-op mixed transactions are valid", "[loadgen]")
     auto& app = *nodes[0]; // pick a node to generate load
 
     uint32_t txRate = 5;
-    uint32_t numAccounts =
-        txRate *
-        static_cast<uint32>(std::chrono::duration_cast<std::chrono::seconds>(
-                                simulation->getExpectedLedgerCloseTime())
-                                .count() *
-                            3);
     auto& loadGen = app.getLoadGenerator();
-    loadGen.generateLoad(GeneratedLoadConfig::createAccountsLoad(
-        /* nAccounts */ numAccounts,
-        /* txRate */ txRate));
     try
     {
-        simulation->crankUntil(
-            [&]() {
-                return app.getMetrics()
-                           .NewMeter({"loadgen", "run", "complete"}, "run")
-                           .count() == 1;
-            },
-            3 * simulation->getExpectedLedgerCloseTime(), false);
-        auto config = GeneratedLoadConfig::txLoad(LoadGenMode::MIXED_CLASSIC,
-                                                  numAccounts, 100, txRate);
+        auto config = GeneratedLoadConfig::txLoad(
+            LoadGenMode::MIXED_CLASSIC,
+            app.getConfig().GENESIS_TEST_ACCOUNT_COUNT, 100, txRate);
         config.getMutDexTxPercent() = 50;
         loadGen.generateLoad(config);
         simulation->crankUntil(
             [&]() {
                 return app.getMetrics()
                            .NewMeter({"loadgen", "run", "complete"}, "run")
-                           .count() == 2;
+                           .count() == 1;
             },
             15 * simulation->getExpectedLedgerCloseTime(), false);
     }
     catch (...)
     {
-        auto problems = loadGen.checkAccountSynced(app, false);
+        auto problems = loadGen.checkAccountSynced(app);
         REQUIRE(problems.empty());
     }
 
     REQUIRE(app.getMetrics()
                 .NewMeter({"loadgen", "txn", "rejected"}, "txn")
                 .count() == 0);
-    REQUIRE(app.getMetrics()
-                .NewMeter({"loadgen", "account", "created"}, "account")
-                .count() == numAccounts);
     auto nonDexOps = app.getMetrics()
                          .NewMeter({"loadgen", "payment", "submitted"}, "op")
                          .count();
@@ -916,7 +883,12 @@ TEST_CASE("Upgrade setup with metrics reset", "[loadgen]")
 {
     // Create a simulation with two nodes
     Simulation::pointer sim = Topologies::pair(
-        Simulation::OVER_LOOPBACK, sha256(getTestConfig().NETWORK_PASSPHRASE));
+        Simulation::OVER_LOOPBACK, sha256(getTestConfig().NETWORK_PASSPHRASE),
+        [&](int i) {
+            auto cfg = getTestConfig(i);
+            cfg.GENESIS_TEST_ACCOUNT_COUNT = 1; // Create account at genesis
+            return cfg;
+        });
     sim->startAllNodes();
     sim->crankUntil([&]() { return sim->haveAllExternalized(3, 1); },
                     2 * sim->getExpectedLedgerCloseTime(), false);
@@ -927,12 +899,6 @@ TEST_CASE("Upgrade setup with metrics reset", "[loadgen]")
         app->getMetrics().NewMeter({"loadgen", "run", "complete"}, "run");
     medida::Meter& runsFailed =
         app->getMetrics().NewMeter({"loadgen", "run", "failed"}, "run");
-
-    // Add an account
-    loadgen.generateLoad(GeneratedLoadConfig::createAccountsLoad(
-        /* nAccounts */ 1, /* txRate */ 1));
-    sim->crankUntil([&]() { return runsComplete.count() == 1; },
-                    5 * sim->getExpectedLedgerCloseTime(), false);
 
     // Clear metrics to reset run count
     app->clearMetrics("");


### PR DESCRIPTION
Resolves #4677 
Resolves #4445 

While testing the pipelining prototype, I ran into a few annoyances in tests, specifically related to account creation path. We've been wanting to fix those anyway, so I went ahead and cleaned that up to ease further testing. We should merge this PR when master is open.

Most of the code was put together by @claude 