### PR TITLE
properly initialize seed for RandomEviction cache

### DIFF
--- a/src/util/Math.cpp
+++ b/src/util/Math.cpp
@@ -6,6 +6,7 @@
 #include "crypto/SecretKey.h"
 #include "crypto/ShortHash.h"
 #include "util/GlobalChecks.h"
+#include "util/RandomEvictionCache.h"
 #include "util/UnorderedMap.h"
 #include <Tracy.hpp>
 #include <algorithm>
@@ -188,6 +189,7 @@ reinitializeAllGlobalStateWithSeedInternal(unsigned int seed)
     srand(seed);
     getGlobalRandomEngine().seed(seed);
     randHash::initialize();
+    randomEvictionCacheSeed = seed;
 }
 
 void


### PR DESCRIPTION
# Description

Fixes a bug where the `RandomEvictionCache` seed was not properly set.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
