### PR TITLE
Allow specification of classic transaction sizes in bytes

### DIFF
--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -1158,7 +1158,7 @@ LoadGenerator::creationTransaction(uint64_t startAccount, uint64_t numItems,
     mInitialAccountsCreated = true;
     return std::make_pair(sourceAcc,
                           mTxGenerator.createTransactionFramePtr(
-                              sourceAcc, creationOps, false, std::nullopt));
+                              sourceAcc, creationOps, std::nullopt));
 }
 
 std::pair<TxGenerator::TestAccountPtr, TransactionFrameBaseConstPtr>

--- a/src/simulation/TxGenerator.cpp
+++ b/src/simulation/TxGenerator.cpp
@@ -200,32 +200,54 @@ TxGenerator::createAccounts(uint64_t start, uint64_t count, uint32_t ledgerNum,
 
 TransactionFrameBasePtr
 TxGenerator::createTransactionFramePtr(
-    TxGenerator::TestAccountPtr from, std::vector<Operation> ops, bool pretend,
-    std::optional<uint32_t> maxGeneratedFeeRate)
+    TxGenerator::TestAccountPtr from, std::vector<Operation> ops,
+    std::optional<uint32_t> maxGeneratedFeeRate,
+    std::optional<uint8_t> memoSize)
 {
     auto txf = transactionFromOperations(
         mApp, from->getSecretKey(), from->nextSequenceNumber(), ops,
         generateFee(maxGeneratedFeeRate, ops.size()));
-    if (pretend)
+    if (memoSize.has_value())
     {
+        // TODO: what if more than 28?
+        assert(*memoSize <= 28);
         Memo memo(MEMO_TEXT);
-        memo.text() = std::string(28, ' ');
+        memo.text() = std::string(*memoSize, ' ');
         txbridge::setMemo(txf, memo);
+    }
+    return txf;
+}
 
-        txbridge::setMinTime(txf, 0);
-        txbridge::setMaxTime(txf, UINT64_MAX);
-
-        txbridge::getSignatures(txf).clear();
-        txf->addSignature(from->getSecretKey());
+// Given ops of currentSize bytes, conditionally modify memo or add padding
+// operation to get byteSize approximately equal to desiredSize
+static void
+addPadding(vector<Operation>& ops, std::optional<uint8_t>& memoSize,
+           uint32_t desiredSize, uint32_t currentSize)
+{
+    if (desiredSize <= currentSize) {
+        return;
     }
 
-    return txf;
+    // Adding a padding op with 0 padding adds 12 bytes to a transaction
+    uint32_t constexpr paddingSize = 12;
+
+    if (desiredSize < currentSize + paddingSize) {
+        // Adding a size-0 memo takes 4 bytes (for storing the size of the memo)
+        if (desiredSize - currentSize < 4) {
+            memoSize = 0;
+        } else {
+            memoSize = desiredSize - currentSize - 4;
+        }
+        return;
+    }
+
+    ops.emplace_back(txtest::padForTesting(desiredSize - paddingSize - currentSize));
 }
 
 std::pair<TxGenerator::TestAccountPtr, TransactionFrameBasePtr>
 TxGenerator::paymentTransaction(uint32_t numAccounts, uint32_t offset,
                                 uint32_t ledgerNum, uint64_t sourceAccount,
-                                uint32_t opCount,
+                                uint32_t bytes,
                                 std::optional<uint32_t> maxGeneratedFeeRate)
 {
     TxGenerator::TestAccountPtr to, from;
@@ -233,15 +255,16 @@ TxGenerator::paymentTransaction(uint32_t numAccounts, uint32_t offset,
     std::tie(from, to) =
         pickAccountPair(numAccounts, offset, ledgerNum, sourceAccount);
     vector<Operation> paymentOps;
-    paymentOps.reserve(opCount);
-    for (uint32_t i = 0; i < opCount; ++i)
-    {
-        paymentOps.emplace_back(txtest::payment(to->getPublicKey(), amount));
-    }
+    paymentOps.emplace_back(txtest::payment(to->getPublicKey(), amount));
 
-    return std::make_pair(from,
-                          createTransactionFramePtr(from, paymentOps, false,
-                                                    maxGeneratedFeeRate));
+    // smallest size in bytes of a transaction with just the payment
+    uint64_t constexpr basePaymentTxSize = 204;
+    std::optional<uint8_t> memoSize;
+    addPadding(paymentOps, memoSize, bytes, basePaymentTxSize);
+
+    return std::make_pair(from, createTransactionFramePtr(from, paymentOps,
+                                                          maxGeneratedFeeRate,
+                                                          memoSize));
 }
 
 std::pair<TxGenerator::TestAccountPtr, TransactionFrameBasePtr>
@@ -262,8 +285,7 @@ TxGenerator::manageOfferTransaction(uint32_t ledgerNum, uint64_t accountId,
             100));
     }
     return std::make_pair(
-        account,
-        createTransactionFramePtr(account, ops, false, maxGeneratedFeeRate));
+        account, createTransactionFramePtr(account, ops, maxGeneratedFeeRate));
 }
 
 std::pair<TxGenerator::TestAccountPtr, TransactionFrameBaseConstPtr>
