### PR TITLE
Add experimental flag for dalek library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,6 +1357,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.13.1",
  "cxx",
+ "ed25519-dalek",
  "itertools 0.10.5",
  "log",
  "rand",

--- a/src/crypto/SecretKey.h
+++ b/src/crypto/SecretKey.h
@@ -143,6 +143,9 @@ void clearVerifySigCache();
 void seedVerifySigCache(unsigned int seed);
 void flushVerifySigCacheCounts(uint64_t& hits, uint64_t& misses);
 
+// Enable or disable using Rust ed25519-dalek for signature verification.
+void setUseRustDalekVerify(bool useRust);
+
 PublicKey random();
 #ifdef BUILD_TESTS
 PublicKey pseudoRandomForTesting();

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -135,6 +135,9 @@ ApplicationImpl::ApplicationImpl(VirtualClock& clock, Config const& cfg)
 
     mNetworkID = sha256(mConfig.NETWORK_PASSPHRASE);
 
+    PubKeyUtils::setUseRustDalekVerify(
+        mConfig.EXPERIMENTAL_RUST_DALEK_SIG_VERIFY);
+
     TracyAppInfo(STELLAR_CORE_VERSION.c_str(), STELLAR_CORE_VERSION.size());
     TracyAppInfo(mConfig.NETWORK_PASSPHRASE.c_str(),
                  mConfig.NETWORK_PASSPHRASE.size());

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -171,6 +171,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     BACKGROUND_OVERLAY_PROCESSING = true;
     EXPERIMENTAL_PARALLEL_LEDGER_APPLY = false;
     EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION = false;
+    EXPERIMENTAL_RUST_DALEK_SIG_VERIFY = false;
     BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT = 14; // 2^14 == 16 kb
     BUCKETLIST_DB_INDEX_CUTOFF = 20;             // 20 mb
     BUCKETLIST_DB_MEMORY_FOR_CACHING = 0;
