### PR TITLE
Replace unsaturated add calculations for limits in herder

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,3 +2,5 @@
 Write fee bump tests to go along with any new regular transaction tests or any logic changes to transaction processing and application.
 
 If you see TransactionFrame being touched, always check if FeeBumpTransactionFrame support was also added, and report if changes are potentially missing.
+
+Report any numeric operations that may cause overflow or underflow (e.g., adding two `uint32_t`s near their maximum value).

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -2239,8 +2239,8 @@ HerderImpl::maybeHandleUpgrade()
         auto const& conf =
             mApp.getLedgerManager().getLastClosedSorobanNetworkConfig();
 
-        auto maybeNewMaxTxSize =
-            conf.txMaxSizeBytes() + getFlowControlExtraBuffer();
+        auto maybeNewMaxTxSize = saturatingAdd<uint32_t>(
+            conf.txMaxSizeBytes(), getFlowControlExtraBuffer());
         if (maybeNewMaxTxSize > mMaxTxSize)
         {
             diff = maybeNewMaxTxSize - mMaxTxSize;
@@ -2290,8 +2290,10 @@ HerderImpl::start()
         {
             auto const& conf =
                 mApp.getLedgerManager().getLastClosedSorobanNetworkConfig();
-            mMaxTxSize = std::max(mMaxTxSize, conf.txMaxSizeBytes() +
-                                                  getFlowControlExtraBuffer());
+            mMaxTxSize =
+                std::max(mMaxTxSize,
+                         saturatingAdd<uint32_t>(conf.txMaxSizeBytes(),
+                                                 getFlowControlExtraBuffer()));
         }
 
         maybeSetupSorobanQueue(version);

--- a/src/simulation/ApplyLoad.cpp
+++ b/src/simulation/ApplyLoad.cpp
@@ -140,7 +140,7 @@ ApplyLoad::calculateRequiredHotArchiveEntries(Config const& cfg)
         auto weight = cfg.APPLY_LOAD_NUM_RO_ENTRIES_DISTRIBUTION_FOR_TESTING[i];
 
         totalWeight += weight;
-        weightedSum += entries * weight;
+        weightedSum += static_cast<double>(entries) * weight;
     }
 
     double avgROEntriesPerTx = totalWeight > 0 ? weightedSum / totalWeight : 0;

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -82,4 +82,17 @@ saturatingMultiply(int64_t a, int64_t b)
 
     return a * b;
 }
+
+// Saturating addition for unsigned ints: returns a + b, capped at type max.
+template <typename T>
+inline T
+saturatingAdd(T a, T b)
+{
+    static_assert(std::is_unsigned<T>());
+    if (a > std::numeric_limits<T>::max() - b)
+    {
+        return std::numeric_limits<T>::max();
+    }
+    return a + b;
+}
 }


### PR DESCRIPTION
Resolves #4903, given the feedback comments to copilot on #4906. It may also be worth doing a code search to see if we should do saturating arithmetic elsewhere.