@@ -1207,31 +1229,19 @@ TxGenerator::sorobanRandomUploadResources()
 std::pair<TxGenerator::TestAccountPtr, TransactionFrameBaseConstPtr>
 TxGenerator::pretendTransaction(uint32_t numAccounts, uint32_t offset,
                                 uint32_t ledgerNum, uint64_t sourceAccount,
-                                uint32_t opCount,
+                                uint32_t bytes,
                                 std::optional<uint32_t> maxGeneratedFeeRate)
 {
     vector<Operation> ops;
-    ops.reserve(opCount);
     auto acc = findAccount(sourceAccount, ledgerNum);
-    for (uint32 i = 0; i < opCount; i++)
-    {
-        auto args = SetOptionsArguments{};
 
-        // We make SetOptionsOps such that we end up
-        // with a n-op transaction that is exactly 100n + 240 bytes.
-        args.inflationDest = std::make_optional<AccountID>(acc->getPublicKey());
-        args.homeDomain = std::make_optional<std::string>(std::string(16, '*'));
-        if (i == 0)
-        {
-            // The first operation needs to be bigger to achieve
-            // 100n + 240 bytes.
-            args.homeDomain->append(std::string(8, '*'));
-            args.signer = std::make_optional<Signer>(Signer{});
-        }
-        ops.push_back(txtest::setOptions(args));
-    }
+    // base transaction size in bytes of a transaction with no operations [TODO: valid?]
+    uint64_t baseTxSize = 148;
+    std::optional<uint8_t> memoSize;
+    addPadding(ops, memoSize, bytes, baseTxSize);
+
     return std::make_pair(
-        acc, createTransactionFramePtr(acc, ops, true, maxGeneratedFeeRate));
+        acc, createTransactionFramePtr(acc, ops, maxGeneratedFeeRate));
 }
 
 }

--- a/src/simulation/TxGenerator.h
+++ b/src/simulation/TxGenerator.h
@@ -110,13 +110,13 @@ class TxGenerator
 
     TransactionFrameBaseConstPtr
     createTransactionFramePtr(TestAccountPtr from, std::vector<Operation> ops,
-                              bool pretend,
-                              std::optional<uint32_t> maxGeneratedFeeRate);
+                              std::optional<uint32_t> maxGeneratedFeeRate,
+                              std::optional<uint8_t> memoSize = std::nullopt);
 
     std::pair<TestAccountPtr, TransactionFrameBaseConstPtr>
     paymentTransaction(uint32_t numAccounts, uint32_t offset,
                        uint32_t ledgerNum, uint64_t sourceAccount,
-                       uint32_t opCount,
+                       uint32_t bytes,
                        std::optional<uint32_t> maxGeneratedFeeRate);
 
     std::pair<TestAccountPtr, TransactionFrameBaseConstPtr>
@@ -164,7 +164,7 @@ class TxGenerator
     std::pair<TestAccountPtr, TransactionFrameBaseConstPtr>
     pretendTransaction(uint32_t numAccounts, uint32_t offset,
                        uint32_t ledgerNum, uint64_t sourceAccount,
-                       uint32_t opCount,
+                       uint32_t bytes,
                        std::optional<uint32_t> maxGeneratedFeeRate);
 
     int generateFee(std::optional<uint32_t> maxGeneratedFeeRate, size_t opsCnt);

