### PR TITLE
Apply phase fixes

### DIFF
--- a/src/catchup/ApplyBucketsWork.cpp
+++ b/src/catchup/ApplyBucketsWork.cpp
@@ -190,14 +190,14 @@ ApplyBucketsWork::doWork()
 {
     ZoneScoped;
 
-    // Step 0: Applying Buckets resets DB state, so we need to reset
-    // LedgerManager apply state phase to `SETTING_UP_STATE`. We'll do this with
+    // Step 0: Applying Buckets resets DB state, so we need to make sure
+    // LedgerManager apply state phase == `SETTING_UP_STATE`. We'll do this with
     // step 1 below for convience.
 
     // Step 1: index live buckets. Step 2: apply buckets. Step 3: assume state
     if (!mIndexBucketsWork)
     {
-        mApp.getLedgerManager().markApplyStateReset();
+        mApp.getLedgerManager().assertSetupPhase();
 
         // Spawn indexing work for the first time. Hot Archive buckets aren't
         // needed for apply (since we only store live state in SQL tables), so

--- a/src/catchup/CatchupWork.cpp
+++ b/src/catchup/CatchupWork.cpp
@@ -220,6 +220,11 @@ CatchupWork::downloadApplyBuckets()
             CLOG_ERROR(History, "Malformed HAS: invalid buckets");
             return false;
         }
+
+        // Next step after verifying the HAS is to ApplyBuckets to DB. This
+        // invalidates the curent LedgerState, so we need to reset to the setup
+        // LedgerManager phase.
+        app.getLedgerManager().markApplyStateReset();
         return true;
     };
     auto verifyHAS = std::make_shared<WorkWithCallback>(mApp, "verify-has",

--- a/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
+++ b/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
@@ -58,6 +58,7 @@ struct BucketListGenerator
     {
         std::map<std::string, std::shared_ptr<LiveBucket>> buckets;
         auto has = getHistoryArchiveState(app);
+        app->getLedgerManager().markApplyStateReset();
         auto& wm = app->getWorkScheduler();
         wm.executeWork<T>(buckets, has,
                           app->getConfig().LEDGER_PROTOCOL_VERSION,

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -332,6 +332,8 @@ class LedgerManager
                                  LedgerCloseData const& ledgerData,
                                  CompleteConstLedgerStatePtr newLedgerState,
                                  bool upgradeApplied) = 0;
+
+    virtual void assertSetupPhase() const = 0;
 #ifdef BUILD_TESTS
     void
     applyLedger(LedgerCloseData const& ledgerData)

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1338,8 +1338,6 @@ LedgerManagerImpl::ledgerCloseComplete(uint32_t lcl, bool calledViaExternalize,
         mApp.getHerder().lastClosedLedgerIncreased(
             appliedLatest, ledgerData.getTxSet(), upgradeApplied);
     }
-
-    mApplyState.markEndOfCommitting();
 }
 
 void
@@ -1719,6 +1717,12 @@ LedgerManagerImpl::applyLedger(LedgerCloseData const& ledgerData,
             ledgerSeq + 1, initialLedgerVers,
             mApplyState.getSorobanNetworkConfigForCommit());
     }
+
+    // At this point, we've committed all changes to the Apply State for this
+    // ledger. While the following functions will publish this state to other
+    // subsystems, that's not relevant for Apply State phases since ApplyState
+    // is only accessed by LedgerManager's apply threads.
+    mApplyState.markEndOfCommitting();
 
     // Steps 5, 6, 7 are done in `advanceLedgerStateAndPublish`
     // NB: appliedLedgerState is invalidated after this call.

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -562,6 +562,12 @@ class LedgerManagerImpl : public LedgerManager
     void handleUpgradeAffectingSorobanInMemoryStateSize(
         AbstractLedgerTxn& upgradeLtx) override;
 
+    void
+    assertSetupPhase() const override
+    {
+        mApplyState.assertSetupPhase();
+    }
+
 #ifdef BUILD_TESTS
     friend class BucketTestUtils::LedgerManagerForBucketTests;
 #endif


### PR DESCRIPTION
# Description

Fixes two bugs in the `LedgerManager::ApplyPhase` invariants.

1. Invalid setup -> setup state transition when calling `applyBucketsForLCL`. The fix for this is calling `markApplyStateReset` before entering `ApplyBucketsWork`, since when calling `ApplyBucketsWork` via `applyBucketsForLCL`, we're already in setup mode.
2. Race condition with background apply. We now mark the end of the COMMIT phase in the apply thread after `ltx.commit` instead of in the callback.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
