### PR TITLE
Check account existence before background tx sig validation

### DIFF
--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -80,22 +80,26 @@ populateSignatureCache(AppConnector& app, TransactionFrameBaseConstPtr tx)
     // FeeBumpTransactionFrame
     auto const sourceAccount = ledgerSnapshot.getAccount(tx->getFeeSourceID());
 
-    // Check signature, which will add the result to the signature cache. This
-    // is safe to do here (pre-validation) because:
-    // 1. The signatures themselves are fixed and cannot change, and
-    // 2. In the unlikely case that the account's signers or thresholds have
-    //    changed (and we haven't heard of it yet), the validation and apply
-    //    functions still contain `checkSignature` calls, which will cause a
-    //    cache miss in that case and force a recheck of the signatures with
-    //    up-to-date signers/thresholds.
-    //
-    // Note that we always use a threshold of HIGH for the signatures to ensure
-    // we check all signatures for any possible operation that may be in the
-    // transaction. Performance analysis has shown that the overlay thread
-    // contains significant extra capacity and can handle this extra load.
-    tx->checkSignature(
-        signatureChecker, sourceAccount,
-        sourceAccount.current().data.account().thresholds[THRESHOLD_HIGH]);
+    if (sourceAccount)
+    {
+        // Check signature, which will add the result to the signature cache.
+        // This is safe to do here (pre-validation) because:
+        // 1. The signatures themselves are fixed and cannot change, and
+        // 2. In the unlikely case that the account's signers or thresholds have
+        //    changed (and we haven't heard of it yet), the validation and apply
+        //    functions still contain `checkSignature` calls, which will cause a
+        //    cache miss in that case and force a recheck of the signatures with
+        //    up-to-date signers/thresholds.
+        //
+        // Note that we always use a threshold of HIGH for the signatures to
+        // ensure we check all signatures for any possible operation that may be
+        // in the transaction. Performance analysis has shown that the overlay
+        // thread contains significant extra capacity and can handle this extra
+        // load.
+        tx->checkSignature(
+            signatureChecker, sourceAccount,
+            sourceAccount.current().data.account().thresholds[THRESHOLD_HIGH]);
+    }
 }
 } // namespace
 


### PR DESCRIPTION
Fixes #4887.

This change adds a check that a transactions source account exists before it attempts to validate the transaction's signatures in the background transaction signature validation flow. The bulk of this change is actually the addition of a test that verifies that the fix works.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
