### PR TITLE
Update Autoconf input file for clang-19 support to use compile time tests when runtime tests fail with sanitizer option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -192,6 +192,9 @@ AS_IF([test x != "x$sanitizeopts"], [
   sanflags="-fsanitize=$sanitizeopts -fno-omit-frame-pointer"
   CFLAGS="$CFLAGS $sanflags"
   CXXFLAGS="$CXXFLAGS $sanflags"
+  
+  # Add sanitizer flags to LDFLAGS for proper linking
+  LDFLAGS="$LDFLAGS -fsanitize=$sanitizeopts"
 
   # compile our own libraries when sanitizers are enabled
   libsodium_INTERNAL=yes
@@ -269,15 +272,34 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[#include <filesystem>]],
 	      [[return std::filesystem::exists(std::filesystem::path("hello"));]])],
               [AC_MSG_RESULT([yes]); FS_WORKS=yes],
               [AC_MSG_RESULT([no]); FS_WORKS=no])
+
+# If runtime test failed but we have sanitizers enabled, try compile-time test
+# since sanitizers can interfere with filesystem runtime tests
+if test "$FS_WORKS" = "no" && test "x$sanitizeopts" != "x"; then
+    AC_MSG_CHECKING([to see if <filesystem> compiles without extra libs (sanitizer mode)])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <filesystem>]],
+	              [[return std::filesystem::exists(std::filesystem::path("hello"));]])],
+                      [AC_MSG_RESULT([yes]); FS_WORKS=yes],
+                      [AC_MSG_RESULT([no])])
+fi
+
 for testlib in -lstdc++fs -lc++fs; do
     if test "$FS_WORKS" = "no"; then
         fs_save_LIBS="$LIBS"
         LIBS="$testlib $LIBS"
         AC_MSG_CHECKING([to see if <filesystem> works with $testlib])
-        AC_RUN_IFELSE([AC_LANG_PROGRAM([[#include <filesystem>]],
-		      [[return std::filesystem::exists(std::filesystem::path("hello"));]])],
-                  [AC_MSG_RESULT([yes]); FS_WORKS=yes],
-                  [AC_MSG_RESULT([no]); FS_WORKS=no; LIBS="$fs_save_LIBS"])
+        # Use compile test if sanitizers are enabled, runtime test otherwise
+        if test "x$sanitizeopts" != "x"; then
+            AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <filesystem>]],
+		                  [[return std::filesystem::exists(std::filesystem::path("hello"));]])],
+                              [AC_MSG_RESULT([yes]); FS_WORKS=yes],
+                              [AC_MSG_RESULT([no]); FS_WORKS=no; LIBS="$fs_save_LIBS"])
+        else
+            AC_RUN_IFELSE([AC_LANG_PROGRAM([[#include <filesystem>]],
+		              [[return std::filesystem::exists(std::filesystem::path("hello"));]])],
+                          [AC_MSG_RESULT([yes]); FS_WORKS=yes],
+                          [AC_MSG_RESULT([no]); FS_WORKS=no; LIBS="$fs_save_LIBS"])
+        fi
     fi
 done
 if test "$FS_WORKS" = "no"; then


### PR DESCRIPTION
### What
When using clang-19, we were getting linker errors with enable-asan. Update Autoconf input file to use compile time tests if runtime tests fail with address sanitizer option.

```
configure:  Enabling asan, see https://clang.llvm.org/docs/AddressSanitizer.html 
configure: WARNING: Asan will not instrument rust without --enable-unified-rust-unsafe-for-production
checking to see if <filesystem> works without any extra libs... no
checking to see if <filesystem> works with -lstdc++fs... no
checking to see if <filesystem> works with -lc++fs... no
configure: error: C++17 <filesystem> does not work with any known linker flags
make[1]: *** [debian/rules:40: override_dh_auto_configure] Error 1
make[1]: Leaving directory '/build/stellar-core-23.0.1'
make: *** [debian/rules:30: build] Error 2
```

### Why
During testing for clang-19, there was an error with enable-asan that would fail the runtime test with std::filesystem. Adding compile time test as a fallback worked and Jenkins job was able to build both Jammy and Noble stellar-core packages. 
I am not fully sure if this is the right way to fix it so would like some review feedback.