### PR TITLE
Make `ApplicationImpl::mConfig` const

### DIFF
--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -290,11 +290,6 @@ class Application
     // Access the load generator for manual operation.
     virtual LoadGenerator& getLoadGenerator() = 0;
 
-    // Returns the mutable config of the app. This is only useful for testing
-    // the config flags that are used in dynamic fashion (i.e. not for the app
-    // initialization), use with caution.
-    virtual Config& getMutableConfig() = 0;
-
     virtual std::shared_ptr<TestAccount> getRoot() = 0;
 
     // Access the runtime overlay-only mode flag for testing

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -1126,11 +1126,6 @@ ApplicationImpl::getLoadGenerator()
     }
     return *mLoadGenerator;
 }
-Config&
-ApplicationImpl::getMutableConfig()
-{
-    return mConfig;
-}
 
 std::shared_ptr<TestAccount>
 ApplicationImpl::getRoot()

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -122,8 +122,6 @@ class ApplicationImpl : public Application
 
     virtual LoadGenerator& getLoadGenerator() override;
 
-    virtual Config& getMutableConfig() override;
-
     virtual std::shared_ptr<TestAccount> getRoot() override;
 
     virtual bool getRunInOverlayOnlyMode() const override;
@@ -147,7 +145,7 @@ class ApplicationImpl : public Application
 
   private:
     VirtualClock& mVirtualClock;
-    Config mConfig;
+    Config const mConfig;
 
     // NB: The io_context should come first, then the 'manager' sub-objects,
     // then the threads. Do not reorder these fields.


### PR DESCRIPTION
Resolves #4551, that is, mark `mConfig` as `const` (and replace the use of `getMutableConfig`).