### PR TITLE
Soroban apply optimization

### DIFF
--- a/src/rust/src/soroban_proto_any.rs
+++ b/src/rust/src/soroban_proto_any.rs
@@ -768,8 +768,11 @@ impl ProtocolSpecificModuleCache {
     // (threadsafe) ModuleCache to pass to separate C++-launched threads, to
     // allow multithreaded compilation.
     pub(crate) fn shallow_clone(&self) -> Result<Self, Box<dyn std::error::Error>> {
-        let mut new = Self::new()?;
-        new.module_cache = self.module_cache.clone();
-        Ok(new)
+        let compilation_context = CoreCompilationContext::new()?;
+        let module_cache = self.module_cache.clone();
+        Ok(ProtocolSpecificModuleCache {
+            module_cache,
+            mem_bytes_consumed: std::sync::atomic::AtomicU64::new(0),
+        })
     }
 }

--- a/src/rust/src/soroban_proto_any.rs
+++ b/src/rust/src/soroban_proto_any.rs
@@ -768,7 +768,6 @@ impl ProtocolSpecificModuleCache {
     // (threadsafe) ModuleCache to pass to separate C++-launched threads, to
     // allow multithreaded compilation.
     pub(crate) fn shallow_clone(&self) -> Result<Self, Box<dyn std::error::Error>> {
-        let compilation_context = CoreCompilationContext::new()?;
         let module_cache = self.module_cache.clone();
         Ok(ProtocolSpecificModuleCache {
             module_cache,

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -1152,9 +1152,10 @@ InvokeHostFunctionOpFrame::doApplyForSoroban(
                                 PARALLEL_SOROBAN_PHASE_PROTOCOL_VERSION));
 
     // Create ApplyHelper and delegate processing to it
+    auto moduleCache = app.getModuleCache();
     InvokeHostFunctionPreV23ApplyHelper helper(
         app, ltx, sorobanBasePrngSeed, res, refundableFeeTracker, opMeta, *this,
-        sorobanConfig, app.getModuleCache());
+        sorobanConfig, moduleCache);
     return helper.apply();
 }
 

--- a/src/transactions/ParallelApplyUtils.cpp
+++ b/src/transactions/ParallelApplyUtils.cpp
@@ -814,6 +814,12 @@ ThreadParallelApplyLedgerState::getSorobanConfig() const
     return mSorobanConfig;
 }
 
+SearchableHotArchiveSnapshotConstPtr const&
+ThreadParallelApplyLedgerState::getHotArchiveSnapshot() const
+{
+    return mHotArchiveSnapshot;
+}
+
 OpParallelApplyLedgerState::OpParallelApplyLedgerState(
     ThreadParallelApplyLedgerState const& parent)
     : mThreadState(parent)

--- a/src/transactions/ParallelApplyUtils.cpp
+++ b/src/transactions/ParallelApplyUtils.cpp
@@ -596,6 +596,7 @@ ThreadParallelApplyLedgerState::ThreadParallelApplyLedgerState(
     , mLiveSnapshot(app.copySearchableLiveBucketListSnapshot())
     , mInMemorySorobanState(global.mInMemorySorobanState)
     , mSorobanConfig(global.mSorobanConfig)
+    , mModuleCache(app.getModuleCache())
 {
     releaseAssertOrThrow(global.getSnapshotLedgerSeq() ==
                          getSnapshotLedgerSeq());
@@ -745,6 +746,7 @@ ThreadParallelApplyLedgerState::setEffectsDeltaFromSuccessfulOp(
     ParallelTxReturnVal const& res, ParallelLedgerInfo const& ledgerInfo,
     TxEffects& effects) const
 {
+    ZoneScoped;
     releaseAssertOrThrow(res.getSuccess());
     for (auto const& [lk, le] : res.getModifiedEntryMap())
     {
@@ -820,6 +822,12 @@ ThreadParallelApplyLedgerState::getHotArchiveSnapshot() const
     return mHotArchiveSnapshot;
 }
 
+rust::Box<rust_bridge::SorobanModuleCache> const&
+ThreadParallelApplyLedgerState::getModuleCache() const
+{
+    return mModuleCache;
+}
+
 OpParallelApplyLedgerState::OpParallelApplyLedgerState(
     ThreadParallelApplyLedgerState const& parent)
     : mThreadState(parent)
@@ -851,6 +859,7 @@ OpParallelApplyLedgerState::upsertEntry(LedgerKey const& key,
                                         LedgerEntry const& entry,
                                         uint32_t ledgerSeq)
 {
+    ZoneScoped;
     // There are 4 cases:
     //
     //  1. The entry exists in the parent maps (thread state or live snapshot)

--- a/src/transactions/ParallelApplyUtils.h
+++ b/src/transactions/ParallelApplyUtils.h
@@ -166,6 +166,8 @@ class ThreadParallelApplyLedgerState
     uint32_t getSnapshotLedgerSeq() const;
 
     SorobanNetworkConfig const& getSorobanConfig() const;
+
+    SearchableHotArchiveSnapshotConstPtr const& getHotArchiveSnapshot() const;
 };
 
 class GlobalParallelApplyLedgerState

--- a/src/transactions/ParallelApplyUtils.h
+++ b/src/transactions/ParallelApplyUtils.h
@@ -80,6 +80,8 @@ class ThreadParallelApplyLedgerState
     // and thus common for all the threads.
     SorobanNetworkConfig const& mSorobanConfig;
 
+    rust::Box<rust_bridge::SorobanModuleCache> mModuleCache;
+
     // Contains entries restored by any tx/op in the current thread's tx cluster
     // from the current stage of the parallel apply phase. Any entry should only
     // be in one of the two sub-maps here, live or hot. The entry in the map is
@@ -168,6 +170,8 @@ class ThreadParallelApplyLedgerState
     SorobanNetworkConfig const& getSorobanConfig() const;
 
     SearchableHotArchiveSnapshotConstPtr const& getHotArchiveSnapshot() const;
+
+    rust::Box<rust_bridge::SorobanModuleCache> const& getModuleCache() const;
 };
 
 class GlobalParallelApplyLedgerState

--- a/src/transactions/RestoreFootprintOpFrame.h
+++ b/src/transactions/RestoreFootprintOpFrame.h
@@ -27,7 +27,7 @@ class RestoreFootprintOpFrame : public OperationFrame
                       SorobanNetworkConfig const& sorobanConfig,
                       Hash const& sorobanBasePrngSeed, OperationResult& res,
                       std::optional<RefundableFeeTracker>& refundableFeeTracker,
-                      OperationMetaBuilder& opMeta) const;
+                      OperationMetaBuilder& opMeta) const override;
     bool doApply(AppConnector& app, AbstractLedgerTxn& ltx,
                  OperationResult& res,
                  OperationMetaBuilder& opMeta) const override;

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -1945,12 +1945,9 @@ TransactionFrame::parallelApply(
         return {false, {}};
     }
 
