### PR TITLE
Add loadgen option to set ledgerMaxDependentTxClusters

### DIFF
--- a/src/herder/ParallelTxSetBuilder.cpp
+++ b/src/herder/ParallelTxSetBuilder.cpp
@@ -617,7 +617,7 @@ buildSurgePricedParallelSorobanPhase(
         CLOG_DEBUG(Herder,
                    "Parallel Soroban tx set nomination: {} stages => {} total "
                    "inclusion fee",
-                   results[i].mTotalInclusionFee, results[i].mStages.size());
+                   results[i].mStages.size(), results[i].mTotalInclusionFee);
         if (results[i].mTotalInclusionFee < maxTotalInclusionFee)
         {
             continue;

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -1299,6 +1299,8 @@ CommandHandler::generateLoad(std::string const& params, std::string& retStr)
                 parseOptionalParam<uint32_t>(map, "nominit");
             upgradeCfg.nominationTimeoutIncrementMilliseconds =
                 parseOptionalParam<uint32_t>(map, "nominc");
+            upgradeCfg.ledgerMaxDependentTxClusters =
+                parseOptionalParam<uint32_t>(map, "maxtxclstrs");
         }
 
         if (cfg.mode == LoadGenMode::MIXED_CLASSIC_SOROBAN)

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -864,11 +864,14 @@ CommandHandler::sorobanInfo(std::string const& params, std::string& retStr)
             archivalInfo["average_bucket_list_size"] =
                 static_cast<Json::UInt64>(conf.getAverageSorobanStateSize());
 
-            // SCP timing settings
             if (protocolVersionStartsFrom(
                     lm.getLastClosedLedgerHeader().header.ledgerVersion,
                     ProtocolVersion::V_23))
             {
+                res["max_dependent_tx_clusters"] =
+                    conf.ledgerMaxDependentTxClusters();
+
+                // SCP timing settings
                 auto& scpSettings = res["scp"];
                 scpSettings["ledger_close_time_ms"] =
                     conf.ledgerTargetCloseTimeMilliseconds();


### PR DESCRIPTION
# Description

Add loadgen option to set ledgerMaxDependentTxClusters.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
