### PR TITLE
Minor no-op cleanups

### DIFF
--- a/src/herder/ParallelTxSetBuilder.cpp
+++ b/src/herder/ParallelTxSetBuilder.cpp
@@ -254,7 +254,7 @@ class Stage
         BuilderTx const& tx,
         std::unordered_set<Cluster const*> const& txConflicts) const
     {
-        int64_t newInstructions = tx.mInstructions;
+        uint64_t newInstructions = tx.mInstructions;
         for (auto const* cluster : txConflicts)
         {
             newInstructions += cluster->mInstructions;
@@ -371,7 +371,7 @@ class Stage
     // enough to run in the close-time target on the guaranteed parallelism.
     std::vector<BitSet> mBinPacking;
     std::vector<uint64_t> mBinInstructions;
-    int64_t mInstructions = 0;
+    uint64_t mInstructions = 0;
     ParallelPartitionConfig mConfig;
     bool mTriedCompactingBinPacking = false;
 };

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -4310,7 +4310,7 @@ TEST_CASE("ledger state update flow with parallel apply", "[herder][parallel]")
                 REQUIRE(lm.getLastClosedLedgerNum() == lcl);
                 REQUIRE(lm.getLastClosedLedgerHAS().currentLedger ==
                         lastHeader.ledgerSeq);
-                REQUIRE(lm.getLastClosedSnaphot()->getLedgerHeader() ==
+                REQUIRE(lm.getLastClosedSnapshot()->getLedgerHeader() ==
                         lastHeader);
 
                 // Apply state got committed, but has not yet been propagated to
@@ -4365,7 +4365,7 @@ TEST_CASE("ledger state update flow with parallel apply", "[herder][parallel]")
                 auto readOnly = lm.getLastClosedLedgerHeader();
                 REQUIRE(readOnly.header.ledgerSeq == lcl + 1);
                 REQUIRE(lm.getLastClosedLedgerNum() == lcl + 1);
-                REQUIRE(lm.getLastClosedSnaphot()->getLedgerHeader() ==
+                REQUIRE(lm.getLastClosedSnapshot()->getLedgerHeader() ==
                         readOnly.header);
                 auto has = lm.getLastClosedLedgerHAS();
                 REQUIRE(has.currentLedger == readOnly.header.ledgerSeq);

--- a/src/ledger/LedgerCloseMetaFrame.cpp
+++ b/src/ledger/LedgerCloseMetaFrame.cpp
@@ -68,38 +68,22 @@ LedgerCloseMetaFrame::reserveTxProcessing(size_t n)
 }
 
 void
-LedgerCloseMetaFrame::pushTxProcessingEntry()
+LedgerCloseMetaFrame::pushTxFeeProcessing(
+    LedgerEntryChanges const& feeProcessing)
 {
     switch (mVersion)
     {
     case 0:
         mLedgerCloseMeta.v0().txProcessing.emplace_back();
+        mLedgerCloseMeta.v0().txProcessing.back().feeProcessing = feeProcessing;
         break;
     case 1:
         mLedgerCloseMeta.v1().txProcessing.emplace_back();
+        mLedgerCloseMeta.v1().txProcessing.back().feeProcessing = feeProcessing;
         break;
     case 2:
         mLedgerCloseMeta.v2().txProcessing.emplace_back();
-        break;
-    default:
-        releaseAssert(false);
-    }
-}
-
-void
-LedgerCloseMetaFrame::setLastTxProcessingFeeProcessingChanges(
-    LedgerEntryChanges const& changes)
-{
-    switch (mVersion)
-    {
-    case 0:
-        mLedgerCloseMeta.v0().txProcessing.back().feeProcessing = changes;
-        break;
-    case 1:
-        mLedgerCloseMeta.v1().txProcessing.back().feeProcessing = changes;
-        break;
-    case 2:
-        mLedgerCloseMeta.v2().txProcessing.back().feeProcessing = changes;
+        mLedgerCloseMeta.v2().txProcessing.back().feeProcessing = feeProcessing;
         break;
     default:
         releaseAssert(false);

--- a/src/ledger/LedgerCloseMetaFrame.h
+++ b/src/ledger/LedgerCloseMetaFrame.h
@@ -19,9 +19,8 @@ class LedgerCloseMetaFrame
 
     LedgerHeaderHistoryEntry& ledgerHeader();
     void reserveTxProcessing(size_t n);
-    void pushTxProcessingEntry();
-    void
-    setLastTxProcessingFeeProcessingChanges(LedgerEntryChanges const& changes);
+    void pushTxFeeProcessing(LedgerEntryChanges const& feeProcessing);
+
     void setTxProcessingMetaAndResultPair(TransactionMeta&& tm,
                                           TransactionResultPair&& rp,
                                           int index);

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -230,7 +230,7 @@ class LedgerManager
     getLastClosedLedgerHeader() const = 0;
 
     // Get bucketlist snapshot of LCL
-    virtual SearchableSnapshotConstPtr getLastClosedSnaphot() const = 0;
+    virtual SearchableSnapshotConstPtr getLastClosedSnapshot() const = 0;
 
     // return the HAS that corresponds to the last closed ledger as persisted in
     // the database

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -2130,9 +2130,7 @@ LedgerManagerImpl::processFeesSeqNums(
 
                 if (ledgerCloseMeta)
                 {
-                    ledgerCloseMeta->pushTxProcessingEntry();
-                    ledgerCloseMeta->setLastTxProcessingFeeProcessingChanges(
-                        ltxTx.getChanges());
+                    ledgerCloseMeta->pushTxFeeProcessing(ltxTx.getChanges());
                 }
                 ++index;
                 ltxTx.commit();

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1955,7 +1955,7 @@ LedgerManagerImpl::maybeResetLedgerCloseMetaDebugStream(uint32_t ledgerSeq)
 }
 
 SearchableSnapshotConstPtr
-LedgerManagerImpl::getLastClosedSnaphot() const
+LedgerManagerImpl::getLastClosedSnapshot() const
 {
     releaseAssert(threadIsMain());
     releaseAssert(mLastClosedLedgerState);

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -551,7 +551,7 @@ class LedgerManagerImpl : public LedgerManager
     void maybeResetLedgerCloseMetaDebugStream(uint32_t ledgerSeq);
 
     SorobanMetrics& getSorobanMetrics() override;
-    SearchableSnapshotConstPtr getLastClosedSnaphot() const override;
+    SearchableSnapshotConstPtr getLastClosedSnapshot() const override;
     virtual bool
     isApplying() const override
     {

--- a/src/ledger/LedgerStateSnapshot.cpp
+++ b/src/ledger/LedgerStateSnapshot.cpp
@@ -240,7 +240,7 @@ LedgerSnapshot::LedgerSnapshot(Application& app)
     else
 #endif
         mGetter = std::make_unique<BucketSnapshotState>(
-            app.getLedgerManager().getLastClosedSnaphot());
+            app.getLedgerManager().getLastClosedSnapshot());
 }
 
 LedgerSnapshot::LedgerSnapshot(SearchableSnapshotConstPtr snapshot)

--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -71,7 +71,7 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
     }
 #endif
 
-    virtual ~FeeBumpTransactionFrame(){};
+    ~FeeBumpTransactionFrame() override = default;
 
     void
     preParallelApply(AppConnector& app, AbstractLedgerTxn& ltx,

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -160,9 +160,7 @@ class TransactionFrame : public TransactionFrameBase
     TransactionFrame(TransactionFrame const&) = delete;
     TransactionFrame() = delete;
 
-    virtual ~TransactionFrame()
-    {
-    }
+    ~TransactionFrame() override = default;
 
     Hash const& getFullHash() const override;
     Hash const& getContentsHash() const override;

--- a/src/transactions/TransactionFrameBase.h
+++ b/src/transactions/TransactionFrameBase.h
@@ -239,5 +239,7 @@ class TransactionFrameBase
     // Returns true if this TX is a soroban transaction with a
     // RestoreFootprintOp.
     virtual bool isRestoreFootprintTx() const = 0;
+
+    virtual ~TransactionFrameBase() = default;
 };
 }


### PR DESCRIPTION
# Description

Resolves #X

- Refactor tx fee processing meta setting into a single function.
- Consistently use uint64_t for instructions in ParallelTxSetBuilder
- Typo fix: getLastClosedSnapShot

- Cleanup TransactionFrame destructors.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
