### PR TITLE
Added max sac TPS test

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -78,6 +78,8 @@ ledger.apply.success                      | counter   | count of successfully ap
 ledger.apply.failure                      | counter   | count of failed applied transactions
 ledger.apply-soroban.success              | counter   | count of successfully applied soroban transactions
 ledger.apply-soroban.failure              | counter   | count of failed applied soroban transactions
+ledger.apply-soroban.max-clusters         | counter   | maximum number of clusters across all stages in a ledger
+ledger.apply-soroban.stages               | counter   | number of stages used for parallel apply in a ledger
 ledger.catchup.duration                   | timer     | time between entering LM_CATCHING_UP_STATE and entering LM_SYNCED_STATE
 ledger.invariant.failure                  | counter   | number of times invariants failed
 ledger.ledger.close                       | timer     | time to close a ledger (excluding consensus)
@@ -87,6 +89,7 @@ ledger.metastream.write                   | timer     | time spent writing data 
 ledger.operation.apply                    | timer     | time applying an operation
 ledger.operation.count                    | histogram | number of operations per ledger
 ledger.transaction.apply                  | timer     | time to apply one transaction
+ledger.transaction.total-apply            | timer     | cumulative time to apply all transactions in a ledger
 ledger.transaction.count                  | histogram | number of transactions per ledger
 ledger.transaction.internal-error         | counter   | number of internal errors since start
 loadgen.payment.native                    | meter     | loadgenerator: native payment submitted

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -192,6 +192,7 @@ LedgerManagerImpl::LedgerApplyMetrics::LedgerApplyMetrics(
     medida::MetricsRegistry& registry)
     : mSorobanMetrics(registry)
     , mTransactionApply(registry.NewTimer({"ledger", "transaction", "apply"}))
+    , mTotalTxApply(registry.NewTimer({"ledger", "transaction", "total-apply"}))
     , mTransactionCount(
           registry.NewHistogram({"ledger", "transaction", "count"}))
     , mOperationCount(registry.NewHistogram({"ledger", "operation", "count"}))
@@ -209,6 +210,10 @@ LedgerManagerImpl::LedgerApplyMetrics::LedgerApplyMetrics(
           registry.NewCounter({"ledger", "apply-soroban", "success"}))
     , mSorobanTransactionApplyFailed(
           registry.NewCounter({"ledger", "apply-soroban", "failure"}))
+    , mMaxClustersPerLedger(
+          registry.NewCounter({"ledger", "apply-soroban", "max-clusters"}))
+    , mStagesPerLedger(
+          registry.NewCounter({"ledger", "apply-soroban", "stages"}))
     , mMetaStreamBytes(
           registry.NewMeter({"ledger", "metastream", "bytes"}, "byte"))
     , mMetaStreamWriteTime(registry.NewTimer({"ledger", "metastream", "write"}))
