### PR TITLE
Use a separate PRNG in LedgerTxn cache

### DIFF
--- a/src/util/RandomEvictionCache.h
+++ b/src/util/RandomEvictionCache.h
@@ -57,8 +57,8 @@ class RandomEvictionCache : public NonMovableOrCopyable
     // Each cache keeps some counters just to monitor its performance.
     Counters mCounters;
 
-    // Optionally use a dedicated random engine
-    bool const mSeparatePRNG{false};
+    // Use a dedicated random engine, with an option to disable
+    bool const mSeparatePRNG{true};
     stellar_default_random_engine mRandEngine;
 
     // Randomly pick two elements and evict the less-recently-used one.
@@ -89,7 +89,7 @@ class RandomEvictionCache : public NonMovableOrCopyable
 
   public:
     explicit RandomEvictionCache(size_t maxSize)
-        : mMaxSize(maxSize), mSeparatePRNG(false)
+        : mMaxSize(maxSize), mSeparatePRNG(true)
     {
         mValueMap.reserve(maxSize + 1);
         mValuePtrs.reserve(maxSize + 1);


### PR DESCRIPTION
multi-threaded access to PRNG strikes again - https://github.com/stellar/stellar-core/pull/4879 recently added a main thread assert, which causes LedgerTxn's random eviction cache to trip. While auditing the code, I noticed that BucketIndex code uses global PRNG in its cache. This PR forces RandomEvictionCache to always use a separate PRNG. 