### PR TITLE
Initialize std::tm properly in isoStringToTm

### DIFF
--- a/src/util/Timer.cpp
+++ b/src/util/Timer.cpp
@@ -156,7 +156,7 @@ VirtualClock::tmToSystemPoint(tm t)
 std::tm
 VirtualClock::isoStringToTm(std::string const& iso)
 {
-    std::tm res;
+    std::tm res{};
     std::istringstream ss(iso);
     ss >> std::get_time(&res, "%Y-%m-%dT%H:%M:%SZ");
     if (!ss)


### PR DESCRIPTION
# Description

Resolves #X

Initialize std::tm properly in isoStringToTm.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
