### PR TITLE
Changes to support Ubuntu 24.04 builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -193,6 +193,9 @@ AS_IF([test x != "x$sanitizeopts"], [
   CFLAGS="$CFLAGS $sanflags"
   CXXFLAGS="$CXXFLAGS $sanflags"
 
+  # Add sanitizer flags to LDFLAGS for proper linking
+  LDFLAGS="$LDFLAGS -fsanitize=$sanitizeopts"
+
   # compile our own libraries when sanitizers are enabled
   libsodium_INTERNAL=yes
   xdrpp_INTERNAL=yes
@@ -269,15 +272,34 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM([[#include <filesystem>]],
 	      [[return std::filesystem::exists(std::filesystem::path("hello"));]])],
               [AC_MSG_RESULT([yes]); FS_WORKS=yes],
               [AC_MSG_RESULT([no]); FS_WORKS=no])
+
+# If runtime test failed but we have sanitizers enabled, try compile-time test
+# since sanitizers can interfere with filesystem runtime tests
+if test "$FS_WORKS" = "no" && test "x$sanitizeopts" != "x"; then
+    AC_MSG_CHECKING([to see if <filesystem> compiles without extra libs (sanitizer mode)])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <filesystem>]],
+	              [[return std::filesystem::exists(std::filesystem::path("hello"));]])],
+                      [AC_MSG_RESULT([yes]); FS_WORKS=yes],
+                      [AC_MSG_RESULT([no])])
+fi
+
 for testlib in -lstdc++fs -lc++fs; do
     if test "$FS_WORKS" = "no"; then
         fs_save_LIBS="$LIBS"
         LIBS="$testlib $LIBS"
         AC_MSG_CHECKING([to see if <filesystem> works with $testlib])
-        AC_RUN_IFELSE([AC_LANG_PROGRAM([[#include <filesystem>]],
-		      [[return std::filesystem::exists(std::filesystem::path("hello"));]])],
-                  [AC_MSG_RESULT([yes]); FS_WORKS=yes],
-                  [AC_MSG_RESULT([no]); FS_WORKS=no; LIBS="$fs_save_LIBS"])
+        # Use compile test if sanitizers are enabled, runtime test otherwise
+        if test "x$sanitizeopts" != "x"; then
+            AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <filesystem>]],
+		                  [[return std::filesystem::exists(std::filesystem::path("hello"));]])],
+                              [AC_MSG_RESULT([yes]); FS_WORKS=yes],
+                              [AC_MSG_RESULT([no]); FS_WORKS=no; LIBS="$fs_save_LIBS"])
+        else
+            AC_RUN_IFELSE([AC_LANG_PROGRAM([[#include <filesystem>]],
+		              [[return std::filesystem::exists(std::filesystem::path("hello"));]])],
+                          [AC_MSG_RESULT([yes]); FS_WORKS=yes],
+                          [AC_MSG_RESULT([no]); FS_WORKS=no; LIBS="$fs_save_LIBS"])
+        fi
     fi
 done
 if test "$FS_WORKS" = "no"; then

--- a/docker/setup
+++ b/docker/setup
@@ -7,9 +7,26 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 
 # We need apt-transport-https for adding apt.stellar.org in the Dockerfile
-apt-get install -y wget curl python-six python3-colorama python3-pip postgresql-client sqlite3 apt-transport-https gnupg2
+apt-get install -y wget curl python3-six python3-colorama python3-pip postgresql-client sqlite3 apt-transport-https gnupg2
 
-pip3 install awscli --upgrade  # for uploading history to s3
+if grep "VERSION_CODENAME=jammy" /etc/os-release; then
+  echo "Setting up LLVM repo in the 22.04 Ubuntu base"
+  wget -O /etc/apt/trusted.gpg.d/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key
+
+  cat > /etc/apt/sources.list.d/llvm.list <<EOF
+  deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main
+  deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main
+EOF
+fi
+
+# Install aws cli for uploading history to S3
+if grep "VERSION_CODENAME=jammy" /etc/os-release; then
+  pip3 install awscli --upgrade
+else
+  # Ubuntu 24.04 or later need extra flag
+  pip3 install awscli --upgrade --break-system-packages
+fi
+
 
 # install test dependencies if STELLAR_CORE_VERSION ends with '~buildtests'
 if [[ "$STELLAR_CORE_VERSION" == *~buildtests ]]; then


### PR DESCRIPTION
#4928 What

* update docker building to support Ubuntu 24.04
* fix address sanitizer fallback to compile time tests if runtime tests fail

# Why

We need to start publishing 24.04 packages

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
