### PR TITLE
Rust debug improvememnt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,10 @@ members = ["src/rust"]
 [profile.release]
 codegen-units = 1
 lto = true
+# Note: setting debug=true here is only going to cause debuginfo to be
+# generated for polymorphic functions inlined from sub-crates and/or
+# functions defined in the top-level rust crate, not the soroban sub
+# crates. They need to have debug=true set in their Cargo.toml files
+# (or you can build with `make RUST_PROFILE=dev` to get them built with
+# debug-and-no-opt).
+debug = true

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,0 +1,67 @@
+---
+title: Debugging
+---
+
+This is a little howto on building stellar-core -- both its C++ and Rust components -- for debugging, and running it under an interactive debugger: specifically Visual Studio Code
+
+## Build variants
+
+  - The default build will create `stellar-core` with optimization _and_ debuginfo. The Rust soroban sub-crates may or may not have debuginfo enabled depending on whether, in their local `Cargo.toml` files, the `release` profile has `debug=true` in it. If not you may need to manually turn it on.
+
+  - The default build can be made more debugging-friendly by turning _off_ optimization. This will allow the debugger to see more variables and functions, do less inlining and variable elimination.
+    - For C++ code this involves overriding `CXXFLAGS` to contain `-O0` rather than `-O2` (and don't forget to keep `-g` for debugging!)
+    - For Rust code this involves switching `RUST_PROFILE` to the `dev` profile.
+    - So for both you will want something like: `make CXXFLAGS='-O0 -g' RUST_PROFILE=dev`
+
+## Configuring VSCode for Debugging
+
+  - Install the CodeLLDB extension. This will automatically download and install an appropriate `lldb` binary.
+
+  - Run the menu command Run => Open Configurations (or otherwise edit the launch.json file) and set the configuration to the following:
+    ```json
+    {
+        "version": "0.2.0",
+        "configurations": [
+            {
+                "type": "lldb",
+                "request": "launch",
+                "name": "Debug",
+                "program": "${workspaceFolder}/src/stellar-core",
+                "args": ["test","--all-versions"],
+                "env": {"ASAN_OPTIONS": "alloc_dealloc_mismatch=0"},
+                "cwd": "${workspaceFolder}"
+            }
+        ]
+    }
+    ```
+
+  - Adjust the `args` entry there to customize the core run you actually want to debug. Usually you will want to run it with a specific offline catchup configuration or a specific test.
+
+## Configuring VSCode for automatic per-test execution and debugging
+
+  - Install the "C++ TestMate" extension.
+
+  - Add the following to your local settings.json file:
+    ```json
+    {
+        "testMate.cpp.test.advancedExecutables": [
+            {
+                "pattern": "${workspaceFolder}/src/stellar-core",
+                "catch2": {
+                    "prependTestListingArgs": ["test"],
+                    "prependTestRunningArgs": ["test"],
+                    "ignoreTestEnumerationStdErr": true,
+                    "testGrouping": {
+                        "groupBySource": {}
+                    }
+                }
+            }
+        ]
+    }
+    ```
+
+  - Click the testing tab on the far left hand panel of the editor (there is a little icon that looks like a beaker full of liquid: I think the idea is that this represents doing science in a chemistry lab?)
+
+  - The primary sidebar should automatically populate with all the tests in `stellar-core` grouped by file, and if you hover over any of them there should be a little arrow button to run the test and an arrow with a little bug that will let you invoke the debugger on that test.
+
+  - If you open one of core's unit test files (eg. `src/transactions/test/InvokeHostFunctionTests.cpp`) the individual tests should now also have a little arrow at the line declaring `TEST_CASE` and you can click that arrow to run it or right-click to get a menu of options including "debug test".

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -129,10 +129,20 @@ RUST_BIN_DIR=$(RUST_BUILD_DIR)/bin
 RUST_TARGET_DIR=$(top_builddir)/target
 RUST_CXXBRIDGE=$(RUST_BIN_DIR)/cxxbridge
 RUST_PROFILE=release
+
+# Of course, RUST_PROFILE can't be used as an argument directly because cargo
+# doesn't let you pass --debug, that's the default! you can only pass --release.
+# So we have to derive a new variable here.
+RUST_PROFILE_ARG := $(if $(findstring release,$(RUST_PROFILE)),--release,)
+
+# Also for even more nonsense reasons the debug profile name is actually `dev`
+# but only in the command line, the target subdirectory gets called `debug`.
+RUST_PROFILE_DIR := $(if $(findstring release,$(RUST_PROFILE)),release,debug)
+
 RUST_DEP_TREE_STAMP=$(RUST_BUILD_DIR)/src/dep-trees/equal-trees.stamp
 SOROBAN_LIBS_STAMP=$(RUST_BUILD_DIR)/soroban/soroban-libs.stamp
 RUST_HOST_DEPFILES=rust/Cargo.toml $(top_srcdir)/Cargo.toml $(top_srcdir)/Cargo.lock $(RUST_DEP_TREE_STAMP)
-LIBRUST_STELLAR_CORE=$(RUST_TARGET_DIR)/$(RUST_PROFILE)/librust_stellar_core.a
+LIBRUST_STELLAR_CORE=$(RUST_TARGET_DIR)/$(RUST_PROFILE_DIR)/librust_stellar_core.a
 stellar_core_LDADD += $(LIBRUST_STELLAR_CORE) -ldl
 
 SOROBAN_BUILD_DIR=$(abspath $(RUST_BUILD_DIR))/soroban
@@ -178,7 +188,7 @@ endif
 SOROBAN_MAX_PROTOCOL=$(lastword $(sort $(ALL_SOROBAN_PROTOCOLS)))
 
 define soroban_lib_dir
-$(shell printf '$(SOROBAN_BUILD_DIR)/%s/target/$(RUST_PROFILE)' $(1))
+$(shell printf '$(SOROBAN_BUILD_DIR)/%s/target/$(RUST_PROFILE_DIR)' $(1))
 endef
 
 define soroban_rlib
@@ -226,11 +236,6 @@ $(RUST_DEP_TREE_STAMP): $(wildcard rust/soroban/*/Cargo.*) Makefile $(RUST_TOOLC
 		fi; \
 	done
 	touch $@
-
-# Of course, RUST_PROFILE can't be used as an argument directly because cargo
-# doesn't let you pass --debug, that's the default! you can only pass --release.
-# So we have to derive a new variable here.
-RUST_PROFILE_ARG := $(if $(findstring release,$(RUST_PROFILE)),--release,)
 
 # This next build command looks a little weird but it's necessary. We have to
 # provide an auxiliary metadata string (using RUSTFLAGS=-Cmetadata=$*)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -130,6 +130,12 @@ RUST_TARGET_DIR=$(top_builddir)/target
 RUST_CXXBRIDGE=$(RUST_BIN_DIR)/cxxbridge
 RUST_PROFILE=release
 
+check-rust-profile: Makefile
+	@case "$(RUST_PROFILE)" in \
+		release|dev) ;; \
+		*) echo "Error: RUST_PROFILE must be 'release' or 'dev', got '$(RUST_PROFILE)'" >&2; exit 1;; \
+	esac
+
 # Of course, RUST_PROFILE can't be used as an argument directly because cargo
 # doesn't let you pass --debug, that's the default! you can only pass --release.
 # So we have to derive a new variable here.
@@ -207,7 +213,7 @@ ALL_SOROBAN_LIBS=$(foreach proto,$(ALL_SOROBAN_PROTOCOLS),$(call soroban_rlib,$(
 ALL_SOROBAN_EXTERN_ARGS=$(foreach proto,$(ALL_SOROBAN_PROTOCOLS),$(call soroban_extern_flag,$(proto)))
 ALL_SOROBAN_DEPEND_ARGS=$(foreach proto,$(ALL_SOROBAN_PROTOCOLS),$(call soroban_depend_flag,$(proto)))
 
-$(RUST_CXXBRIDGE): Makefile $(RUST_TOOLCHAIN_FILE)
+$(RUST_CXXBRIDGE): Makefile $(RUST_TOOLCHAIN_FILE) check-rust-profile
 	mkdir -p $(RUST_BIN_DIR)
 	CARGO_HTTP_MULTIPLEXING=false $(CARGO) install --force --locked --root $(RUST_BUILD_DIR) cxxbridge-cmd --version 1.0.68
 


### PR DESCRIPTION
This improves the rust debugging situation a bit. Not perfect but a step in the right direction.

  - It builds the top-level `librust_stellar_core.a` crate using `debug=true` in release profile. This is similar to the change https://github.com/stellar/rs-soroban-env/pull/1580 on the soroban crates.
  - It adds support to the makefile to build with `make RUST_PROFILE=dev` which builds all the rust crates in non-optimized mode, and with debuginfo. This is similar to the way we do non-optimized debug builds of stellar core today via `make CXXFLAGS='-O0 -g'`, manually overriding automake variables.

I also recommend merging https://github.com/stellar/rs-soroban-env/pull/1580 and bumping the soroban submodules to take it, so that we have optimized-with-debuginfo as the default across the build; though of course that does change the submodule hash / require a new soroban release, and maybe we want to hold off on that until final, I'm not sure.