### PR TITLE
Add a set of randomized tests that ensure parallel apply logic stability

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -728,6 +728,7 @@ exit /b 0
     <ClCompile Include="..\..\src\transactions\test\ManageDataTests.cpp" />
     <ClCompile Include="..\..\src\transactions\test\MergeTests.cpp" />
     <ClCompile Include="..\..\src\transactions\test\OfferTests.cpp" />
+    <ClCompile Include="..\..\src\transactions\test\ParallelApplyTest.cpp" />
     <ClCompile Include="..\..\src\transactions\test\PathPaymentStrictSendTests.cpp" />
     <ClCompile Include="..\..\src\transactions\test\PathPaymentTests.cpp" />
     <ClCompile Include="..\..\src\transactions\test\PaymentTests.cpp" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1414,6 +1414,9 @@
     <ClCompile Include="..\..\src\ledger\InMemorySorobanState.cpp">
       <Filter>ledger</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\transactions\test\ParallelApplyTest.cpp">
+      <Filter>transactions\tests</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\util\cpptoml.h">

--- a/src/ledger/LedgerCloseMetaFrame.cpp
+++ b/src/ledger/LedgerCloseMetaFrame.cpp
@@ -306,6 +306,22 @@ LedgerCloseMetaFrame::getTransactionMeta(size_t index) const
 }
 
 LedgerEntryChanges const&
+LedgerCloseMetaFrame::getPreTxApplyFeeProcessing(size_t index) const
+{
+    switch (mVersion)
+    {
+    case 0:
+        return mLedgerCloseMeta.v0().txProcessing.at(index).feeProcessing;
+    case 1:
+        return mLedgerCloseMeta.v1().txProcessing.at(index).feeProcessing;
+    case 2:
+        return mLedgerCloseMeta.v2().txProcessing.at(index).feeProcessing;
+    default:
+        releaseAssert(false);
+    }
+}
+
+LedgerEntryChanges const&
 LedgerCloseMetaFrame::getPostTxApplyFeeProcessing(size_t index) const
 {
     releaseAssert(mVersion == 2);
@@ -314,6 +330,31 @@ LedgerCloseMetaFrame::getPostTxApplyFeeProcessing(size_t index) const
         .postTxApplyFeeProcessing;
 }
 
-#endif
+void
+LedgerCloseMetaFrame::sortTxMetaByHash()
+{
+    auto sortTxMeta = [](auto& txProcessing) {
+        std::sort(txProcessing.begin(), txProcessing.end(),
+                  [](auto const& a, auto const& b) {
+                      return a.result.transactionHash <
+                             b.result.transactionHash;
+                  });
+    };
+    switch (mVersion)
+    {
+    case 0:
+        sortTxMeta(mLedgerCloseMeta.v0().txProcessing);
+        break;
+    case 1:
+        sortTxMeta(mLedgerCloseMeta.v1().txProcessing);
+        break;
+    case 2:
+        sortTxMeta(mLedgerCloseMeta.v2().txProcessing);
+        break;
+    default:
+        releaseAssert(false);
+    }
+}
 
+#endif
 }

--- a/src/ledger/LedgerCloseMetaFrame.h
+++ b/src/ledger/LedgerCloseMetaFrame.h
@@ -45,8 +45,9 @@ class LedgerCloseMetaFrame
     xdr::xvector<LedgerKey> const& getEvictedKeys() const;
     size_t getTransactionResultMetaCount() const;
     TransactionMeta const& getTransactionMeta(size_t index) const;
+    LedgerEntryChanges const& getPreTxApplyFeeProcessing(size_t index) const;
     LedgerEntryChanges const& getPostTxApplyFeeProcessing(size_t index) const;
-
+    void sortTxMetaByHash();
 #endif
 
   private:

--- a/src/ledger/NetworkConfig.cpp
+++ b/src/ledger/NetworkConfig.cpp
@@ -2234,6 +2234,78 @@ SorobanNetworkConfig::updateRecalibratedCostTypesForV20(
 
     ltx.commit();
 }
+
+bool
+SorobanNetworkConfig::operator==(SorobanNetworkConfig const& other) const
+{
+    return mMaxContractSizeBytes == other.maxContractSizeBytes() &&
+           mMaxContractDataKeySizeBytes ==
+               other.maxContractDataKeySizeBytes() &&
+           mMaxContractDataEntrySizeBytes ==
+               other.maxContractDataEntrySizeBytes() &&
+
+           mLedgerMaxInstructions == other.ledgerMaxInstructions() &&
+           mTxMaxInstructions == other.txMaxInstructions() &&
+           mFeeRatePerInstructionsIncrement ==
+               other.feeRatePerInstructionsIncrement() &&
+           mTxMemoryLimit == other.txMemoryLimit() &&
+
+           mLedgerMaxDiskReadEntries == other.ledgerMaxDiskReadEntries() &&
+           mLedgerMaxDiskReadBytes == other.ledgerMaxDiskReadBytes() &&
+           mLedgerMaxWriteLedgerEntries ==
+               other.ledgerMaxWriteLedgerEntries() &&
+           mLedgerMaxWriteBytes == other.ledgerMaxWriteBytes() &&
+           mLedgerMaxTxCount == other.ledgerMaxTxCount() &&
+
+           mTxMaxDiskReadEntries == other.txMaxDiskReadEntries() &&
+           mTxMaxFootprintEntries == other.txMaxFootprintEntries() &&
+           mTxMaxDiskReadBytes == other.txMaxDiskReadBytes() &&
+           mTxMaxWriteLedgerEntries == other.txMaxWriteLedgerEntries() &&
+           mTxMaxWriteBytes == other.txMaxWriteBytes() &&
+           mFeeDiskReadLedgerEntry == other.feeDiskReadLedgerEntry() &&
+           mFeeWriteLedgerEntry == other.feeWriteLedgerEntry() &&
+           mFeeDiskRead1KB == other.feeDiskRead1KB() &&
+           mFeeFlatRateWrite1KB == other.feeFlatRateWrite1KB() &&
+           mSorobanStateTargetSizeBytes ==
+               other.sorobanStateTargetSizeBytes() &&
+
+           mRentFee1KBSorobanStateSizeLow ==
+               other.rentFee1KBSorobanStateSizeLow() &&
+           mRentFee1KBSorobanStateSizeHigh ==
+               other.rentFee1KBSorobanStateSizeHigh() &&
+           mSorobanStateRentFeeGrowthFactor ==
+               other.sorobanStateRentFeeGrowthFactor() &&
+
+           mFeeHistorical1KB == other.feeHistorical1KB() &&
+
+           mTxMaxContractEventsSizeBytes ==
+               other.txMaxContractEventsSizeBytes() &&
+           mFeeContractEvents1KB == other.feeContractEventsSize1KB() &&
+
+           mLedgerMaxTransactionsSizeBytes ==
+               other.ledgerMaxTransactionSizesBytes() &&
+           mTxMaxSizeBytes == other.txMaxSizeBytes() &&
+           mFeeTransactionSize1KB == other.feeTransactionSize1KB() &&
+
+           mCpuCostParams == other.cpuCostParams() &&
+           mMemCostParams == other.memCostParams() &&
+
+           mLedgerMaxDependentTxClusters ==
+               other.ledgerMaxDependentTxClusters() &&
+
+           mStateArchivalSettings == other.stateArchivalSettings() &&
+
+           mLedgerTargetCloseTimeMilliseconds ==
+               other.ledgerTargetCloseTimeMilliseconds() &&
+           mNominationTimeoutInitialMilliseconds ==
+               other.nominationTimeoutInitialMilliseconds() &&
+           mNominationTimeoutIncrementMilliseconds ==
+               other.nominationTimeoutIncrementMilliseconds() &&
+           mBallotTimeoutInitialMilliseconds ==
+               other.ballotTimeoutInitialMilliseconds() &&
+           mBallotTimeoutIncrementMilliseconds ==
+               other.ballotTimeoutIncrementMilliseconds();
+}
 #endif
 
 bool
@@ -2327,79 +2399,6 @@ SorobanNetworkConfig::computeRentWriteFee(uint32_t protocolVersion)
     mFeeRent1KB = rust_bridge::compute_rent_write_fee_per_1kb(
         Config::CURRENT_LEDGER_PROTOCOL_VERSION, protocolVersion,
         mAverageSorobanStateSize, feeConfig);
