### PR TITLE
Parallel apply cleanup

### DIFF
--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -2273,7 +2273,6 @@ LedgerManagerImpl::applySorobanStageClustersInParallel(
     SorobanNetworkConfig const& sorobanConfig,
     ParallelLedgerInfo const& ledgerInfo)
 {
-
     std::vector<std::unique_ptr<ThreadParallelApplyLedgerState>> threadStates;
     std::vector<std::future<std::unique_ptr<ThreadParallelApplyLedgerState>>>
         threadFutures;
@@ -2295,8 +2294,19 @@ LedgerManagerImpl::applySorobanStageClustersInParallel(
     for (auto& threadFuture : threadFutures)
     {
         releaseAssert(threadFuture.valid());
-        auto futureResult = threadFuture.get();
-        threadStates.emplace_back(std::move(futureResult));
+        try
+        {
+            auto futureResult = threadFuture.get();
+            threadStates.emplace_back(std::move(futureResult));
+        }
+        catch (const std::exception& e)
+        {
+            printErrorAndAbort("Exception on apply thread: ", e.what());
+        }
+        catch (...)
+        {
+            printErrorAndAbort("Unknown exception on apply thread");
+        }
     }
     threadFutures.clear();
     return threadStates;

--- a/src/transactions/ParallelApplyStage.h
+++ b/src/transactions/ParallelApplyStage.h
@@ -39,7 +39,8 @@ class TxEffects
     void
     setDeltaEntry(LedgerKey const& key, LedgerTxnDelta::EntryDelta const& delta)
     {
-        mDelta.entry.emplace(key, delta);
+        auto it = mDelta.entry.emplace(key, delta);
+        releaseAssertOrThrow(it.second);
     }
 
     void

--- a/src/transactions/ParallelApplyUtils.cpp
+++ b/src/transactions/ParallelApplyUtils.cpp
@@ -124,21 +124,19 @@ maybeMergeRoTTLBumps(LedgerKey const& key, ParallelApplyEntry const& newEntry,
     // Read Only bumps will always be updating a pre-existing value. TTL
     // creation (!oldEntry) or deletion (!newEntry) are write conflicts that
     // don't have merge special casing.
-    if (newEntry.mLedgerEntry && oldEntry.mLedgerEntry)
+    if (newEntry.mLedgerEntry && oldEntry.mLedgerEntry && key.type() == TTL)
     {
         auto const& newLe = newEntry.mLedgerEntry.value();
         auto& oldLe = oldEntry.mLedgerEntry.value();
-        if (key.type() == TTL)
+
+        releaseAssertOrThrow(newLe.data.type() == TTL);
+        releaseAssertOrThrow(oldLe.data.type() == TTL);
+        if (readWriteSet.find(key) == readWriteSet.end())
         {
-            releaseAssertOrThrow(newLe.data.type() == TTL);
-            releaseAssertOrThrow(oldLe.data.type() == TTL);
-            if (readWriteSet.find(key) == readWriteSet.end())
-            {
-                auto const& newTTL = newLe.data.ttl().liveUntilLedgerSeq;
-                auto& oldTTL = oldLe.data.ttl().liveUntilLedgerSeq;
-                oldTTL = std::max(oldTTL, newTTL);
-                return true;
-            }
+            auto const& newTTL = newLe.data.ttl().liveUntilLedgerSeq;
+            auto& oldTTL = oldLe.data.ttl().liveUntilLedgerSeq;
+            oldTTL = std::max(oldTTL, newTTL);
+            return true;
         }
     }
     return false;
@@ -508,8 +506,6 @@ GlobalParallelApplyLedgerState::commitChangesFromThread(
     AppConnector& app, ThreadParallelApplyLedgerState const& thread,
     ApplyStage const& stage)
 {
-    releaseAssert(threadIsMain() ||
-                  app.threadIsType(Application::ThreadType::APPLY));
     auto readWriteSet = getReadWriteKeysForStage(stage);
     for (auto const& [key, entry] : thread.getEntryMap())
     {
@@ -524,6 +520,9 @@ GlobalParallelApplyLedgerState::commitChangesFromThreads(
     std::vector<std::unique_ptr<ThreadParallelApplyLedgerState>> const& threads,
     ApplyStage const& stage)
 {
+    releaseAssert(threadIsMain() ||
+                  app.threadIsType(Application::ThreadType::APPLY));
+
     for (auto const& thread : threads)
     {
         commitChangesFromThread(app, *thread, stage);


### PR DESCRIPTION
# Description

1. Add insertion check in `ParallelApplyStage::setDeltaEntry`.
2. Move thread assertion to `ParallelApplyUtils::commitChangesFromThreads`.
3. Exception handling in `LedgerManagerImpl::applySorobanStageClustersInParallel`.
4. Remove unnecessary nesting from `maybeMergeRoTTLBumps`. 

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
