### PR TITLE
Update quorum set documentation

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -936,9 +936,10 @@ mkdir="mkdir -p /var/lib/stellar-core/history/vs/{0}"
 #  *** this section is for advanced users and exists mostly for historical reasons ***
 #    the preferred way to configure your quorum set is to use instead [[VALIDATORS]]
 #
-# It can be nested up to 2 levels: {A,B,C,{D,E,F},{G,H,{I,J,K,L}}}
+# It can be nested up to 4 levels {A,B,C,{D,E,F},{G,H,I,{J,K,L,{M,N,O,{P,Q,R}}}}}
 # THRESHOLD_PERCENT is how many have to agree (1-100%) within a given set.
 # Each set is treated as one vote.
+# Consider the following example: {A,B,C,{D,E,F},{G,H,{I,J,K,L}}}
 # So for example in the above there are 5 things that can vote:
 # individual validators: A,B,C, and the sets {D,E,F} and {G,H with subset {I,J,K,L}}
 # the sets each have their own threshold.


### PR DESCRIPTION
Resolves #4541 (replaces outdated documentation for quorum set nesting of 2, since nesting limit is now 4).