--- a/src/simulation/test/LoadGeneratorTests.cpp
+++ b/src/simulation/test/LoadGeneratorTests.cpp
@@ -11,10 +11,13 @@
 #include "simulation/LoadGenerator.h"
 #include "simulation/Topologies.h"
 #include "test/Catch2.h"
+#include "test/TxTests.h"
 #include "test/test.h"
+#include "transactions/TransactionFrame.h"
 #include "transactions/test/SorobanTxTestUtils.h"
 #include "util/Math.h"
 #include "util/finally.h"
+#include "xdrpp/marshal.h"
 #include <fmt/format.h>
 
 using namespace stellar;
@@ -1075,4 +1078,47 @@ TEST_CASE("apply load", "[loadgen][applyload]")
               al.getReadEntryUtilization().mean() / 1000.0);
     CLOG_INFO(Perf, "Write entry utilization {}%",
               al.getWriteEntryUtilization().mean() / 1000.0);
+}
+
+TEST_CASE("confirm minimum tx sizes", "[loadgen]")
+{
+    // If this test fails, the byte size values in
+    // TxGenerator::paymentTransaction and TxGenerator::pretendTransaction need
+    // to be updated, and TxGenerator.cpp:addPadding
+    Config cfg(getTestConfig());
+    cfg.LEDGER_PROTOCOL_VERSION = Config::CURRENT_LEDGER_PROTOCOL_VERSION;
+    cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION =
+        Config::CURRENT_LEDGER_PROTOCOL_VERSION;
+    VirtualClock clock;
+    Application::pointer app = createTestApplication(clock, cfg);
+    auto root = app->getRoot();
+    auto source =
+        root->create("", app->getLedgerManager().getLastMinBalance(0));
+    std::vector<Operation> ops;
+    ops.push_back(txtest::payment(source.getPublicKey(), 1));
+    auto tx = txtest::transactionFromOperationsV1(*app, source.getSecretKey(),
+                                                  1, ops, 0);
+    REQUIRE(xdr::xdr_argpack_size(*tx->toStellarMessage()) == 204);
+
+    Memo memo(MEMO_TEXT);
+    memo.text() = "";
+    tx = txtest::transactionFromOperationsV1(*app, source.getSecretKey(), 1,
+                                             ops, 0, std::nullopt, std::nullopt,
+                                             memo);
+    REQUIRE(xdr::xdr_argpack_size(*tx->toStellarMessage()) == 208);
+
+    ops.push_back(txtest::padForTesting(0));
+    tx = txtest::transactionFromOperationsV1(*app, source.getSecretKey(), 1,
+                                             ops, 0);
+    REQUIRE(xdr::xdr_argpack_size(*tx->toStellarMessage()) == 216);
+
+    ops.clear();
+    tx = txtest::transactionFromOperationsV1(*app, source.getSecretKey(), 1,
+                                             ops, 0);
+    REQUIRE(xdr::xdr_argpack_size(*tx->toStellarMessage()) == 148);
+
+    ops.push_back(txtest::padForTesting(0));
+    tx = txtest::transactionFromOperationsV1(*app, source.getSecretKey(), 1,
+                                             ops, 0);
+    REQUIRE(xdr::xdr_argpack_size(*tx->toStellarMessage()) == 160);
 }

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -1672,6 +1672,15 @@ liquidityPoolWithdraw(PoolID const& poolID, int64_t amount, int64_t minAmountA,
     return op;
 }
 
