### PR TITLE
Add SCP timing params to sorobaninfo query

### DIFF
--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -863,6 +863,25 @@ CommandHandler::sorobanInfo(std::string const& params, std::string& retStr)
             // non-configurable settings
             archivalInfo["average_bucket_list_size"] =
                 static_cast<Json::UInt64>(conf.getAverageSorobanStateSize());
+
+            // SCP timing settings
+            if (protocolVersionStartsFrom(
+                    lm.getLastClosedLedgerHeader().header.ledgerVersion,
+                    ProtocolVersion::V_23))
+            {
+                auto& scpSettings = res["scp"];
+                scpSettings["ledger_close_time_ms"] =
+                    conf.ledgerTargetCloseTimeMilliseconds();
+                scpSettings["nomination_timeout_ms"] =
+                    conf.nominationTimeoutInitialMilliseconds();
+                scpSettings["nomination_timeout_inc_ms"] =
+                    conf.nominationTimeoutIncrementMilliseconds();
+                scpSettings["ballot_timeout_ms"] =
+                    conf.ballotTimeoutInitialMilliseconds();
+                scpSettings["ballot_timeout_inc_ms"] =
+                    conf.ballotTimeoutIncrementMilliseconds();
+            }
+
             retStr = res.toStyledString();
         }
         else if (format == "detailed")


### PR DESCRIPTION
# Description

Adds CAP 70 fields to `sorobaninfo` query for super cluster.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
