### PR TITLE
Make information about (potentially) dead nodes available to operators

### DIFF
--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -306,6 +306,10 @@ Most commands return their results in JSON format.
   * `delayed`: participating in the latest consensus rounds, but slower than others.
   * `agree`: running just fine.
 
+  If `transitive` is set or the node is the local node, the returned object has
+  a `maybe_dead_nodes` key with an array value containing nodes in the local
+  quorum set that might be dead (were `missing` for a 15 minute period).
+
 * **scp**
   `scp?[limit=n][&fullkeys=false]`<br>
   Returns a JSON object with the internal state of the SCP engine for the last

--- a/src/herder/Herder.cpp
+++ b/src/herder/Herder.cpp
@@ -20,5 +20,6 @@ uint32 const Herder::LEDGER_VALIDITY_BRACKET = 100;
 std::chrono::nanoseconds const Herder::TIMERS_THRESHOLD_NANOSEC(5000000);
 uint32 const Herder::SCP_EXTRA_LOOKBACK_LEDGERS = 3u;
 std::chrono::minutes const Herder::TX_SET_GC_DELAY(1);
+std::chrono::minutes const Herder::CHECK_FOR_DEAD_NODES_MINUTES(15);
 uint32 const Herder::FLOW_CONTROL_BYTES_EXTRA_BUFFER(2000);
 }

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -58,6 +58,11 @@ class Herder
     // How many seconds of inactivity before evicting a node.
     static std::chrono::seconds const NODE_EXPIRATION_SECONDS;
 
+    // How often to check for dead nodes in local quorum set: every
+    // CHECK_FOR_DEAD_NODES_MINUTES minutes, warn about any node that didn't
+    // send an SCP message in the last interval
+    static std::chrono::minutes const CHECK_FOR_DEAD_NODES_MINUTES;
+
     // How many ledger in the future we consider an envelope viable.
     static uint32 const LEDGER_VALIDITY_BRACKET;
 

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -310,6 +310,11 @@ class HerderImpl : public Herder
 
     VirtualTimer mTxSetGarbageCollectTimer;
 
+    // Every CHECK_FOR_DEAD_NODES_MINUTES, we keep track of all nodes that SCP
+    // reports as missing throughout the interval.
+    VirtualTimer mCheckForDeadNodesTimer;
+    void startCheckForDeadNodesInterval();
+
     Application& mApp;
     LedgerManager& mLedgerManager;
 

--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -137,6 +137,14 @@ class HerderSCPDriver : public SCPDriver
 
     Json::Value getQsetLagInfo(bool summary, bool fullKeys);
 
+    // report the nodes identified as maybe dead (missing in SCP during the last
+    // CHECK_FOR_DEAD_NODES_MINUTES interval)
+    Json::Value getMaybeDeadNodes(bool fullKeys);
+
+    // Begin a new interval for checking for dead nodes--set current dead nodes
+    // as missing nodes from previous interval
+    void startCheckForDeadNodesInterval();
+
     // Application-specific weight function. This function uses the quality
     // levels from automatic quorum set generation to determine the weight of a
     // validator. It is designed to ensure that:
@@ -231,6 +239,12 @@ class HerderSCPDriver : public SCPDriver
     // timers used by SCP
     // indexed by slotIndex, timerID
     std::map<uint64_t, std::map<int, std::unique_ptr<VirtualTimer>>> mSCPTimers;
+
+    // The nodes that have exclusively been marked missing during the current
+    // interval.
+    std::set<NodeID> mMissingNodes;
+    // The nodes that were missing during the previous interval.
+    std::set<NodeID> mDeadNodes;
 
     // validity of txSet
     mutable RandomEvictionCache<TxSetValidityKey, bool, TxSetValidityKeyHash>