-}
-
-bool
-SorobanNetworkConfig::operator==(SorobanNetworkConfig const& other) const
-{
-    return mMaxContractSizeBytes == other.maxContractSizeBytes() &&
-           mMaxContractDataKeySizeBytes ==
-               other.maxContractDataKeySizeBytes() &&
-           mMaxContractDataEntrySizeBytes ==
-               other.maxContractDataEntrySizeBytes() &&
-
-           mLedgerMaxInstructions == other.ledgerMaxInstructions() &&
-           mTxMaxInstructions == other.txMaxInstructions() &&
-           mFeeRatePerInstructionsIncrement ==
-               other.feeRatePerInstructionsIncrement() &&
-           mTxMemoryLimit == other.txMemoryLimit() &&
-
-           mLedgerMaxDiskReadEntries == other.ledgerMaxDiskReadEntries() &&
-           mLedgerMaxDiskReadBytes == other.ledgerMaxDiskReadBytes() &&
-           mLedgerMaxWriteLedgerEntries ==
-               other.ledgerMaxWriteLedgerEntries() &&
-           mLedgerMaxWriteBytes == other.ledgerMaxWriteBytes() &&
-           mLedgerMaxTxCount == other.ledgerMaxTxCount() &&
-
-           mTxMaxDiskReadEntries == other.txMaxDiskReadEntries() &&
-           mTxMaxFootprintEntries == other.txMaxFootprintEntries() &&
-           mTxMaxDiskReadBytes == other.txMaxDiskReadBytes() &&
-           mTxMaxWriteLedgerEntries == other.txMaxWriteLedgerEntries() &&
-           mTxMaxWriteBytes == other.txMaxWriteBytes() &&
-           mFeeDiskReadLedgerEntry == other.feeDiskReadLedgerEntry() &&
-           mFeeWriteLedgerEntry == other.feeWriteLedgerEntry() &&
-           mFeeDiskRead1KB == other.feeDiskRead1KB() &&
-           mFeeFlatRateWrite1KB == other.feeFlatRateWrite1KB() &&
-           mSorobanStateTargetSizeBytes ==
-               other.sorobanStateTargetSizeBytes() &&
-
-           mRentFee1KBSorobanStateSizeLow ==
-               other.rentFee1KBSorobanStateSizeLow() &&
-           mRentFee1KBSorobanStateSizeHigh ==
-               other.rentFee1KBSorobanStateSizeHigh() &&
-           mSorobanStateRentFeeGrowthFactor ==
-               other.sorobanStateRentFeeGrowthFactor() &&
-
-           mFeeHistorical1KB == other.feeHistorical1KB() &&
-
-           mTxMaxContractEventsSizeBytes ==
-               other.txMaxContractEventsSizeBytes() &&
-           mFeeContractEvents1KB == other.feeContractEventsSize1KB() &&
-
-           mLedgerMaxTransactionsSizeBytes ==
-               other.ledgerMaxTransactionSizesBytes() &&
-           mTxMaxSizeBytes == other.txMaxSizeBytes() &&
-           mFeeTransactionSize1KB == other.feeTransactionSize1KB() &&
-
-           mCpuCostParams == other.cpuCostParams() &&
-           mMemCostParams == other.memCostParams() &&
-
-           mLedgerMaxDependentTxClusters ==
-               other.ledgerMaxDependentTxClusters() &&
-
-           mStateArchivalSettings == other.stateArchivalSettings() &&
-           mEvictionIterator == other.evictionIterator() &&
-
-           mLedgerTargetCloseTimeMilliseconds ==
-               other.ledgerTargetCloseTimeMilliseconds() &&
-           mNominationTimeoutInitialMilliseconds ==
-               other.nominationTimeoutInitialMilliseconds() &&
-           mNominationTimeoutIncrementMilliseconds ==
-               other.nominationTimeoutIncrementMilliseconds() &&
-           mBallotTimeoutInitialMilliseconds ==
-               other.ballotTimeoutInitialMilliseconds() &&
-           mBallotTimeoutIncrementMilliseconds ==
-               other.ballotTimeoutIncrementMilliseconds();
 }
 
 } // namespace stellar

--- a/src/ledger/NetworkConfig.h
+++ b/src/ledger/NetworkConfig.h
@@ -442,8 +442,9 @@ class SorobanNetworkConfig
     // to have more accurage modelled CPU and memory costs in tests and
     // especially the benchmarks.
     static void updateRecalibratedCostTypesForV20(AbstractLedgerTxn& ltx);
-#endif
+
     bool operator==(SorobanNetworkConfig const& other) const;
+#endif
 
   private:
     void loadMaxContractSize(LedgerTxnReadOnly const& roLtx);

--- a/src/test/TestAccount.h
+++ b/src/test/TestAccount.h
@@ -4,6 +4,8 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include <vector>
+
 #include "crypto/SecretKey.h"
 #include "transactions/TransactionFrame.h"
 #include "transactions/test/TransactionTestFrame.h"
@@ -42,6 +44,11 @@ class TestAccount
 
     TestAccount create(SecretKey const& secretKey, uint64_t initialBalance);
     TestAccount create(std::string const& name, uint64_t initialBalance);
+    std::vector<TestAccount> createBatch(std::vector<std::string> const& names,
+                                         uint64_t initialBalance);
+    std::vector<TestAccount>
+    createBatch(std::vector<SecretKey> const& secretKeys,
+                uint64_t initialBalance);
     void merge(PublicKey const& into);
     void inflation();
 
@@ -177,6 +184,8 @@ class TestAccount
     uint32_t getNumSubEntries() const;
 
     bool exists() const;
+
+    void applyOpsBatch(std::vector<Operation> const& ops);
 
   private:
     Application& mApp;

