### PR TITLE
WIP: Tsan on rust

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -94,6 +94,11 @@ AX_APPEND_COMPILE_FLAGS($WFLAGS)
 AX_APPEND_COMPILE_FLAGS([-pthread])
 AC_LANG_POP(C)
 
+AC_ARG_ENABLE(unified-rust-unsafe-for-production,
+    AS_HELP_STRING([--enable-unified-rust-unsafe-for-production],
+        [Build rust crates as a single cargo library, risking version drift]))
+AM_CONDITIONAL(UNIFIED_RUST, [test "x$enable_unified_rust_unsafe_for_production" = "xyes"])
+
 unset sanitizeopts
 
 AC_ARG_ENABLE([asan],
@@ -101,6 +106,11 @@ AC_ARG_ENABLE([asan],
         [build with asan (address-sanitizer) instrumentation]))
 AS_IF([test "x$enable_asan" = "xyes"], [
   AC_MSG_NOTICE([ Enabling asan, see https://clang.llvm.org/docs/AddressSanitizer.html ])
+
+  AS_IF([test "xyes" != "x$enable_unified_rust_unsafe_for_production"], [
+    AC_MSG_WARN(Asan will not instrument rust without --enable-unified-rust-unsafe-for-production)
+  ])
+
   sanitizeopts="address"
 ])
 
@@ -121,8 +131,11 @@ AC_ARG_ENABLE([threadsanitizer],
 AS_IF([test "x$enable_threadsanitizer" = "xyes"], [
   AC_MSG_NOTICE([ enabling thread-sanitizer, see https://clang.llvm.org/docs/ThreadSanitizer.html ])
 
+  AS_IF([test "xyes" != "x$enable_unified_rust_unsafe_for_production"], [
+    AC_MSG_ERROR(Enabling tsan requires --enable-unified-rust-unsafe-for-production)
+  ])
   AS_IF([test x != "x$sanitizeopts"], [
-    AC_MSG_ERROR(Cannot enable multiple checkers at once)
+    AC_MSG_ERROR(Cannot enable multiple sanitizers at once)
   ])
   sanitizeopts="thread"
 ])
@@ -145,7 +158,7 @@ AS_IF([test "x$enable_memcheck" = "xyes"], [
   AC_MSG_NOTICE([ To completely enable poison destructor set MSAN_OPTIONS=poison_in_dtor=1 before running the program ])
 
   AS_IF([test x != "x$sanitizeopts"], [
-    AC_MSG_ERROR(Cannot enable multiple checkers at once)
+    AC_MSG_ERROR(Cannot enable multiple sanitizers at once)
   ])
   sanitizeopts="memory -fsanitize-memory-track-origins=2 -fsanitize-memory-use-after-dtor"
 
@@ -169,7 +182,7 @@ AC_ARG_ENABLE([undefinedcheck],
 AS_IF([test "x$enable_undefinedcheck" = "xyes"], [
   AC_MSG_NOTICE([ enabling undefined-behavior-sanitizer, see https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html ])
   AS_IF([test x != "x$sanitizeopts"], [
-    AC_MSG_ERROR(Cannot enable multiple checkers at once)
+    AC_MSG_ERROR(Cannot enable multiple sanitizers at once)
   ])
   sanitizeopts="undefined"
 ])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -117,13 +117,15 @@ BUILT_SOURCES += rust/RustBridge.h rust/RustBridge.cpp
 stellar_core_SOURCES += rust/RustBridge.h rust/RustBridge.cpp
 
 RUST_TOOLCHAIN_FILE=$(top_srcdir)/rust-toolchain.toml
-RUST_TOOLCHAIN_CHANNEL=$(shell sed -n 's/channel *= *"\([^"]*\)"/\1/p' $(RUST_TOOLCHAIN_FILE))
+RUST_TOOLCHAIN_FILE_CHANNEL=$(shell sed -n 's/channel *= *"\([^"]*\)"/\1/p' $(RUST_TOOLCHAIN_FILE))
+RUST_TOOLCHAIN_CHANNEL=$(if $(findstring sanitize,$(CXXFLAGS)),nightly,$(RUST_TOOLCHAIN_FILE_CHANNEL))
 CARGO=cargo +$(RUST_TOOLCHAIN_CHANNEL)
 
 # we pass RUST_TOOLCHAIN_CHANNEL by environment variable
 # to tests since they can't take command-line arguments.
 export RUST_TOOLCHAIN_CHANNEL
 
+RUST_TARGET=$(shell rustc -vV | sed -n 's/host: //p')
 RUST_BUILD_DIR=$(top_builddir)/src/rust
 RUST_BIN_DIR=$(RUST_BUILD_DIR)/bin
 RUST_TARGET_DIR=$(top_builddir)/target
@@ -132,7 +134,7 @@ RUST_PROFILE=release
 RUST_DEP_TREE_STAMP=$(RUST_BUILD_DIR)/src/dep-trees/equal-trees.stamp
 SOROBAN_LIBS_STAMP=$(RUST_BUILD_DIR)/soroban/soroban-libs.stamp
 RUST_HOST_DEPFILES=rust/Cargo.toml $(top_srcdir)/Cargo.toml $(top_srcdir)/Cargo.lock $(RUST_DEP_TREE_STAMP)
-LIBRUST_STELLAR_CORE=$(RUST_TARGET_DIR)/$(RUST_PROFILE)/librust_stellar_core.a
+LIBRUST_STELLAR_CORE=$(RUST_TARGET_DIR)/$(RUST_TARGET)/$(RUST_PROFILE)/librust_stellar_core.a
 stellar_core_LDADD += $(LIBRUST_STELLAR_CORE) -ldl
 
 SOROBAN_BUILD_DIR=$(abspath $(RUST_BUILD_DIR))/soroban
@@ -178,7 +180,7 @@ endif
 SOROBAN_MAX_PROTOCOL=$(lastword $(sort $(ALL_SOROBAN_PROTOCOLS)))
 
 define soroban_lib_dir
-$(shell printf '$(SOROBAN_BUILD_DIR)/%s/target/$(RUST_PROFILE)' $(1))
+$(shell printf '$(SOROBAN_BUILD_DIR)/%s/target/$(RUST_TARGET)/$(RUST_PROFILE)' $(1))
 endef
 
 define soroban_rlib
@@ -231,6 +233,44 @@ $(RUST_DEP_TREE_STAMP): $(wildcard rust/soroban/*/Cargo.*) Makefile $(RUST_TOOLC
 # doesn't let you pass --debug, that's the default! you can only pass --release.
 # So we have to derive a new variable here.
 RUST_PROFILE_ARG := $(if $(findstring release,$(RUST_PROFILE)),--release,)
+
+# The "unified" rust build is a special non-production mode that builds all of
+# the rust dependencies of librust_stellar_core.a through a single cargo
+# invocation, which is actually the "normal" way cargo operates, but which also
+# has the negative side effect of resolving (merging) different point releases
+# and pre-release minor versions across transitive dependencies, which means we
+# can't control the _exact_ transitive dependencies as well as we'd like.
+#
+# So we only use the unified rust build for certain special cases such as
+# testing with asan/tsan (they seem to only work well when built this way) and
+# use the non-unified build (with separate .a files for each separate soroban
+# version) for production builds.
+
+if UNIFIED_RUST
+
+RUSTFLAGS_ASAN := $(if $(findstring -fsanitize=address,$(CXXFLAGS)),-Zsanitizer=address,)
+RUSTFLAGS_TSAN := $(if $(findstring -fsanitize=thread,$(CXXFLAGS)),-Zsanitizer=thread,)
+RUSTFLAGS_SANI := $(RUSTFLAGS_ASAN) $(RUSTFLAGS_TSAN)
+CARGOFLAGS_BUILDSTD := $(if $(findstring sanitizer,$(RUSTFLAGS_SANI)),-Zbuild-std,)
+RUSTFLAGS_CFGS := $(if $(findstring sanitizer,$(RUSTFLAGS_SANI)),--cfg curve25519_dalek_backend=\"serial\",)
+
+$(LIBRUST_STELLAR_CORE): $(RUST_HOST_DEPFILES) $(SRC_RUST_FILES) Makefile $(RUST_TOOLCHAIN_FILE)
+	rm -rf $(abspath $(RUST_TARGET_DIR))
+	CC="$(CC)" CXX="$(CXX)" LD="$(LD)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" CXXSTDLIB="$(CXXSTDLIB)" LDFLAGS="$(LDFLAGS)" \
+	RUSTFLAGS="$(RUSTFLAGS_SANI) $(RUSTFLAGS_CFGS)" \
+	CARGO_NET_GIT_FETCH_WITH_CLI=true \
+	$(CARGO) rustc \
+		$(CARGOFLAGS_BUILDSTD) \
+		--package stellar-core \
+		--target $(RUST_TARGET) \
+		--features unified \
+		$(RUST_PROFILE_ARG) \
+		--locked \
+		--target-dir $(abspath $(RUST_TARGET_DIR)) \
+		$(CARGO_FEATURE_TRACY) $(CARGO_FEATURE_NEXT) $(CARGO_FEATURE_TESTUTILS)
+	ranlib $@
+
+else # !UNIFIED_RUST
 
 # This next build command looks a little weird but it's necessary. We have to
 # provide an auxiliary metadata string (using RUSTFLAGS=-Cmetadata=$*)
@@ -292,10 +332,11 @@ $(SOROBAN_LIBS_STAMP): $(wildcard rust/soroban/p*/Cargo.lock) Makefile $(RUST_DE
 		esac ; \
 		cd $(abspath $(RUST_BUILD_DIR))/soroban/$$proto && \
 		CC="$(CC)" CXX="$(CXX)" LD="$(LD)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" CXXSTDLIB="$(CXXSTDLIB)" LDFLAGS="$(LDFLAGS)" \
-		RUSTFLAGS="-Cmetadata=$$proto $(RUSTFLAGS_ASAN)" \
+		RUSTFLAGS="-Cmetadata=$$proto" \
 		CARGO_NET_GIT_FETCH_WITH_CLI=true \
 		$(CARGO) build \
 			--package soroban-env-host \
+			--target $(RUST_TARGET) \
 			$(RUST_PROFILE_ARG) \
 			--locked \
 			$$FEATURE_FLAGS \
@@ -319,10 +360,10 @@ $(SOROBAN_LIBS_STAMP): $(wildcard rust/soroban/p*/Cargo.lock) Makefile $(RUST_DE
 $(LIBRUST_STELLAR_CORE): $(RUST_HOST_DEPFILES) $(SRC_RUST_FILES) Makefile $(SOROBAN_LIBS_STAMP) $(RUST_TOOLCHAIN_FILE)
 	rm -rf $(abspath $(RUST_TARGET_DIR))
 	CC="$(CC)" CXX="$(CXX)" LD="$(LD)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" CXXSTDLIB="$(CXXSTDLIB)" LDFLAGS="$(LDFLAGS)" \
-	RUSTFLAGS="$(RUSTFLAGS_ASAN)" \
 	CARGO_NET_GIT_FETCH_WITH_CLI=true \
 	$(CARGO) rustc \
 		--package stellar-core \
+		--target $(RUST_TARGET) \
 		$(RUST_PROFILE_ARG) \
 		--locked \
 		--target-dir $(abspath $(RUST_TARGET_DIR)) \
@@ -331,6 +372,8 @@ $(LIBRUST_STELLAR_CORE): $(RUST_HOST_DEPFILES) $(SRC_RUST_FILES) Makefile $(SORO
 		$(ALL_SOROBAN_EXTERN_ARGS) \
 		$(ALL_SOROBAN_DEPEND_ARGS)
 	ranlib $@
+
+endif # UNIFIED_RUST
 
 $(srcdir)/src.mk: $(top_srcdir)/make-mks
 	cd $(top_srcdir) && ./make-mks

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -80,36 +80,51 @@ tracy-client = { version = "=0.17.0", features = [
 #
 
 # Note: due to some subtle mis-features in Cargo's unification of transitive
-# dependency versions, we do _not_ refer to all the separate soroban crate
-# versions directly here. See $(top_srcdir)/src/Makefile.am for the logic that
-# builds each crate separately and then provides them to the stellar-core crate
-# here.
+# dependency versions, we do _not_ usually use to all the separate soroban crate
+# versions listed directly here. See $(top_srcdir)/src/Makefile.am for the logic
+# that builds each crate separately and then provides them to the stellar-core
+# crate here.
 #
-# However this fact makes it difficult to use an IDE to work on this crate since
-# the IDE will not be able to resolve the hosts to anything at all. So for the sake
-# of making IDE-edits, we keep some commented-out copies of the host dependencies
-# here. These are not used by the build system, but if you uncomment them while
-# working they will allow your IDE to at least find "nearly correct" versions of
-# the host dependencies. Make sure they are commented back out before committing
-# (and be careful to reset any changes the IDE makes to Cargo.lock)
+# However that type of "non-unified" build breaks sanitizer builds, and also
+# makes it difficult to use an IDE to work on this crate since the IDE will not
+# be able to resolve the hosts to anything at all. So we keep some _optional_
+# copies of the host dependencies here, and allow enabling them with the
+# `unified` feature here.
+#
+# To reiterate: the soroban-env-host-p{21,22,23}... dependency blocks listed
+# here are NOT part of the default build. The default build relies on the
+# versions pinned as git submodules.
+#
+# However, you can _manually_ switch the default build by enabling the `unified`
+# feature using a feature-toggle in an IDE (eg. using the VS Code "Rust Feature
+# Toggler" extension), and the build system (src/Makefile.am) can be configured
+# to use the `unified` feature if you configure with
+# --enable-unified-rust-unsafe-for-production.
+#
+# If you do a unified build, be careful to reset any changes the IDE makes to
+# Cargo.lock! The unified build will re-resolve transitive dependencies and
+# unify them, perturbing the contents of the lockfile.
 
-# [dependencies.soroban-env-host-p23]
-# version = "=23.0.0"
-# git = "https://github.com/stellar/rs-soroban-env"
-# package = "soroban-env-host"
-# rev = "31cb455b87a25a1c049360b5422c411deae63ba2"
+[dependencies.soroban-env-host-p23]
+version = "=23.0.0-rc.2"
+git = "https://github.com/stellar/rs-soroban-env"
+package = "soroban-env-host"
+rev = "339d5957d2a258ca888d2f7eb50e92e425555256"
+optional = true
 
-# [dependencies.soroban-env-host-p22]
-# version = "=22.0.0"
-# git = "https://github.com/stellar/rs-soroban-env"
-# package = "soroban-env-host"
-# rev = "1cd8b8dca9aeeca9ce45b129cd923992b32dc258"
+[dependencies.soroban-env-host-p22]
+version = "=22.0.0"
+git = "https://github.com/stellar/rs-soroban-env"
+package = "soroban-env-host"
+rev = "80ebd78a53d608f76f4a5955fd9b03248efcb7c1"
+optional = true
 
-# [dependencies.soroban-env-host-p21]
-# version = "=21.2.2"
-# git = "https://github.com/stellar/rs-soroban-env"
-# package = "soroban-env-host"
-# rev = "7eeddd897cfb0f700f938b0c8d6f0541150d1fcb"
+[dependencies.soroban-env-host-p21]
+version = "=21.2.2"
+git = "https://github.com/stellar/rs-soroban-env"
+package = "soroban-env-host"
+rev = "7eeddd897cfb0f700f938b0c8d6f0541150d1fcb"
+optional = true
 
 # The test wasms and synth-wasm crate should usually be taken from the highest
 # supported host, since test material usually just grows over time.
@@ -117,12 +132,12 @@ tracy-client = { version = "=0.17.0", features = [
 [dependencies.soroban-test-wasms]
 version = "=22.0.0"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "a3f7fca9c2ad89796c7525a648da086543502dd5"
+rev = "80ebd78a53d608f76f4a5955fd9b03248efcb7c1"
 
 [dependencies.soroban-synth-wasm]
 version = "=22.0.0"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "a3f7fca9c2ad89796c7525a648da086543502dd5"
+rev = "80ebd78a53d608f76f4a5955fd9b03248efcb7c1"
 
 [dependencies.stellar-quorum-analyzer]
 version = "0.1.0"
@@ -130,6 +145,10 @@ git = "https://github.com/stellar/stellar-quorum-analyzer"
 rev = "678acf18ee635c4270e241030d6e83bb0b98b5d5"
 
 [features]
+
+# Turn on the optional unified build. This is typically only useful in an IDE or when
+# orchestrated by the build system. See note above and in docs/CONTRIBUTING.md.
+unified = ["dep:soroban-env-host-p21", "dep:soroban-env-host-p22", "dep:soroban-env-host-p23"]
 
 tracy = ["dep:tracy-client"]
 

--- a/src/rust/src/soroban_proto_all.rs
+++ b/src/rust/src/soroban_proto_all.rs
@@ -31,7 +31,7 @@ use crate::RustBuf;
 
 // We also alias the latest soroban as soroban_curr to help reduce churn in code
 // that's just always supposed to use the latest.
-pub(crate) use p22 as soroban_curr;
+pub(crate) use p23 as soroban_curr;
 
 #[path = "."]
 pub(crate) mod p23 {


### PR DESCRIPTION
This is a WIP branch for properly enabling rust-with-tsan inside the core build (currently extending https://github.com/stellar/stellar-core/pull/4817 to facilitate running those parallel testcases, but it doesn't depend on any of that work).

Unfortunately propagating the tsan flags through our "separate crates build" is .. extremely hard to get working right.

So I took a different tack here and just added a mode -- `--enable-unified-rust-unsafe-for-production` -- to the core build system that builds `librust_stellar_core.a` as a single cargo invocation "the normal way you'd expect", and the way we _used_ to, building the sub-soroban crates as direct dependencies resolved by cargo and linked directly into that crate, not driven by automake. This all works! And nice to know: it also shows no tsan errors in our code currently.

So this is .. very convenient for fiddling with cargo-supported build tricks like "turning on tsan" (and it's also helpful to have as a mode we can switch in the IDE while editing/debugging) but it _does_ risk drift in transitive dependencies -- it undermines the whole reason we have the "separate crates build" in the first place.