### PR TITLE
Remove unnecessary disk write

### DIFF
--- a/src/bucket/BucketListBase.cpp
+++ b/src/bucket/BucketListBase.cpp
@@ -225,11 +225,10 @@ BucketLevel<LiveBucket>::prepareFirstLevel(Application& app,
     // This bucket is the "level -1" snap bucket, which is created and
     // immediately merges with level 0 curr. This merge will produce a
     // BucketIndex for the result, so there's no reason to index this Bucket
-    // before it merges.
-    auto snap = LiveBucket::fresh(
+    // before it merges or write it to disk since it's merged in-memory.
+    auto snap = LiveBucket::freshInMemoryOnly(
         app.getBucketManager(), currLedgerProtocol, inputVectors...,
-        countMergeEvents, app.getClock().getIOContext(), doFsync,
-        /*storeInMemory=*/true, /*shouldIndex=*/false);
+        countMergeEvents);
 
     auto& bucketManager = app.getBucketManager();
     auto& ctx = app.getClock().getIOContext();

--- a/src/bucket/BucketOutputIterator.cpp
+++ b/src/bucket/BucketOutputIterator.cpp
@@ -168,8 +168,7 @@ template <typename BucketT>
 std::shared_ptr<BucketT>
 BucketOutputIterator<BucketT>::getBucket(
     BucketManager& bucketManager, MergeKey* mergeKey,
-    std::optional<std::vector<typename BucketT::EntryT>> inMemoryState,
-    bool shouldIndex)
+    std::optional<std::vector<typename BucketT::EntryT>> inMemoryState)
 {
     ZoneScoped;
     if (mBuf)
@@ -199,7 +198,7 @@ BucketOutputIterator<BucketT>::getBucket(
     // either it's a new bucket or we just reconstructed a bucket
     // we already have, in any case ensure we have an index
     if (auto b = bucketManager.getBucketIfExists<BucketT>(hash);
-        ((!b || !b->isIndexed()) && shouldIndex))
+        (!b || !b->isIndexed()))
     {
         // Create index using in-memory state instead of file IO if available
         if constexpr (std::is_same_v<BucketT, LiveBucket>)

--- a/src/bucket/BucketOutputIterator.h
+++ b/src/bucket/BucketOutputIterator.h
@@ -55,7 +55,6 @@ template <typename BucketT> class BucketOutputIterator
     std::shared_ptr<BucketT> getBucket(
         BucketManager& bucketManager, MergeKey* mergeKey = nullptr,
         std::optional<std::vector<typename BucketT::EntryT>> inMemoryState =
-            std::nullopt,
-        bool shouldIndex = true);
+            std::nullopt);
 };
 }

--- a/src/bucket/LiveBucket.h
+++ b/src/bucket/LiveBucket.h
@@ -108,14 +108,22 @@ class LiveBucket : public BucketBase<LiveBucket, LiveBucketIndex>,
     // Create a fresh bucket from given vectors of init (created) and live
     // (updated) LedgerEntries, and dead LedgerEntryKeys. The bucket will
     // be sorted, hashed, and adopted in the provided BucketManager.
-    // If storeInMemory is true, populates mEntries.
     static std::shared_ptr<LiveBucket>
     fresh(BucketManager& bucketManager, uint32_t protocolVersion,
           std::vector<LedgerEntry> const& initEntries,
           std::vector<LedgerEntry> const& liveEntries,
           std::vector<LedgerKey> const& deadEntries, bool countMergeEvents,
-          asio::io_context& ctx, bool doFsync, bool storeInMemory = false,
-          bool shouldIndex = true);
+          asio::io_context& ctx, bool doFsync);
+
+    // Create a fresh bucket that exists only in memory, without writing to
+    // disk, calculating a hash, or indexing. This should only be used for
+    // "level -1" snap buckets that are immediately merged into level 0.
+    static std::shared_ptr<LiveBucket>
+    freshInMemoryOnly(BucketManager& bucketManager, uint32_t protocolVersion,
+                      std::vector<LedgerEntry> const& initEntries,
+                      std::vector<LedgerEntry> const& liveEntries,
+                      std::vector<LedgerKey> const& deadEntries,
+                      bool countMergeEvents);
 
     // Returns true if the given BucketEntry should be dropped in the bottom
     // level bucket (i.e. DEADENTRY)


### PR DESCRIPTION
# Description

Removes a redundant write from the BucketList `addBatch` path.

Currently, when writing a new bucket to the level 0 BucketList, we first write a "level -1" snap bucket. This bucket then immediately merges into the `curr` Bucket. The issue is, creating this level -1 bucket is quite expensive, as we write entries to a file, hash them, call fsync, but then never actually use the file for anything or adopt it into the BucketList. This change removes these redundant hash and write operations. There should be no safety concerns, as the level -1 bucket was never adopted into the BucketList, so persisting it prior to the merge didn't give us any better guarantees than a memory based merge.

This shaves about 25% off write times on NVME validator SKU and probably much more on EBS systems:

<img width="874" height="228" alt="image" src="https://github.com/user-attachments/assets/2396255f-e4b2-4991-8314-62d1fb587455" />


# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