-    auto& internalErrorCounter = app.getMetrics().NewCounter(
-        {"ledger", "transaction", "internal-error"});
     bool reportInternalErrOnException = true;
     try
     {
-        auto liveSnapshot = app.copySearchableLiveBucketListSnapshot();
         // We do not want to increase the internal-error metric count for
         // older ledger versions. The minimum ledger version for which we
         // start internal-error counting is defined in the app config.
@@ -2026,6 +2023,8 @@ TransactionFrame::parallelApply(
     // ledger is a newer version.
     if (reportInternalErrOnException)
     {
+        auto& internalErrorCounter = app.getMetrics().NewCounter(
+            {"ledger", "transaction", "internal-error"});
         internalErrorCounter.inc();
     }
     return {false, {}};

--- a/src/transactions/TransactionMeta.cpp
+++ b/src/transactions/TransactionMeta.cpp
@@ -405,6 +405,7 @@ OperationMetaBuilder::setLedgerChangesFromSuccessfulOp(
     ThreadParallelApplyLedgerState const& threadState,
     ParallelTxReturnVal const& res, uint32_t ledgerSeq)
 {
+    ZoneScoped;
     if (!mEnabled)
     {
         return;

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -8719,8 +8719,6 @@ TEST_CASE("apply generated parallel tx sets", "[soroban][parallelapply]")
     test.invokeExtendOp(client.getContract().getKeys(), 10'000);
 
     auto& lm = app.getLedgerManager();
-    auto& root = test.getRoot();
-    const int64_t startingBalance = lm.getLastMinBalance(50);
 
     stellar::uniform_int_distribution<uint32_t> keyDist(0, keys.size() - 1);
     stellar::uniform_int_distribution<uint32_t> actionDist(0,


### PR DESCRIPTION
# Description

Resolves a perf degradation in single thread soroban apply from 22.4.1 -> 23.0.1.

After back-porting  `max_sac_tps` test to 22.4.1, I noticed that we say about a ~35% decrease (3250 -> 2140) in overall TPS in the single threaded SAC TPS test. Note that this test doesn't parse any modules and used in-memory BucketList state, so new p23 features should not have any impact.

This decrease was due to tech debt introduced in the apply path refactor for parallelism. Specifically, we were needlessly calling expensive, locking getters excessively. After doing some fairly trivial cleanup, we are back to the same TPS we were seeing before in 22.4.1. Here's a tracy graph with a comparison of the tech debt changes. Surprisingly, just a few minor functions accounted for over 50% of our apply time in the SAC case:

<img width="1132" height="889" alt="Screenshot_2025-09-26_11-36-06" src="https://github.com/user-attachments/assets/f798b1b6-eb5a-45a8-b62e-1b667d93547e" />

This is rebased on https://github.com/stellar/stellar-core/pull/4941, so opening as a draft for now until that gets merged.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
