### PR TITLE
Remove obsolete test (that happens to do AC_RUN and breaks some environments)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -261,30 +261,7 @@ AS_IF([test "x$enable_afl" = "xyes"], [
 ])
 AM_CONDITIONAL([USE_AFL_FUZZ], [test "x$enable_afl" == "xyes"])
 
-# check to see if we need to append -lstdc++fs or -lc++fs to access
-# functionality from <filesystem> (for some reason this was thought
-# a good idea in gcc 8 and clang 8)
-AC_MSG_CHECKING([to see if <filesystem> works without any extra libs])
-AC_RUN_IFELSE([AC_LANG_PROGRAM([[#include <filesystem>]],
-	      [[return std::filesystem::exists(std::filesystem::path("hello"));]])],
-              [AC_MSG_RESULT([yes]); FS_WORKS=yes],
-              [AC_MSG_RESULT([no]); FS_WORKS=no])
-for testlib in -lstdc++fs -lc++fs; do
-    if test "$FS_WORKS" = "no"; then
-        fs_save_LIBS="$LIBS"
-        LIBS="$testlib $LIBS"
-        AC_MSG_CHECKING([to see if <filesystem> works with $testlib])
-        AC_RUN_IFELSE([AC_LANG_PROGRAM([[#include <filesystem>]],
-		      [[return std::filesystem::exists(std::filesystem::path("hello"));]])],
-                  [AC_MSG_RESULT([yes]); FS_WORKS=yes],
-                  [AC_MSG_RESULT([no]); FS_WORKS=no; LIBS="$fs_save_LIBS"])
-    fi
-done
-if test "$FS_WORKS" = "no"; then
-   AC_MSG_ERROR([C++17 <filesystem> does not work with any known linker flags])
-fi
-
-# prefer 10 as it's the one we use
+# prefer 12 as it's the one we use
 AC_CHECK_PROGS(CLANG_FORMAT, [clang-format-12 clang-format])
 AM_CONDITIONAL([USE_CLANG_FORMAT], [test "x$CLANG_FORMAT" != "x"])
 


### PR DESCRIPTION
This test is obsolete in the first place (we don't build on clang 8 at all anymore) but also, incidentally, since it runs AC_RUN_IFELSE it winds up executing a binary it built, and this happens after asan is enabled, and so in a few specific environments where asan doesn't work (eg. old versions of docker when running under qemu-user; also seemingly pbuilder) this causes configuration to fail entirely.

There's no real way to make asan work in these environments, we have to just avoid running conftests after asan is turned on. We could move this test above the asan enabling part of configure, but again, it's an obsolete test; simpler just to remove it entirely.

(The underlying qemu issue appears to be this: https://gitlab.com/qemu-project/qemu/-/issues/290)