+Operation
+padForTesting(uint32_t bytes)
+{
+    Operation op;
+    op.body.type(PAD_FOR_TESTING);
+    op.body.padForTestingOp().padding = xdr::opaque_vec<>(bytes);
+    return op;
+}
+
 OperationResult const&
 getFirstResult(TransactionTestFramePtr tx)
 {

--- a/src/test/TxTests.h
+++ b/src/test/TxTests.h
@@ -291,6 +291,8 @@ Operation liquidityPoolDeposit(PoolID const& poolID, int64_t maxAmountA,
 Operation liquidityPoolWithdraw(PoolID const& poolID, int64_t amount,
                                 int64_t minAmountA, int64_t minAmountB);
 
+Operation padForTesting(uint32_t bytes);
+
 Asset makeNativeAsset();
 Asset makeInvalidAsset();
 Asset makeAsset(SecretKey const& issuer, std::string const& code);

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -25,6 +25,7 @@
 #include "transactions/ManageSellOfferOpFrame.h"
 #include "transactions/MergeOpFrame.h"
 #include "transactions/MutableTransactionResult.h"
+#include "transactions/PadForTestingOpFrame.h"
 #include "transactions/PathPaymentStrictReceiveOpFrame.h"
 #include "transactions/PathPaymentStrictSendOpFrame.h"
 #include "transactions/PaymentOpFrame.h"
@@ -123,6 +124,10 @@ OperationFrame::makeHelper(Operation const& op, TransactionFrame const& tx,
         return std::make_shared<ExtendFootprintTTLOpFrame>(op, tx);
     case RESTORE_FOOTPRINT:
         return std::make_shared<RestoreFootprintOpFrame>(op, tx);
+#ifdef BUILD_TESTS
+    case PAD_FOR_TESTING:
+        return std::make_shared<PadForTestingOpFrame>(op, tx);
+#endif
     default:
         ostringstream err;
         err << "Unknown Tx type: " << op.body.type();

--- a/src/transactions/PadForTestingOpFrame.cpp
+++ b/src/transactions/PadForTestingOpFrame.cpp
@@ -1,0 +1,48 @@
+#pragma once
+
+// Copyright 2017 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "transactions/PadForTestingOpFrame.h"
+
+#ifdef BUILD_TESTS
+namespace stellar
+{
+ThresholdLevel
+PadForTestingOpFrame::getThresholdLevel() const
+{
+    return ThresholdLevel::LOW;
+}
+
+bool
+PadForTestingOpFrame::isOpSupported(LedgerHeader const& header) const
+{
+    return true;
+}
+
+PadForTestingOpFrame::PadForTestingOpFrame(Operation const& op,
+                                           TransactionFrame const& parentTx)
+    : OperationFrame(op, parentTx)
+    , mPadForTestingOp(mOperation.body.padForTestingOp())
+{
+}
+
+bool
+PadForTestingOpFrame::doApply(
+    AppConnector& app, AbstractLedgerTxn& ltx, Hash const& sorobanBasePrngSeed,
+    OperationResult& res,
+    std::optional<RefundableFeeTracker>& refundableFeeTracker,
+    OperationMetaBuilder& opMeta) const
+{
+    return true;
+}
+
+bool
+PadForTestingOpFrame::doCheckValid(uint32_t ledgerVersion,
+                                   OperationResult& res) const
+{
+    return true;
+}
+}
+#endif

--- a/src/transactions/PadForTestingOpFrame.h
+++ b/src/transactions/PadForTestingOpFrame.h
@@ -1,0 +1,33 @@
+#pragma once
+
+// Copyright 2017 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "ledger/LedgerTxn.h"
+#include "ledger/LedgerTxnEntry.h"
+#include "ledger/LedgerTxnHeader.h"
+#include "transactions/OperationFrame.h"
+
+#ifdef BUILD_TESTS
+namespace stellar
+{
+class PadForTestingOpFrame : public OperationFrame
+{
+    ThresholdLevel getThresholdLevel() const override;
+    bool isOpSupported(LedgerHeader const& header) const override;
+
+    PadForTestingOp const& mPadForTestingOp;
+
+  public:
+    PadForTestingOpFrame(Operation const& op, TransactionFrame const& parentTx);
+
+    bool doApply(AppConnector& app, AbstractLedgerTxn& ltx,
+                 Hash const& sorobanBasePrngSeed, OperationResult& res,
+                 std::optional<RefundableFeeTracker>& refundableFeeTracker,
+                 OperationMetaBuilder& opMeta) const override;
+    bool doCheckValid(uint32_t ledgerVersion,
+                      OperationResult& res) const override;
+};
+}
+#endif


### PR DESCRIPTION
Resolves #4483. Depends on https://github.com/stellar/stellar-xdr/issues/282. Update payment and pretend transaction generation throughout loadgen to support byte distribution for sizing.