### PR TITLE
Fix "Time sliced static topology survey" test.

### DIFF
--- a/src/overlay/test/SurveyManagerTests.cpp
+++ b/src/overlay/test/SurveyManagerTests.cpp
@@ -48,8 +48,8 @@ surveyTopologyTimeSliced(Application& surveyor, PublicKey const& surveyed,
         "&outboundpeerindex=" + std::to_string(outboundPeerIndex);
     std::string const response = surveyor.getCommandHandler().manualCmd(cmd);
 
-    // Detect failure by looking for the word "failed" in the response
-    return response.find("failed") == std::string::npos;
+    // Detect failure by looking for the word "exception" in the response
+    return response.find("exception") == std::string::npos;
 }
 
 // Crank the simulation for a short time to allow survey messages to propagate


### PR DESCRIPTION
#4854 broke the "Time sliced static topology survey" test. Since this test was okay in the PR until c3a2ecd6931dd27fa0477b572108b5209cf0503c (after some reviews) and the test was tagged `[acceptance]`, the break wasn't caught pre-merge. Note that the problem introduced in that commit is that the word "failed" was removed from the error thrown in `SurveyManager::addPeerToBacklog`. To avoid similar problems with this particular testcase in the future, change the word we're looking for from "failed" to "exception".