### PR TITLE
Remove option to use global prng in random eviction cache

### DIFF
--- a/src/crypto/SecretKey.cpp
+++ b/src/crypto/SecretKey.cpp
@@ -42,8 +42,7 @@ namespace stellar
 // has no effect on correctness.
 
 static std::mutex gVerifySigCacheMutex;
-static RandomEvictionCache<Hash, bool> gVerifySigCache(0xffff,
-                                                       /* separatePRNG */ true);
+static RandomEvictionCache<Hash, bool> gVerifySigCache(0xffff);
 static uint64_t gVerifyCacheHit = 0;
 static uint64_t gVerifyCacheMiss = 0;
 
@@ -322,10 +321,10 @@ PubKeyUtils::clearVerifySigCache()
 }
 
 void
-PubKeyUtils::maybeSeedVerifySigCache(unsigned int seed)
+PubKeyUtils::seedVerifySigCache(unsigned int seed)
 {
     std::lock_guard<std::mutex> guard(gVerifySigCacheMutex);
-    gVerifySigCache.maybeSeed(seed);
+    gVerifySigCache.seed(seed);
 }
 
 void

--- a/src/crypto/SecretKey.h
+++ b/src/crypto/SecretKey.h
@@ -140,7 +140,7 @@ bool verifySig(PublicKey const& key, Signature const& signature,
                ByteSlice const& bin);
 
 void clearVerifySigCache();
-void maybeSeedVerifySigCache(unsigned int seed);
+void seedVerifySigCache(unsigned int seed);
 void flushVerifySigCacheCounts(uint64_t& hits, uint64_t& misses);
 
 PublicKey random();

--- a/src/herder/QuorumIntersectionCheckerImpl.cpp
+++ b/src/herder/QuorumIntersectionCheckerImpl.cpp
@@ -277,7 +277,7 @@ QuorumIntersectionCheckerImpl::QuorumIntersectionCheckerImpl(
     , mQuiet(quiet)
     , mTSC()
     , mInterruptFlag(interruptFlag)
-    , mCachedQuorums(MAX_CACHED_QUORUMS_SIZE, /*separatePRNG=*/true)
+    , mCachedQuorums(MAX_CACHED_QUORUMS_SIZE)
     , mRand(seed)
 {
     buildGraph(qmap);

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -321,7 +321,7 @@ OverlayManagerImpl::OverlayManagerImpl(Application& app)
                      mApp.getConfig().TARGET_PEER_CONNECTIONS, mSurveyManager)
     , mResolvingPeersWithBackoff(true)
     , mResolvingPeersRetryCount(0)
-    , mScheduledMessages(100000, true)
+    , mScheduledMessages(100000)
 {
     mPeerSources[PeerType::INBOUND] = std::make_unique<RandomPeerSource>(
         mPeerManager, RandomPeerSource::nextAttemptCutoff(PeerType::INBOUND));

--- a/src/util/Math.cpp
+++ b/src/util/Math.cpp
@@ -185,7 +185,7 @@ reinitializeAllGlobalStateWithSeedInternal(unsigned int seed)
 {
     lastGlobalSeed = seed;
     PubKeyUtils::clearVerifySigCache();
-    PubKeyUtils::maybeSeedVerifySigCache(seed);
+    PubKeyUtils::seedVerifySigCache(seed);
     srand(seed);
     getGlobalRandomEngine().seed(seed);
     randHash::initialize();

--- a/src/util/RandomEvictionCache.h
+++ b/src/util/RandomEvictionCache.h
@@ -65,8 +65,6 @@ class RandomEvictionCache : public NonMovableOrCopyable
     // Each cache keeps some counters just to monitor its performance.
     Counters mCounters;
 
-    // Use a dedicated random engine, with an option to disable
-    bool const mSeparatePRNG{true};
     stellar_default_random_engine mRandEngine;
 
     // Randomly pick two elements and evict the less-recently-used one.
@@ -79,11 +77,7 @@ class RandomEvictionCache : public NonMovableOrCopyable
             return;
         }
         auto getRandIndex = [&]() {
-            if (mSeparatePRNG)
-            {
-                return rand_uniform<size_t>(0, sz - 1, mRandEngine);
-            }
-            return rand_uniform<size_t>(0, sz - 1);
+            return rand_uniform<size_t>(0, sz - 1, mRandEngine);
         };
         MapValueType*& vp1 = mValuePtrs.at(getRandIndex());
         MapValueType*& vp2 = mValuePtrs.at(getRandIndex());
@@ -97,28 +91,16 @@ class RandomEvictionCache : public NonMovableOrCopyable
 
   public:
     explicit RandomEvictionCache(size_t maxSize)
-        : mMaxSize(maxSize)
-        , mSeparatePRNG(true)
-        , mRandEngine(randomEvictionCacheSeed)
-    {
-        mValueMap.reserve(maxSize + 1);
-        mValuePtrs.reserve(maxSize + 1);
-    }
-
-    RandomEvictionCache(size_t maxSize, bool separatePRNG)
-        : mMaxSize(maxSize), mSeparatePRNG(separatePRNG)
+        : mMaxSize(maxSize), mRandEngine(randomEvictionCacheSeed)
     {
         mValueMap.reserve(maxSize + 1);
         mValuePtrs.reserve(maxSize + 1);
     }
 
     void
-    maybeSeed(unsigned int seed)
+    seed(unsigned int seed)
     {
-        if (mSeparatePRNG)
-        {
-            mRandEngine.seed(seed);
-        }
+        mRandEngine.seed(seed);
     }
 
     size_t


### PR DESCRIPTION
# Description

None of the caches use the global prng anymore, so we can remove the constructor that allows it's usage. 

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
