### PR TITLE
Add redis to the perftests image

### DIFF
--- a/docker/setup
+++ b/docker/setup
@@ -37,9 +37,12 @@ else
   pip3 install awscli --upgrade --break-system-packages
 fi
 
-
 # install test dependencies if STELLAR_CORE_VERSION ends with '~buildtests'
 if [[ "$STELLAR_CORE_VERSION" == *~buildtests ]]; then
+  apt-get install -y redis-tools
+fi
+# install test dependencies if STELLAR_CORE_VERSION ends with '~perftests'
+if [[ "$STELLAR_CORE_VERSION" == *~perftests ]]; then
   apt-get install -y redis-tools
 fi
 


### PR DESCRIPTION
### What

Add redis to the perftests image

### Why

Redis-cli is a dependency of the paralle catchup V2 supercluster mission. We'd like to run parallel catchup with the perftests build as it's faster than the buildtests build.