@@ -1114,6 +1115,10 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                  [&]() {
                      EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION =
                          readBool(item);
+                 }},
+                {"EXPERIMENTAL_RUST_DALEK_SIG_VERIFY",
+                 [&]() {
+                     EXPERIMENTAL_RUST_DALEK_SIG_VERIFY = readBool(item);
                  }},
                 {"ARTIFICIALLY_DELAY_LEDGER_CLOSE_FOR_TESTING",
                  [&]() {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -523,6 +523,10 @@ class Config : public std::enable_shared_from_this<Config>
     // also enabled. (experimental)
     bool EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION;
 
+    // Use ed25519-dalek Rust library for signature verification instead of
+    // libsodium. (experimental)
+    bool EXPERIMENTAL_RUST_DALEK_SIG_VERIFY;
+
     // When set to true, BucketListDB indexes are persisted on-disk so that the
     // BucketList does not need to be reindexed on startup. Defaults to true.
     // This should only be set to false for testing purposes

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -20,6 +20,9 @@ rand = "=0.8.5"
 
 itertools = "=0.10.5"
 
+# ed25519-dalek for faster signature verification
+ed25519-dalek = "2.1.1"
+
 # NB: tracy is quite particular about version compatibility. There must only be
 # one _implementation_ of the C++ tracy symbols in the final binary (brought in
 # by the tracy-client-sys crate) and the version and all feature flags must

--- a/src/rust/src/bridge.rs
+++ b/src/rust/src/bridge.rs
@@ -180,6 +180,16 @@ pub(crate) mod rust_bridge {
         fn to_base64(b: &CxxVector<u8>, mut s: Pin<&mut CxxString>);
         fn from_base64(s: &CxxString, mut b: Pin<&mut CxxVector<u8>>);
         fn check_sensible_soroban_config_for_protocol(core_max_proto: u32);
+
+        // Ed25519 signature verification using dalek library.
+        // Returns true if signature is valid, false otherwise.
+        // This function never throws/panics - it returns false for any invalid input.
+        unsafe fn verify_ed25519_signature_dalek(
+            public_key_ptr: *const u8,
+            signature_ptr: *const u8,
+            message_ptr: *const u8,
+            message_len: usize,
+        ) -> bool;
         fn invoke_host_function(
             config_max_protocol: u32,
             enable_diagnostics: bool,
@@ -376,6 +386,7 @@ pub(crate) mod rust_bridge {
 // code so they have to be in scope here.
 use crate::b64::*;
 use crate::common::*;
+use crate::ed25519_verify::*;
 use crate::i128::*;
 use crate::log::*;
 use crate::quorum_checker::*;

--- a/src/rust/src/ed25519_verify.rs
+++ b/src/rust/src/ed25519_verify.rs
@@ -1,0 +1,39 @@
+// Copyright 2025 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+
+// Verifies an ed25519 signature using the dalek library.
+// This function takes raw pointers to avoid copying data across the Rust/C++ boundary.
+//
+// # Safety
+// The caller must ensure that:
+// - `public_key_ptr` points to at least 32 bytes of readable memory
+// - `signature_ptr` points to at least 64 bytes of readable memory
+// - `message_ptr` points to at least `message_len` bytes of readable memory
+// - All pointers remain valid for the duration of the call
+#[no_mangle]
+pub unsafe extern "C" fn verify_ed25519_signature_dalek(
+    public_key_ptr: *const u8,
+    signature_ptr: *const u8,
+    message_ptr: *const u8,
+    message_len: usize,
+) -> bool {
+    let _span = tracy_span!("verify_ed25519_signature_dalek");
+
+    // C++ caller must provide valid pointers
+    let pk_bytes = &*(public_key_ptr as *const [u8; 32]);
+    let sig_bytes = &*(signature_ptr as *const [u8; 64]);
+    let message = std::slice::from_raw_parts(message_ptr, message_len);
+
+    // Parse public key
+    let verifying_key = match VerifyingKey::from_bytes(pk_bytes) {
+        Ok(key) => key,
+        Err(_) => return false, // Invalid public key format
+    };
+
+    // Create signature (from_bytes returns the signature directly)
+    let signature = Signature::from_bytes(sig_bytes);
+    verifying_key.verify(message, &signature).is_ok()
+}

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -29,6 +29,7 @@ pub(crate) mod common;
 pub(crate) mod soroban_proto_all;
 
 mod b64;
+mod ed25519_verify;
 mod i128;
 mod log;
 mod quorum_checker;

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -330,6 +330,9 @@ getTestConfig(int instanceNumber, Config::TestDbMode mode)
         thisConfig.HTTP_QUERY_PORT = 0;
         thisConfig.QUERY_SNAPSHOT_LEDGERS = 0;
 
+        // Enable experimental Rust dalek signature verification for tests
+        thisConfig.EXPERIMENTAL_RUST_DALEK_SIG_VERIFY = true;
+
 #ifdef BEST_OFFER_DEBUGGING
         thisConfig.BEST_OFFER_DEBUGGING_ENABLED = true;
 #endif


### PR DESCRIPTION
# Description

Adds an experimental flag to use Rust ed25519-dalek  instead of libsodium for signature verification.

It turns out the Rust ed25519-dalek signature library is quite a bit faster than libsodium. On my local laptop, we see 21% reduction in signature verification time:

Rust:

<img width="733" height="469" alt="image" src="https://github.com/user-attachments/assets/c93c41f3-10a5-4d57-9b51-e886c988c62b" />

vs. libsodium:

<img width="736" height="509" alt="image" src="https://github.com/user-attachments/assets/4f407a64-6873-487d-aedd-c5ac3566bf94" />

Note that the `verifySig` zone has both cache hits and misses. Look at the "Group medians", which represent times where we have a cache miss and actually do the verification work.

I've used the exact same dalek library and version that we use in env. This should probably be synchronized in some way, but I'm not quite sure how, so I just manually added the version string in the cargo.toml for now. This _might_ be a protocol change, as I've been reading about how some ed25519 libraries actual have [different verification criteria](https://hdevalence.ca/blog/2020-10-04-its-25519am/), so we'll need to investigate this some more before making it non-experimental, default behavior.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