--- a/src/transactions/test/ParallelApplyTest.cpp
+++ b/src/transactions/test/ParallelApplyTest.cpp
@@ -1,0 +1,1304 @@
+// Copyright 2025 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+// This file is dedicated to a set of complex tests that generate random
+// transaction sets, apply them to the ledger with different parallel execution
+// schedules, and ensure that the results never diverge (outside of a narrow
+// set of the expected differences).
+#include "test/Catch2.h"
+
+#include <limits>
+
+#include "main/Application.h"
+#include "test/TestUtils.h"
+#include "test/TxTests.h"
+#include "transactions/OperationFrame.h"
+#include "transactions/TransactionFrameBase.h"
+#include "transactions/test/SorobanTxTestUtils.h"
+#include "util/UnorderedSet.h"
+
+using namespace stellar;
+using namespace stellar::txtest;
+
+namespace
+{
+
+// The constants below define the general test generation parameters.
+
+// Min/max number fraction of the entries that are uploaded to ledger before
+// executing the test transactions.
+double const MIN_PREUPLOADED_ENTRIES_FRACTION = 0.1;
+double const MAX_PREUPLOADED_ENTRIES_FRACTION = 0.8;
+// Min/max number fraction of the preuploaed entries that are expired.
+double const MIN_EXPIRED_ENTRY_FRACTION = 0.0;
+double const MAX_EXPIRED_ENTRY_FRACTION = 0.3;
+
+// Average number of additional keys added to Soroban transaction footprints.
+double const MEAN_ADDITIONAL_FOOTPRINT_KEYS = 10.0;
+// Maximum number of additional keys added to Soroban transaction footprints.
+int const MAX_ADDITONAL_FOOTPRINT_KEYS = 30;
+
+// Min/max fraction of the keys added to read-only footprints (the rest are
+// added to the read-write footprints).
+double const MIN_READ_ONLY_FOOTPRINT_FRACTION = 0.05;
+double const MAX_READ_ONLY_FOOTPRINT_FRACTION = 0.95;
+
+// Maximum number of stages to use for applying transactions in parallel.
+int const MAX_STAGE_COUNT = 4;
+// The number of independent key clusters to generate. This also limits the
+// maximum number of apply threads we can use.
+int const KEY_CLUSTER_COUNT = 8;
+
+// Initial balance of the test trustlines.
+int const TRUSTLINE_BALANCE = 1'000'000;
+// The initial TTL of the persistent test entries.
+int const MIN_PERSISTENT_TTL = 10;
+
+// TTL extensions for the persistent entries that are expired but still in the
+// live state during the test execution.
+int const TTL_EXTENSION_FOR_EXPIRED_IN_LIVE_STATE = 30;
+
+// Number of test runs to perform for each scenario.
+int const TEST_RUN_COUNT = 25;
+
+using ResultType = std::tuple<
+    std::vector<TransactionFrameBaseConstPtr>, TransactionResultSet,
+    LedgerCloseMetaFrame,
+    std::vector<std::pair<LedgerKey, std::pair<std::optional<LedgerEntry>,
+                                               std::optional<LedgerEntry>>>>>;
+
+struct TestConfig
+{
+    int randomWasmCount{};
+    int contractDataKeyCount{};
+    int trustlineCount{};
+    int classicTxCount{};
+    int restoreTxCount{};
+    int extendTxCount{};
+    int testScenarioCount{};
+};
+
+UnorderedMap<LedgerKey, std::vector<LedgerEntryChange>>
+groupLedgerEntryChanges(LedgerEntryChanges const& changes)
+{
+    UnorderedMap<LedgerKey, std::vector<LedgerEntryChange>> changesByKey;
+    for (auto const& change : changes)
+    {
+        LedgerKey key;
+        switch (change.type())
+        {
+        case LEDGER_ENTRY_CREATED:
+            key = LedgerEntryKey(change.created());
+            break;
+        case LEDGER_ENTRY_STATE:
+            key = LedgerEntryKey(change.state());
+            break;
+        case LEDGER_ENTRY_UPDATED:
+            key = LedgerEntryKey(change.updated());
+            break;
+        case LEDGER_ENTRY_RESTORED:
+            key = LedgerEntryKey(change.restored());
+            break;
+        case LEDGER_ENTRY_REMOVED:
+            key = change.removed();
+            break;
+        }
+        changesByKey[key].push_back(change);
+    }
+    return changesByKey;
+}
+
+void
+expectTTLBump(std::vector<LedgerEntryChange> const& changes)
+{
+    REQUIRE(changes.size() == 2);
+    REQUIRE(changes[0].type() == LEDGER_ENTRY_STATE);
+    REQUIRE(changes[1].type() == LEDGER_ENTRY_UPDATED);
+    REQUIRE(changes[0].state().data.ttl() < changes[1].updated().data.ttl());
+}
+
+// Compares the results from two runs of `applyTestTransactions`.
+// We only expect `res1` to ever be from protocol 22.
+// `singleStage` indicates that both results come from a single stage runs
+// (with any number of clusters).
+void
+compareResults(bool res1IsP22, bool singleStage, ResultType const& res1,
+               ResultType const& res2, uint32_t hotArchiveEntryCreatedLedger)
+{
+    // Fees are different between the protocols. Since we observe
+    // TTLs at the stage boundaries, we can only expect exactly the
+    // same changes (and thus fees) when there is only a single
+    // stage.
+    bool expectExactChanges = !res1IsP22 && singleStage;
+
+    auto const& [txs1, results1, lcm1, entries1] = res1;
+    auto const& [txs2, results2, lcm2, entries2] = res2;
+    int const txCount = txs1.size();
+    REQUIRE(results1.results.size() == txCount);
+    REQUIRE(results2.results.size() == txCount);
+    for (int i = 0; i < txCount; ++i)
+    {
+        REQUIRE(txs1[i]->getFullHash() == txs2[i]->getFullHash());
+        REQUIRE(results1.results[i].transactionHash ==
+                results2.results[i].transactionHash);
+        if (expectExactChanges)
+        {
+            REQUIRE(results1.results[i].result == results2.results[i].result);
+        }
+        else
+        {
+            // Don't compare fees as they might be different.
+            REQUIRE(results1.results[i].result.result ==
+                    results2.results[i].result.result);
+        }
+    }
+    REQUIRE(lcm1.getTransactionResultMetaCount() == txCount);
+    REQUIRE(lcm2.getTransactionResultMetaCount() == txCount);
+
+    if (expectExactChanges)
+    {
+        for (int i = 0; i < txCount; ++i)
+        {
+            REQUIRE(lcm1.getPreTxApplyFeeProcessing(i) ==
+                    lcm2.getPreTxApplyFeeProcessing(i));
+            REQUIRE(lcm1.getPostTxApplyFeeProcessing(i) ==
+                    lcm2.getPostTxApplyFeeProcessing(i));
+        }
+    }
+
+    for (int txId = 0; txId < txCount; ++txId)
+    {
+        if (!isSuccessResult(results1.results[txId].result))
+        {
+            continue;
+        }
+        auto const& tx = txs1[txId];
+        TransactionMetaFrame txMeta1(lcm1.getTransactionMeta(txId));
+        TransactionMetaFrame txMeta2(lcm2.getTransactionMeta(txId));
+        auto changes1 =
+            groupLedgerEntryChanges(txMeta1.getLedgerEntryChangesAtOp(0));
+        auto changes2 =
+            groupLedgerEntryChanges(txMeta2.getLedgerEntryChangesAtOp(0));
+        if (!tx->isSoroban())
+        {
+            continue;
+        }
+
+        UnorderedSet<LedgerKey> rwKeys;
+        if (tx->isSoroban())
+        {
+            rwKeys.insert(tx->sorobanResources().footprint.readWrite.begin(),
+                          tx->sorobanResources().footprint.readWrite.end());
+        }
+
+        if (expectExactChanges)
+        {
+            REQUIRE(changes1.size() == changes2.size());
+        }
+        else if (res1IsP22)
+        {
+            // In protocol 22 we may only have less changes due to some
+            // TTL bumps being no-ops due to more eager TTL observation.
+            REQUIRE(changes1.size() <= changes2.size());
+        }
+        UnorderedSet<LedgerKey> usedKeys2;
+
+        for (auto const& [key, entryChanges1] : changes1)
+        {
+            if (auto it = changes2.find(key); it != changes2.end())
+            {
+                auto const& [_, entryChanges2] = *it;
+                usedKeys2.insert(key);
+                REQUIRE(entryChanges1.size() == entryChanges2.size());
+                bool isRoTtlBump = key.type() == TTL && rwKeys.count(key) == 0;
+                // After p22 only RO TTL bumps may diverge due to stage
+                // observations.
+                // In p22 the restoration lastModifiedLedgerSeq may diverge
+                // (we handle that below).
+                if (expectExactChanges || (!isRoTtlBump && !res1IsP22))
+                {
+                    REQUIRE(entryChanges1 == entryChanges2);
+                    continue;
+                }
+                if (entryChanges1 != entryChanges2)
+                {
+                    if (key.type() == TTL)
+                    {
+                        // At least ensure that in both cases we've
+                        // performed a TTL bump. Note: We could be more
+                        // precise here by taking the stage observations and
+                        // protocol versions into account, but that would be
+                        // a bit too complex.
+                        expectTTLBump(entryChanges1);
+                        expectTTLBump(entryChanges2);
+                    }
+                    else
+                    {
+                        REQUIRE(res1IsP22);
+                        // The p22 entries are always in the live state, so
+                        // we expect the restoration lastModifiedLedgerSeq
+                        // to stay the same as it was on entry creation.
+                        REQUIRE(entryChanges1.at(0)
+                                    .restored()
+                                    .lastModifiedLedgerSeq ==
+                                hotArchiveEntryCreatedLedger);
+                        // That's the only diff we expect, so just update
+                        // lastModifiedLedgerSeq and proceed to comparing
+                        // the diffs.
+                        auto modifiedEntryChanges1 = entryChanges1;
+                        modifiedEntryChanges1.at(0)
+                            .restored()
+                            .lastModifiedLedgerSeq = entryChanges2.at(0)
+                                                         .restored()
+                                                         .lastModifiedLedgerSeq;
+                        REQUIRE(modifiedEntryChanges1 == entryChanges2);
+                    }
+                }
+            }
+            else
+            {
+                // We only may end up here if we deal with a read-only TTL
+                // bump that is redundant if TTL is more eagerly observed.
+                REQUIRE(!res1IsP22);
+                REQUIRE(!expectExactChanges);
+                REQUIRE(key.type() == TTL);
+                REQUIRE(rwKeys.count(key) == 0);
+                expectTTLBump(entryChanges1);
+            }
+        }
+
+        for (auto const& [key, entryChanges2] : changes2)
+        {
+            if (usedKeys2.count(key) > 0)
+            {
+                continue;
+            }
+            REQUIRE(!expectExactChanges);
+            REQUIRE(rwKeys.count(key) == 0);
+            // We only may end up here if we deal with a read-only TTL
+            // bump that is redundant if TTL is more eagerly observed.
+            expectTTLBump(entryChanges2);
+        }
+    }
+
+    // The final state of all entries must be the same.
+    REQUIRE(entries1.size() == entries2.size());
+    for (int i = 0; i < entries1.size(); ++i)
+    {
+        // In p23+ we don't expect any differences at all.
+        if (!res1IsP22)
+        {
+            REQUIRE(entries1[i] == entries2[i]);
+            continue;
+        }
+        // In p22 there is no hot archive, so we need to account for that.
+        auto const& [key1, entryPair1] = entries1[i];
+        auto const& [liveEntry1, hotArchiveEntry1] = entryPair1;
+        auto const& [key2, entryPair2] = entries2[i];
+        auto const& [liveEntry2, hotArchiveEntry2] = entryPair2;
+        REQUIRE(key1 == key2);
+        REQUIRE(!hotArchiveEntry1);
+        // Entry is in the live state in both cases.
+        if (!hotArchiveEntry2)
+        {
+            if (!liveEntry1)
+            {
+                REQUIRE(!liveEntry2);
+            }
+            else if (liveEntry1 != liveEntry2)
+            {
+                if (key1.type() == TTL)
+                {
+                    // For TTL entries we expect that in p22 they always
+                    // stay in the live state, while in p23+ they may be
+                    // removed if the entry has been moved to hot archive.
+                    // That's the only kind of diff we expect.
+                    REQUIRE(!liveEntry2);
+                    // The TTL of the entry is either non-bumped, or extended
+                    // for long enough to be in the live state in the ledger
+                    // where the transactions were applied.
+                    auto nonBumpedTTL =
+                        hotArchiveEntryCreatedLedger + MIN_PERSISTENT_TTL - 1;
+                    auto smallBumpTTL = hotArchiveEntryCreatedLedger + 1 +
+                                        TTL_EXTENSION_FOR_EXPIRED_IN_LIVE_STATE;
+                    bool isExpectedTTL =
+                        liveEntry1->data.ttl().liveUntilLedgerSeq ==
+                            nonBumpedTTL ||
+                        liveEntry1->data.ttl().liveUntilLedgerSeq ==
+                            smallBumpTTL;
+                    REQUIRE(isExpectedTTL);
+                }
+                else
+                {
+                    REQUIRE(liveEntry2);
+                    // As with the similar meta check above, the
+                    // lastModifiedLedgerSeq may be different in p22 due
+                    // to absence of hot archive.
+                    REQUIRE(liveEntry1->lastModifiedLedgerSeq ==
+                            hotArchiveEntryCreatedLedger);
+                    // That's the only diff we expect, so just update
+                    // lastModifiedLedgerSeq and proceed to comparing
+                    // the diffs.
+                    auto modifiedLiveEntry1 = *liveEntry1;
+                    modifiedLiveEntry1.lastModifiedLedgerSeq =
+                        liveEntry2->lastModifiedLedgerSeq;
+                    REQUIRE(modifiedLiveEntry1 == *liveEntry2);
+                }
+            }
+
+            REQUIRE(!hotArchiveEntry2);
+        }
+        else
+        {
+            // Entry is in hot archive in p23+ and is still in live state
+            // in p22.
+            REQUIRE(liveEntry1 == hotArchiveEntry2);
+            REQUIRE(!liveEntry2);
+        }
+    }
+}
+
+// This function sets up a new application with randomly generated, but stable
+// (thanks to the seed) test data, applies a set of classic and Soroban
+// transactions and returns the results of the transactions, the corresponding
+// meta and the final state of the ledger entries.
+// The transactions, meta, and results are all sorted by the transaction hash
+// for the sake of comparison.
+// This is meant to be called multiple times with the same seed and different
+// protocol versions and parallelization settings, then the results can be
+// compared via `compareResults`.
+// The setup includes creation of the trustlines and upload of some contract
+// data and contract code entries, some of which expire and maybe are also
+// evicted to the hot archive.
+// The transaction mix includes:
+// - classic transactions that perform payments between the trustlines
+// - Wasm uploads
+// - contract data creations/updates/deletions via contract call
+// - SAC transfers between the trustlines set up above
+// - ExtendFootprintTTLOp transactions that extend data and code entries
+// - RestoreFootprintOp transactions that restore data and code entries
+// All the Soroban operations also have random read and write entries added to
+// the footprint. When `autoRestore` is true, the test will also automatically
+// restore any expired entries that are being accessed (otherwise we just let
+// the transactions fail).
+ResultType
+applyTestTransactions(TestConfig const& testConfig, uint32_t protocolVersion,
+                      int64_t seed, bool autoRestore, int stageCount,
+                      int applyClusterCount,
+                      std::vector<RustBuf> const& randomWasms,
+                      uint32_t& hotArchiveEntryCreatedLedger)
+{
+    int const INVOKE_HOST_FN_TX_COUNT =
+        (testConfig.contractDataKeyCount + testConfig.randomWasmCount +
+         testConfig.trustlineCount) *
+        3;
+
+    int const SOURCE_ACCOUNT_COUNT =
+        INVOKE_HOST_FN_TX_COUNT + testConfig.restoreTxCount +
+        testConfig.extendTxCount + testConfig.classicTxCount;
+
+    REQUIRE(applyClusterCount <= KEY_CLUSTER_COUNT);
+
+    // NB: This test must perform reproducible random setup multiple times.
+    // Make sure to only use the rng defined here and not rely on any
+    // global random engines.
+    std::mt19937 testRng(seed);
+
+    stellar::uniform_int_distribution<uint64_t> contractDataEntryValueDistr;
+
+    if (autoRestore)
+    {
+        REQUIRE(
+            protocolVersionStartsFrom(protocolVersion, ProtocolVersion::V_23));
+    }
+    Config cfg = getTestConfig();
+    cfg.LEDGER_PROTOCOL_VERSION = protocolVersion;
+    cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION = protocolVersion;
+    cfg.ENABLE_SOROBAN_DIAGNOSTIC_EVENTS = true;
+    cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE = 2000;
+    cfg.BACKFILL_RESTORE_META = true;
+    SorobanTest test(
+        cfg, /*useTestLimits=*/true, [&](SorobanNetworkConfig& cfg) {
+            cfg.mStateArchivalSettings.minPersistentTTL = 100'000;
+            // Set the eviction level low to make sure the entries are
+            // evicted fast enough, but not 1, so that it's possible to
+            // have expired and not evicted entries.
+            cfg.mStateArchivalSettings.startingEvictionScanLevel = 2;
+            // Make sure we evict all the entries when we can for
+            // simplicity.
+            cfg.mStateArchivalSettings.evictionScanSize = 10'000'000;
+
+            // Increase the limits even further to not worry about them.
+            cfg.mTxMaxSizeBytes = 10'000'000;
+            cfg.mLedgerMaxTransactionsSizeBytes =
+                std::numeric_limits<uint32_t>::max();
+
+            cfg.mLedgerMaxInstructions = std::numeric_limits<int64_t>::max();
+
+            cfg.mTxMaxDiskReadBytes = 10000 * 1024;
+            cfg.mTxMaxDiskReadEntries = 1000;
+            cfg.mTxMaxWriteLedgerEntries = 500;
+            if (protocolVersionStartsFrom(protocolVersion,
+                                          ProtocolVersion::V_23))
+            {
+                cfg.mTxMaxFootprintEntries = 1500;
+            }
+            cfg.mTxMaxWriteBytes = 10000 * 1024;
+
+            cfg.mLedgerMaxDiskReadEntries =
+                std::numeric_limits<uint32_t>::max();
+            cfg.mLedgerMaxDiskReadBytes = std::numeric_limits<uint32_t>::max();
+            cfg.mLedgerMaxWriteLedgerEntries =
+                std::numeric_limits<uint32_t>::max();
+            cfg.mLedgerMaxWriteBytes = std::numeric_limits<uint32_t>::max();
+
+            cfg.mLedgerMaxTxCount = 10000;
+        });
+    auto applyValidTxs = [&test](auto const& txs) {
+        auto resultSet = closeLedger(test.getApp(), txs);
+        REQUIRE(txs.size() == resultSet.results.size());
+        for (auto const& res : resultSet.results)
+        {
+            REQUIRE(isSuccessResult(res.result));
+        }
+    };
+
+    std::vector<std::string> accountNames;
+    for (int i = 0; i < SOURCE_ACCOUNT_COUNT; ++i)
+    {
+        accountNames.push_back("a" + std::to_string(i));
+    }
+    auto accounts = test.getRoot().createBatch(
+        accountNames,
+        test.getApp().getLedgerManager().getLastMinBalance(10000));
+
+    Asset asset = makeAsset(test.getRoot().getSecretKey(), "aaa");
+
+    std::vector<TransactionFrameBaseConstPtr> trustlineSetupTxs;
+
+    for (int i = 0; i < testConfig.trustlineCount; ++i)
+    {
+        trustlineSetupTxs.push_back(accounts[i].tx(
+            {changeTrust(asset, std::numeric_limits<int64_t>::max())}));
+    }
+
+    applyValidTxs(trustlineSetupTxs);
+    std::vector<Operation> trustlinePayments;
+    for (int i = 0; i < testConfig.trustlineCount; ++i)
+    {
+        trustlinePayments.push_back(
+            payment(accounts[i].getPublicKey(), asset, TRUSTLINE_BALANCE));
+    }
+    test.getRoot().applyOpsBatch(trustlinePayments);
+
+    AssetContractTestClient assetClient(test, asset);
+    ContractStorageTestClient storageClient(test, 10'000'000);
+    modifySorobanNetworkConfig(test.getApp(), [](SorobanNetworkConfig& cfg) {
+        cfg.mStateArchivalSettings.minTemporaryTTL = 16;
+        cfg.mStateArchivalSettings.minPersistentTTL = MIN_PERSISTENT_TTL;
+    });
+
+    std::vector<TransactionFrameBaseConstPtr> setupTxs;
+    std::vector<LedgerKey> preuploadedEntryKeys;
+    double preuploadedEntriesFraction = std::uniform_real_distribution<>(
+        MIN_PREUPLOADED_ENTRIES_FRACTION,
+        MAX_PREUPLOADED_ENTRIES_FRACTION)(testRng);
+    int const PREUPLOADED_WASM_COUNT =
+        preuploadedEntriesFraction * testConfig.randomWasmCount;
+    for (int i = 0; i < PREUPLOADED_WASM_COUNT; ++i)
+    {
+        auto uploadResources = defaultUploadWasmResourcesWithoutFootprint(
+            randomWasms[i], protocolVersion);
+        auto tx =
+            makeSorobanWasmUploadTx(test.getApp(), accounts.at(setupTxs.size()),
+                                    randomWasms[i], uploadResources, 100);
+        preuploadedEntryKeys.push_back(
+            uploadResources.footprint.readWrite.at(0));
+        setupTxs.push_back(tx);
+    }
+    int const PREUPLOADED_CONTRACT_DATA_KEY_COUNT =
+        preuploadedEntriesFraction * testConfig.contractDataKeyCount;
+    for (int i = 0; i < PREUPLOADED_CONTRACT_DATA_KEY_COUNT; ++i)
+    {
+        auto key = "key" + std::to_string(i);
+
+        auto putInvocation = storageClient.putInvocation(
+            key,
+            i % 2 == 0 ? ContractDataDurability::PERSISTENT
+                       : ContractDataDurability::TEMPORARY,
+            contractDataEntryValueDistr(testRng));
+        auto spec = putInvocation.getSpec();
+        auto const& dataKey = spec.getResources().footprint.readWrite.at(0);
+        REQUIRE(dataKey.type() == LedgerEntryType::CONTRACT_DATA);
+        preuploadedEntryKeys.push_back(dataKey);
+
+        setupTxs.push_back(
+            putInvocation.withExactNonRefundableResourceFee().createTx(
+                &accounts.at(setupTxs.size())));
+    }
+
+    applyValidTxs(setupTxs);
+    hotArchiveEntryCreatedLedger = test.getLCLSeq();
+
+    double expiredEntryFraction = std::uniform_real_distribution<>(
+        MIN_EXPIRED_ENTRY_FRACTION, MAX_EXPIRED_ENTRY_FRACTION)(testRng);
+    int liveEntryCount =
+        preuploadedEntryKeys.size() * (1.0 - expiredEntryFraction);
+    int expiredEntryCount = preuploadedEntryKeys.size() - liveEntryCount;
+    // Bump some entries that are supposed to expire a little bit to make
+    // sure they are expired, but not yet moved to the hot archive.
+    int expiredInLiveStateEntryCount =
+        0.5 * expiredEntryFraction * preuploadedEntryKeys.size();
+    stellar::shuffle(preuploadedEntryKeys.begin(), preuploadedEntryKeys.end(),
+                     testRng);
+
+    std::vector<TransactionFrameBaseConstPtr> bumpTxs;
+    SorobanResources bumpResources;
+    bumpResources.diskReadBytes =
+        protocolVersionStartsFrom(protocolVersion, ProtocolVersion::V_23)
+            ? 0
+            : test.getNetworkCfg().txMaxDiskReadBytes();
+    for (int i = 0; i < liveEntryCount; ++i)
+    {
+        auto lk = getTTLKey(preuploadedEntryKeys[i]);
+        bumpResources.footprint.readOnly.push_back(preuploadedEntryKeys[i]);
+    }
+    bumpTxs.push_back(test.createExtendOpTx(
+        bumpResources, 1000, 100, 100'000'000, &accounts.at(bumpTxs.size())));
+    SorobanResources smallBumpResources = bumpResources;
+    smallBumpResources.footprint.readOnly.clear();
+    for (int i = 0; i < expiredInLiveStateEntryCount; ++i)
+    {
+        auto lk = getTTLKey(preuploadedEntryKeys[liveEntryCount + i]);
+        smallBumpResources.footprint.readOnly.push_back(
+            preuploadedEntryKeys[liveEntryCount + i]);
+    }
+    // Extend the entries to live for TTL_EXTENSION_FOR_EXPIRED_IN_LIVE_STATE
+    // (=30) ledgers, which should be enough to trigger eviction at level 2 for
+    // entries that live for just 10 ledgers.
+    bumpTxs.push_back(test.createExtendOpTx(
+        smallBumpResources, TTL_EXTENSION_FOR_EXPIRED_IN_LIVE_STATE, 100,
+        100'000'000, &accounts.at(bumpTxs.size())));
+    applyValidTxs(bumpTxs);
+
+    // Close TTL_EXTENSION_FOR_EXPIRED_IN_LIVE_STATE ledgers to let the entries
+    // to expire, and for some of the entries to be evicted/removed.
+    for (int i = 0; i < TTL_EXTENSION_FOR_EXPIRED_IN_LIVE_STATE; ++i)
+    {
+        closeLedger(test.getApp());
+    }
+    for (int i = 0; i < preuploadedEntryKeys.size(); ++i)
+    {
+        auto const& key = preuploadedEntryKeys[i];
+        if (i < liveEntryCount)
+        {
+            REQUIRE(test.getEntryExpirationStatus(key) ==
+                    ExpirationStatus::LIVE);
+        }
+        else if (i < liveEntryCount + expiredInLiveStateEntryCount)
+        {
+            REQUIRE(test.getEntryExpirationStatus(key) ==
+                    ExpirationStatus::EXPIRED_IN_LIVE_STATE);
+        }
+        else
+        {
+            if (isTemporaryEntry(key))
+            {
+                REQUIRE(test.getEntryExpirationStatus(key) ==
+                        ExpirationStatus::NOT_FOUND);
+            }
+            else
+            {
+                if (protocolVersionStartsFrom(protocolVersion,
+                                              ProtocolVersion::V_23))
+                {
+                    REQUIRE(test.getEntryExpirationStatus(key) ==
+                            ExpirationStatus::HOT_ARCHIVE);
+                }
+                else
+                {
+                    // There is no hot archive in p22.
+                    REQUIRE(test.getEntryExpirationStatus(key) ==
+                            ExpirationStatus::EXPIRED_IN_LIVE_STATE);
+                }
+            }
+        }
+    }
+
+    std::vector<LedgerKey> allKeys = preuploadedEntryKeys;
+    for (int i = PREUPLOADED_WASM_COUNT; i < testConfig.randomWasmCount; ++i)
+    {
+        LedgerKey key(CONTRACT_CODE);
+        key.contractCode().hash = sha256(randomWasms[i]);
+        allKeys.push_back(key);
+    }
+    for (int i = PREUPLOADED_CONTRACT_DATA_KEY_COUNT;
+         i < testConfig.contractDataKeyCount; ++i)
+    {
+        auto key = "key" + std::to_string(i);
+        LedgerKey k = storageClient.getContract().getDataKey(
+            makeSymbolSCVal(key), i % 2 == 0
+                                      ? ContractDataDurability::PERSISTENT
+                                      : ContractDataDurability::TEMPORARY);
+        allKeys.push_back(k);
+    }
+
+    for (int i = 0; i < testConfig.trustlineCount; ++i)
+    {
+        allKeys.push_back(trustlineKey(accounts[i].getPublicKey(), asset));
+    }
+
+    stellar::shuffle(allKeys.begin(), allKeys.end(), testRng);
+    // We put all the keys into clusters and then generate transactions that
+    // only access the keys from a single cluster. This way we can easily build
+    // parallel transaction sets without any conflicting clusters.
+    std::vector<std::vector<LedgerKey>> keyClusters(KEY_CLUSTER_COUNT);
+    // Keep track of the created trustlines per cluster for the sake of easier
+    // SAC transfer generation.
+    std::vector<std::vector<LedgerKey>> trustlineClusters(KEY_CLUSTER_COUNT);
+    for (int i = 0; i < allKeys.size(); ++i)
+    {
+        keyClusters[i % KEY_CLUSTER_COUNT].push_back(allKeys[i]);
+        if (allKeys[i].type() == TRUSTLINE)
+        {
+            trustlineClusters[i % KEY_CLUSTER_COUNT].push_back(allKeys[i]);
+        }
+    }
+
+    std::vector<std::vector<TransactionFrameBaseConstPtr>> sorobanTxsPerCluster(
+        KEY_CLUSTER_COUNT);
+    int sorobanTxCount = 0;
+
+    stellar::uniform_int_distribution<> clusterDistr(0, KEY_CLUSTER_COUNT - 1);
+    std::poisson_distribution<> additionalFootprintDistr(
+        MEAN_ADDITIONAL_FOOTPRINT_KEYS);
+
+    // Subtle: we define a single random read-only fraction for *all* the
+    // test transactions in order to get distinctly different footprint
+    // patterns in different test runs. Just using per-transaction
+    // randomness would result in uniform 'on average' patterns that are
+    // likely to provide similar coverage across runs.
+    double const readOnlyFootprintEntriesFraction =
+        std::uniform_real_distribution<>(MIN_READ_ONLY_FOOTPRINT_FRACTION,
+                                         MAX_READ_ONLY_FOOTPRINT_FRACTION)(
+            testRng);
+
+    auto test_rand_flip = [&testRng]() {
+        return stellar::uniform_int_distribution<>(0, 1)(testRng) != 0;
+    };
+
+    stellar::uniform_int_distribution<> resizeSizeDistr(1, 10);
+    stellar::uniform_int_distribution<> extendTtlDistr(100, 5000);
+    // Make sure some transfers will fail due to insufficient balance.
+    stellar::uniform_int_distribution<> transferAmountDistr(
+        1, TRUSTLINE_BALANCE * 1.2);
+
+    for (int txId = 0; txId < INVOKE_HOST_FN_TX_COUNT; ++txId)
+    {
+        auto clusterId = clusterDistr(testRng);
+        auto& cluster = keyClusters[clusterId];
+        stellar::uniform_int_distribution<> keyIdDistr(0, cluster.size() - 1);
+        // Pick the key from the cluster that defines the type of operation
+        // we perform.
+        auto const& opKey = cluster[keyIdDistr(testRng)];
+
+        // Throw-away tx that we build with helpers. We're only
+        // interested in the operation and the initial footprint in its
+        // resources.
+        TransactionFrameBaseConstPtr tx;
+        TestAccount* operationSourceAccount = nullptr;
+        switch (opKey.type())
+        {
+        // For contract code perform a Wasm upload.
+        case CONTRACT_CODE:
+        {
+            auto wasmIt = std::find_if(
+                randomWasms.begin(), randomWasms.end(), [&](auto const& wasm) {
+                    return sha256(wasm) == opKey.contractCode().hash;
+                });
+            REQUIRE(wasmIt != randomWasms.end());
+            auto resources = defaultUploadWasmResourcesWithoutFootprint(
+                *wasmIt, protocolVersion);
+            resources.footprint.readWrite.push_back(opKey);
+
+            tx = makeSorobanWasmUploadTx(test.getApp(), test.getRoot(), *wasmIt,
+                                         resources, 100);
+
+            break;
+        }
+        // For contract data perform a put, delete or resize_and_extend
+        // operation.
+        case CONTRACT_DATA:
+        {
+            // Temp entries can't be extended with the test contract, so
+            // always use `put` function for them. For persistent
+            // entries, randomly choose between `put`, `delete` and
+            // `resize_and_extend`.
+            if (isTemporaryEntry(opKey) || test_rand_flip())
+            {
+                if (test_rand_flip())
+                {
+                    auto invocation = storageClient.putInvocation(
+                        opKey.contractData().key.sym(),
+                        opKey.contractData().durability,
+                        contractDataEntryValueDistr(testRng));
+                    tx = invocation.createTx();
+                }
+                else
+                {
+                    auto invocation = storageClient.delInvocation(
+                        opKey.contractData().key.sym(),
+                        opKey.contractData().durability);
+                    tx = invocation.createTx();
+                }
+            }
+            else
+            {
+                auto extendTo = extendTtlDistr(testRng);
+                auto threshold =
+                    stellar::uniform_int_distribution<>(1, extendTo)(testRng);
+                auto invocation =
+                    storageClient.resizeStorageAndExtendInvocation(
+                        opKey.contractData().key.sym(),
+                        resizeSizeDistr(testRng), threshold, extendTo);
+                tx = invocation.createTx();
+            }
+
+            break;
+        }
+        // For trustlines perform a SAC transfer.
+        case TRUSTLINE:
+        {
+            operationSourceAccount = &*std::find_if(
+                accounts.begin(), accounts.end(), [&](auto const& a) {
+                    return a.getPublicKey() == opKey.trustLine().accountID;
+                });
+            // NB: self-payment is fine, so we don't need to compare
+            // destination to source.
+            auto const& otherTrustline = trustlineClusters.at(clusterId).at(
+                stellar::uniform_int_distribution<>(
+                    0, trustlineClusters[clusterId].size() - 1)(testRng));
+            bool fromIssuer, toIssuer;
+            SCAddress toAddr;
+            auto invocation = assetClient.transferInvocation(
+                *operationSourceAccount,
+                makeAccountAddress(otherTrustline.trustLine().accountID),
+                transferAmountDistr(testRng), fromIssuer, toIssuer, toAddr);
+            tx = invocation.createTx();
+            break;
+        }
+        default:
+            REQUIRE(false);
+            break;
+        }
+
+        auto op = tx->getOperationFrames().front()->getOperation();
+        auto resources = tx->sorobanResources();
+        // Ensure the resources are sufficient for any operation most of
+        // the time.
+        resources.instructions = 100'000'000;
+        resources.diskReadBytes = 100'000;
+        resources.writeBytes = 100'000;
+        std::vector<uint32_t> archivedIndices;
+
+        // Extend the footprint with random keys from the cluster.
+        int additionalKeyCount = std::min(additionalFootprintDistr(testRng),
+                                          MAX_ADDITONAL_FOOTPRINT_KEYS);
+        additionalKeyCount =
+            std::min<int>(additionalKeyCount, cluster.size() - 1);
+        stellar::shuffle(cluster.begin(), cluster.end(), testRng);
+        int readOnlyKeyCount =
+            readOnlyFootprintEntriesFraction * additionalKeyCount;
+        UnorderedSet<LedgerKey> footprintKeys(
+            resources.footprint.readOnly.begin(),
+            resources.footprint.readOnly.end());
+        footprintKeys.insert(resources.footprint.readWrite.begin(),
+                             resources.footprint.readWrite.end());
+
+        for (int addKeyId = 0; addKeyId < additionalKeyCount; ++addKeyId)
+        {
+            if (footprintKeys.count(cluster[addKeyId]) > 0)
+            {
+                continue;
+            }
+            auto const& addedKey = cluster[addKeyId];
+            if (autoRestore && isSorobanEntry(addedKey) &&
+                !isTemporaryEntry(addedKey) &&
+                isExpiredStatus(test.getEntryExpirationStatus(addedKey)))
+            {
+                // If this would've been read-only key, increase the
+                // count of read-only keys in order to keep the expected
+                // RO/RW ratio.
+                if (addKeyId < readOnlyKeyCount)
+                {
+                    ++readOnlyKeyCount;
+                }
+                resources.footprint.readWrite.push_back(addedKey);
+                continue;
+            }
+
+            if (addKeyId < readOnlyKeyCount)
+            {
+                resources.footprint.readOnly.push_back(cluster[addKeyId]);
+            }
+            else
+            {
+                resources.footprint.readWrite.push_back(cluster[addKeyId]);
+            }
+        }
+        if (autoRestore)
+        {
+            for (int i = 0; i < resources.footprint.readWrite.size(); ++i)
+            {
+                auto const& k = resources.footprint.readWrite[i];
+                if (isSorobanEntry(k) && !isTemporaryEntry(k) &&
+                    isExpiredStatus(test.getEntryExpirationStatus(k)))
+                {
+                    archivedIndices.push_back(i);
+                }
+            }
+        }
+        std::vector<SecretKey> opKeys;
+        if (operationSourceAccount != nullptr &&
+            operationSourceAccount->getPublicKey().ed25519() !=
+                accounts.at(sorobanTxCount).getPublicKey().ed25519())
+        {
+            opKeys.push_back(operationSourceAccount->getSecretKey());
+            op = operationSourceAccount->op(op);
+        }
+        auto maybeArchivedIndices = archivedIndices.empty()
+                                        ? std::nullopt
+                                        : std::make_optional(archivedIndices);
+        tx = sorobanTransactionFrameFromOps(
+            test.getApp().getNetworkID(), accounts.at(sorobanTxCount++), {op},
+            opKeys, resources, 1000, 100'000'000, std::nullopt, std::nullopt,
+            maybeArchivedIndices);
+        sorobanTxsPerCluster[clusterId].push_back(tx);
+    }
+    // Generate ExtendFootprintTTLOp transactions that only extend keys from
+    // a single cluster.
+    for (int txId = 0; txId < testConfig.extendTxCount; ++txId)
+    {
+        auto clusterId = clusterDistr(testRng);
+        auto& cluster = keyClusters[clusterId];
+        SorobanResources resources{};
+        resources.diskReadBytes = 100'000;
+        resources.writeBytes = 100'000;
+        stellar::shuffle(cluster.begin(), cluster.end(), testRng);
+        int extendedKeyCount = stellar::uniform_int_distribution<>(
+            1, std::max<int>(cluster.size() / 2, 1))(testRng);
+        for (auto const& k : cluster)
+        {
+            if (isSorobanEntry(k) &&
+                (isTemporaryEntry(k) ||
+                 !isExpiredStatus(test.getEntryExpirationStatus(k))))
+            {
+                resources.footprint.readOnly.push_back(k);
+                if (resources.footprint.readOnly.size() >= extendedKeyCount)
+                {
+                    break;
+                }
+            }
+        }
+        if (resources.footprint.readOnly.empty())
+        {
+            continue;
+        }
+        auto tx =
+            test.createExtendOpTx(resources, extendTtlDistr(testRng), 1000,
+                                  100'000'000, &accounts.at(sorobanTxCount++));
+        sorobanTxsPerCluster[clusterId].push_back(tx);
+    }
+
+    // Generate RestoreFootprintTtlOp transactions that only restore keys from
+    // a single cluster.
+    for (int txId = 0; txId < testConfig.restoreTxCount; ++txId)
+    {
+        auto clusterId = clusterDistr(testRng);
+        auto& cluster = keyClusters[clusterId];
+        SorobanResources resources{};
+        resources.diskReadBytes = 100'000;
+        resources.writeBytes = 100'000;
+        stellar::shuffle(cluster.begin(), cluster.end(), testRng);
+        int restoredKeyCount = stellar::uniform_int_distribution<>(
+            1, std::max<int>(cluster.size() / 3, 1))(testRng);
+
+        for (auto const& k : cluster)
+        {
+            if (isSorobanEntry(k) && !isTemporaryEntry(k) &&
+                (isExpiredStatus(test.getEntryExpirationStatus(k)) ||
+                 (test_rand_flip() && test_rand_flip())))
+            {
+                resources.footprint.readWrite.push_back(k);
+                if (resources.footprint.readWrite.size() >= restoredKeyCount)
+                {
+                    break;
+                }
+            }
+        }
+        if (resources.footprint.readWrite.empty())
+        {
+            continue;
+        }
+        auto tx = test.createRestoreTx(resources, 1000, 100'000'000,
+                                       &accounts.at(sorobanTxCount++));
+        sorobanTxsPerCluster[clusterId].push_back(tx);
+    }
+
+    // Generate some classic transfers between the trustlines that are also
+    // used for SAC transfers above.
+    std::vector<TransactionFrameBaseConstPtr> classicTxs;
+    stellar::uniform_int_distribution<> trustlineDistr(
+        0, testConfig.trustlineCount - 1);
+    for (int txId = 0; txId < testConfig.classicTxCount; ++txId)
+    {
+        auto& source = accounts[trustlineDistr(testRng)];
+        auto& dest = accounts[trustlineDistr(testRng)];
+        int amount = transferAmountDistr(testRng);
+        auto op = source.op(payment(dest.getPublicKey(), asset, amount));
+        auto txEnv = accounts.at(sorobanTxCount + txId).tx({op})->getEnvelope();
+        if (source.getPublicKey().ed25519() !=
+            accounts.at(sorobanTxCount + txId).getPublicKey().ed25519())
+        {
+            sign(test.getApp().getNetworkID(), source.getSecretKey(),
+                 txEnv.v1());
+        }
+
+        classicTxs.push_back(TransactionFrameBase::makeTransactionFromWire(
+            test.getApp().getNetworkID(), txEnv));
+    }
+
+    std::vector<TransactionFrameBaseConstPtr> sorobanTxs;
+    // We reduce the number of the clusters from KEY_CLUSTER_COUNT to
+    // applyClusterCount via merging the clusters and 'interleaving' the
+    // transactions within the cluster randomly.
+    std::vector<std::vector<uint32_t>> applyClusters(applyClusterCount);
+    int clustersPerApplyCluster = KEY_CLUSTER_COUNT / applyClusterCount +
+                                  (KEY_CLUSTER_COUNT % applyClusterCount != 0);
+    auto mergeClusters = [&](int from, int to, int applyClusterId) {
+        stellar::uniform_int_distribution<> clusterDistr(from, to);
+        std::unordered_set<int> usedClusters;
+        std::vector<int> idInCluster(to - from + 1);
+        while (usedClusters.size() < to - from + 1)
+        {
+            int clusterId = clusterDistr(testRng);
+            if (usedClusters.count(clusterId) > 0)
+            {
+                continue;
+            }
+            if (idInCluster[clusterId - from] >=
+                sorobanTxsPerCluster[clusterId].size())
+            {
+                usedClusters.insert(clusterId);
+                continue;
+            }
+            applyClusters[applyClusterId].push_back(sorobanTxs.size());
+            sorobanTxs.push_back(
+                sorobanTxsPerCluster[clusterId][idInCluster[clusterId - from]]);
+            ++idInCluster[clusterId - from];
+        }
+    };
+    for (int i = 0, applyClusterId = 0; i < KEY_CLUSTER_COUNT;
+         i += clustersPerApplyCluster, ++applyClusterId)
+    {
+        mergeClusters(
+            i, std::min(i + clustersPerApplyCluster - 1, KEY_CLUSTER_COUNT - 1),
+            applyClusterId);
+    }
+    // After we have built the target number of clusters, split every cluster
+    // into `stageCount` stages and build the final apply order.
+    ParallelSorobanOrder sorobanApplyOrder(
+        stageCount, std::vector<std::vector<uint32_t>>(applyClusterCount));
+    for (int applyClusterId = 0; applyClusterId < applyClusters.size();
+         ++applyClusterId)
+    {
+        int sizePerStage =
+            applyClusters[applyClusterId].size() / stageCount +
+            (applyClusters[applyClusterId].size() % stageCount != 0);
+        for (int stageId = 0; stageId < stageCount; ++stageId)
+        {
+            auto& cluster = sorobanApplyOrder.at(stageId).at(applyClusterId);
+            REQUIRE(cluster.empty());
+            int begin = stageId * sizePerStage;
+            if (begin >= applyClusters[applyClusterId].size())
+            {
+                break;
+            }
+            int end = std::min<int>((stageId + 1) * sizePerStage,
+                                    applyClusters[applyClusterId].size());
+            cluster.insert(cluster.begin(),
+                           applyClusters[applyClusterId].begin() + begin,
+                           applyClusters[applyClusterId].begin() + end);
+        }
+    }
+    for (auto& stage : sorobanApplyOrder)
+    {
+        for (int clusterId = 0; clusterId < stage.size(); ++clusterId)
+        {
+            if (stage[clusterId].empty())
+            {
+                stage.erase(stage.begin() + clusterId);
+                --clusterId;
+            }
+        }
+    }
+    for (int stageId = 0; stageId < sorobanApplyOrder.size(); ++stageId)
+    {
+        if (sorobanApplyOrder[stageId].empty())
+        {
+            sorobanApplyOrder.erase(sorobanApplyOrder.begin() + stageId);
+            --stageId;
+        }
+    }
+    auto allTxs = classicTxs;
+    allTxs.insert(allTxs.end(), sorobanTxs.begin(), sorobanTxs.end());
+    {
+        LedgerSnapshot ls(test.getApp());
+        auto diag = DiagnosticEventManager::createDisabled();
+        for (auto const& tx : allTxs)
+        {
+            bool isValid = tx->checkValid(test.getApp().getAppConnector(), ls,
+                                          0, 0, 0, diag)
+                               ->isSuccess();
+            if (!isValid)
+            {
+                tx->checkValid(test.getApp().getAppConnector(), ls, 0, 0, 0,
+                               diag);
+            }
+            REQUIRE(isValid);
+        }
+    }
+
+    TransactionResultSet resultSet;
+    if (protocolVersionStartsFrom(protocolVersion,
+                                  PARALLEL_SOROBAN_PHASE_PROTOCOL_VERSION))
+    {
+        resultSet = closeLedger(test.getApp(), allTxs, sorobanApplyOrder);
+    }
+    else
+    {
+        resultSet = closeLedger(test.getApp(), allTxs, /*strictOrder=*/true);
+    }
+    REQUIRE(resultSet.results.size() == allTxs.size());
+    for (auto const& res : resultSet.results)
+    {
+        if (!isSuccessResult(res.result))
+        {
+            // Errors are expected, but we want the fees and limits to not
+            // be a reason, as these could be not stable between protocol
+            // versions.
+            REQUIRE(res.result.result.results()[0].code() !=
+                    INVOKE_HOST_FUNCTION_INSUFFICIENT_REFUNDABLE_FEE);
+            REQUIRE(res.result.result.results()[0].code() !=
+                    INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
+            REQUIRE(res.result.result.results()[0].code() !=
+                    EXTEND_FOOTPRINT_TTL_RESOURCE_LIMIT_EXCEEDED);
+            REQUIRE(res.result.result.results()[0].code() !=
+                    EXTEND_FOOTPRINT_TTL_INSUFFICIENT_REFUNDABLE_FEE);
+            REQUIRE(res.result.result.results()[0].code() !=
+                    RESTORE_FOOTPRINT_RESOURCE_LIMIT_EXCEEDED);
+            REQUIRE(res.result.result.results()[0].code() !=
+                    RESTORE_FOOTPRINT_INSUFFICIENT_REFUNDABLE_FEE);
+        }
+    }
+    std::vector<std::pair<LedgerKey, std::pair<std::optional<LedgerEntry>,
+                                               std::optional<LedgerEntry>>>>
+        finalEntries;
+    LedgerSnapshot ls(test.getApp());
+    auto hotArchive = test.getApp()
+                          .getBucketManager()
+                          .getBucketSnapshotManager()
+                          .copySearchableHotArchiveBucketListSnapshot();
+    releaseAssert(hotArchive);
+    for (auto const& k : allKeys)
+    {
+        std::optional<LedgerEntry> liveEntry;
+        std::optional<LedgerEntry> archivedEntry;
+        if (auto e = ls.load(k))
+        {
+            liveEntry = e.current();
+            // All the entries that were in the live state and were
+            // not immediately bumped will be evicted to the hot archive, so
+            // live entries should not be expired.
+            if (protocolVersionStartsFrom(protocolVersion,
+                                          ProtocolVersion::V_23) &&
+                isSorobanEntry(k))
+            {
+                REQUIRE(!isExpiredStatus(test.getEntryExpirationStatus(k)));
+            }
+        }
+        else if (isSorobanEntry(k))
+        {
+            if (auto e = hotArchive->load(k))
+            {
+                archivedEntry = e->archivedEntry();
+            }
+        }
+        finalEntries.push_back({k, {liveEntry, archivedEntry}});
+
+        // Also add TTL entry as allKeys doesn't contain them.
+        if (isSorobanEntry(k))
+        {
+            LedgerKey ttlKey = getTTLKey(k);
+            std::optional<LedgerEntry> liveTtlEntry;
+            if (auto e = ls.load(ttlKey))
+            {
+                liveTtlEntry = e.current();
+            }
+            finalEntries.push_back({ttlKey, {liveTtlEntry, std::nullopt}});
+        }
+    }
+
+    // Sort everything by hash to make the comparison easier.
+    // Note, that while the 'canonical' apply order could be stable as long
+    // as there is only a single stage, it is tricky to match it when
+    // there are multiple stages. The normalization also allows us to
+    // randomly merge clusters in order to improve test coverage.
+    std::sort(allTxs.begin(), allTxs.end(), [](const auto& a, const auto& b) {
+        return a->getFullHash() < b->getFullHash();
+    });
+    std::sort(resultSet.results.begin(), resultSet.results.end(),
+              [](const auto& a, const auto& b) {
+                  return a.transactionHash < b.transactionHash;
+              });
+    auto lcm = test.getLastLcm();
+    lcm.sortTxMetaByHash();
+    return std::make_tuple(allTxs, resultSet, lcm, finalEntries);
+}
+
+void
+runTest(int64_t seed, std::vector<std::pair<int, int>> const& scenarios,
+        bool autoRestore, std::vector<RustBuf> const& randomWasms,
+        TestConfig const& testConfig)
+{
+    CAPTURE(seed, autoRestore);
+    // Note: we could also compare results across different protocol
+    // versions past 23, but that's not necessary at the moment.
+    auto protocolVersion = Config::CURRENT_LEDGER_PROTOCOL_VERSION;
+    // This is a 'global' variable that marks the expected creation ledger
+    // of the entries that are supposed to be evicted into the hot archive
+    // in p23. This is necessary for the precise comparison with p22 that
+    // doesn't have hot archive. It's expect that this will stay same
+    // across all the runs of the test.
+    uint32_t hotArchiveEntryCreatedLedger = 0;
+
+    auto baseResult =
+        applyTestTransactions(testConfig, protocolVersion, seed, autoRestore, 1,
+                              1, randomWasms, hotArchiveEntryCreatedLedger);
+
+    for (int scenarioId = 0; scenarioId < testConfig.testScenarioCount;
+         ++scenarioId)
+    {
+        auto [stageCount, clusterCount] = scenarios[scenarioId];
+        CAPTURE(stageCount, clusterCount);
+
+        auto runResult = applyTestTransactions(
+            testConfig, protocolVersion, seed, autoRestore, stageCount,
+            clusterCount, randomWasms, hotArchiveEntryCreatedLedger);
+        compareResults(false, stageCount == 1, baseResult, runResult,
+                       hotArchiveEntryCreatedLedger);
+    }
+    if (!autoRestore)
+    {
+        INFO("pre-parallel-soroban protocol");
+        auto preParallelSorobanResult = applyTestTransactions(
+            testConfig,
+            static_cast<uint32_t>(PARALLEL_SOROBAN_PHASE_PROTOCOL_VERSION) - 1,
+            seed, autoRestore, 1, 1, randomWasms, hotArchiveEntryCreatedLedger);
+        compareResults(true, true, preParallelSorobanResult, baseResult,
+                       hotArchiveEntryCreatedLedger);
+    }
+}
+
+void
+runTestCase(TestConfig const& testConfig)
+{
+    std::vector<RustBuf> randomWasms;
+    stellar::uniform_int_distribution<int64_t> seedDist;
+    for (int i = 0; i < testConfig.randomWasmCount; ++i)
+    {
+        randomWasms.push_back(
+            rust_bridge::get_random_wasm(1000, seedDist(Catch::rng())));
+    }
+
+    std::vector<std::pair<int, int>> scenarios;
+    for (int stageCount = 1; stageCount <= MAX_STAGE_COUNT; ++stageCount)
+    {
+        for (int clusterCount = 1; clusterCount <= KEY_CLUSTER_COUNT;
+             ++clusterCount)
+        {
+            scenarios.emplace_back(stageCount, clusterCount);
+        }
+    }
+
+    for (int testIter = 0; testIter < TEST_RUN_COUNT; ++testIter)
+    {
+        CAPTURE(testIter);
+        int64_t seed = Catch::rng()();
+        stellar::shuffle(scenarios.begin(), scenarios.end(), Catch::rng());
+        runTest(seed, scenarios, testIter % 2, randomWasms, testConfig);
+    }
+}
+
+TEST_CASE("parallel soroban application results are independent of transaction "
+          "partitioning - tiny scenario",
+          "[soroban][parallelapply]")
+{
+    TestConfig testConfig;
+    testConfig.randomWasmCount = 2;
+    testConfig.contractDataKeyCount = 5;
+    testConfig.trustlineCount = 3;
+    testConfig.classicTxCount = 5;
+    testConfig.restoreTxCount = 2;
+    testConfig.extendTxCount = 2;
+    testConfig.testScenarioCount = KEY_CLUSTER_COUNT * MAX_STAGE_COUNT / 2;
+    runTestCase(testConfig);
+}
+
+TEST_CASE("parallel soroban application results are independent of transaction "
+          "partitioning - small scenario",
+          "[soroban][parallelapply]")
+{
+    TestConfig testConfig;
+    testConfig.randomWasmCount = 6;
+    testConfig.contractDataKeyCount = 20;
+    testConfig.trustlineCount = 10;
+    testConfig.classicTxCount = 20;
+    testConfig.restoreTxCount = 10;
+    testConfig.extendTxCount = 10;
+    testConfig.testScenarioCount = 3;
+    runTestCase(testConfig);
+}
+
+TEST_CASE("parallel soroban application results are independent of transaction "
+          "partitioning - medium scenario",
+          "[soroban][parallelapply]")
+{
+    TestConfig testConfig;
+    testConfig.randomWasmCount = 30;
+    testConfig.contractDataKeyCount = 100;
+    testConfig.trustlineCount = 50;
+    testConfig.classicTxCount = 100;
+    testConfig.restoreTxCount = 50;
+    testConfig.extendTxCount = 50;
+    testConfig.testScenarioCount = 3;
+    runTestCase(testConfig);
+}
+
+TEST_CASE("parallel soroban application results are independent of transaction "
+          "partitioning - large scenario",
+          "[soroban][parallelapply]")
+{
+    TestConfig testConfig;
+    testConfig.randomWasmCount = 50;
+    testConfig.contractDataKeyCount = 200;
+    testConfig.trustlineCount = 100;
+    testConfig.classicTxCount = 200;
+    testConfig.restoreTxCount = 100;
+    testConfig.extendTxCount = 100;
+    testConfig.testScenarioCount = 3;
+    runTestCase(testConfig);
+}
+
+} // namespace

--- a/src/transactions/test/SorobanTxTestUtils.cpp
+++ b/src/transactions/test/SorobanTxTestUtils.cpp
@@ -227,6 +227,13 @@ makeSorobanWasmUploadTx(Application& app, TestAccount& source,
                                           inclusionFee, uploadResourceFee);
 }
 