--- a/src/overlay/PeerBareAddress.cpp
+++ b/src/overlay/PeerBareAddress.cpp
@@ -97,7 +97,8 @@ PeerBareAddress::resolve(std::string const& ipPort, Application& app,
     if (ip.empty())
     {
         throw std::runtime_error(fmt::format(
-            FMT_STRING("Could not resolve '{}': {}"), ipPort, ec.message()));
+            FMT_STRING("Could not resolve '{}': no IPv4 addresses found"),
+            ipPort));
     }
 
     unsigned short port = defaultPort;
@@ -106,9 +107,9 @@ PeerBareAddress::resolve(std::string const& ipPort, Application& app,
         int parsedPort = atoi(m[3].str().c_str());
         if (parsedPort <= 0 || parsedPort > UINT16_MAX)
         {
-            throw std::runtime_error(
-                fmt::format(FMT_STRING("Could not resolve '{}': {}"), ipPort,
-                            ec.message()));
+            throw std::runtime_error(fmt::format(
+                FMT_STRING("Could not resolve '{}': port out of range"),
+                ipPort));
         }
         port = static_cast<unsigned short>(parsedPort);
     }

--- a/src/overlay/TCPPeer.h
+++ b/src/overlay/TCPPeer.h
@@ -127,7 +127,7 @@ class TCPPeer : public Peer
     // write-buffers freed during the ASIO write into those buffers, which
     // would cause memory corruption.
     //
-    // As a retult, the lifetime of a TCPPeer is _not_ the same as the time it
+    // As a result, the lifetime of a TCPPeer is _not_ the same as the time it
     // is known to the OverlayManager. We can drop a TCPPeer from the
     // OverlayManager's registration a while before it's actually destroyed.
     // To properly manage load, therefore, we have to separately track the

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -238,6 +238,29 @@ SCP::getJsonQuorumInfo(NodeID const& id, bool summary, bool fullKeys,
     return ret;
 }
 
+std::set<NodeID>
+SCP::getMissingNodes(NodeID const& id, uint64 index)
+{
+    std::set<NodeID> ret;
+    if (index == 0)
+    {
+        index = mKnownSlots.rbegin()->first;
+    }
+    if (getSlot(index, false))
+    {
+        auto qSet = getLocalNode()->getQuorumSet();
+        // Categorize each node's state.
+        LocalNode::forAllNodes(qSet, [&](NodeID const& n) {
+            if (getState(n, index) == SCP::QuorumInfoNodeState::MISSING)
+            {
+                ret.insert(n);
+            }
+            return true;
+        });
+    }
+    return ret;
+}
+
 bool
 SCP::isValidator()
 {

--- a/src/scp/SCP.h
+++ b/src/scp/SCP.h
@@ -85,6 +85,10 @@ class SCP
     Json::Value getJsonQuorumInfo(NodeID const& id, bool summary,
                                   bool fullKeys = false, uint64 index = 0);
 
+    // index = 0 for returning information for the latest known slot.
+    // Get a list of nodes from id's quorum set that are missing in consensus
+    std::set<NodeID> getMissingNodes(NodeID const& id, uint64 index = 0);
+
     // Purges all data relative to all the slots whose slotIndex is smaller
     // than the specified `maxSlotIndex` except for slotToKeep slot.
     void purgeSlots(uint64 maxSlotIndex, uint64 slotToKeep);

--- a/src/util/test/TimerTests.cpp
+++ b/src/util/test/TimerTests.cpp
@@ -207,6 +207,9 @@ TEST_CASE("shared virtual time advances only when all apps idle",
     // and affect this timer test.
     app1->getOverlayManager().shutdown();
     app2->getOverlayManager().shutdown();
+    // Similarly, we need to stop the Herder timers
+    app1->getHerder().shutdown();
+    app2->getHerder().shutdown();
 
     size_t app1Event = 0;
     size_t app2Event = 0;


### PR DESCRIPTION
Resolves #4901. Adds `maybe_dead_nodes` to the `/quorum` endpoint which contains nodes that have been missing in SCP quorums for 15 minutes.