### PR TITLE
Real races and other minor fixes

### DIFF
--- a/lib/autocheck/include/autocheck/generator_combinators.hpp
+++ b/lib/autocheck/include/autocheck/generator_combinators.hpp
@@ -13,9 +13,7 @@ namespace autocheck {
     class mapped_generator {
       public:
         typedef
-          typename std::result_of<
-            Func(typename Gen::result_type&&, size_t)
-          >::type
+          typename std::invoke_result_t<Func, typename Gen::result_type&&, size_t>
           result_type;
 
       private:

--- a/src/bucket/BucketManager.cpp
+++ b/src/bucket/BucketManager.cpp
@@ -399,6 +399,10 @@ BucketManager::reportLiveBucketIndexCacheMetrics()
 
     mLiveBucketIndexCacheEntries.set_count(totalCacheEntries);
     mLiveBucketIndexCacheBytes.set_count(totalEstimatedBytes);
+    TracyPlot("bucketlistDB.cache.entries",
+              static_cast<int64_t>(totalCacheEntries));
+    TracyPlot("bucketlistDB.cache.bytes",
+              static_cast<int64_t>(totalEstimatedBytes));
 }
 
 template <>

--- a/src/bucket/DiskIndex.cpp
+++ b/src/bucket/DiskIndex.cpp
@@ -156,7 +156,7 @@ DiskIndex<BucketT>::DiskIndex(BucketManager& bm,
     std::streamoff pageUpperBound = 0;
     typename BucketT::EntryT be;
     size_t iter = 0;
-    size_t count = 0;
+    size_t _count = 0;
 
     std::vector<uint64_t> keyHashes;
     auto seed = shortHash::getShortHashInitKey();
@@ -182,7 +182,7 @@ DiskIndex<BucketT>::DiskIndex(BucketManager& bm,
 
         if (!isBucketMetaEntry<BucketT>(be))
         {
-            ++count;
+            ++_count;
             LedgerKey key = getBucketLedgerKey(be);
 
             // Track type boundaries
@@ -291,7 +291,7 @@ DiskIndex<BucketT>::DiskIndex(BucketManager& bm,
 
     CLOG_DEBUG(Bucket, "Indexed {} positions in {}", mData.keysToOffset.size(),
                filename.filename());
-    ZoneValue(static_cast<int64_t>(count));
+    ZoneValue(static_cast<int64_t>(_count));
 
     if (bm.getConfig().BUCKETLIST_DB_PERSIST_INDEX)
     {

--- a/src/bucket/test/BucketIndexTests.cpp
+++ b/src/bucket/test/BucketIndexTests.cpp
@@ -177,7 +177,7 @@ class BucketIndexTest
             // Sample ~4% of entries if not a cache test
             // For cache tests we want to load all entries to test eviction
             // behavior
-            if (isCacheTest || mDist(gRandomEngine) < 10)
+            if (isCacheTest || mDist(getGlobalRandomEngine()) < 10)
             {
                 for (auto const& e : entries)
                 {
@@ -254,7 +254,7 @@ class BucketIndexTest
         std::vector<LedgerEntry> toUpdate;
         auto f = [&](std::vector<LedgerEntry> const& entries) {
             // Actually update/destroy entries for ~4% of ledgers
-            if (mDist(gRandomEngine) < 10)
+            if (mDist(getGlobalRandomEngine()) < 10)
             {
                 for (auto& e : toUpdate)
                 {
@@ -300,7 +300,7 @@ class BucketIndexTest
             else
             {
                 // Sample ~15% of entries to be destroyed/updated
-                if (mDist(gRandomEngine) < 40)
+                if (mDist(getGlobalRandomEngine()) < 40)
                 {
                     for (auto const& e : entries)
                     {
@@ -649,7 +649,7 @@ class BucketIndexPoolShareTest : public BucketIndexTest
             std::vector<LedgerEntry> poolEntries;
             std::vector<LedgerKey> toDelete;
             std::vector<LedgerEntry> toUpdate;
-            if (mDist(gRandomEngine) < 30)
+            if (mDist(getGlobalRandomEngine()) < 30)
             {
                 auto pool =
                     LedgerTestUtils::generateValidUniqueLedgerEntriesWithTypes(
@@ -693,7 +693,8 @@ class BucketIndexPoolShareTest : public BucketIndexTest
                 entries.emplace_back(trustline2);
             }
             // Write new version via delete
-            else if (shouldMultiVersion && mDist(gRandomEngine) < 10 &&
+            else if (shouldMultiVersion &&
+                     mDist(getGlobalRandomEngine()) < 10 &&
                      !mTestEntries.empty())
             {
                 // Arbitrarily pick first entry of map
@@ -702,7 +703,8 @@ class BucketIndexPoolShareTest : public BucketIndexTest
                 mTestEntries.erase(iter);
             }
             // Write new version via modify
-            else if (shouldMultiVersion && mDist(gRandomEngine) < 10 &&
+            else if (shouldMultiVersion &&
+                     mDist(getGlobalRandomEngine()) < 10 &&
                      !mTestEntries.empty())
             {
                 // Arbitrarily pick first entry of map

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -763,7 +763,7 @@ sizeOfTests()
     {
         for (uint32_t level = 0; level < BucketListT::kNumLevels; ++level)
         {
-            uint32_t ledger = dist(gRandomEngine);
+            uint32_t ledger = dist(getGlobalRandomEngine());
             if (BucketListT::sizeOfSnap(ledger, level) > 0)
             {
                 uint32_t oldestInCurr =
@@ -826,8 +826,8 @@ snapSteadyStateTest()
         stellar::uniform_int_distribution<uint32_t> distHigh(boundary);
         for (uint32_t i = 0; i < 1000; ++i)
         {
-            uint32_t low = distLow(gRandomEngine);
-            uint32_t high = distHigh(gRandomEngine);
+            uint32_t low = distLow(getGlobalRandomEngine());
+            uint32_t high = distHigh(getGlobalRandomEngine());
             REQUIRE(BucketListT::sizeOfSnap(low, level) < half);
             REQUIRE(BucketListT::sizeOfSnap(high, level) == half);
         }
@@ -863,8 +863,8 @@ deepestCurrTest()
     stellar::uniform_int_distribution<uint32_t> distHigh(boundary);
     for (uint32_t i = 0; i < 1000; ++i)
     {
-        uint32_t low = distLow(gRandomEngine);
-        uint32_t high = distHigh(gRandomEngine);
+        uint32_t low = distLow(getGlobalRandomEngine());
+        uint32_t high = distHigh(getGlobalRandomEngine());
         REQUIRE(BucketListT::sizeOfCurr(low, deepest) == 0);
         REQUIRE(BucketListT::oldestLedgerInCurr(low, deepest) ==
                 std::numeric_limits<uint32_t>::max());

--- a/src/bucket/test/BucketTests.cpp
+++ b/src/bucket/test/BucketTests.cpp
@@ -240,7 +240,8 @@ TEST_CASE_VERSIONS("merging bucket entries", "[bucket]")
             {
                 liveIdxs.emplace_back(i);
             }
-            stellar::shuffle(liveIdxs.begin(), liveIdxs.end(), gRandomEngine);
+            stellar::shuffle(liveIdxs.begin(), liveIdxs.end(),
+                             getGlobalRandomEngine());
             for (size_t src = 0; src < live.size(); ++src)
             {
                 size_t dst = liveIdxs.at(src);

--- a/src/crypto/Random.cpp
+++ b/src/crypto/Random.cpp
@@ -21,7 +21,7 @@ randomBytes(size_t length)
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     stellar::uniform_int_distribution<unsigned short> dist(0, 255);
     std::generate(vec.begin(), vec.end(), [&]() {
-        return static_cast<uint8_t>(dist(stellar::gRandomEngine));
+        return static_cast<uint8_t>(dist(stellar::getGlobalRandomEngine()));
     });
 #else
     randombytes_buf(vec.data(), length);

--- a/src/crypto/SecretKey.cpp
+++ b/src/crypto/SecretKey.cpp
@@ -618,7 +618,7 @@ Hash
 HashUtils::pseudoRandomForTesting()
 {
     Hash res;
-    auto bytes = getPRNGBytes(res.size(), gRandomEngine);
+    auto bytes = getPRNGBytes(res.size(), getGlobalRandomEngine());
     for (size_t i = 0; i < bytes.size(); ++i)
     {
         res[i] = bytes[i];

--- a/src/crypto/test/CryptoTests.cpp
+++ b/src/crypto/test/CryptoTests.cpp
@@ -324,7 +324,7 @@ TEST_CASE("StrKey tests", "[crypto]")
 
     auto randomB32 = []() {
         char res;
-        char d = static_cast<char>(gRandomEngine() % 32);
+        char d = static_cast<char>(getGlobalRandomEngine()() % 32);
         if (d < 6)
         {
             res = d + '2';

--- a/src/database/test/DatabaseTests.cpp
+++ b/src/database/test/DatabaseTests.cpp
@@ -296,7 +296,7 @@ TEST_CASE("postgres performance", "[db][pgperf][!hide]")
                 soci::transaction sqltx(session);
                 for (int64_t j = 0; j < sz; ++j)
                 {
-                    int64_t r = dist(gRandomEngine);
+                    int64_t r = dist(getGlobalRandomEngine());
                     session << "insert into txtest (a,b,c) values (:a,:b,:c)",
                         soci::use(r), soci::use(pk), soci::use(j);
                 }
@@ -316,7 +316,7 @@ TEST_CASE("postgres performance", "[db][pgperf][!hide]")
                 soci::transaction subtx(session);
                 for (int64_t k = 0; k < div; ++k)
                 {
-                    int64_t r = dist(gRandomEngine);
+                    int64_t r = dist(getGlobalRandomEngine());
                     pk++;
                     session << "insert into txtest (a,b,c) values (:a,:b,:c)",
                         soci::use(r), soci::use(pk), soci::use(k);

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1974,8 +1974,7 @@ HerderImpl::checkAndMaybeReanalyzeQuorumMap()
         mLastQuorumMapIntersectionState->mInterruptFlag = false;
         mLastQuorumMapIntersectionState->mCheckingQuorumMapHash = curr;
         auto& cfg = mApp.getConfig();
-        releaseAssert(threadIsMain());
-        auto seed = gRandomEngine();
+        auto seed = getGlobalRandomEngine()();
 
         auto ledger = trackingConsensusLedgerIndex();
         auto nNodes = qmap.size();

--- a/src/herder/QuorumIntersectionCheckerImpl.cpp
+++ b/src/herder/QuorumIntersectionCheckerImpl.cpp
@@ -277,7 +277,7 @@ QuorumIntersectionCheckerImpl::QuorumIntersectionCheckerImpl(
     , mQuiet(quiet)
     , mTSC()
     , mInterruptFlag(interruptFlag)
-    , mCachedQuorums(MAX_CACHED_QUORUMS_SIZE)
+    , mCachedQuorums(MAX_CACHED_QUORUMS_SIZE, /*separatePRNG=*/true)
     , mRand(seed)
 {
     buildGraph(qmap);

--- a/src/herder/SurgePricingUtils.cpp
+++ b/src/herder/SurgePricingUtils.cpp
@@ -71,8 +71,11 @@ computeBetterFee(TransactionFrameBase const& tx, int64_t refFeeBid,
 }
 
 SurgePricingPriorityQueue::TxComparator::TxComparator(bool isGreater,
-                                                      size_t seed)
-    : mIsGreater(isGreater), mSeed(seed)
+                                                      size_t _seed)
+    : mIsGreater(isGreater)
+#ifndef BUILD_TESTS
+    , mSeed(_seed)
+#endif
 {
 }
 

--- a/src/herder/SurgePricingUtils.h
+++ b/src/herder/SurgePricingUtils.h
@@ -222,7 +222,9 @@ class SurgePricingPriorityQueue
                         TransactionFrameBasePtr const& tx2) const;
 
         bool const mIsGreater;
+#ifndef BUILD_TESTS
         size_t mSeed;
+#endif
     };
 
     using TxSortedSet = std::set<TransactionFrameBasePtr, TxComparator>;

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -187,7 +187,7 @@ ClassicTransactionQueue::allowTxBroadcast(TimestampedTx const& tx)
                 std::geometric_distribution<uint32_t> dist(
                     mApp.getConfig().FLOOD_ARB_TX_DAMPING_FACTOR);
                 uint32_t k = maxBroadcast - allowance;
-                allowTx = dist(gRandomEngine) >= k;
+                allowTx = dist(getGlobalRandomEngine()) >= k;
             }
 
             // If we've decided to admit a tx, bump all pairs on the path.

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -5935,7 +5935,8 @@ testWeights(std::vector<ValidatorEntry> const& validators)
     {
         uint64_t weight = herder.getHerderSCPDriver().getNodeWeight(
             validator.mKey, cfg.QUORUM_SET, false);
-        double normalizedWeight = static_cast<double>(weight) / UINT64_MAX;
+        double normalizedWeight =
+            static_cast<double>(weight) / static_cast<double>(UINT64_MAX);
         normalizedOrgWeights[validator.mHomeDomain] += normalizedWeight;
 
         std::string const& org = validator.mHomeDomain;

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -2251,7 +2251,6 @@ testSCPDriver(uint32 protocolVersion, uint32_t maxTxSetSize, size_t expectedOps)
     {
         auto& herder = static_cast<HerderImpl&>(app->getHerder());
         auto seq = herder.trackingConsensusLedgerIndex() + 1;
-        auto ct = app->timeNow() + 1;
 
         auto& cache = herder.getHerderSCPDriver().getTxSetValidityCache();
         REQUIRE(cache.getCounters().mHits == 0);
@@ -4997,7 +4996,6 @@ TEST_CASE("do not flood too many transactions with DEX separation",
 
         auto app = simulation->getNode(mainKey.getPublicKey());
         auto const& cfg = app->getConfig();
-        auto& lm = app->getLedgerManager();
         auto& herder = static_cast<HerderImpl&>(app->getHerder());
         auto& tq = herder.getTransactionQueue();
 

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -5990,7 +5990,7 @@ TEST_CASE("getNodeWeight", "[herder]")
 static Value
 getRandomValue()
 {
-    auto h = sha256(fmt::format("value {}", gRandomEngine()));
+    auto h = sha256(fmt::format("value {}", getGlobalRandomEngine()()));
     return xdr::xdr_to_opaque(h);
 }
 
@@ -6452,7 +6452,7 @@ testUnresponsiveTimeouts(Topology const& qs, int numUnresponsive,
     std::transform(validators.begin(), validators.end(),
                    std::back_inserter(nodeIDs),
                    [](ValidatorEntry const& v) { return v.mKey; });
-    stellar::shuffle(nodeIDs.begin(), nodeIDs.end(), gRandomEngine);
+    stellar::shuffle(nodeIDs.begin(), nodeIDs.end(), getGlobalRandomEngine());
     std::set<NodeID> unresponsive(nodeIDs.begin(),
                                   nodeIDs.begin() + numUnresponsive);
 

--- a/src/herder/test/QuorumIntersectionTests.cpp
+++ b/src/herder/test/QuorumIntersectionTests.cpp
@@ -134,7 +134,7 @@ runIntersectionCriticalGroupsCheck(QuorumTracker::QuorumMap const& initQmap,
         [&interruptFlag](QuorumIntersectionChecker::QuorumSetMap const& qmap,
                          std::optional<Config> const& config) -> bool {
         auto checker = QuorumIntersectionChecker::create(
-            qmap, config, interruptFlag, gRandomEngine());
+            qmap, config, interruptFlag, getGlobalRandomEngine()());
         return checker->networkEnjoysQuorumIntersection();
     };
     return QuorumIntersectionChecker::getIntersectionCriticalGroups(
@@ -199,8 +199,8 @@ TEST_CASE("quorum intersection basic 4-node", "[herder][quorumintersection]")
 
     Config cfg(getTestConfig());
     std::atomic<bool> flag{false};
-    auto qic =
-        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag,
+                                                 getGlobalRandomEngine()());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 
     REQUIRE(networkEnjoysQuorumIntersectionV2Wrapper(qm, cfg));
@@ -227,8 +227,8 @@ TEST_CASE("quorum non intersection basic 4-node",
 
     Config cfg(getTestConfig());
     std::atomic<bool> flag{false};
-    auto qic =
-        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag,
+                                                 getGlobalRandomEngine()());
     REQUIRE(!qic->networkEnjoysQuorumIntersection());
 
     REQUIRE(!networkEnjoysQuorumIntersectionV2Wrapper(qm, cfg));
@@ -260,8 +260,8 @@ TEST_CASE("quorum non intersection 6-node", "[herder][quorumintersection]")
 
     Config cfg(getTestConfig());
     std::atomic<bool> flag{false};
-    auto qic =
-        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag,
+                                                 getGlobalRandomEngine()());
     REQUIRE(!qic->networkEnjoysQuorumIntersection());
 
     REQUIRE(!networkEnjoysQuorumIntersectionV2Wrapper(qm, cfg));
@@ -310,8 +310,8 @@ TEST_CASE("quorum intersection 6-node with subquorums",
 
     Config cfg(getTestConfig());
     std::atomic<bool> flag{false};
-    auto qic =
-        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag,
+                                                 getGlobalRandomEngine()());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 
     REQUIRE(networkEnjoysQuorumIntersectionV2Wrapper(qm, cfg));
@@ -344,8 +344,8 @@ TEST_CASE("quorum non intersection basic 6-node",
 
     Config cfg(getTestConfig());
     std::atomic<bool> flag{false};
-    auto qic =
-        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag,
+                                                 getGlobalRandomEngine()());
     REQUIRE(!qic->networkEnjoysQuorumIntersection());
 
     REQUIRE(!networkEnjoysQuorumIntersectionV2Wrapper(qm, cfg));
@@ -397,8 +397,8 @@ TEST_CASE("quorum non intersection 6-node with subquorums",
 
     Config cfg(getTestConfig());
     std::atomic<bool> flag{false};
-    auto qic =
-        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag,
+                                                 getGlobalRandomEngine()());
     REQUIRE(!qic->networkEnjoysQuorumIntersection());
 
     REQUIRE(!networkEnjoysQuorumIntersectionV2Wrapper(qm, cfg));
@@ -476,8 +476,8 @@ TEST_CASE("quorum plausible non intersection", "[herder][quorumintersection]")
     qm[pkCOINQVEST2] = QuorumTracker::NodeInfo{qsCOINQVEST, 0};
 
     std::atomic<bool> flag{false};
-    auto qic =
-        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag,
+                                                 getGlobalRandomEngine()());
     REQUIRE(!qic->networkEnjoysQuorumIntersection());
 
     REQUIRE(!networkEnjoysQuorumIntersectionV2Wrapper(qm, cfg));
@@ -617,8 +617,8 @@ TEST_CASE("quorum intersection 4-org fully-connected - elide all minquorums",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic =
-        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag,
+                                                 getGlobalRandomEngine()());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 
     REQUIRE(networkEnjoysQuorumIntersectionV2Wrapper(qm, cfg));
@@ -638,8 +638,8 @@ TEST_CASE("quorum intersection 3-org 3-node open line",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic =
-        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag,
+                                                 getGlobalRandomEngine()());
     REQUIRE(!qic->networkEnjoysQuorumIntersection());
 
     REQUIRE(!networkEnjoysQuorumIntersectionV2Wrapper(qm, cfg));
@@ -658,8 +658,8 @@ TEST_CASE("quorum intersection 3-org 2-node open line",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic =
-        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag,
+                                                 getGlobalRandomEngine()());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 
     REQUIRE(networkEnjoysQuorumIntersectionV2Wrapper(qm, cfg));
@@ -681,8 +681,8 @@ TEST_CASE("quorum intersection 3-org 3-node closed ring",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic =
-        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag,
+                                                 getGlobalRandomEngine()());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 
     REQUIRE(networkEnjoysQuorumIntersectionV2Wrapper(qm, cfg));
@@ -709,8 +709,8 @@ TEST_CASE("quorum intersection 3-org 3-node closed one-way ring",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic =
-        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag,
+                                                 getGlobalRandomEngine()());
     REQUIRE(!qic->networkEnjoysQuorumIntersection());
 
     REQUIRE(!networkEnjoysQuorumIntersectionV2Wrapper(qm, cfg));
@@ -737,8 +737,8 @@ TEST_CASE("quorum intersection 3-org 2-node closed one-way ring",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic =
-        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag,
+                                                 getGlobalRandomEngine()());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 
     REQUIRE(networkEnjoysQuorumIntersectionV2Wrapper(qm, cfg));
@@ -770,8 +770,8 @@ TEST_CASE("quorum intersection 3-org 2-node 2-of-3 asymmetric",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic =
-        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag,
+                                                 getGlobalRandomEngine()());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 
     REQUIRE(networkEnjoysQuorumIntersectionV2Wrapper(qm, cfg));
@@ -820,8 +820,8 @@ TEST_CASE("quorum intersection 8-org core-and-periphery dangling",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic =
-        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag,
+                                                 getGlobalRandomEngine()());
     REQUIRE(!qic->networkEnjoysQuorumIntersection());
 
     REQUIRE(!networkEnjoysQuorumIntersectionV2Wrapper(qm, cfg));
@@ -876,8 +876,8 @@ TEST_CASE("quorum intersection 8-org core-and-periphery balanced",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic =
-        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag,
+                                                 getGlobalRandomEngine()());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 
     REQUIRE(networkEnjoysQuorumIntersectionV2Wrapper(qm, cfg));
@@ -927,8 +927,8 @@ TEST_CASE("quorum intersection 8-org core-and-periphery unbalanced",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic =
-        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag,
+                                                 getGlobalRandomEngine()());
     REQUIRE(!qic->networkEnjoysQuorumIntersection());
 
     REQUIRE(!networkEnjoysQuorumIntersectionV2Wrapper(qm, cfg));
@@ -983,8 +983,8 @@ TEST_CASE("quorum intersection 6-org 1-node 4-null qsets",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic =
-        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag,
+                                                 getGlobalRandomEngine()());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
     REQUIRE(qic->getMaxQuorumsFound() == 0);
 
@@ -1032,8 +1032,8 @@ TEST_CASE("quorum intersection 4-org 1-node 4-null qsets",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic =
-        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag,
+                                                 getGlobalRandomEngine()());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
     REQUIRE(qic->getMaxQuorumsFound() == 0);
 
@@ -1048,8 +1048,8 @@ TEST_CASE("quorum intersection 6-org 3-node fully-connected",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic =
-        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag,
+                                                 getGlobalRandomEngine()());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 
     REQUIRE(networkEnjoysQuorumIntersectionV2Wrapper(qm, cfg));
@@ -1065,8 +1065,8 @@ TEST_CASE("quorum intersection scaling test",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic =
-        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag,
+                                                 getGlobalRandomEngine()());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 
     REQUIRE(networkEnjoysQuorumIntersectionV2Wrapper(qm, cfg));
@@ -1091,7 +1091,7 @@ TEST_CASE("quorum intersection interruption", "[herder][quorumintersection]")
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> interruptFlag{false};
     auto qic = QuorumIntersectionChecker::create(qm, cfg, interruptFlag,
-                                                 gRandomEngine());
+                                                 getGlobalRandomEngine()());
     std::thread canceller([&interruptFlag]() {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
         interruptFlag = true;
@@ -1229,8 +1229,8 @@ TEST_CASE("quorum intersection criticality",
     cfg = configureShortNames(cfg, orgs);
     debugQmap(cfg, qm);
     std::atomic<bool> flag{false};
-    auto qic =
-        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag,
+                                                 getGlobalRandomEngine()());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 
     auto groups = runIntersectionCriticalGroupsCheck(qm, cfg, flag);
@@ -1295,8 +1295,8 @@ TEST_CASE("quorum intersection finds smaller SCC with quorums",
     cfg = configureShortNames(cfg, orgs);
     debugQmap(cfg, qm);
     std::atomic<bool> flag{false};
-    auto qic =
-        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag,
+                                                 getGlobalRandomEngine()());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
     REQUIRE(qic->getMaxQuorumsFound() != 0);
 

--- a/src/herder/test/TxSetTests.cpp
+++ b/src/herder/test/TxSetTests.cpp
@@ -3179,8 +3179,6 @@ TEST_CASE("parallel tx set building benchmark",
             int txSize = genValue(txSizeDistr, MAX_TX_SIZE);
             int readBytes = genValue(readBytesDistr, MAX_READ_BYTES_PER_TX);
             int writeBytes = genValue(writeBytesDistr, MAX_WRITE_BYTES_PER_TX);
-            int readCount = genValue(readCountDistr, MAX_READS_PER_TX);
-            int writeCount = genValue(writeCountDistr, MAX_WRITES_PER_TX);
             txs.push_back(createTx(insns, txKeys[i].first, txKeys[i].second,
                                    feeDistr(Catch::rng()), readBytes,
                                    writeBytes, txSize));

--- a/src/herder/test/TxSetTests.cpp
+++ b/src/herder/test/TxSetTests.cpp
@@ -360,15 +360,15 @@ TEST_CASE("generalized tx set XDR validation", "[txset]")
             parallelPhase({{2}, {}}, false), false,
             "parallel Soroban - one of the stages has no clusters");
         scenarios[1].emplace_back(
-            parallelPhase({{2}, {{0}}, {3, 5}}, false), false,
+            parallelPhase({{2}, {0}, {3, 5}}, false), false,
             "parallel Soroban - one of the stages has empty cluster");
         scenarios[1].emplace_back(
-            parallelPhase({{2}, {{0}}}, false), false,
+            parallelPhase({{2}, {0}}, false), false,
             "parallel Soroban - one of the stages has empty cluster");
         scenarios[1].emplace_back(parallelPhase({{}, {}, {}}, false), false,
                                   "parallel Soroban - multiple empty stages");
         scenarios[1].emplace_back(
-            parallelPhase({{{}, {0}}, {{0}}, {}}, false), false,
+            parallelPhase({{{}, 0}, {0}, {}}, false), false,
             "parallel Soroban - multiple empty and empty cluster stages");
         scenarios[1].emplace_back(
             parallelPhase({{10, 2, 0, 1, 3}}, false), false,

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -3820,8 +3820,7 @@ TEST_CASE("upgrade state size window", "[bucketlist][upgrades]")
     };
 
     // Write some data to the ledger
-    auto& contract =
-        test.deployWasmContract(rust_bridge::get_random_wasm(2000, 100));
+    test.deployWasmContract(rust_bridge::get_random_wasm(2000, 100));
 
     uint64_t const expectedInMemorySize = 81297;
 

--- a/src/history/HistoryArchiveManager.cpp
+++ b/src/history/HistoryArchiveManager.cpp
@@ -162,7 +162,7 @@ HistoryArchiveManager::selectRandomReadableHistoryArchive() const
     else
     {
         stellar::uniform_int_distribution<size_t> dist(0, archives.size() - 1);
-        size_t i = dist(gRandomEngine);
+        size_t i = dist(getGlobalRandomEngine());
         CLOG_DEBUG(History, "Fetching from readable history archive #{}, '{}'",
                    i, archives[i]->getName());
         return archives[i];

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -607,7 +607,6 @@ CatchupSimulation::generateRandomLedger(uint32_t version)
 
     auto& txsSucceeded =
         getApp().getMetrics().NewCounter({"ledger", "apply", "success"});
-    auto lastSucceeded = txsSucceeded.count();
 
     lm.applyLedger(mLedgerCloseDatas.back());
 

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -476,7 +476,7 @@ CatchupSimulation::generateRandomLedger(uint32_t version)
                                           &carol,     &eve,   &stroopy};
     stellar::uniform_int_distribution<> accountDistr(0, accounts.size() - 1);
     auto randomAccount = [&accounts, &accountDistr]() -> TestAccount& {
-        return *accounts.at(accountDistr(gRandomEngine));
+        return *accounts.at(accountDistr(getGlobalRandomEngine()));
     };
 
     std::vector<TransactionFrameBasePtr> txs;

--- a/src/invariant/test/AccountSubEntriesCountIsValidTests.cpp
+++ b/src/invariant/test/AccountSubEntriesCountIsValidTests.cpp
@@ -229,14 +229,14 @@ modifyRandomSubEntryFromAccount(Application& app, LedgerEntry& le,
     {
         stellar::uniform_int_distribution<uint32_t> dist(
             0, uint32_t(acc.signers.size()) - 1);
-        acc.signers.at(dist(gRandomEngine)) = validSignerGenerator();
+        acc.signers.at(dist(getGlobalRandomEngine())) = validSignerGenerator();
         updateAccountSubEntries(app, le, lePrev, 0, {});
     }
     else
     {
         stellar::uniform_int_distribution<uint32_t> dist(
             0, uint32_t(subentries.size()) - 1);
-        auto index = dist(gRandomEngine);
+        auto index = dist(getGlobalRandomEngine());
         auto se = subentries.at(index);
         auto se2 = generateRandomModifiedSubEntry(le, se);
         subentries.at(index) = se2;
@@ -266,7 +266,7 @@ deleteRandomSubEntryFromAccount(Application& app, LedgerEntry& le,
         stellar::uniform_int_distribution<uint32_t> dist(
             0, uint32_t(acc.signers.size()) - 1);
 
-        auto pos = dist(gRandomEngine);
+        auto pos = dist(getGlobalRandomEngine());
         acc.signers.erase(acc.signers.begin() + pos);
         if (hasAccountEntryExtV2(acc))
         {
@@ -280,7 +280,7 @@ deleteRandomSubEntryFromAccount(Application& app, LedgerEntry& le,
     {
         stellar::uniform_int_distribution<uint32_t> dist(
             0, uint32_t(subentries.size()) - 1);
-        auto index = dist(gRandomEngine);
+        auto index = dist(getGlobalRandomEngine());
         auto se = subentries.at(index);
         subentries.erase(subentries.begin() + index);
         updateAccountSubEntries(app, le, lePrev,
@@ -323,7 +323,7 @@ TEST_CASE("Create account then add signers and subentries",
         std::vector<LedgerEntry> subentries;
         for (uint32_t j = 0; j < 50; ++j)
         {
-            auto change = changesDist(gRandomEngine);
+            auto change = changesDist(getGlobalRandomEngine());
             if (change > 0 || le.data.account().numSubEntries == 0)
             {
                 addRandomSubEntryToAccount(*app, le, subentries);

--- a/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
+++ b/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
@@ -150,7 +150,7 @@ struct BucketListGenerator
         {
             auto dist = stellar::uniform_int_distribution<size_t>(
                 0, liveDeletable.size() - 1);
-            auto index = dist(gRandomEngine);
+            auto index = dist(getGlobalRandomEngine());
             auto iter = liveDeletable.begin();
             std::advance(iter, index);
             if (iter->type() == CONFIG_SETTING)
@@ -259,7 +259,7 @@ struct SelectBucketListGenerator : public BucketListGenerator
                 stellar::uniform_int_distribution<size_t> dist(
                     0, mLiveKeys.size() - 1);
                 auto iter = mLiveKeys.begin();
-                std::advance(iter, dist(gRandomEngine));
+                std::advance(iter, dist(getGlobalRandomEngine()));
 
                 mSelected = std::make_shared<LedgerEntry>(
                     ltx.loadWithoutRecord(*iter).current());
@@ -499,7 +499,7 @@ TEST_CASE("BucketListIsConsistentWithDatabase added entries",
             2, blg.mLedgerSeq);
         auto le =
             LedgerTestUtils::generateValidLedgerEntryWithTypes({OFFER}, 10);
-        le.lastModifiedLedgerSeq = addAtLedgerDist(gRandomEngine);
+        le.lastModifiedLedgerSeq = addAtLedgerDist(getGlobalRandomEngine());
         REQUIRE_THROWS_AS(blg.applyBuckets<ApplyBucketsWorkAddEntry>(le),
                           InvariantDoesNotHold);
     }
@@ -598,7 +598,8 @@ TEST_CASE("BucketListIsConsistentWithDatabase bucket bounds",
 
         for (uint32_t i = 0; i < 10; ++i)
         {
-            uint32_t ledgerToModify = ledgerToModifyDist(gRandomEngine);
+            uint32_t ledgerToModify =
+                ledgerToModifyDist(getGlobalRandomEngine());
             uint32_t maxLowTargetLedger = 0;
             uint32_t minHighTargetLedger = 0;
             if (ledgerToModify >=
@@ -622,8 +623,8 @@ TEST_CASE("BucketListIsConsistentWithDatabase bucket bounds",
             stellar::uniform_int_distribution<uint32_t> highTargetLedgerDist(
                 minHighTargetLedger, std::numeric_limits<int32_t>::max());
 
-            uint32_t lowTarget = lowTargetLedgerDist(gRandomEngine);
-            uint32_t highTarget = highTargetLedgerDist(gRandomEngine);
+            uint32_t lowTarget = lowTargetLedgerDist(getGlobalRandomEngine());
+            uint32_t highTarget = highTargetLedgerDist(getGlobalRandomEngine());
             for (auto target : {lowTarget, highTarget})
             {
                 LastModifiedBucketListGenerator blg(ledgerToModify, target);

--- a/src/invariant/test/LiabilitiesMatchOffersTests.cpp
+++ b/src/invariant/test/LiabilitiesMatchOffersTests.cpp
@@ -51,7 +51,7 @@ updateAccountWithRandomBalance(LedgerEntry le, Application& app,
     REQUIRE(lbound <= ubound);
 
     stellar::uniform_int_distribution<int64_t> dist(lbound, ubound);
-    account.balance = dist(gRandomEngine);
+    account.balance = dist(getGlobalRandomEngine());
     return le;
 }
 

--- a/src/ledger/InMemorySorobanState.cpp
+++ b/src/ledger/InMemorySorobanState.cpp
@@ -581,6 +581,14 @@ InMemorySorobanState::reportMetrics(SorobanMetrics& metrics) const
     metrics.mContractDataStateSize.set_count(mContractDataStateSize);
     metrics.mContractCodeEntryCount.set_count(mContractCodeEntries.size());
     metrics.mContractDataEntryCount.set_count(mContractDataEntries.size());
+    TracyPlot("soroban.in-memory-state.contract-code-size",
+              static_cast<int64_t>(mContractCodeStateSize));
+    TracyPlot("soroban.in-memory-state.contract-data-size",
+              static_cast<int64_t>(mContractDataStateSize));
+    TracyPlot("soroban.in-memory-state.contract-code-entries",
+              static_cast<int64_t>(mContractCodeEntries.size()));
+    TracyPlot("soroban.in-memory-state.contract-data-entries",
+              static_cast<int64_t>(mContractDataEntries.size()));
 }
 
 void

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1285,7 +1285,7 @@ maybeSimulateSleep(Config const& cfg, size_t opSize,
         {
             sleepFor +=
                 cfg.OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING[distribution(
-                    gRandomEngine)];
+                    getGlobalRandomEngine())];
         }
         std::chrono::microseconds applicationTime =
             closeTime.checkElapsedTime();

--- a/src/ledger/test/LedgerTxnTests.cpp
+++ b/src/ledger/test/LedgerTxnTests.cpp
@@ -501,7 +501,7 @@ TEST_CASE("LedgerTxn round trip", "[ledgertxn]")
         while (modifyBatch.size() < MODIFY_ENTRIES)
         {
             auto iter = entries.begin();
-            std::advance(iter, dist(gRandomEngine));
+            std::advance(iter, dist(getGlobalRandomEngine()));
             modifyBatch[iter->first] =
                 generateLedgerEntryWithSameKey(iter->second);
         }
@@ -524,7 +524,7 @@ TEST_CASE("LedgerTxn round trip", "[ledgertxn]")
         while (eraseBatch.size() < ERASE_ENTRIES)
         {
             auto iter = entries.begin();
-            std::advance(iter, dist(gRandomEngine));
+            std::advance(iter, dist(getGlobalRandomEngine()));
             if (iter->first.type() == CONFIG_SETTING)
             {
                 continue;
@@ -575,7 +575,7 @@ TEST_CASE("LedgerTxn round trip", "[ledgertxn]")
             generateModify(ltx1, updatedEntries);
             generateErase(ltx1, updatedEntries, updatedDead);
 
-            if (entries.empty() || shouldCommitDist(gRandomEngine))
+            if (entries.empty() || shouldCommitDist(getGlobalRandomEngine()))
             {
                 entries = updatedEntries;
                 dead = updatedDead;

--- a/src/main/test/ConfigTests.cpp
+++ b/src/main/test/ConfigTests.cpp
@@ -563,8 +563,8 @@ TEST_CASE("operation filter configuration", "[config]")
         {
             vals.emplace_back(static_cast<OperationType>(v));
         }
-        stellar::shuffle(vals.begin(), vals.end(), gRandomEngine);
-        vals.resize(dist(gRandomEngine));
+        stellar::shuffle(vals.begin(), vals.end(), getGlobalRandomEngine());
+        vals.resize(dist(getGlobalRandomEngine()));
         loadConfig(vals);
     }
 }

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -1174,7 +1174,7 @@ OverlayManagerImpl::extractPeersFromMap(
 void
 OverlayManagerImpl::shufflePeerList(std::vector<Peer::pointer>& peerList)
 {
-    stellar::shuffle(peerList.begin(), peerList.end(), gRandomEngine);
+    stellar::shuffle(peerList.begin(), peerList.end(), getGlobalRandomEngine());
 }
 
 bool

--- a/src/overlay/PeerManager.cpp
+++ b/src/overlay/PeerManager.cpp
@@ -159,8 +159,8 @@ PeerManager::loadRandomPeers(PeerQuery const& query, size_t size)
     size_t maxOffset = count > size ? count - size : 0;
     size_t offset = rand_uniform<size_t>(0, maxOffset);
     result = loadPeers(size, offset, where, bindToStatement);
-
-    stellar::shuffle(std::begin(result), std::end(result), gRandomEngine);
+    stellar::shuffle(std::begin(result), std::end(result),
+                     getGlobalRandomEngine());
     return result;
 }
 
@@ -371,7 +371,7 @@ computeBackoff(size_t numFailures)
     uint32 backoffCount = static_cast<uint32>(
         std::min<size_t>(MAX_BACKOFF_EXPONENT, numFailures));
     auto nsecs =
-        std::chrono::seconds(static_cast<uint32>(gRandomEngine()) %
+        std::chrono::seconds(static_cast<uint32>(getGlobalRandomEngine()()) %
                                  ((1u << backoffCount) * SECONDS_PER_BACKOFF) +
                              1);
     return nsecs;

--- a/src/overlay/test/LoopbackPeer.cpp
+++ b/src/overlay/test/LoopbackPeer.cpp
@@ -301,7 +301,7 @@ LoopbackPeer::deliverOne()
         mOutQueue.pop_front();
 
         // Possibly duplicate the message and requeue it at the front.
-        if (mDuplicateProb(gRandomEngine))
+        if (mDuplicateProb(getGlobalRandomEngine()))
         {
             CLOG_INFO(Overlay, "LoopbackPeer duplicated message");
             mOutQueue.emplace_front(duplicateMessage(msg));
@@ -309,7 +309,7 @@ LoopbackPeer::deliverOne()
         }
 
         // Possibly requeue it at the back and return, reordering.
-        if (mReorderProb(gRandomEngine) && mOutQueue.size() > 0)
+        if (mReorderProb(getGlobalRandomEngine()) && mOutQueue.size() > 0)
         {
             CLOG_INFO(Overlay, "LoopbackPeer reordered message");
             mStats.messagesReordered++;
@@ -318,15 +318,15 @@ LoopbackPeer::deliverOne()
         }
 
         // Possibly flip some bits in the message.
-        if (mDamageProb(gRandomEngine))
+        if (mDamageProb(getGlobalRandomEngine()))
         {
             CLOG_INFO(Overlay, "LoopbackPeer damaged message");
-            if (damageMessage(gRandomEngine, msg.mMessage))
+            if (damageMessage(getGlobalRandomEngine(), msg.mMessage))
                 mStats.messagesDamaged++;
         }
 
         // Possibly just drop the message on the floor.
-        if (mDropProb(gRandomEngine))
+        if (mDropProb(getGlobalRandomEngine()))
         {
             CLOG_INFO(Overlay, "LoopbackPeer dropped message");
             mStats.messagesDropped++;

--- a/src/overlay/test/OverlayTopologyTests.cpp
+++ b/src/overlay/test/OverlayTopologyTests.cpp
@@ -228,7 +228,7 @@ TEST_CASE("peer churn", "[overlay][connectivity][!hide]")
             randomIndexes.push_back(i);
         }
         stellar::shuffle(std::begin(randomIndexes), std::end(randomIndexes),
-                         gRandomEngine);
+                         getGlobalRandomEngine());
         // One-by-one add a node, ensure everyone can connect
         for (int i = 0; i < randomIndexes.size(); i++)
         {

--- a/src/scp/test/SCPTests.cpp
+++ b/src/scp/test/SCPTests.cpp
@@ -35,7 +35,8 @@ static void
 setupValues()
 {
     std::vector<Value> v;
-    std::string d = fmt::format("SEED_VALUE_DATA_{}", gRandomEngine());
+    std::string d =
+        fmt::format("SEED_VALUE_DATA_{}", getGlobalRandomEngine()());
     for (int i = 0; i < 4; i++)
     {
         auto h = sha256(fmt::format("{}/{}", d, i));

--- a/src/simulation/ApplyLoad.cpp
+++ b/src/simulation/ApplyLoad.cpp
@@ -609,7 +609,7 @@ ApplyLoad::benchmark()
     std::vector<uint64_t> shuffledAccounts(accounts.size());
     std::iota(shuffledAccounts.begin(), shuffledAccounts.end(), 0);
     stellar::shuffle(std::begin(shuffledAccounts), std::end(shuffledAccounts),
-                     gRandomEngine);
+                     getGlobalRandomEngine());
 
     bool limitHit = false;
     for (auto accountIndex : shuffledAccounts)

--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -189,7 +189,7 @@ resilienceTest(Simulation::pointer sim)
     {
         // now restart a random node i, will reconnect to
         // j to join the network
-        auto i = gen(gRandomEngine);
+        auto i = gen(getGlobalRandomEngine());
         auto j = (i + 1) % nbNodes;
 
         auto victimID = nodes[i];

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -60,7 +60,7 @@ sampleDiscrete(std::vector<T> const& values,
 
     std::discrete_distribution<uint32_t> distribution(weights.begin(),
                                                       weights.end());
-    return values.at(distribution(gRandomEngine));
+    return values.at(distribution(getGlobalRandomEngine()));
 }
 } // namespace
 
@@ -1041,7 +1041,7 @@ LoadGenerator::createMixedClassicSorobanTransaction(
     std::discrete_distribution<uint32_t> dist({mixCfg.payWeight,
                                                mixCfg.sorobanUploadWeight,
                                                mixCfg.sorobanInvokeWeight});
-    switch (dist(gRandomEngine))
+    switch (dist(getGlobalRandomEngine()))
     {
     case 0:
     {

--- a/src/simulation/TxGenerator.cpp
+++ b/src/simulation/TxGenerator.cpp
@@ -40,7 +40,7 @@ sampleDiscrete(std::vector<T> const& values,
 
     std::discrete_distribution<uint32_t> distribution(weights.begin(),
                                                       weights.end());
-    return values.at(distribution(gRandomEngine));
+    return values.at(distribution(getGlobalRandomEngine()));
 }
 } // namespace
 
@@ -111,8 +111,9 @@ TxGenerator::generateFee(std::optional<uint32_t> maxGeneratedFeeRate,
         // transaction comparisons.
         auto fractionalFeeDistr = uniform_int_distribution<uint32_t>(
             0, static_cast<uint32_t>(opsCnt) - 1);
-        fee = static_cast<uint32_t>(opsCnt) * feeRateDistr(gRandomEngine) +
-              fractionalFeeDistr(gRandomEngine);
+        fee = static_cast<uint32_t>(opsCnt) *
+                  feeRateDistr(getGlobalRandomEngine()) +
+              fractionalFeeDistr(getGlobalRandomEngine());
     }
     else
     {
@@ -617,7 +618,7 @@ TxGenerator::invokeSorobanLoadTransactionV2(
                                xdr::xvector<LedgerKey>& footprint) {
         for (uint32_t i = 0; i < entryCount; ++i)
         {
-            uint64_t entryId = entryDist(gRandomEngine);
+            uint64_t entryId = entryDist(getGlobalRandomEngine());
             if (usedEntries.emplace(entryId).second)
             {
                 auto lk = contractDataKey(instance.contractID, makeU64(entryId),

--- a/src/test/Catch2.h
+++ b/src/test/Catch2.h
@@ -31,7 +31,7 @@ class CatchupRange;
 
 namespace historytestutils
 {
-class CatchupPerformedWork;
+struct CatchupPerformedWork;
 } // namespace historytestutils
 } // namespace stellar
 

--- a/src/test/check-nondet
+++ b/src/test/check-nondet
@@ -11,7 +11,7 @@
 if git grep 'std::rand()' '*.h' '*.cpp'
 then
     echo
-    echo "please use stellar::gRandomEngine instead of std::rand since the latter is not"
+    echo "please use stellar::getGlobalRandomEngine() instead of std::rand since the latter is not"
     echo "identical on all platforms and other library code may call it unexpectedly."
     exit 1
 fi

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -7884,7 +7884,7 @@ TEST_CASE("parallel txs", "[tx][soroban][parallelapply]")
                 .getInclusionFee();
         for (size_t i = 0; i < 6; i++)
         {
-            auto extendTo = dist(gRandomEngine);
+            auto extendTo = dist(getGlobalRandomEngine());
             extendTos.emplace_back(extendTo);
 
             // The first tx will be a rw, the rest are ro
@@ -8643,10 +8643,11 @@ TEST_CASE("apply generated parallel tx sets", "[tx][soroban][parallelapply]")
         auto resources = lm.maxLedgerResources(true);
         for (auto& account : accounts)
         {
-            auto const& key = keys.at(keyDist(gRandomEngine));
-            auto const& action = actions.at(actionDist(gRandomEngine));
+            auto const& key = keys.at(keyDist(getGlobalRandomEngine()));
+            auto const& action =
+                actions.at(actionDist(getGlobalRandomEngine()));
             auto const& durability =
-                durabilities.at(durabilityDist(gRandomEngine));
+                durabilities.at(durabilityDist(getGlobalRandomEngine()));
 
             SorobanInvocationSpec spec;
             std::vector<SCVal> args;
@@ -8658,7 +8659,7 @@ TEST_CASE("apply generated parallel tx sets", "[tx][soroban][parallelapply]")
             else if (action == "extend")
             {
                 spec = client.readKeySpec(key, durability);
-                auto ttl = ttlDist(gRandomEngine);
+                auto ttl = ttlDist(getGlobalRandomEngine());
                 args = {makeSymbolSCVal(key), makeU32SCVal(ttl),
                         makeU32SCVal(ttl)};
             }
@@ -8801,7 +8802,7 @@ TEST_CASE("read-only bumps across threads", "[tx][soroban][parallelapply]")
     std::vector<TransactionFrameBaseConstPtr> sorobanTxs;
     for (auto& account : accounts)
     {
-        auto extendTo = dist(gRandomEngine);
+        auto extendTo = dist(getGlobalRandomEngine());
         maxExtension = std::max(maxExtension, extendTo);
 
         auto inv = client.getContract().prepareInvocation(

--- a/src/transactions/test/MergeTests.cpp
+++ b/src/transactions/test/MergeTests.cpp
@@ -971,10 +971,6 @@ TEST_CASE_VERSIONS("merge event reconciler", "[tx][merge]")
 
     // set up world
     auto root = app->getRoot();
-
-    int64_t trustLineBalance = 100000;
-    int64_t trustLineLimit = trustLineBalance * 10;
-
     auto txfee = app->getLedgerManager().getLastTxFee();
 
     const int64_t minBalance =

--- a/src/transactions/test/ParallelApplyTest.cpp
+++ b/src/transactions/test/ParallelApplyTest.cpp
@@ -543,7 +543,6 @@ applyTestTransactions(TestConfig const& testConfig, uint32_t protocolVersion,
         MIN_EXPIRED_ENTRY_FRACTION, MAX_EXPIRED_ENTRY_FRACTION)(testRng);
     int liveEntryCount =
         preuploadedEntryKeys.size() * (1.0 - expiredEntryFraction);
-    int expiredEntryCount = preuploadedEntryKeys.size() - liveEntryCount;
     // Bump some entries that are supposed to expire a little bit to make
     // sure they are expired, but not yet moved to the hot archive.
     int expiredInLiveStateEntryCount =

--- a/src/transactions/test/ParallelApplyTest.cpp
+++ b/src/transactions/test/ParallelApplyTest.cpp
@@ -1086,18 +1086,35 @@ applyTestTransactions(TestConfig const& testConfig, uint32_t protocolVersion,
             // Errors are expected, but we want the fees and limits to not
             // be a reason, as these could be not stable between protocol
             // versions.
-            REQUIRE(res.result.result.results()[0].code() !=
-                    INVOKE_HOST_FUNCTION_INSUFFICIENT_REFUNDABLE_FEE);
-            REQUIRE(res.result.result.results()[0].code() !=
-                    INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
-            REQUIRE(res.result.result.results()[0].code() !=
-                    EXTEND_FOOTPRINT_TTL_RESOURCE_LIMIT_EXCEEDED);
-            REQUIRE(res.result.result.results()[0].code() !=
-                    EXTEND_FOOTPRINT_TTL_INSUFFICIENT_REFUNDABLE_FEE);
-            REQUIRE(res.result.result.results()[0].code() !=
-                    RESTORE_FOOTPRINT_RESOURCE_LIMIT_EXCEEDED);
-            REQUIRE(res.result.result.results()[0].code() !=
-                    RESTORE_FOOTPRINT_INSUFFICIENT_REFUNDABLE_FEE);
+            auto const& tr = res.result.result.results()[0].tr();
+            switch (tr.type())
+            {
+            case INVOKE_HOST_FUNCTION:
+            {
+                auto code = tr.invokeHostFunctionResult().code();
+                REQUIRE(code !=
+                        INVOKE_HOST_FUNCTION_INSUFFICIENT_REFUNDABLE_FEE);
+                REQUIRE(code != INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
+            }
+            break;
+            case EXTEND_FOOTPRINT_TTL:
+            {
+                auto code = tr.extendFootprintTTLResult().code();
+                REQUIRE(code != EXTEND_FOOTPRINT_TTL_RESOURCE_LIMIT_EXCEEDED);
+                REQUIRE(code !=
+                        EXTEND_FOOTPRINT_TTL_INSUFFICIENT_REFUNDABLE_FEE);
+            }
+            break;
+            case RESTORE_FOOTPRINT:
+            {
+                auto code = tr.restoreFootprintResult().code();
+                REQUIRE(code != RESTORE_FOOTPRINT_RESOURCE_LIMIT_EXCEEDED);
+                REQUIRE(code != RESTORE_FOOTPRINT_INSUFFICIENT_REFUNDABLE_FEE);
+            }
+            break;
+            default:
+                break;
+            }
         }
     }
     std::vector<std::pair<LedgerKey, std::pair<std::optional<LedgerEntry>,

--- a/src/transactions/test/SorobanTxTestUtils.cpp
+++ b/src/transactions/test/SorobanTxTestUtils.cpp
@@ -300,6 +300,9 @@ makeTransferEvent(const stellar::Hash& contractId, Asset const& asset,
                            asset.alphaNum12().assetCode.end()) +
                ":" + KeyUtils::toStrKey(asset.alphaNum12().issuer);
         break;
+    default:
+        releaseAssertOrThrow(false);
+        break;
     }
 
     std::vector<SCVal> topics = {makeSymbolSCVal("transfer"),

--- a/src/util/Math.h
+++ b/src/util/Math.h
@@ -25,7 +25,7 @@ bool rand_flip();
 
 typedef std::minstd_rand stellar_default_random_engine;
 
-extern stellar_default_random_engine gRandomEngine;
+stellar_default_random_engine& getGlobalRandomEngine();
 
 template <typename T>
 T
@@ -38,7 +38,7 @@ template <typename T>
 T
 rand_uniform(T lo, T hi)
 {
-    return rand_uniform<T>(lo, hi, gRandomEngine);
+    return rand_uniform<T>(lo, hi, getGlobalRandomEngine());
 }
 
 template <typename T>
@@ -71,7 +71,7 @@ void initializeAllGlobalState();
 // This function should be called any time you need to reset stellar-core's
 // global state based on a seed value, such as before each fuzz run or each unit
 // test. It's declared here because most cases that want to call it are already
-// including Math.h in order to use gRandomEngine. It's not present in
+// including Math.h in order to use getGlobalRandomEngine(). It's not present in
 // non-BUILD_TESTS runs because long-running single-application processes
 // shouldn't be resetting globals like this mid-run -- especially not things
 // like hash function keys.

--- a/src/util/test/CacheTests.cpp
+++ b/src/util/test/CacheTests.cpp
@@ -104,7 +104,7 @@ TEST_CASE("RandomEvictionCache works as a cache", "[randomevictioncache]")
 TEST_CASE("RandomEvictionCache does not thrash",
           "[randomevictioncachethrash][!hide]")
 {
-    gRandomEngine.seed(std::time(nullptr) & UINT32_MAX);
+    getGlobalRandomEngine().seed(std::time(nullptr) & UINT32_MAX);
     size_t sz = 1000;
     RandomEvictionCache<size_t, size_t> cache(sz);
     auto const& ctrs = cache.getCounters();

--- a/src/util/test/MetricTests.cpp
+++ b/src/util/test/MetricTests.cpp
@@ -240,7 +240,7 @@ class SlidingWindowTester
         : mSlidingWindowSample(kDefaultSampleSize, kDefaultWindowTime)
         , mTimestamp(medida::Clock::now())
     {
-        mSlidingWindowSample.Seed(stellar::gRandomEngine());
+        mSlidingWindowSample.Seed(stellar::getGlobalRandomEngine()());
     }
     template <typename Dist, typename... Args>
     void
@@ -253,7 +253,7 @@ class SlidingWindowTester
         while (mTimestamp < endTime)
         {
             uint64_t sample =
-                static_cast<uint64_t>(dist(stellar::gRandomEngine));
+                static_cast<uint64_t>(dist(stellar::getGlobalRandomEngine()));
             mSlidingWindowSample.Update(sample, mTimestamp);
             mSamples.emplace_back(sample, mTimestamp);
             mTimestamp += timeStep;
@@ -372,7 +372,7 @@ sampleFrom(Args... args)
     std::vector<double> sample;
     for (size_t i = 0; i < 10000; ++i)
     {
-        sample.emplace_back(dist(stellar::gRandomEngine));
+        sample.emplace_back(dist(stellar::getGlobalRandomEngine()));
     }
     return medida::stats::Snapshot(sample);
 }
@@ -588,7 +588,7 @@ testCKMSSample(int const count, Args... args)
     Dist dist(std::forward<Args>(args)...);
     for (int i = 0; i < count; i++)
     {
-        auto x = static_cast<int64_t>(dist(stellar::gRandomEngine));
+        auto x = static_cast<int64_t>(dist(stellar::getGlobalRandomEngine()));
         values.push_back(x);
         hist.Update(x);
     }


### PR DESCRIPTION
Handful of issues found during tsan testing. None super serious:

- Mainly: fix a race on the global PRNG between the random eviction cache in the old QI checker and other threads
- Preventatively: route all access to the global PRNG through a function that does a main thread check 
- One very edge-casey use-after-free that tsan found 
- A bunch of warning fixes (unused variables and such)
- One warning fix related to comparing wrong result-code types in tests, i don't _think_ this is a serious one given how it's used but it seemed worth fixing

I also added a few more tracy plots that show the sizes of the in-memory live BL and module cache.