### PR TITLE
Consider Soroban limits in overlay

### DIFF
--- a/src/overlay/FlowControl.cpp
+++ b/src/overlay/FlowControl.cpp
@@ -468,8 +468,10 @@ FlowControl::addMsgAndMaybeTrimQueue(std::shared_ptr<StellarMessage const> msg)
 
     size_t dropped = 0;
 
+    auto& lm = mAppConnector.getLedgerManager();
     uint32_t const limit =
-        mAppConnector.getLedgerManager().getLastMaxTxSetSizeOps();
+        lm.getLastMaxTxSetSizeOps() +
+        lm.getLastClosedSorobanNetworkConfig().ledgerMaxTxCount();
     auto& om = mOverlayMetrics;
     if (type == TRANSACTION)
     {

--- a/src/overlay/TxAdverts.cpp
+++ b/src/overlay/TxAdverts.cpp
@@ -66,6 +66,14 @@ TxAdverts::startAdvertTimer()
     });
 }
 
+size_t
+TxAdverts::getTxLimit()
+{
+    auto& lm = mApp.getLedgerManager();
+    return lm.getLastMaxTxSetSizeOps() +
+           lm.getLastClosedSorobanNetworkConfig().ledgerMaxTxCount();
+}
+
 void
 TxAdverts::queueOutgoingAdvert(Hash const& txHash)
 {
@@ -108,7 +116,8 @@ void
 TxAdverts::retryIncomingAdvert(std::list<Hash>& list)
 {
     mTxHashesToRetry.splice(mTxHashesToRetry.end(), list);
-    while (size() > mApp.getLedgerManager().getLastMaxTxSetSizeOps())
+    size_t const limit = getTxLimit();
+    while (size() > limit)
     {
         popIncomingAdvert();
     }
@@ -123,11 +132,11 @@ TxAdverts::queueIncomingAdvert(TxAdvertVector const& txHashes, uint32_t seq)
     }
 
     auto it = txHashes.begin();
-    size_t const limit = mApp.getLedgerManager().getLastMaxTxSetSizeOps();
+    size_t const limit = getTxLimit();
     if (txHashes.size() > limit)
     {
-        // If txHashes has more than getLastMaxTxSetSizeOps txns, then
-        // the first (txHashes.size() - getLastMaxTxSetSizeOps) txns will be
+        // If txHashes has more than limit txns, then
+        // the first (txHashes.size() - limit) txns will be
         // popped in the while loop below. Therefore, we won't even bother
         // pushing them.
         it += txHashes.size() - limit;

--- a/src/overlay/TxAdverts.h
+++ b/src/overlay/TxAdverts.h
@@ -41,6 +41,12 @@ class TxAdverts
     void rememberHash(Hash const& hash, uint32_t ledgerSeq);
     void flushAdvert();
     void startAdvertTimer();
+#ifdef BUILD_TESTS
+  public:
+#endif
+    // Get the maximum size for transaction hashes to process, considering both
+    // Soroban and classic limits
+    size_t getTxLimit();
 
   public:
     TxAdverts(Application& app);

--- a/src/overlay/test/OverlayTests.cpp
+++ b/src/overlay/test/OverlayTests.cpp
@@ -828,6 +828,7 @@ TEST_CASE("peers during auth", "[overlay][connections]")
     testutil::shutdownWorkScheduler(*app1);
 }
 
+//
 TEST_CASE("outbound queue filtering", "[overlay][flowcontrol]")
 {
     auto networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
@@ -938,7 +939,10 @@ TEST_CASE("outbound queue filtering", "[overlay][flowcontrol]")
     }
     SECTION("txs, limit reached")
     {
-        uint32_t limit = node->getLedgerManager().getLastMaxTxSetSizeOps();
+        auto& lm = node->getLedgerManager();
+        uint32_t limit =
+            lm.getLastMaxTxSetSizeOps() +
+            lm.getLastClosedSorobanNetworkConfig().ledgerMaxTxCount();
         StellarMessage msg;
         msg.type(TRANSACTION);
         auto byteSize =
@@ -1047,7 +1051,10 @@ TEST_CASE("outbound queue filtering", "[overlay][flowcontrol]")
         {
             // Adverts/demands aren't affected by the byte limit
             peer->getFlowControl()->setOutboundQueueLimit(1);
-            uint32_t limit = node->getLedgerManager().getLastMaxTxSetSizeOps();
+            auto& lm = node->getLedgerManager();
+            uint32_t limit =
+                lm.getLastMaxTxSetSizeOps() +
+                lm.getLastClosedSorobanNetworkConfig().ledgerMaxTxCount();
             for (uint32_t i = 0; i < limit + 10; ++i)
             {
                 StellarMessage adv, dem, txn;

--- a/src/overlay/test/TxAdvertsTests.cpp
+++ b/src/overlay/test/TxAdvertsTests.cpp
@@ -24,7 +24,7 @@ TEST_CASE("advert queue", "[flood][pullmode][acceptance]")
         flushed = true;
     });
 
-    auto limit = app->getLedgerManager().getLastMaxTxSetSizeOps();
+    auto limit = pullMode.getTxLimit();
     auto getHash = [](auto i) { return sha256(std::to_string(i)); };
 
     SECTION("incoming adverts")


### PR DESCRIPTION
Resolves #4732. Currently, this does the naive update of adding the Soroban tx limit to the classic ops limit. The calculation is also repeated a few times to support iteration (in this PR) and potential differences between pull mode and flood mode—this will need to get cleaned up. Putting this up now so the spots to update are apparent and so there is a spot for discussion.

Pull mode doesn't know ahead of time whether the transactions are Soroban or classic, but the queue limit is per peer, so we could plausibly lower it. Also, the limit is on advertised hashes that we haven't yet received full transactions for. Similarly, in flood mode, this is just limiting the outstanding messages to a given peer. That is, in both modes, although we do need some limit to cap maximum memory usage, the particular limit is somewhat arbitrary (consider also #3514).