### PR TITLE
Added batched max_sac_tps configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,8 +1314,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-test-wasms"
-version = "23.0.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=688bc34e6cd15c71742139e625268c7f30f55a92#688bc34e6cd15c71742139e625268c7f30f55a92"
+version = "23.0.2"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=30249f0549141dbe7fdce84b6401a4235dbad64f#30249f0549141dbe7fdce84b6401a4235dbad64f"
 
 [[package]]
 name = "soroban-wasmi"

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -1681,11 +1681,6 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                      APPLY_LOAD_MAX_SAC_TPS_TARGET_CLOSE_TIME_MS =
                          readInt<uint32_t>(item, 10);
                  }},
-                {"APPLY_LOAD_MAX_SAC_TPS_TEST_ITERATIONS",
-                 [&]() {
-                     APPLY_LOAD_MAX_SAC_TPS_TEST_ITERATIONS =
-                         readInt<uint32_t>(item);
-                 }},
                 {"APPLY_LOAD_MAX_SAC_TPS_MIN_TPS",
                  [&]() {
                      APPLY_LOAD_MAX_SAC_TPS_MIN_TPS = readInt<uint32_t>(item);
@@ -1694,6 +1689,12 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                  [&]() {
                      APPLY_LOAD_MAX_SAC_TPS_MAX_TPS = readInt<uint32_t>(item);
                  }},
+                {"APPLY_LOAD_BATCH_SAC_COUNT",
+                 [&]() {
+                     APPLY_LOAD_BATCH_SAC_COUNT = readInt<uint32_t>(item, 1);
+                 }},
+                {"APPLY_LOAD_TIME_WRITES",
+                 [&]() { APPLY_LOAD_TIME_WRITES = readBool(item); }},
                 {"GENESIS_TEST_ACCOUNT_COUNT",
                  [&]() {
                      GENESIS_TEST_ACCOUNT_COUNT = readInt<uint32_t>(item, 0);

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -387,12 +387,6 @@ class Config : public std::enable_shared_from_this<Config>
     uint32_t APPLY_LOAD_NUM_ACCOUNTS = 0;
     uint32_t APPLY_LOAD_NUM_LEDGERS = 100;
 
-    // MAX_SAC_TPS mode specific parameters
-    uint32_t APPLY_LOAD_MAX_SAC_TPS_TARGET_CLOSE_TIME_MS = 1000;
-    uint32_t APPLY_LOAD_MAX_SAC_TPS_TEST_ITERATIONS = 3;
-    uint32_t APPLY_LOAD_MAX_SAC_TPS_MIN_TPS = 100;
-    uint32_t APPLY_LOAD_MAX_SAC_TPS_MAX_TPS = 50000;
-
     // Number of read-only and read-write entries in the apply-load
     // transactions. Every entry will have
     // `APPLY_LOAD_DATA_ENTRY_SIZE_FOR_TESTING` size.
@@ -404,6 +398,22 @@ class Config : public std::enable_shared_from_this<Config>
     // Number of events to generate in the apply-load transactions.
     std::vector<uint32_t> APPLY_LOAD_EVENT_COUNT_FOR_TESTING;
     std::vector<uint32_t> APPLY_LOAD_EVENT_COUNT_DISTRIBUTION_FOR_TESTING;
+
+    // MAX_SAC_TPS mode specific parameters
+    uint32_t APPLY_LOAD_MAX_SAC_TPS_TARGET_CLOSE_TIME_MS = 1000;
+    uint32_t APPLY_LOAD_MAX_SAC_TPS_MIN_TPS = 100;
+    uint32_t APPLY_LOAD_MAX_SAC_TPS_MAX_TPS = 50000;
+
+    // Number of SAC payments to include in each tx for MAX_SAC_TPS mode.
+    // If set to 1, each TX will be a single SAC invocation.
+    // If set to > 1, each TX will invoke the specified number of SAC sub
+    // invocations. Note that TPS measurement count each SAC invocation as one
+    // "transaction".
+    uint32_t APPLY_LOAD_BATCH_SAC_COUNT = 1;
+
+    // If set to true, database writes will count towards TPS calculation.
+    // Otherwise, BucketList writes will not be counted.
+    bool APPLY_LOAD_TIME_WRITES = true;
 
     // Waits for merges to complete before applying transactions during catchup
     bool CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING;

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -130,9 +130,9 @@ optional = true
 # supported host, since test material usually just grows over time.
 
 [dependencies.soroban-test-wasms]
-version = "=23.0.0"
+version = "=23.0.2"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "688bc34e6cd15c71742139e625268c7f30f55a92"
+rev = "30249f0549141dbe7fdce84b6401a4235dbad64f"
 
 [dependencies.soroban-synth-wasm]
 version = "=23.0.0"

--- a/src/rust/src/bridge.rs
+++ b/src/rust/src/bridge.rs
@@ -206,7 +206,7 @@ pub(crate) mod rust_bridge {
         fn get_test_wasm_complex() -> Result<RustBuf>;
         fn get_test_wasm_loadgen() -> Result<RustBuf>;
         fn get_test_wasm_err() -> Result<RustBuf>;
-        fn get_test_contract_sac_transfer() -> Result<RustBuf>;
+        fn get_test_contract_sac_transfer(protocol_version: u32) -> Result<RustBuf>;
         fn get_write_bytes() -> Result<RustBuf>;
         fn get_invoke_contract_wasm() -> Result<RustBuf>;
 

--- a/src/rust/src/soroban_test_wasm.rs
+++ b/src/rust/src/soroban_test_wasm.rs
@@ -40,12 +40,16 @@ pub(crate) fn get_test_wasm_loadgen() -> Result<RustBuf, Box<dyn std::error::Err
     })
 }
 
-pub(crate) fn get_test_contract_sac_transfer() -> Result<RustBuf, Box<dyn std::error::Error>> {
+pub(crate) fn get_test_contract_sac_transfer(
+    protocol_version: u32,
+) -> Result<RustBuf, Box<dyn std::error::Error>> {
+    let wasm_bytes = if protocol_version >= 23 {
+        soroban_test_wasms::CONTRACT_SAC_TRANSFER_CONTRACT_P23
+    } else {
+        soroban_test_wasms::CONTRACT_SAC_TRANSFER_CONTRACT
+    };
     Ok(RustBuf {
-        data: soroban_test_wasms::CONTRACT_SAC_TRANSFER_CONTRACT
-            .iter()
-            .cloned()
-            .collect(),
+        data: wasm_bytes.iter().cloned().collect(),
     })
 }
 

--- a/src/simulation/ApplyLoad.cpp
+++ b/src/simulation/ApplyLoad.cpp
@@ -535,7 +535,8 @@ ApplyLoad::setupBatchTransferContracts()
     auto const& lm = mApp.getLedgerManager();
 
     // First, upload the batch_transfer contract WASM
-    auto wasm = rust_bridge::get_test_contract_sac_transfer();
+    auto wasm = rust_bridge::get_test_contract_sac_transfer(
+        mApp.getConfig().LEDGER_PROTOCOL_VERSION);
     xdr::opaque_vec<> wasmBytes;
     wasmBytes.assign(wasm.data.begin(), wasm.data.end());
 

--- a/src/simulation/ApplyLoad.h
+++ b/src/simulation/ApplyLoad.h
@@ -71,6 +71,7 @@ class ApplyLoad
     void setupUpgradeContract();
     void setupLoadContract();
     void setupXLMContract();
+    void setupBatchTransferContracts();
     void setupBucketList();
 
     // Run iterations at the given TPS. Reports average time over all runs, in
@@ -81,6 +82,9 @@ class ApplyLoad
     // conflicts.
     void generateSacPayments(std::vector<TransactionFrameBasePtr>& txs,
                              uint32_t count);
+
+    // Calculate instructions per transaction based on batch size
+    uint64_t calculateInstructionsPerTx() const;
 
     // Iterate over all available accounts to make sure they are loaded into the
     // BucketListDB cache. Note that this should be run everytime an account
@@ -104,6 +108,8 @@ class ApplyLoad
     TxGenerator::ContractInstance mLoadInstance;
     // Used to generate XLM payments
     TxGenerator::ContractInstance mSACInstanceXLM;
+    // Used for batch transfers, one instance for each cluster
+    std::vector<TxGenerator::ContractInstance> mBatchTransferInstances;
     size_t mDataEntryCount = 0;
     size_t mDataEntrySize = 0;
 
@@ -123,6 +129,9 @@ class ApplyLoad
 
     ApplyLoadMode mMode;
     TxGenerator mTxGenerator;
+
+    // Counter for generating unique destination addresses for SAC payments
+    uint32_t mDestCounter = 0;
 };
 
 }

