### PR TITLE
Cache transaction validity

### DIFF
--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -235,5 +235,12 @@ class Herder
 
     virtual bool isBannedTx(Hash const& hash) const = 0;
     virtual TransactionFrameBaseConstPtr getTx(Hash const& hash) const = 0;
+
+    // Check transaction validity with caching, returns shared_ptr to
+    // MutableTransactionResultBase
+    virtual TransactionResultConstPtr checkValidCached(
+        LedgerSnapshot const& ls, TransactionFrameBaseConstPtr const& tx,
+        uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+        DiagnosticEventManager& diagnosticEvents) = 0;
 };
 }

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -75,7 +75,7 @@ class TransactionQueue
     struct AddResult
     {
         TransactionQueue::AddResultCode code;
-        MutableTxResultPtr txResult;
+        TransactionResultConstPtr txResult;
         xdr::xvector<DiagnosticEvent> mDiagnosticEvents;
 
         // AddResult with no txResult
@@ -83,11 +83,11 @@ class TransactionQueue
 
         // AddResult from existing transaction result
         explicit AddResult(TransactionQueue::AddResultCode addCode,
-                           MutableTxResultPtr payload);
+                           TransactionResultConstPtr payload);
 
         // Same as above, also populating diagnostics
         explicit AddResult(TransactionQueue::AddResultCode addCode,
-                           MutableTxResultPtr payload,
+                           TransactionResultConstPtr payload,
                            xdr::xvector<DiagnosticEvent>&& diagnostics);
 
         // AddResult with error txResult with the specified txErrorCode

--- a/src/herder/TxSetUtils.cpp
+++ b/src/herder/TxSetUtils.cpp
@@ -8,6 +8,7 @@
 #include "crypto/Random.h"
 #include "crypto/SHA.h"
 #include "database/Database.h"
+#include "herder/Herder.h"
 #include "ledger/LedgerManager.h"
 #include "ledger/LedgerTxn.h"
 #include "ledger/LedgerTxnEntry.h"
@@ -178,10 +179,10 @@ TxSetUtils::getInvalidTxList(TxFrameList const& txs, Application& app,
     auto diagnostics = DiagnosticEventManager::createDisabled();
     for (auto const& tx : txs)
     {
-        auto txResult = tx->checkValid(app.getAppConnector(), ls, 0,
-                                       lowerBoundCloseTimeOffset,
-                                       upperBoundCloseTimeOffset, diagnostics);
-        if (!txResult->isSuccess())
+        auto res = app.getHerder().checkValidCached(
+            ls, tx, lowerBoundCloseTimeOffset, upperBoundCloseTimeOffset,
+            diagnostics);
+        if (!res->isSuccess())
         {
             invalidTxs.emplace_back(tx);
         }

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -605,9 +605,6 @@ CatchupSimulation::generateRandomLedger(uint32_t version)
 
     mLedgerCloseDatas.emplace_back(ledgerSeq, txSet, sv);
 
-    auto& txsSucceeded =
-        getApp().getMetrics().NewCounter({"ledger", "apply", "success"});
-
     lm.applyLedger(mLedgerCloseDatas.back());
 
     auto const& lclh = lm.getLastClosedLedgerHeader();

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -242,6 +242,18 @@ FeeBumpTransactionFrame::checkSignature(SignatureChecker& signatureChecker,
     return signatureChecker.checkSignature(signers, neededWeight);
 }
 
+std::optional<TimeBounds const> const
+FeeBumpTransactionFrame::getTimeBounds() const
+{
+    return mInnerTx->getTimeBounds();
+}
+
+std::optional<LedgerBounds const> const
+FeeBumpTransactionFrame::getLedgerBounds() const
+{
+    return mInnerTx->getLedgerBounds();
+}
+
 MutableTxResultPtr
 FeeBumpTransactionFrame::checkValid(
     AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,

--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -143,6 +143,9 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
     Duration getMinSeqAge() const override;
     uint32 getMinSeqLedgerGap() const override;
 
+    std::optional<TimeBounds const> const getTimeBounds() const override;
+    std::optional<LedgerBounds const> const getLedgerBounds() const override;
+
     void
     insertKeysForFeeProcessing(UnorderedSet<LedgerKey>& keys) const override;
     void insertKeysForTxApply(UnorderedSet<LedgerKey>& keys) const override;

--- a/src/transactions/MutableTransactionResult.h
+++ b/src/transactions/MutableTransactionResult.h
@@ -12,6 +12,9 @@
 namespace stellar
 {
 
+using TransactionResultConstPtr =
+    std::shared_ptr<MutableTransactionResultBase const>;
+
 // This class tracks the refundable resources and corresponding fees for a
 // transaction.
 // This can not be instantiated directly and is only accessible through

--- a/src/transactions/TransactionBridge.cpp
+++ b/src/transactions/TransactionBridge.cpp
@@ -203,6 +203,47 @@ setMaxTime(std::shared_ptr<TransactionTestFrame const> tx, TimePoint maxTime)
         }
     }
 }
+
+void
+setLedgerBounds(TransactionTestFramePtr tx, std::optional<uint32_t> minLedger,
+                std::optional<uint32_t> maxLedger)
+{
+    auto& env = tx->getMutableEnvelope();
+    if (env.type() == ENVELOPE_TYPE_TX)
+    {
+        auto& cond = env.v1().tx.cond;
+        if (cond.type() == PRECOND_NONE)
+        {
+            cond.type(PRECOND_V2);
+        }
+
+        if (cond.type() == PRECOND_TIME)
+        {
+            TimeBounds tb = cond.timeBounds();
+            cond.type(PRECOND_V2);
+            cond.v2().timeBounds.activate();
+            cond.v2().timeBounds->minTime = tb.minTime;
+            cond.v2().timeBounds->maxTime = tb.maxTime;
+        }
+
+        if (minLedger || maxLedger)
+        {
+            cond.v2().ledgerBounds.activate();
+            if (minLedger)
+            {
+                cond.v2().ledgerBounds->minLedger = *minLedger;
+            }
+            if (maxLedger)
+            {
+                cond.v2().ledgerBounds->maxLedger = *maxLedger;
+            }
+        }
+        else
+        {
+            cond.v2().ledgerBounds.reset();
+        }
+    }
+}
 #endif
 }
 }

