### PR TITLE
Run the build with check-test-tx-meta sequentially to get most cache hits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,12 +142,24 @@ jobs:
           echo Build with $CC and $CXX
           echo "Running first scenario"
           ./ci-build.sh --use-temp-db --protocol ${{ matrix.protocol }}
-          echo "Running second scenario with --check-test-tx-meta flag"
-          ./ci-build.sh --use-temp-db --protocol ${{ matrix.protocol }} --check-test-tx-meta
 
       # We only _save_ to the cache when we had a cache miss and are running on master.
-      - uses: actions/cache/save@v4
+      - name: Save cache after first build
+        uses: actions/cache/save@v4
         if: ${{ steps.cache.outputs.cache-hit != 'true' && github.ref_name == 'master' }}
         with:
           path: ${{ env.CACHED_PATHS }}
           key: ${{ steps.cache.outputs.cache-primary-key }}
+
+      - name: Build for check-test-tx-meta scenario
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          if test "${{ matrix.toolchain }}" = "gcc" ; then
+            export CC='gcc'
+            export CXX='g++'
+          else
+            export CC='clang'
+            export CXX='clang++'
+          fi
+          echo "Running second scenario with --check-test-tx-meta flag"
+          ./ci-build.sh --use-temp-db --protocol ${{ matrix.protocol }} --check-test-tx-meta


### PR DESCRIPTION
We currently have a matrix scenario to run with and without the flag check-test-tx-meta. This means they run in parallel jobs and don't take advantage of caching. 
Running the build with check-test-tx-meta sequentially would get the most cache hits.
The tradeoff is that we would have longer CI run by not putting the build with check-test-tx-meta flag in a parallel job.

See the outcome in https://github.com/stellar/stellar-core/actions/runs/17438212726 where there are 4 parallel CI jobs taking between 26 to 37 minutes.

This PR is making these changes,

1. Run the tests with check-test-tx-meta sequentially after the regular build and test scenario instead of parallel. This would reduce the cost of not having to build again and use local filesystem cache. (maybe 16 core runners are more expensive?)
2. Save the build to Github cache as soon as its available
3. Make ci-build.sh idempotent
