### PR TITLE
BucketList fixes

### DIFF
--- a/src/bucket/BucketInputIterator.cpp
+++ b/src/bucket/BucketInputIterator.cpp
@@ -51,7 +51,7 @@ BucketInputIterator<BucketT>::loadEntry()
             }
             mMetadata = mEntry.metaEntry();
 
-            if constexpr (std::is_same_v<BucketT, HotArchiveBucketEntry>)
+            if constexpr (std::is_same_v<BucketT, HotArchiveBucket>)
             {
                 if (mMetadata.ext.v() != 1 ||
                     mMetadata.ext.bucketListType() != HOT_ARCHIVE)

--- a/src/bucket/BucketSnapshot.cpp
+++ b/src/bucket/BucketSnapshot.cpp
@@ -47,6 +47,7 @@ BucketSnapshotBase<BucketT>::getEntryAtOffset(LedgerKey const& k,
                                               size_t pageSize) const
 {
     ZoneScoped;
+    releaseAssertOrThrow(pageSize > 0);
     if (isEmpty())
     {
         return {nullptr, false};
@@ -56,16 +57,7 @@ BucketSnapshotBase<BucketT>::getEntryAtOffset(LedgerKey const& k,
     stream.seek(pos);
 
     typename BucketT::EntryT be;
-    if (pageSize == 0)
-    {
-        if (stream.readOne(be))
-        {
-            auto entry = std::make_shared<typename BucketT::EntryT const>(be);
-            mBucket->getIndex().maybeAddToCache(entry);
-            return {entry, false};
-        }
-    }
-    else if (stream.readPage(be, k, pageSize))
+    if (stream.readPage(be, k, pageSize))
     {
         auto entry = std::make_shared<typename BucketT::EntryT const>(be);
         mBucket->getIndex().maybeAddToCache(entry);

--- a/src/bucket/BucketUtils.cpp
+++ b/src/bucket/BucketUtils.cpp
@@ -101,6 +101,11 @@ MergeCounters::operator==(MergeCounters const& other) const
         mRunningMergeReattachments == other.mRunningMergeReattachments &&
         mFinishedMergeReattachments == other.mFinishedMergeReattachments &&
 
+        mPreShadowRemovalProtocolMerges ==
+            other.mPreShadowRemovalProtocolMerges &&
+        mPostShadowRemovalProtocolMerges ==
+            other.mPostShadowRemovalProtocolMerges &&
+
         mNewMetaEntries == other.mNewMetaEntries &&
         mNewInitEntries == other.mNewInitEntries &&
         mNewLiveEntries == other.mNewLiveEntries &&

--- a/src/bucket/HotArchiveBucket.cpp
+++ b/src/bucket/HotArchiveBucket.cpp
@@ -91,19 +91,8 @@ HotArchiveBucket::mergeCasesWithEqualKeys(
     std::function<void(HotArchiveBucketEntry const&)> putFunc,
     uint32_t protocolVersion)
 {
-    auto const& oldEntry = inputSource.getOldEntry();
-    auto const& newEntry = inputSource.getNewEntry();
-
-    // If two identical keys have the same type, throw an error. Otherwise,
-    // take the newer key.
-    if (oldEntry.type() == newEntry.type())
-    {
-        throw std::runtime_error(
-            "Malformed Hot Archive bucket: two identical keys with "
-            "the same type.");
-    }
-
-    putFunc(newEntry);
+    // Always take the newer entry.
+    putFunc(inputSource.getNewEntry());
     inputSource.advanceNew();
     inputSource.advanceOld();
 }

--- a/src/bucket/LiveBucketIndex.cpp
+++ b/src/bucket/LiveBucketIndex.cpp
@@ -29,7 +29,7 @@ std::streamoff
 LiveBucketIndex::getPageSize(Config const& cfg, size_t bucketSize)
 {
     // Convert cfg param from MB to bytes
-    if (auto cutoff = cfg.BUCKETLIST_DB_INDEX_CUTOFF * 1'000'000;
+    if (auto cutoff = cfg.BUCKETLIST_DB_INDEX_CUTOFF * 1024 * 1024;
         bucketSize < cutoff)
     {
         return 0;

--- a/src/catchup/IndexBucketsWork.cpp
+++ b/src/catchup/IndexBucketsWork.cpp
@@ -70,8 +70,18 @@ IndexBucketsWork<BucketT>::IndexWork::postWork()
             if (bm.getConfig().BUCKETLIST_DB_PERSIST_INDEX &&
                 fs::exists(indexFilename))
             {
-                self->mIndex = loadIndex<BucketT>(bm, indexFilename,
-                                                  self->mBucket->getSize());
+                try
+                {
+                    self->mIndex = loadIndex<BucketT>(bm, indexFilename,
+                                                      self->mBucket->getSize());
+                }
+                // If we get an exception from an invalid index file, ignore it
+                // and reindex the Bucket.
+                catch (std::runtime_error&)
+                {
+                    CLOG_WARNING(Bucket, "Invalid or corrupt index file: {}",
+                                 indexFilename);
+                }
 
                 // If we could not load the index from the file, file is out of
                 // date. Delete and create a new index.

--- a/src/catchup/IndexBucketsWork.h
+++ b/src/catchup/IndexBucketsWork.h
@@ -20,7 +20,7 @@ template <class BucketT> class IndexBucketsWork : public Work
     class IndexWork : public BasicWork
     {
         std::shared_ptr<BucketT> mBucket;
-        std::unique_ptr<typename BucketT::IndexT const> mIndex;
+        std::unique_ptr<typename BucketT::IndexT const> mIndex{nullptr};
         BasicWork::State mState{BasicWork::State::WORK_WAITING};
 
         void postWork();

--- a/src/catchup/IndexBucketsWork.h
+++ b/src/catchup/IndexBucketsWork.h
@@ -20,7 +20,7 @@ template <class BucketT> class IndexBucketsWork : public Work
     class IndexWork : public BasicWork
     {
         std::shared_ptr<BucketT> mBucket;
-        std::unique_ptr<typename BucketT::IndexT const> mIndex{nullptr};
+        std::unique_ptr<typename BucketT::IndexT const> mIndex;
         BasicWork::State mState{BasicWork::State::WORK_WAITING};
 
         void postWork();


### PR DESCRIPTION
# Description

Includes a variety of BucketList related fixes and cleanups.

The first commit removes a faulty assert from the Hot Archive, which can cause core to crash. The assert is intended to check that ARCHIVED entries in the hot archive are not updated, since the value should be immutable. However, if an entry is archived, removed from the Hot Archive via restore, then archived again, it is possible that two ARCHIVED entries for the same key merge, as the newer ARCHIVED entry may annihilate the RESTORED entry before merging with the older ARCHIVED entry.

The following commits address minor issues from the p23 security audit draft. Specifically, they address issues 2, 7, 9, 14, and 18. 

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