+bool
+isExpiredStatus(ExpirationStatus status)
+{
+    return status == ExpirationStatus::EXPIRED_IN_LIVE_STATE ||
+           status == ExpirationStatus::HOT_ARCHIVE;
+}
+
 SorobanResources
 defaultUploadWasmResourcesWithoutFootprint(RustBuf const& wasm,
                                            uint32_t ledgerVersion)
@@ -1102,7 +1109,8 @@ SorobanTest::invokeArchivalOp(TransactionFrameBaseConstPtr tx,
 }
 
 Hash
-SorobanTest::uploadWasm(RustBuf const& wasm, SorobanResources& uploadResources)
+SorobanTest::uploadWasm(RustBuf const& wasm, SorobanResources& uploadResources,
+                        int64_t additionalRefundableFee)
 {
     SCBytes expectedWasm(wasm.data.begin(), wasm.data.end());
     Hash expectedWasmHash = sha256(expectedWasm);
@@ -1125,8 +1133,8 @@ SorobanTest::uploadWasm(RustBuf const& wasm, SorobanResources& uploadResources)
         previousLiveUntilLedger = getTTL(contractCodeLedgerKey);
     }
 
-    auto tx =
-        makeSorobanWasmUploadTx(getApp(), *mRoot, wasm, uploadResources, 1000);
+    auto tx = makeSorobanWasmUploadTx(getApp(), *mRoot, wasm, uploadResources,
+                                      1000, additionalRefundableFee);
     REQUIRE(isSuccessResult(invokeTx(tx)));
 
     // Verify the uploaded contract code is correct.
