### PR TITLE
Added size and count metrics for in-memory caches

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -51,6 +51,8 @@ bucketlistDB-<X>.<Y>.sum                  | counter   | sum of time (microsecond
 bucketlistDB-<X>.<Y>.count                | counter   | number of times single entry of type <Y> on BucketList <X> (live/hotArchive) is loaded
 bucketlistDB-cache.hit                    | meter     | number of cache hits on Live BucketList Disk random eviction cache
 bucketlistDB-cache.miss                   | meter     | number of cache misses on Live BucketList Disk random eviction cache
+bucketlistDB.cache.entries                | counter   | number of entries currently in Live BucketList index cache
+bucketlistDB.cache.bytes                  | counter   | estimated size in bytes of entries in Live BucketList index cache
 crypto.verify.hit                         | meter     | number of signature cache hits
 crypto.verify.miss                        | meter     | number of signature cache misses
 crypto.verify.total                       | meter     | sum of both hits and misses
@@ -260,3 +262,7 @@ soroban.module-cache.num-entries             | counter   | current number of ent
 soroban.module-cache.compilation-time        | timer     | times each contract compilation when adding to module cache
 soroban.module-cache.rebuild-time            | timer     | times each rebuild of module cache (including all compilations)
 soroban.module-cache.rebuild-bytes           | counter   | bytes of WASM bytecode compiled in last rebuild of module cache
+soroban.in-memory-state.contract-code-size   | counter   | size in bytes of non-evicted ContractCode entries according to memory cost model
+soroban.in-memory-state.contract-data-size   | counter   | size in bytes of ContractData entries in memory
+soroban.in-memory-state.contract-code-entries   | counter   | number of ContractCode entries in memory
+soroban.in-memory-state.contract-data-entries   | counter   | number of ContractData entries in memory

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -103,6 +103,8 @@ class BucketManager : NonMovableOrCopyable
     medida::Counter& mArchiveBucketListSizeCounter;
     medida::Meter& mCacheHitMeter;
     medida::Meter& mCacheMissMeter;
+    medida::Counter& mLiveBucketIndexCacheEntries;
+    medida::Counter& mLiveBucketIndexCacheBytes;
     EvictionCounters mBucketListEvictionCounters;
     MergeCounters mLiveMergeCounters;
     MergeCounters mHotArchiveMergeCounters;
@@ -168,6 +170,8 @@ class BucketManager : NonMovableOrCopyable
     template <class BucketT>
     void noteEmptyMergeOutputInternal(MergeKey const& mergeKey,
                                       FutureMapT<BucketT>& futureMap);
+
+    void reportLiveBucketIndexCacheMetrics();
 
 #ifdef BUILD_TESTS
     bool mUseFakeTestValuesForNextClose{false};

--- a/src/bucket/LiveBucket.cpp
+++ b/src/bucket/LiveBucket.cpp
@@ -327,6 +327,16 @@ LiveBucket::containsBucketIdentity(BucketEntry const& id) const
     return false;
 }
 
+size_t
+LiveBucket::getIndexCacheSize() const
+{
+    if (mIndex)
+    {
+        return mIndex->getCurrentCacheSize();
+    }
+    return 0;
+}
+
 #ifdef BUILD_TESTS
 void
 LiveBucket::apply(Application& app) const

--- a/src/bucket/LiveBucket.h
+++ b/src/bucket/LiveBucket.h
@@ -60,6 +60,9 @@ class LiveBucket : public BucketBase<LiveBucket, LiveBucketIndex>,
     // BucketEntry exists in the bucket. For testing.
     bool containsBucketIdentity(BucketEntry const& id) const;
 
+    // Returns the current cache size for this bucket's index
+    size_t getIndexCacheSize() const;
+
     // At version 11, we added support for INITENTRY and METAENTRY. Before this
     // we were only supporting LIVEENTRY and DEADENTRY.
     static constexpr ProtocolVersion

--- a/src/bucket/LiveBucketIndex.cpp
+++ b/src/bucket/LiveBucketIndex.cpp
@@ -400,6 +400,18 @@ LiveBucketIndex::getMaxCacheSize() const
 }
 #endif
 
+size_t
+LiveBucketIndex::getCurrentCacheSize() const
+{
+    if (shouldUseCache())
+    {
+        std::shared_lock<std::shared_mutex> lock(mCacheMutex);
+        return mCache->size();
+    }
+
+    return 0;
+}
+
 template LiveBucketIndex::LiveBucketIndex(BucketManager const& bm,
                                           cereal::BinaryInputArchive& ar,
                                           std::streamoff pageSize);

--- a/src/bucket/LiveBucketIndex.h
+++ b/src/bucket/LiveBucketIndex.h
@@ -153,5 +153,6 @@ class LiveBucketIndex : public NonMovableOrCopyable
     bool operator==(LiveBucketIndex const& in) const;
     size_t getMaxCacheSize() const;
 #endif
+    size_t getCurrentCacheSize() const;
 };
 }

