### PR TITLE
Small fixes to apply load

### DIFF
--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -1930,14 +1930,10 @@ runApplyLoad(CommandLineArgs const& args)
                 config.IGNORE_MESSAGE_LIMITS_FOR_TESTING = true;
             }
 
-            if (mode != ApplyLoadMode::MAX_SAC_TPS)
-            {
-                TmpDirManager tdm(std::string("soroban-storage-meta-"));
-                TmpDir td = tdm.tmpDir("soroban-meta-ok");
-                std::string metaPath = td.getName() + "/stream.xdr";
-
-                config.METADATA_OUTPUT_STREAM = metaPath;
-            }
+            TmpDirManager tdm(std::string("soroban-storage-meta-"));
+            TmpDir td = tdm.tmpDir("soroban-meta-ok");
+            std::string metaPath = td.getName() + "/stream.xdr";
+            config.METADATA_OUTPUT_STREAM = metaPath;
 
             VirtualClock clock(VirtualClock::REAL_TIME);
             auto appPtr = Application::create(clock, config);

--- a/src/simulation/ApplyLoad.cpp
+++ b/src/simulation/ApplyLoad.cpp
@@ -652,7 +652,6 @@ ApplyLoad::setupBucketList()
                                   archivedEntries, {});
         }
     }
-    lh.ledgerSeq++;
     mDataEntryCount = currentLiveKey;
     releaseAssertOrThrow(mTotalHotArchiveEntries <= currentHotArchiveKey);
 


### PR DESCRIPTION
# Description

Fixes two bugs in apply load:

1. We were incrementing our ledger seq by one too much during BucketList setup, causing issues with the BucketList spill logic.
2. Temporary meta file was being deleted immediately after being set up.  

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