@@ -1221,16 +1229,19 @@ SorobanTest::getApp() const
 TestContract&
 SorobanTest::deployWasmContract(RustBuf const& wasm,
                                 std::optional<SorobanResources> uploadResources,
-                                std::optional<SorobanResources> createResources)
+                                std::optional<SorobanResources> createResources,
+                                int64_t additionalRefundableFee)
 {
-    return deployWasmContract(wasm, {}, uploadResources, createResources);
+    return deployWasmContract(wasm, {}, uploadResources, createResources,
+                              additionalRefundableFee);
 }
 
 TestContract&
 SorobanTest::deployWasmContract(RustBuf const& wasm,
                                 ConstructorParams const& constructorParams,
                                 std::optional<SorobanResources> uploadResources,
-                                std::optional<SorobanResources> createResources)
+                                std::optional<SorobanResources> createResources,
+                                int64_t additionalRefundableFee)
 {
     if (!uploadResources)
     {
@@ -1246,7 +1257,7 @@ SorobanTest::deployWasmContract(RustBuf const& wasm,
             static_cast<uint32_t>(wasm.data.size() + 1000);
         createResources->writeBytes = 1000;
     }
-    Hash wasmHash = uploadWasm(wasm, *uploadResources);
+    Hash wasmHash = uploadWasm(wasm, *uploadResources, additionalRefundableFee);
     SCAddress contractAddress = createContract(
         makeContractIDPreimage(*mRoot,
                                sha256(std::to_string(mContracts.size()))),
@@ -1413,6 +1424,31 @@ SorobanTest::isEntryLive(LedgerKey const& k, uint32_t ledgerSeq)
     auto ttlLtxe = ltx.loadWithoutRecord(ttlKey);
     REQUIRE(ttlLtxe);
     return isLive(ttlLtxe.current(), ledgerSeq);
+}
+
+ExpirationStatus
+SorobanTest::getEntryExpirationStatus(LedgerKey const& key)
+{
+    auto ttlKey = getTTLKey(key);
+    LedgerSnapshot ls(getApp());
+    if (auto lse = ls.load(ttlKey))
+    {
+        if (lse.current().data.ttl().liveUntilLedgerSeq <= getLCLSeq())
+        {
+            return ExpirationStatus::EXPIRED_IN_LIVE_STATE;
+        }
+        return ExpirationStatus::LIVE;
+    }
+    auto hotArchive = getApp()
+                          .getBucketManager()
+                          .getBucketSnapshotManager()
+                          .copySearchableHotArchiveBucketListSnapshot();
+    releaseAssert(hotArchive);
+    if (hotArchive->load(key) != nullptr)
+    {
+        return ExpirationStatus::HOT_ARCHIVE;
+    }
+    return ExpirationStatus::NOT_FOUND;
 }
 
 void
@@ -1660,16 +1696,17 @@ AssetContractTestClient::getTransferTx(TestAccount& fromAcc,
     return tx;
 }
 
-bool
-AssetContractTestClient::transfer(TestAccount& fromAcc,
-                                  SCAddress const& maybeMuxedToAddr,
-                                  int64_t amount)
+TestContract::Invocation
+AssetContractTestClient::transferInvocation(TestAccount& fromAcc,
+                                            SCAddress const& maybeMuxedToAddr,
+                                            int64_t amount, bool& fromIsIssuer,
+                                            bool& toIsIssuer, SCAddress& toAddr)
 {
     SCVal fromVal(SCV_ADDRESS);
     fromVal.address() = makeAccountAddress(fromAcc.getPublicKey());
 
     SCVal toVal(SCV_ADDRESS);
-    SCAddress toAddr = maybeMuxedToAddr;
+    toAddr = maybeMuxedToAddr;
     if (maybeMuxedToAddr.type() != SCAddressType::SC_ADDRESS_TYPE_MUXED_ACCOUNT)
     {
         toVal.address() = maybeMuxedToAddr;
@@ -1688,8 +1725,8 @@ AssetContractTestClient::transfer(TestAccount& fromAcc,
 
     auto spec = defaultSpec();
 
-    bool fromIsIssuer = false;
-    bool toIsIssuer = false;
+    fromIsIssuer = false;
+    toIsIssuer = false;
     if (mAsset.type() != ASSET_TYPE_NATIVE)
     {
         spec = spec.extendReadOnlyFootprint({makeIssuerKey(mAsset)});
@@ -1710,7 +1747,10 @@ AssetContractTestClient::transfer(TestAccount& fromAcc,
         }
         else
         {
-            spec = spec.extendReadWriteFootprint({toBalanceKey});
+            if (toBalanceKey != fromBalanceKey)
+            {
+                spec = spec.extendReadWriteFootprint({toBalanceKey});
+            }
         }
     }
     else
@@ -1718,15 +1758,29 @@ AssetContractTestClient::transfer(TestAccount& fromAcc,
         spec = spec.setReadWriteFootprint({fromBalanceKey, toBalanceKey});
     }
 
-    auto preTransferFromBalance = mAsset.type() == ASSET_TYPE_NATIVE
-                                      ? fromAcc.getBalance()
-                                      : fromAcc.getTrustlineBalance(mAsset);
-    auto preTransferToBalance = getBalance(toAddr);
     auto invocation =
         mContract
             .prepareInvocation("transfer", {fromVal, toVal, makeI128(amount)},
                                spec)
             .withAuthorizedTopCall();
+    return invocation;
+}
+
+bool
+AssetContractTestClient::transfer(TestAccount& fromAcc,
+                                  SCAddress const& maybeMuxedToAddr,
+                                  int64_t amount)
+{
+    bool fromIsIssuer;
+    bool toIsIssuer;
+    SCAddress toAddr;
+    auto invocation = transferInvocation(fromAcc, maybeMuxedToAddr, amount,
+                                         fromIsIssuer, toIsIssuer, toAddr);
+
+    auto preTransferFromBalance = mAsset.type() == ASSET_TYPE_NATIVE
+                                      ? fromAcc.getBalance()
+                                      : fromAcc.getTrustlineBalance(mAsset);
+    auto preTransferToBalance = getBalance(toAddr);
     bool success = invocation.invoke(&fromAcc);
     setLastEvent(invocation, success);
 
@@ -1756,7 +1810,8 @@ AssetContractTestClient::transfer(TestAccount& fromAcc,
             // From is an account so it should never have a contract data
             // balance
             LedgerTxn ltx(mApp.getLedgerTxnRoot());
-            REQUIRE(!ltx.load(makeContractDataBalanceKey(fromVal.address())));
+            auto fromAddr = makeAccountAddress(fromAcc.getPublicKey());
+            REQUIRE(!ltx.load(makeContractDataBalanceKey(fromAddr)));
         }
 
         if (toIsIssuer)
@@ -1916,9 +1971,11 @@ AssetContractTestClient::clawback(TestAccount& admin, SCAddress const& fromAddr,
     return success;
 }
 
-ContractStorageTestClient::ContractStorageTestClient(SorobanTest& test)
-    : mContract(
-          test.deployWasmContract(rust_bridge::get_test_wasm_contract_data()))
+ContractStorageTestClient::ContractStorageTestClient(
+    SorobanTest& test, int64_t additionalRefundableFee)
+    : mContract(test.deployWasmContract(
+          rust_bridge::get_test_wasm_contract_data(), std::nullopt,
+          std::nullopt, additionalRefundableFee))
 {
 }
 
@@ -1971,6 +2028,14 @@ ContractStorageTestClient::isEntryLive(std::string const& key,
 {
     return mContract.getTest().isEntryLive(
         mContract.getDataKey(makeSymbolSCVal(key), durability), ledgerSeq);
+}
+
+ExpirationStatus
+ContractStorageTestClient::getEntryExpirationStatus(
+    std::string const& key, ContractDataDurability durability)
+{
+    return mContract.getTest().getEntryExpirationStatus(
+        mContract.getDataKey(makeSymbolSCVal(key), durability));
 }
 
 TestContract::Invocation


### PR DESCRIPTION
# Description

The tests generate random ledger state and random transaction sets that operate on that ledger state, apply them to the ledger with different parallel execution schedules and protocol versions, and ensure that the results never diverge (outside of a narrow set of the expected differences).


# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