--- a/src/ledger/InMemorySorobanState.h
+++ b/src/ledger/InMemorySorobanState.h
@@ -22,6 +22,8 @@
 namespace stellar
 {
 
+class SorobanMetrics;
+
 // TTLData stores both liveUntilLedgerSeq and lastModifiedLedgerSeq for TTL
 // entries. This allows us to construct a LedgerEntry for TTLs without having to
 // redundantly store the keyHash.
@@ -309,10 +311,11 @@ class InMemorySorobanState : public NonMovableOrCopyable
 
     // Total size of the in-memory state in bytes as defined by the protocol (
     // including using the in-memory module size for the ContractCode entries).
-    // Note, that this is int64 and not uint64 even though we store this in
+    // Note, that these are int64 and not uint64 even though we store this in
     // ledger as uint64 - neither of the type limits is realistically
     // reachable, but signed int makes math simpler and safer.
-    int64_t mStateSize = 0;
+    int64_t mContractCodeStateSize = 0;
+    int64_t mContractDataStateSize = 0;
 
     // Helper to update an existing ContractData entry's TTL without changing
     // data
@@ -326,7 +329,8 @@ class InMemorySorobanState : public NonMovableOrCopyable
     void checkUpdateInvariants() const;
 
     void updateStateSizeOnEntryUpdate(uint32_t oldEntrySize,
-                                      uint32_t newEntrySize);
+                                      uint32_t newEntrySize,
+                                      bool isContractCode);
 
     // Returns the TTL entry for the given key, or nullptr if not found.
     // LedgerKey must be of type TTL.
@@ -391,6 +395,8 @@ class InMemorySorobanState : public NonMovableOrCopyable
     // memory config settings have been changed, or protocol version has been
     // updated.
     uint64_t getSize() const;
+
+    void reportMetrics(SorobanMetrics& metrics) const;
 
     // Returns the entry for the given key, or nullptr if not found.
     std::shared_ptr<LedgerEntry const> get(LedgerKey const& ledgerKey) const;

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -355,6 +355,17 @@ LedgerManagerImpl::ApplyState::getSorobanInMemoryStateSize() const
 }
 
 void
+LedgerManagerImpl::ApplyState::reportInMemoryMetrics(
+    SorobanMetrics& metrics) const
+{
+    // This assert is not strictly necessary, but we don't really want to
+    // access the state size outside of the snapshotting process during the
+    // LEDGER_CLOSE or SETTING_UP_STATE phase.
+    assertWritablePhase();
+    mInMemorySorobanState.reportMetrics(metrics);
+}
+
+void
 LedgerManagerImpl::ApplyState::manuallyAdvanceLedgerHeader(
     LedgerHeader const& lh)
 {
@@ -1149,6 +1160,8 @@ LedgerManagerImpl::publishSorobanMetrics()
     m.mConfigBucketListTargetSizeByte.set_count(
         conf.sorobanStateTargetSizeBytes());
     m.mConfigFeeWrite1KB.set_count(conf.feeRent1KB());
+
+    mApplyState.reportInMemoryMetrics(m);
 
     // then publish the actual ledger usage
     m.publishAndResetLedgerWideMetrics();

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -242,9 +242,10 @@ class LedgerManagerImpl : public LedgerManager
                                    std::vector<LedgerKey> const& deadEntries,
                                    LedgerHeader const& lh);
 
-        // Note: This is a const getter, but should still only be called in the
+        // Note: These are const getters, but should still only be called in the
         // COMMITTING phase.
         uint64_t getSorobanInMemoryStateSize() const;
+        void reportInMemoryMetrics(SorobanMetrics& metrics) const;
 
         void manuallyAdvanceLedgerHeader(LedgerHeader const& lh);
         // Finishes a compilation started by `startCompilingAllContracts`.

--- a/src/ledger/SorobanMetrics.cpp
+++ b/src/ledger/SorobanMetrics.cpp
@@ -145,6 +145,14 @@ SorobanMetrics::SorobanMetrics(medida::MetricsRegistry& metrics)
           metrics.NewTimer({"soroban", "module-cache", "rebuild-time"}))
     , mModuleCacheRebuildBytes(
           metrics.NewCounter({"soroban", "module-cache", "rebuild-bytes"}))
+    , mContractCodeStateSize(metrics.NewCounter(
+          {"soroban", "in-memory-state", "contract-code-size"}))
+    , mContractDataStateSize(metrics.NewCounter(
+          {"soroban", "in-memory-state", "contract-data-size"}))
+    , mContractCodeEntryCount(metrics.NewCounter(
+          {"soroban", "in-memory-state", "contract-code-entries"}))
+    , mContractDataEntryCount(metrics.NewCounter(
+          {"soroban", "in-memory-state", "contract-data-entries"}))
 
 {
 }

--- a/src/ledger/SorobanMetrics.h
+++ b/src/ledger/SorobanMetrics.h
@@ -119,6 +119,12 @@ class SorobanMetrics
     medida::Timer& mModuleCacheRebuildTime;
     medida::Counter& mModuleCacheRebuildBytes;
 
+    // In-memory state metrics
+    medida::Counter& mContractCodeStateSize;
+    medida::Counter& mContractDataStateSize;
+    medida::Counter& mContractCodeEntryCount;
+    medida::Counter& mContractDataEntryCount;
+
     SorobanMetrics(medida::MetricsRegistry& metrics);
 
     void accumulateModelledCpuInsns(uint64_t insnsCount,


### PR DESCRIPTION
# Description

Resolves #4868

Adds metrics to report the entry count and size of soroban state cache, BucketListDB account cache, and soroban module cache. For the state cache, we report the exact entry count and byte size of ContractData. For the module cache, we report the size of all non-evicted modules based on their modeled memory usage. This may differ from the actual module cache memory usage, since actual memory may be slightly lower than the model and the module cache is garbage collected at a slower rate than eviction. However, this should be generally correct.

For the BucketListDB account cache, I report the number of cached entries and an estimate of the byte size. This avoids doing additional calls to `xdr::xdr_size`, and given that Account entries are much more uniform than soroban entry sizes, this estimate should be good enough.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