--- a/src/transactions/TransactionBridge.h
+++ b/src/transactions/TransactionBridge.h
@@ -6,6 +6,7 @@
 
 #include "xdr/Stellar-transaction.h"
 #include <memory>
+#include <optional>
 
 namespace stellar
 {
@@ -47,6 +48,9 @@ void setMinTime(TransactionTestFramePtr tx, TimePoint minTime);
 
 void setMaxTime(std::shared_ptr<TransactionTestFrame const> tx,
                 TimePoint maxTime);
+void setLedgerBounds(TransactionTestFramePtr tx,
+                     std::optional<uint32_t> minLedger,
+                     std::optional<uint32_t> maxLedger);
 #endif
 }
 }

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -1703,6 +1703,7 @@ TransactionFrame::checkValid(AppConnector& app, LedgerSnapshot const& ls,
                              uint64_t upperBoundCloseTimeOffset,
                              DiagnosticEventManager& diagnosticEvents) const
 {
+    ZoneScoped;
 #ifdef BUILD_TESTS
     if (app.getRunInOverlayOnlyMode())
     {

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -140,8 +140,6 @@ class TransactionFrame : public TransactionFrameBase
                            AbstractLedgerTxn& ltxOuter,
                            MutableTransactionResultBase& txResult) const;
 
-    std::optional<TimeBounds const> const getTimeBounds() const;
-    std::optional<LedgerBounds const> const getLedgerBounds() const;
     bool extraSignersExist() const;
 
     bool validateSorobanOpsConsistency() const;
@@ -329,6 +327,9 @@ class TransactionFrame : public TransactionFrameBase
     std::optional<SequenceNumber const> const getMinSeqNum() const override;
     Duration getMinSeqAge() const override;
     uint32 getMinSeqLedgerGap() const override;
+
+    std::optional<TimeBounds const> const getTimeBounds() const override;
+    std::optional<LedgerBounds const> const getLedgerBounds() const override;
 
     bool hasDexOperations() const override;
 

--- a/src/transactions/TransactionFrameBase.h
+++ b/src/transactions/TransactionFrameBase.h
@@ -209,6 +209,9 @@ class TransactionFrameBase
     virtual Duration getMinSeqAge() const = 0;
     virtual uint32 getMinSeqLedgerGap() const = 0;
 
+    virtual std::optional<TimeBounds const> const getTimeBounds() const = 0;
+    virtual std::optional<LedgerBounds const> const getLedgerBounds() const = 0;
+
     virtual void
     insertKeysForFeeProcessing(UnorderedSet<LedgerKey>& keys) const = 0;
     virtual void insertKeysForTxApply(UnorderedSet<LedgerKey>& keys) const = 0;

--- a/src/transactions/test/TransactionTestFrame.cpp
+++ b/src/transactions/test/TransactionTestFrame.cpp
@@ -180,6 +180,18 @@ TransactionTestFrame::getTxFramePtr() const
     return mTransactionFrame;
 }
 
+std::optional<TimeBounds const> const
+TransactionTestFrame::getTimeBounds() const
+{
+    return mTransactionFrame->getTimeBounds();
+}
+
+std::optional<LedgerBounds const> const
+TransactionTestFrame::getLedgerBounds() const
+{
+    return mTransactionFrame->getLedgerBounds();
+}
+
 bool
 TransactionTestFrame::validateSorobanMemoForFlooding() const
 {

--- a/src/transactions/test/TransactionTestFrame.h
+++ b/src/transactions/test/TransactionTestFrame.h
@@ -128,6 +128,9 @@ class TransactionTestFrame : public TransactionFrameBase
     Duration getMinSeqAge() const override;
     uint32 getMinSeqLedgerGap() const override;
 
+    std::optional<TimeBounds const> const getTimeBounds() const override;
+    std::optional<LedgerBounds const> const getLedgerBounds() const override;
+
     void
     insertKeysForFeeProcessing(UnorderedSet<LedgerKey>& keys) const override;
     void insertKeysForTxApply(UnorderedSet<LedgerKey>& keys) const override;


### PR DESCRIPTION
Resolves https://github.com/stellar/stellar-core-internal/issues/380

### Perf impact:
- On pubnet node, I osberved ~20-25% of cache hits 
```
herder.txvalidity.cache-hits	
count	32169
herder.txvalidity.cache-misses	
count	92490
```

- In simulations, hit rate is around ~50% (we don't use time bounds in synthetic load), and maximum throughput increases by ~10-15%. Latest run:
  - Before: 2167
  - After: 2437 (+12.5%)
  
Update: please ignore simulation results for now, it appears the cluster is very inconsistent at the moment.