@@ -1569,6 +1574,12 @@ LedgerManagerImpl::applyLedger(LedgerCloseData const& ledgerData,
         // first, prefetch source accounts for txset, then charge fees
         prefetchTxSourceIds(mApp.getLedgerTxnRoot(), *applicableTxSet,
                             mApp.getConfig());
+
+        // Time the entire transaction processing phase from fee processing
+        // through transaction application
+        auto totalTxApplyTime =
+            mApplyState.getMetrics().mTotalTxApply.TimeScope();
+
         // Subtle: after this call, `header` is invalidated, and is not safe
         // to use
         auto const mutableTxResults = processFeesSeqNums(
@@ -2269,6 +2280,7 @@ LedgerManagerImpl::applySorobanStageClustersInParallel(
     SorobanNetworkConfig const& sorobanConfig,
     ParallelLedgerInfo const& ledgerInfo)
 {
+    ZoneScoped;
 
     std::vector<std::unique_ptr<ThreadParallelApplyLedgerState>> threadStates;
     std::vector<std::future<std::unique_ptr<ThreadParallelApplyLedgerState>>>
@@ -2347,6 +2359,7 @@ LedgerManagerImpl::applySorobanStage(
     GlobalParallelApplyLedgerState& globalParState, ApplyStage const& stage,
     Hash const& sorobanBasePrngSeed)
 {
+    ZoneScoped;
     auto const& config = app.getConfig();
     auto const& sorobanConfig = getSorobanNetworkConfigForApply();
     auto ledgerInfo = getParallelLedgerInfo(app, header);
@@ -2365,6 +2378,7 @@ LedgerManagerImpl::applySorobanStages(AppConnector& app, AbstractLedgerTxn& ltx,
                                       std::vector<ApplyStage> const& stages,
                                       Hash const& sorobanBasePrngSeed)
 {
+    ZoneScoped;
     GlobalParallelApplyLedgerState globalParState(
         app, ltx, stages, mApplyState.getInMemorySorobanState());
     // LedgerTxn is not passed into applySorobanStage, so there's no risk
@@ -2385,6 +2399,7 @@ LedgerManagerImpl::processResultAndMeta(
     TransactionFrameBase const& tx, MutableTransactionResultBase const& result,
     TransactionResultSet& txResultSet)
 {
+    ZoneScoped;
     TransactionResultPair resultPair;
     resultPair.transactionHash = tx.getContentsHash();
     resultPair.result = result.getXDR();
@@ -2493,6 +2508,18 @@ LedgerManagerImpl::applyTransactions(
     processPostTxSetApply(phases, applyStages, ltx, ledgerCloseMeta,
                           txResultSet);
 
+    // Update cluster and stage metrics
+    if (!applyStages.empty())
+    {
+        size_t maxClusters = 0;
+        for (auto const& stage : applyStages)
+        {
+            maxClusters = std::max(maxClusters, stage.numClusters());
+        }
+        mApplyState.getMetrics().mMaxClustersPerLedger.set_count(maxClusters);
+        mApplyState.getMetrics().mStagesPerLedger.set_count(applyStages.size());
+    }
+
 #ifdef BUILD_TESTS
     releaseAssert(ledgerCloseMeta);
     mLastLedgerCloseMeta = *ledgerCloseMeta;
@@ -2509,6 +2536,7 @@ LedgerManagerImpl::applyParallelPhase(
     uint32_t& index, stellar::AbstractLedgerTxn& ltx, bool enableTxMeta,
     Hash const& sorobanBasePrngSeed)
 {
+    ZoneScoped;
 
     auto const& txSetStages = phase.getParallelStages();
 
@@ -2623,6 +2651,7 @@ LedgerManagerImpl::processPostTxSetApply(
     std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta,
     TransactionResultSet& txResultSet)
 {
+    ZoneScoped;
     for (auto const& phase : phases)
     {
         if (phase.isParallel())

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -68,6 +68,7 @@ class LedgerManagerImpl : public LedgerManager
     {
         SorobanMetrics mSorobanMetrics;
         medida::Timer& mTransactionApply;
+        medida::Timer& mTotalTxApply;
         medida::Histogram& mTransactionCount;
         medida::Histogram& mOperationCount;
         medida::Histogram& mPrefetchHitRate;
@@ -78,6 +79,8 @@ class LedgerManagerImpl : public LedgerManager
         medida::Counter& mTransactionApplyFailed;
         medida::Counter& mSorobanTransactionApplySucceeded;
         medida::Counter& mSorobanTransactionApplyFailed;
+        medida::Counter& mMaxClustersPerLedger;
+        medida::Counter& mStagesPerLedger;
         medida::Meter& mMetaStreamBytes;
         medida::Timer& mMetaStreamWriteTime;
         LedgerApplyMetrics(medida::MetricsRegistry& registry);

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -1926,6 +1926,7 @@ runApplyLoad(CommandLineArgs const& args)
                      1000) *
                     2;
 
+                // Apply Load may exceed TX_SET byte size limits, so ignore them
                 config.IGNORE_MESSAGE_LIMITS_FOR_TESTING = true;
             }
 

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -386,6 +386,12 @@ class Config : public std::enable_shared_from_this<Config>
     uint32_t APPLY_LOAD_NUM_ACCOUNTS = 0;
     uint32_t APPLY_LOAD_NUM_LEDGERS = 100;
 
+    // MAX_SAC_TPS mode specific parameters
+    uint32_t APPLY_LOAD_MAX_SAC_TPS_TARGET_CLOSE_TIME_MS = 1000;
+    uint32_t APPLY_LOAD_MAX_SAC_TPS_TEST_ITERATIONS = 3;
+    uint32_t APPLY_LOAD_MAX_SAC_TPS_MIN_TPS = 100;
+    uint32_t APPLY_LOAD_MAX_SAC_TPS_MAX_TPS = 50000;
+
     // Number of read-only and read-write entries in the apply-load
     // transactions. Every entry will have
     // `APPLY_LOAD_DATA_ENTRY_SIZE_FOR_TESTING` size.
@@ -847,6 +853,9 @@ class Config : public std::enable_shared_from_this<Config>
     // Block byte limits overrides for testing
     size_t TESTING_MAX_SOROBAN_BYTE_ALLOWANCE;
     size_t TESTING_MAX_CLASSIC_BYTE_ALLOWANCE;
+
+    // When set to true, ignores all message and tx set size limits for testing
+    bool IGNORE_MESSAGE_LIMITS_FOR_TESTING;
 
     // Set QUORUM_SET using automatic quorum set configuration based on
     // `validators`.

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -671,9 +671,14 @@ TCPPeer::getIncomingMsgLength()
     length |= header[2];
     length <<= 8;
     length |= header[3];
+    bool ignoreLimits = false;
+#ifdef BUILD_TESTS
+    ignoreLimits = mAppConnector.getConfig().IGNORE_MESSAGE_LIMITS_FOR_TESTING;
+#endif
     if (length <= 0 ||
-        (!isAuthenticated(guard) && (length > MAX_UNAUTH_MESSAGE_SIZE)) ||
-        length > MAX_MESSAGE_SIZE)
+        (!ignoreLimits &&
+         ((!isAuthenticated(guard) && (length > MAX_UNAUTH_MESSAGE_SIZE)) ||
+          length > MAX_MESSAGE_SIZE)))
     {
         mOverlayMetrics.mErrorRead.Mark();
         CLOG_ERROR(Overlay, "{} TCP: message size unacceptable: {}{}",

--- a/src/simulation/ApplyLoad.cpp
+++ b/src/simulation/ApplyLoad.cpp
@@ -1,19 +1,24 @@
 #include "simulation/ApplyLoad.h"
 
+#include <algorithm>
 #include <cmath>
+#include <limits>
 #include <numeric>
+#include <string>
+#include <unordered_map>
 
 #include "bucket/test/BucketTestUtils.h"
 #include "herder/Herder.h"
 #include "ledger/LedgerManager.h"
+#include "ledger/LedgerManagerImpl.h"
+#include "simulation/TxGenerator.h"
 #include "test/TxTests.h"
 #include "transactions/MutableTransactionResult.h"
-#include "transactions/TransactionBridge.h"
 #include "transactions/TransactionUtils.h"
+#include "util/types.h"
 
 #include "herder/HerderImpl.h"
 
-#include "medida/meter.h"
 #include "medida/metrics_registry.h"
 
 #include "bucket/BucketListSnapshotBase.h"
@@ -21,7 +26,6 @@
 #include "util/GlobalChecks.h"
 #include "util/Logging.h"
 #include "util/XDRCereal.h"
-#include "xdrpp/printer.h"
 #include <crypto/SHA.h>
 
 namespace stellar
@@ -77,22 +81,104 @@ getUpgradeConfig(Config const& cfg)
 
     // These values are set above using values from Config, so the assertions
     // will fail if the config file is missing any of these values.
-    releaseAssert(upgradeConfig.ledgerMaxInstructions > 0);
-    releaseAssert(upgradeConfig.txMaxInstructions > 0);
-    releaseAssert(upgradeConfig.ledgerMaxDiskReadEntries > 0);
-    releaseAssert(upgradeConfig.ledgerMaxDiskReadBytes > 0);
-    releaseAssert(upgradeConfig.ledgerMaxWriteLedgerEntries > 0);
-    releaseAssert(upgradeConfig.ledgerMaxWriteBytes > 0);
-    releaseAssert(upgradeConfig.ledgerMaxTxCount > 0);
-    releaseAssert(upgradeConfig.txMaxDiskReadEntries > 0);
-    releaseAssert(upgradeConfig.txMaxDiskReadBytes > 0);
-    releaseAssert(upgradeConfig.txMaxWriteLedgerEntries > 0);
-    releaseAssert(upgradeConfig.txMaxWriteBytes > 0);
-    releaseAssert(upgradeConfig.txMaxContractEventsSizeBytes > 0);
-    releaseAssert(upgradeConfig.ledgerMaxTransactionsSizeBytes > 0);
-    releaseAssert(upgradeConfig.txMaxSizeBytes > 0);
+    releaseAssert(*upgradeConfig.ledgerMaxInstructions > 0);
+    releaseAssert(*upgradeConfig.txMaxInstructions > 0);
+    releaseAssert(*upgradeConfig.ledgerMaxDiskReadEntries > 0);
+    releaseAssert(*upgradeConfig.ledgerMaxDiskReadBytes > 0);
+    releaseAssert(*upgradeConfig.ledgerMaxWriteLedgerEntries > 0);
+    releaseAssert(*upgradeConfig.ledgerMaxWriteBytes > 0);
+    releaseAssert(*upgradeConfig.ledgerMaxTxCount > 0);
+    releaseAssert(*upgradeConfig.txMaxDiskReadEntries > 0);
+    releaseAssert(*upgradeConfig.txMaxDiskReadBytes > 0);
+    releaseAssert(*upgradeConfig.txMaxWriteLedgerEntries > 0);
+    releaseAssert(*upgradeConfig.txMaxWriteBytes > 0);
+    releaseAssert(*upgradeConfig.txMaxContractEventsSizeBytes > 0);
+    releaseAssert(*upgradeConfig.ledgerMaxTransactionsSizeBytes > 0);
+    releaseAssert(*upgradeConfig.txMaxSizeBytes > 0);
     return upgradeConfig;
 }
+
+SorobanUpgradeConfig
+getUpgradeConfigForMaxTPS(Config const& cfg, uint64_t instructionsPerCluster,
+                          uint32_t totalTxs)
+{
+    SorobanUpgradeConfig upgradeConfig;
+    upgradeConfig.ledgerMaxDependentTxClusters =
+        cfg.APPLY_LOAD_LEDGER_MAX_DEPENDENT_TX_CLUSTERS;
+
+    // Set arbitrarily high limits for everything except instructions
+    // and tx count
+    upgradeConfig.maxContractSizeBytes = 65536;
+    upgradeConfig.maxContractDataKeySizeBytes = 250;
+    upgradeConfig.maxContractDataEntrySizeBytes = 65536;
+    upgradeConfig.txMemoryLimit = 41943040;
+    upgradeConfig.liveSorobanStateSizeWindowSampleSize = 30;
+    upgradeConfig.evictionScanSize = 100000;
+    upgradeConfig.startingEvictionScanLevel = 7;
+
+    upgradeConfig.ledgerMaxDiskReadEntries = 100'000'000;
+    upgradeConfig.ledgerMaxDiskReadBytes = 100'000'000;
+    upgradeConfig.ledgerMaxWriteLedgerEntries = 100'000'000;
+    upgradeConfig.ledgerMaxWriteBytes = 100'000'000;
+    upgradeConfig.txMaxDiskReadEntries = 5;
+    upgradeConfig.txMaxFootprintEntries = 5;
+    upgradeConfig.txMaxDiskReadBytes = 10'000;
+    upgradeConfig.txMaxWriteLedgerEntries = 5;
+    upgradeConfig.txMaxWriteBytes = 10'000;
+    upgradeConfig.ledgerMaxTransactionsSizeBytes = 100'000'000;
+    upgradeConfig.txMaxSizeBytes = 10'000;
+    upgradeConfig.txMaxInstructions = 3'000'000;
+    upgradeConfig.txMaxContractEventsSizeBytes = 100'000'000;
+
+    // Increase the default TTL and reduce the rent rate in order to avoid the
+    // state archival and too high rent fees. The apply load test is generally
+    // not concerned about the resource fees.
+    upgradeConfig.minPersistentTTL = 1'000'000'000;
+    upgradeConfig.minTemporaryTTL = 1'000'000'000;
+    upgradeConfig.maxEntryTTL = 1'000'000'001;
+    upgradeConfig.persistentRentRateDenominator = 1'000'000'000'000LL;
+    upgradeConfig.tempRentRateDenominator = 1'000'000'000'000LL;
+
+    // Set the instruction and max tx count just high enough so that we generate
+    // a full ledger. This ensures all available clusters are filled for maximum
+    // parallelism.
+    upgradeConfig.ledgerMaxInstructions = instructionsPerCluster;
+    upgradeConfig.ledgerMaxTxCount = totalTxs;
+
+    releaseAssert(*upgradeConfig.ledgerMaxInstructions > 0);
+    releaseAssert(*upgradeConfig.txMaxInstructions > 0);
+
+    if (*upgradeConfig.ledgerMaxInstructions < *upgradeConfig.txMaxInstructions)
+    {
+        throw std::runtime_error("TPS too low, cannot achieve parallelism");
+    }
+
+    return upgradeConfig;
+}
+}
+
+void
+ApplyLoad::upgradeSettingsForMaxTPS(uint32_t txsToGenerate)
+{
+    // Calculate the actual instructions needed for all transactions. The
+    // ledger max instructions is the total instruction count per cluster. In
+    // order to have max parallelism, we want each cluster to be full, so
+    // upgrade settings such that we have just enough capacity across all
+    // clusters.
+    uint64_t totalInstructions =
+        static_cast<uint64_t>(txsToGenerate) * TxGenerator::SAC_TX_INSTRUCTIONS;
+    uint64_t instructionsPerCluster =
+        totalInstructions /
+        mApp.getConfig().APPLY_LOAD_LEDGER_MAX_DEPENDENT_TX_CLUSTERS;
+
+    // Add a 5% buffer to ensure all transactions can fit
+    instructionsPerCluster =
+        static_cast<uint64_t>(instructionsPerCluster * 1.05);
+
+    auto upgradeConfig = getUpgradeConfigForMaxTPS(
+        mApp.getConfig(), instructionsPerCluster, txsToGenerate);
+
+    applyConfigUpgrade(upgradeConfig);
 }
 
 // Given an index, returns the LedgerKey for an archived entry that is
@@ -192,15 +278,25 @@ ApplyLoad::setup()
 
     setupAccounts();
 
-    if (mMode == ApplyLoadMode::SOROBAN || mMode == ApplyLoadMode::MIX)
+    if (mMode == ApplyLoadMode::SOROBAN || mMode == ApplyLoadMode::MIX ||
+        mMode == ApplyLoadMode::MAX_SAC_TPS)
     {
         setupUpgradeContract();
 
-        upgradeSettings();
+        if (mMode == ApplyLoadMode::MAX_SAC_TPS)
+        {
+            // Just upgrade to a placeholder number of TXs, we'll
+            // upgrade again before each TPS run.
+            upgradeSettingsForMaxTPS(100000);
+        }
+        else
+        {
+            upgradeSettings();
+        }
 
         setupLoadContract();
 
-        if (mMode == ApplyLoadMode::MIX)
+        if (mMode == ApplyLoadMode::MIX || mMode == ApplyLoadMode::MAX_SAC_TPS)
         {
             setupXLMContract();
         }
@@ -298,12 +394,11 @@ ApplyLoad::setupUpgradeContract()
 // To upgrade settings, just modify mUpgradeConfig and then call
 // upgradeSettings()
 void
-ApplyLoad::upgradeSettings()
+ApplyLoad::applyConfigUpgrade(SorobanUpgradeConfig const& upgradeConfig)
 {
     int64_t currApplySorobanSuccess =
         mTxGenerator.getApplySorobanSuccess().count();
     auto const& lm = mApp.getLedgerManager();
-    auto upgradeConfig = getUpgradeConfig(mApp.getConfig());
     auto upgradeBytes =
         mTxGenerator.getConfigUpgradeSetFromLoadConfig(upgradeConfig);
 
@@ -331,6 +426,15 @@ ApplyLoad::upgradeSettings()
     releaseAssert(mTxGenerator.getApplySorobanSuccess().count() -
                       currApplySorobanSuccess ==
                   1);
+}
+
+void
+ApplyLoad::upgradeSettings()
+{
+    releaseAssertOrThrow(mMode != ApplyLoadMode::MAX_SAC_TPS);
+
+    auto upgradeConfig = getUpgradeConfig(mApp.getConfig());
+    applyConfigUpgrade(upgradeConfig);
 }
 
 void
@@ -583,6 +687,8 @@ ApplyLoad::setupBucketList()
 void
 ApplyLoad::benchmark()
 {
+    releaseAssertOrThrow(mMode != ApplyLoadMode::MAX_SAC_TPS);
+
     auto& lm = mApp.getLedgerManager();
     std::vector<TransactionFrameBasePtr> txs;
 
@@ -825,4 +931,181 @@ ApplyLoad::getWriteEntryUtilization()
     return mWriteEntryUtilization;
 }
 
+void
+ApplyLoad::warmAccountCache()
+{
+    auto const& accounts = mTxGenerator.getAccounts();
+    CLOG_INFO(Perf, "Warming account cache with {} accounts.", accounts.size());
+
+    LedgerTxn ltx(mApp.getLedgerTxnRoot());
+    for (auto const& [_, account] : accounts)
+    {
+        auto acc = stellar::loadAccount(ltx, account->getPublicKey());
+        releaseAssert(acc);
+    }
+}
+
+void
+ApplyLoad::findMaxSacTps()
+{
+    releaseAssertOrThrow(mMode == ApplyLoadMode::MAX_SAC_TPS);
+
+    uint32_t minTps = mApp.getConfig().APPLY_LOAD_MAX_SAC_TPS_MIN_TPS;
+    uint32_t maxTps = mApp.getConfig().APPLY_LOAD_MAX_SAC_TPS_MAX_TPS;
+    uint32_t bestTps = 0;
+    double targetCloseTime =
+        mApp.getConfig().APPLY_LOAD_MAX_SAC_TPS_TARGET_CLOSE_TIME_MS;
+
+    CLOG_WARNING(Perf,
+                 "Starting MAX_SAC_TPS binary search between {} and {} TPS",
+                 minTps, maxTps);
+    CLOG_WARNING(Perf, "Target close time: {}ms", targetCloseTime);
+    CLOG_WARNING(Perf, "Num parallel clusters: {}",
+                 mApp.getConfig().APPLY_LOAD_LEDGER_MAX_DEPENDENT_TX_CLUSTERS);
+
+    while (minTps <= maxTps)
+    {
+        uint32_t testTps = (minTps + maxTps) / 2;
+
+        // Calculate transactions per ledger based on target close time
+        uint32_t txsPerLedger = static_cast<uint32_t>(
+            static_cast<double>(testTps) * 1000.0 / targetCloseTime);
+        CLOG_WARNING(Perf, "Testing {} TPS with {} TXs per ledger.", testTps,
+                     txsPerLedger);
+
+        upgradeSettingsForMaxTPS(txsPerLedger);
+
+        double avgCloseTime = benchmarkSacTps(txsPerLedger);
+
+        if (avgCloseTime <= targetCloseTime)
+        {
+            bestTps = testTps;
+            minTps = testTps + 1;
+            CLOG_WARNING(Perf, "Success: {} TPS (avg total tx apply: {:.2f}ms)",
+                         testTps, avgCloseTime);
+        }
+        else
+        {
+            maxTps = testTps - 1;
+            CLOG_WARNING(Perf, "Failed: {} TPS (avg total tx apply: {:.2f}ms)",
+                         testTps, avgCloseTime);
+        }
+    }
+
+    CLOG_WARNING(Perf, "================================================");
+    CLOG_WARNING(Perf, "Maximum sustainable SAC payments per second: {}",
+                 bestTps);
+    CLOG_WARNING(Perf, "With parallelism constraint of {} clusters",
+                 mApp.getConfig().APPLY_LOAD_LEDGER_MAX_DEPENDENT_TX_CLUSTERS);
+    CLOG_WARNING(Perf, "================================================");
+}
+
+double
+ApplyLoad::benchmarkSacTps(uint32_t txsPerLedger)
+{
+    // For timing, we just want to track the TX application itself. This
+    // includes charging fees, applying transactions, and post apply work (like
+    // meta). It does not include writing the results to disk.
+    auto& totalTxApplyTimer =
+        mApp.getMetrics().NewTimer({"ledger", "transaction", "total-apply"});
+
+    std::vector<double> closeTimes;
+    uint32_t iterations =
+        mApp.getConfig().APPLY_LOAD_MAX_SAC_TPS_TEST_ITERATIONS;
+
+    for (uint32_t iter = 0; iter < iterations; ++iter)
+    {
+        warmAccountCache();
+
+        int64_t initialSuccessCount =
+            mTxGenerator.getApplySorobanSuccess().count();
+        totalTxApplyTimer.Clear();
+
+        // Generate exactly enough SAC payment transactions
+        std::vector<TransactionFrameBasePtr> txs;
+        txs.reserve(txsPerLedger);
+
+        generateSacPayments(txs, txsPerLedger);
+        releaseAssertOrThrow(txs.size() == txsPerLedger);
+
+        mApp.getBucketManager().getLiveBucketList().resolveAllFutures();
+        releaseAssert(
+            mApp.getBucketManager().getLiveBucketList().futuresAllResolved());
+
+        closeLedger(txs);
+
+        double applyTime = totalTxApplyTimer.sum();
+        closeTimes.push_back(applyTime);
+        CLOG_WARNING(Perf, "  Iteration {}: {:.2f}ms (total tx apply time)",
+                     iter + 1, applyTime);
+
+        // Check transaction success rate. We should never have any failures,
+        // and all TXs should have been executed.
+        int64_t newSuccessCount =
+            mTxGenerator.getApplySorobanSuccess().count() - initialSuccessCount;
+
+        releaseAssert(mTxGenerator.getApplySorobanFailure().count() == 0);
+        releaseAssert(newSuccessCount == txsPerLedger);
+
+        // Verify we had max parallelism, i.e. 1 stage with
+        // maxDependentTxClusters clusters
+        auto& stagesMetric =
+            mApp.getMetrics().NewCounter({"ledger", "apply-soroban", "stages"});
+        auto& maxClustersMetric = mApp.getMetrics().NewCounter(
+            {"ledger", "apply-soroban", "max-clusters"});
+
+        releaseAssert(stagesMetric.count() == 1);
+        releaseAssert(
+            maxClustersMetric.count() ==
+            mApp.getConfig().APPLY_LOAD_LEDGER_MAX_DEPENDENT_TX_CLUSTERS);
+    }
+
+    // Calculate average close time
+    double avgTime =
+        std::accumulate(closeTimes.begin(), closeTimes.end(), 0.0) /
+        closeTimes.size();
+
+    // Log standard deviation
+    double variance = 0.0;
+    for (double time : closeTimes)
+    {
+        variance += (time - avgTime) * (time - avgTime);
+    }
+    double stdDev = std::sqrt(variance / closeTimes.size());
+
+    CLOG_INFO(Perf,
+              "  Average total tx apply time: {:.2f}ms (std dev: {:.2f}ms), "
+              "all {} txs succeeded",
+              avgTime, stdDev, txsPerLedger * iterations);
+
+    return avgTime;
+}
+
+void
+ApplyLoad::generateSacPayments(std::vector<TransactionFrameBasePtr>& txs,
+                               uint32_t count)
+{
+    auto const& accounts = mTxGenerator.getAccounts();
+    auto& lm = mApp.getLedgerManager();
+
+    releaseAssert(accounts.size() >= count);
+
+    // To maximize parallelism, every payment will have a different source
+    // account and have a new, unique destination C address.
+    for (uint32_t i = 0; i < count; ++i)
+    {
+        SCAddress toAddress(SC_ADDRESS_TYPE_CONTRACT);
+        toAddress.contractId() =
+            sha256(fmt::format("dest_{}_{}", i, lm.getLastClosedLedgerNum()));
+
+        auto it = accounts.find(i);
+        releaseAssert(it != accounts.end());
+
+        auto tx = mTxGenerator.invokeSACPayment(lm.getLastClosedLedgerNum() + 1,
+                                                i, toAddress, mSACInstanceXLM,
+                                                100, 1'000'000);
+
+        txs.push_back(tx.second);
+    }
+}
 }

--- a/src/simulation/TxGenerator.h
+++ b/src/simulation/TxGenerator.h
@@ -88,6 +88,9 @@ struct SorobanUpgradeConfig
 class TxGenerator
 {
   public:
+    // Instructions per SAC transaction
+    static constexpr uint64_t SAC_TX_INSTRUCTIONS = 250'000;
+
     // Special account ID to represent the root account
     static uint64_t const ROOT_ACCOUNT_ID;
 

--- a/src/simulation/test/LoadGeneratorTests.cpp
+++ b/src/simulation/test/LoadGeneratorTests.cpp
@@ -1066,7 +1066,8 @@ TEST_CASE("apply load", "[loadgen][applyload][acceptance]")
               al.getWriteEntryUtilization().mean() / 1000.0);
 }
 
-TEST_CASE("basic MAX_SAC_TPS functionality", "[loadgen][applyload][acceptance]")
+TEST_CASE("basic MAX_SAC_TPS functionality",
+          "[loadgen][applyload][soroban][acceptance]")
 {
     auto cfg = getTestConfig();
     cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE = 1000;


### PR DESCRIPTION
# Description

Adds a Soroban apply only max TPS test. This test generates a set of non-conflicting native asset SAC payments and times how long it takes to just apply the TX set. This includes the pre-apply phase (fees and seqno), apply, and post apply, but does not include BucketList writes. Given a fixed cluster count, a lower bound TPS, an upper bound TPS, and a maximum TX set apply time, the test will do a binary search and report the max TPS achieved.

I also noticed a few gaps and added a couple metrics. I added a metric for stage count, max cluster count, and total apply time. Previously, total apply time could be derived from the transaction apply metric. This is no longer the case. That metric tracks per-tx apply times. However, since we now apply in parallel threads, the sum of each per-tx apply time is greater than the "wall clock" time of the apply phase. The new metric reports wall clock time of the entire apply phase.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