--- a/src/simulation/TxGenerator.h
+++ b/src/simulation/TxGenerator.h
@@ -90,6 +90,7 @@ class TxGenerator
   public:
     // Instructions per SAC transaction
     static constexpr uint64_t SAC_TX_INSTRUCTIONS = 250'000;
+    static constexpr uint64_t BATCH_TRANSFER_TX_INSTRUCTIONS = 500'000;
 
     // Special account ID to represent the root account
     static uint64_t const ROOT_ACCOUNT_ID;
@@ -174,6 +175,12 @@ class TxGenerator
                      SCAddress const& toAddress,
                      ContractInstance const& instance, uint64_t amount,
                      std::optional<uint32_t> maxGeneratedFeeRate);
+
+    std::pair<TestAccountPtr, TransactionFrameBaseConstPtr>
+    invokeBatchTransfer(uint32_t ledgerNum, uint64_t fromAccountId,
+                        ContractInstance const& batchTransferInstance,
+                        ContractInstance const& sacInstance,
+                        std::vector<SCAddress> const& destinations);
     std::pair<TestAccountPtr, TransactionFrameBaseConstPtr>
     invokeSorobanCreateUpgradeTransaction(
         uint32_t ledgerNum, uint64_t accountId, SCBytes const& upgradeBytes,

--- a/src/simulation/test/LoadGeneratorTests.cpp
+++ b/src/simulation/test/LoadGeneratorTests.cpp
@@ -1035,8 +1035,9 @@ TEST_CASE("basic MAX_SAC_TPS functionality",
     cfg.APPLY_LOAD_LEDGER_MAX_DEPENDENT_TX_CLUSTERS = 2;
     cfg.APPLY_LOAD_MAX_SAC_TPS_MIN_TPS = 200;
     cfg.APPLY_LOAD_MAX_SAC_TPS_MAX_TPS = 220;
-    cfg.APPLY_LOAD_MAX_SAC_TPS_TEST_ITERATIONS = 2;
+    cfg.APPLY_LOAD_NUM_LEDGERS = 10;
     cfg.APPLY_LOAD_NUM_ACCOUNTS = 500;
+    cfg.APPLY_LOAD_BATCH_SAC_COUNT = 2;
 
     VirtualClock clock(VirtualClock::REAL_TIME);
     auto app = createTestApplication(clock, cfg);

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -280,8 +280,11 @@ TEST_CASE_VERSIONS("Trustline stellar asset contract",
         REQUIRE(!client.transfer(acc, acc2Addr, 10));
 
         // Now transfer from a contract
-        TestContract& transferContract = test.deployWasmContract(
-            rust_bridge::get_test_contract_sac_transfer());
+        TestContract& transferContract =
+            test.deployWasmContract(rust_bridge::get_test_contract_sac_transfer(
+                app.getLedgerManager()
+                    .getLastClosedLedgerHeader()
+                    .header.ledgerVersion));
 
         REQUIRE(client.mint(issuer, transferContract.getAddress(), 10));
 
@@ -372,7 +375,8 @@ TEST_CASE("Native stellar asset contract",
     // Now test xlm transfer from a contract to another contract and then to an
     // account.
     TestContract& transferContract =
-        test.deployWasmContract(rust_bridge::get_test_contract_sac_transfer());
+        test.deployWasmContract(rust_bridge::get_test_contract_sac_transfer(
+            app.getConfig().LEDGER_PROTOCOL_VERSION));
 
     REQUIRE(client.transfer(a1, transferContract.getAddress(), 10));
 
@@ -421,7 +425,8 @@ TEST_CASE("Native stellar asset contract",
         checkSponsorship(ltx, root.getPublicKey(), 0, nullptr, 0, 2, 2, 0);
     }
 
-    // Test batch_transfer with 5 destinations
+    // Test batch_transfer with 5 destinations (protocol 23+)
+    if (app.getConfig().LEDGER_PROTOCOL_VERSION >= 23)
     {
         auto batchDest1 = root.create("batchDest1", minBalance);
         auto batchDest2 = root.create("batchDest2", minBalance);
@@ -497,7 +502,8 @@ TEST_CASE("Stellar asset contract transfer with CAP-67 address types",
     auto a1Address = makeAccountAddress(a1.getPublicKey());
     auto a2Address = makeAccountAddress(a2.getPublicKey());
     TestContract& transferContract =
-        test.deployWasmContract(rust_bridge::get_test_contract_sac_transfer());
+        test.deployWasmContract(rust_bridge::get_test_contract_sac_transfer(
+            test.getApp().getConfig().LEDGER_PROTOCOL_VERSION));
 
     auto runTest = [&](bool useNativeAsset) {
         Asset tokenAsset = useNativeAsset ? txtest::makeNativeAsset() : asset;

--- a/test-tx-meta-baseline-current/InvokeHostFunctionTests.json
+++ b/test-tx-meta-baseline-current/InvokeHostFunctionTests.json
@@ -44,7 +44,16 @@
 	],
 	"Module cache miss on immediate execution" : [ "+cR3oq2qY0I=", "+cR3oq2qY0I=" ],
 	"Module cache miss on immediate execution|same ledger upload and execution" : [ "otnd+GHMKpE=", "/VLp/3iN+To=", "NDnBxhxdn4o=", "RCvKpCbS0VA=" ],
-	"Native stellar asset contract" : [ "+cR3oq2qY0I=", "DUET1r2TwOg=" ],
+	"Native stellar asset contract" : 
+	[
+		"+cR3oq2qY0I=",
+		"DUET1r2TwOg=",
+		"j3E4E4zpoHM=",
+		"nOOGkrrnOFw=",
+		"UivZvwUUrZ0=",
+		"HnO1VwITuAw=",
+		"NC1BmSQafHo="
+	],
 	"Soroban authorization" : 
 	[
 		"+cR3oq2qY0I=",

--- a/test-tx-meta-baseline-next/InvokeHostFunctionTests.json
+++ b/test-tx-meta-baseline-next/InvokeHostFunctionTests.json
@@ -45,7 +45,16 @@
 	],
 	"Module cache miss on immediate execution" : [ "+cR3oq2qY0I=", "+cR3oq2qY0I=" ],
 	"Module cache miss on immediate execution|same ledger upload and execution" : [ "otnd+GHMKpE=", "/VLp/3iN+To=", "NDnBxhxdn4o=", "RCvKpCbS0VA=" ],
-	"Native stellar asset contract" : [ "+cR3oq2qY0I=", "DUET1r2TwOg=" ],
+	"Native stellar asset contract" : 
+	[
+		"+cR3oq2qY0I=",
+		"DUET1r2TwOg=",
+		"j3E4E4zpoHM=",
+		"nOOGkrrnOFw=",
+		"UivZvwUUrZ0=",
+		"HnO1VwITuAw=",
+		"NC1BmSQafHo="
+	],
 	"Soroban authorization" : 
 	[
 		"+cR3oq2qY0I=",


### PR DESCRIPTION
# Description

Adds a batched payments setting to max_sac_tps. In initial testing, it looks like SAC apply time is bounded by single threaded pre and post invoke steps. Since the instructions required for a single SAC payment are small and invocation time is dominated by these pre and post invoke steps, we saw little improvement with parallelism when measuring SAC payment load.

This PR adds batching functionality, where a single TX will perform many SAC transfers. This increases the instruction count significantly, which we can do in parallel, while not increasing the single threaded pre and post invoke work. Config settings have been added to tune the number of batch payments made per TX. Note that for the purposes of measurement and reporting, "TPS" really refers to "SAC transfers per second" in the batch payment case. 

I've also added the `APPLY_LOAD_TIME_WRITES` flag. When set, we count BucketList write time when calculating max TPS.

Currently a draft until https://github.com/stellar/rs-soroban-env/pull/1595 merges, then I'll update the cargo accordingly.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
