### PR TITLE
Add P23 data corruption verification tool.

### DIFF
--- a/src/ledger/P23HotArchiveBug.cpp
+++ b/src/ledger/P23HotArchiveBug.cpp
@@ -19,6 +19,17 @@ namespace stellar
 {
 namespace p23_hot_archive_bug
 {
+namespace
+{
+LedgerEntry
+decodeLedgerEntry(std::string const& encodedBase64)
+{
+    LedgerEntry entry;
+    fromOpaqueBase64(entry, encodedBase64);
+    return entry;
+}
+} // namespace
+
 using namespace internal;
 
 std::vector<LedgerKey>
@@ -27,8 +38,8 @@ getP23CorruptedHotArchiveKeys()
     std::vector<LedgerKey> result;
     for (size_t i = 0; i < P23_CORRUPTED_HOT_ARCHIVE_ENTRIES_COUNT; ++i)
     {
-        LedgerEntry corruptedEntry;
-        fromOpaqueBase64(corruptedEntry, P23_CORRUPTED_HOT_ARCHIVE_ENTRIES[i]);
+        LedgerEntry corruptedEntry =
+            decodeLedgerEntry(P23_CORRUPTED_HOT_ARCHIVE_ENTRIES[i]);
         result.push_back(LedgerEntryKey(corruptedEntry));
     }
     return result;
@@ -53,13 +64,12 @@ addHotArchiveBatchWithP23HotArchiveFix(
         app.getAppConnector().copySearchableHotArchiveBucketListSnapshot();
     for (size_t i = 0; i < P23_CORRUPTED_HOT_ARCHIVE_ENTRIES_COUNT; ++i)
     {
-        LedgerEntry corruptedEntry;
-        fromOpaqueBase64(corruptedEntry, P23_CORRUPTED_HOT_ARCHIVE_ENTRIES[i]);
+        LedgerEntry corruptedEntry =
+            decodeLedgerEntry(P23_CORRUPTED_HOT_ARCHIVE_ENTRIES[i]);
         LedgerKey corruptedEntryKey = LedgerEntryKey(corruptedEntry);
 
-        LedgerEntry fixedEntry;
-        fromOpaqueBase64(fixedEntry,
-                         P23_CORRUPTED_HOT_ARCHIVE_ENTRY_CORRECT_STATE[i]);
+        LedgerEntry fixedEntry =
+            decodeLedgerEntry(P23_CORRUPTED_HOT_ARCHIVE_ENTRY_CORRECT_STATE[i]);
         LedgerKey fixedEntryKey = LedgerEntryKey(fixedEntry);
         // That would be a bug in the hardcoded data, so this is safe as long
         // as build is not broken.
@@ -124,8 +134,361 @@ addHotArchiveBatchWithP23HotArchiveFix(
                   xdr::xdr_to_string(fixedEntry));
         updatedArchivedEntries.emplace_back(std::move(fixedEntry));
     }
+
+    if (app.getProtocol23CorruptionDataVerifier())
+    {
+        app.getProtocol23CorruptionDataVerifier()->verifyEntryFixesOnP24Upgrade(
+            updatedArchivedEntries);
+    }
+
     app.getBucketManager().addHotArchiveBatch(
         app, header, updatedArchivedEntries, restoredEntries);
 }
+
+bool
+Protocol23CorruptionDataVerifier::loadFromFile(std::string const& path)
+{
+    std::ifstream file(path);
+    if (!file.is_open())
+    {
+        CLOG_ERROR(Ledger, "Failed to open Protocol 23 corruption file: {}",
+                   path);
+        return false;
+    }
+
+    std::string line;
+    size_t lineNumber = 0;
+
+    // Read and skip header line
+    if (!std::getline(file, line))
+    {
+        CLOG_ERROR(Ledger, "Protocol 23 corruption file is empty: {}", path);
+        return false;
+    }
+    lineNumber++;
+
+    // Process each data line
+    while (std::getline(file, line))
+    {
+        lineNumber++;
+        if (line.empty())
+        {
+            continue;
+        }
+
+        if (!parseLine(line, lineNumber))
+        {
+            CLOG_ERROR(Ledger,
+                       "Failed to parse line {} in Protocol 23 corruption file",
+                       lineNumber);
+            return false;
+        }
+    }
+
+    CLOG_INFO(Ledger,
+              "Loaded Protocol 23 corruption data: {} keys, {} evicted "
+              "sequences, {} restored, {} not restored",
+              mKeyToEntries.size(), mEvictedSeqToKeys.size(),
+              mKeyToRestoredSeq.size(), mNotRestoredKeys.size());
+    // Verify the hardcoded data as soon as loading is complete.
+    // Technically, before catchup has been performed we can't tell if the
+    // corrupted data file is valid (i.e. it might be invalid, and hardcoded
+    // data is valid), but we operate under the assumption that the hardcoded
+    // data is in fact correct, i.e. first we prove that hardcoded data matches
+    // the CSV, and then we prove that CSV itself is valid during catchup (and
+    // thus also hardcoded data is valid as well).
+    verifyHardcodedData();
+    return true;
+}
+
+bool
+Protocol23CorruptionDataVerifier::parseLine(std::string const& line,
+                                            size_t lineNumber)
+{
+    // Parse CSV line: ledgerKey,correctLedgerEntry,corruptedLedgerEntry,
+    // evictedLedgerSeq,restoredLedgerSeq
+    std::vector<std::string> fields;
+    std::stringstream ss(line);
+    std::string field;
+
+    while (std::getline(ss, field, ','))
+    {
+        fields.push_back(field);
+    }
+
+    if (fields.size() != 5)
+    {
+        CLOG_ERROR(Ledger,
+                   "Line {}: Expected 5 fields, got {}. Line content: {}",
+                   lineNumber, fields.size(), line);
+        return false;
+    }
+
+    // Strip trailing carriage return from last field if present (CRLF line
+    // endings)
+    if (!fields[4].empty() && fields[4].back() == '\r')
+    {
+        fields[4].pop_back();
+    }
+
+    try
+    {
+        // Decode ledger key
+        LedgerKey ledgerKey;
+        fromOpaqueBase64(ledgerKey, fields[0]);
+        // Decode correct ledger entry
+        LedgerEntry correctEntry = decodeLedgerEntry(fields[1]);
+
+        // Decode corrupted ledger entry
+        LedgerEntry corruptedEntry = decodeLedgerEntry(fields[2]);
+
+        // Parse evicted ledger sequence
+        uint32_t evictedSeq = std::stoul(fields[3]);
+
+        // Parse restored ledger sequence (may be "not-restored")
+        bool isRestored = (fields[4] != "not-restored");
+        std::optional<uint32_t> restoredSeq;
+        if (isRestored)
+        {
+            restoredSeq = std::stoul(fields[4]);
+        }
+
+        // Store in data structures
+        mKeyToEntries.emplace(ledgerKey,
+                              std::make_pair(correctEntry, corruptedEntry));
+
+        // Add to evicted sequence map
+        auto& keysAtSeq = mEvictedSeqToKeys[evictedSeq];
+        keysAtSeq.insert(ledgerKey);
+
+        // Add to restored or not-restored sets
+        if (restoredSeq)
+        {
+            mKeyToRestoredSeq.emplace(ledgerKey, *restoredSeq);
+        }
+        else
+        {
+            mNotRestoredKeys.insert(ledgerKey);
+        }
+
+        return true;
+    }
+    catch (std::exception const& e)
+    {
+        CLOG_ERROR(Ledger, "Line {}: Exception during parsing: {}", lineNumber,
+                   e.what());
+        return false;
+    }
+}
+
+void
+Protocol23CorruptionDataVerifier::verifyHardcodedData() const
+{
+    CLOG_INFO(Ledger,
+              "Verifying hardcoded Protocol 23 corruption data against CSV...");
+
+    // Build maps from hardcoded arrays. Both include the set of all corrupted
+    // keys.
+    UnorderedMap<LedgerKey, LedgerEntry> corruptedMap;
+    UnorderedMap<LedgerKey, LedgerEntry> correctMap;
+
+    for (size_t i = 0; i < P23_CORRUPTED_HOT_ARCHIVE_ENTRIES_COUNT; ++i)
+    {
+        LedgerEntry corruptedEntry =
+            decodeLedgerEntry(P23_CORRUPTED_HOT_ARCHIVE_ENTRIES[i]);
+        corruptedMap.emplace(LedgerEntryKey(corruptedEntry), corruptedEntry);
+
+        LedgerEntry correctEntry =
+            decodeLedgerEntry(P23_CORRUPTED_HOT_ARCHIVE_ENTRY_CORRECT_STATE[i]);
+        correctMap.emplace(LedgerEntryKey(correctEntry), correctEntry);
+    }
+
+    // Verify that the keys in corruptedMap and correctMap match
+    releaseAssert(corruptedMap.size() == correctMap.size());
+    for (auto const& [key, _] : corruptedMap)
+    {
+        releaseAssert(correctMap.find(key) != correctMap.end());
+    }
+
+    // Verify that all keys in the hard coded maps match the CSV data.
+    // mKeyToEntries is a mapping of ledger key -> <correct entry, corrupted
+    // entry> pair, derived from the CSV data.
+    for (auto const& [key, entryPair] : mKeyToEntries)
+    {
+        auto const& [csvCorrectEntry, csvCorruptedEntry] = entryPair;
+
+        auto corruptedIt = corruptedMap.find(key);
+        releaseAssert(corruptedIt != corruptedMap.end());
+        releaseAssert(csvCorruptedEntry == corruptedIt->second);
+
+        auto correctIt = correctMap.find(key);
+        releaseAssert(correctIt != correctMap.end());
+        releaseAssert(csvCorrectEntry == correctIt->second);
+    }
+
+    CLOG_INFO(Ledger,
+              "Successfully verified {} hardcoded entries against CSV data",
+              corruptedMap.size());
+}
+
+void
+Protocol23CorruptionDataVerifier::verifyRestorationOfCorruptedEntry(
+    LedgerKey const& restoredKey, LedgerEntry const& restoredEntry,
+    uint32_t ledgerSeq, uint32_t protocolVersion)
+{
+    if (!protocolVersionEquals(protocolVersion, ProtocolVersion::V_23))
+    {
+        return;
+    }
+    // Modify state using mutex just in case, even though in
+    // p23 we haven't increased the number of threads.
+    std::lock_guard<std::mutex> lock(mMutex);
+
+    // Check if this key is in the corrupted keys map
+    auto restoredIter = mKeyToRestoredSeq.find(restoredKey);
+    if (restoredIter != mKeyToRestoredSeq.end())
+    {
+        // Key is in the corrupted restores map. Assert that the
+        // actual restoration ledger seq matches the ledger seq
+        // in the CSV.
+        releaseAssert(restoredIter->second == ledgerSeq);
+
+        // Validate that the actual restored value is the
+        // corrupt value from the CSV.
+        auto entryIter = mKeyToEntries.find(restoredKey);
+        releaseAssert(entryIter != mKeyToEntries.end());
+        auto const& [correctEntry, corruptedEntry] = entryIter->second;
+        releaseAssert(restoredEntry == corruptedEntry);
+
+        // Make sure this key has not already been restored during the
+        // verification period.
+        releaseAssert(mKeysRestoredDuringCatchup.find(restoredKey) ==
+                      mKeysRestoredDuringCatchup.end());
+        mKeysRestoredDuringCatchup.insert(restoredKey);
+    }
+
+    // Assert that the key is not a key that the CSV file said
+    // was not restored.
+    releaseAssert(mNotRestoredKeys.find(restoredKey) == mNotRestoredKeys.end());
+}
+
+void
+Protocol23CorruptionDataVerifier::verifyArchivalOfCorruptedEntry(
+    EvictedStateVectors const& evictedState, Application& app,
+    uint32_t ledgerSeq, uint32_t protocolVersion)
+{
+    if (!protocolVersionEquals(protocolVersion, ProtocolVersion::V_23))
+    {
+        return;
+    }
+    // Modify state using mutex just in case, even though in
+    // p23 we haven't increased the number of threads.
+    std::lock_guard<std::mutex> lock(mMutex);
+
+    // This database can load the actual, correct version of a
+    // given ledger key. This tells us the value that should
+    // have been evicted.
+    auto liveDatabase = app.getBucketManager()
+                            .getBucketSnapshotManager()
+                            .copySearchableLiveBucketListSnapshot();
+
+    // This is the set of all keys incorrectly evicted for this
+    // ledger
+    auto evictedKeysIter = mEvictedSeqToKeys.find(ledgerSeq);
+    UnorderedSet<LedgerKey> incorrectlyEvictedKeys =
+        evictedKeysIter == mEvictedSeqToKeys.end() ? UnorderedSet<LedgerKey>()
+                                                   : evictedKeysIter->second;
+
+    // Iterate through all evicted keys and check if they are
+    // corrupt.
+    for (auto const& evictedEntry : evictedState.archivedEntries)
+    {
+        // Load the correct value from the live database.
+        auto evictedLedgerKey = LedgerEntryKey(evictedEntry);
+        auto databaseEntry = liveDatabase->load(evictedLedgerKey);
+        releaseAssert(databaseEntry != nullptr);
+
+        // If there was a corruption
+        if (*databaseEntry != evictedEntry)
+        {
+            auto iter = incorrectlyEvictedKeys.find(evictedLedgerKey);
+
+            // Require that if a key was incorrectly evicted, it
+            // was in the CSV input file.
+            releaseAssert(iter != incorrectlyEvictedKeys.end());
+
+            // Assert that both the corrupt value and correct
+            // value from the CSV file match the actual evicted
+            // value and the actual good value from the
+            // database.
+            auto const& [correctCSVEntry, corruptedCSVEntry] =
+                mKeyToEntries.at(evictedLedgerKey);
+
+            releaseAssert(*databaseEntry == correctCSVEntry);
+            releaseAssert(evictedEntry == corruptedCSVEntry);
+
+            // Mark that we have seen a given key
+            incorrectlyEvictedKeys.erase(iter);
+
+            // Make sure this key has not already been evicted during the
+            // verification period.
+            releaseAssert(mKeysEvictedDuringCatchup.find(evictedLedgerKey) ==
+                          mKeysEvictedDuringCatchup.end());
+            mKeysEvictedDuringCatchup.insert(evictedLedgerKey);
+        }
+    }
+
+    // Make sure that we saw and checked all keys that we
+    // incorrectly evicted for this ledger.
+    releaseAssert(incorrectlyEvictedKeys.empty());
+}
+
+void
+Protocol23CorruptionDataVerifier::verifyEntryFixesOnP24Upgrade(
+    std::vector<LedgerEntry> const& entryBatch) const
+{
+    // General note: this check is much more strict than the set of checks
+    // during the upgrade. That's intentional as after the upgrade we'll be 100%
+    // sure these pass (or we will adjust this to match unexpected state
+    // changes that have happened before the upgrade).
+
+    // Verify that the batch only contains the entry fixes, which should be the
+    // case since eviction is disabled.
+    releaseAssert(entryBatch.size() == mNotRestoredKeys.size());
+
+    for (auto const& entry : entryBatch)
+    {
+        LedgerKey entryKey = LedgerEntryKey(entry);
+        // The key must be in the not-restored set.
+        releaseAssert(mNotRestoredKeys.find(entryKey) !=
+                      mNotRestoredKeys.end());
+
+        auto iter = mKeyToEntries.find(entryKey);
+        releaseAssert(iter != mKeyToEntries.end());
+        auto const& [correctEntry, corruptedEntry] = iter->second;
+        // Verify that the entry in the batch matches the correct
+        // value from the CSV file.
+        releaseAssert(entry == correctEntry);
+    }
+
+    if (mKeysRestoredDuringCatchup.size() != mKeyToRestoredSeq.size())
+    {
+        CLOG_FATAL(
+            Ledger,
+            "Not all corrupted restored entries were seen during catchup: saw "
+            "{}, "
+            "expected {}. Make sure catchup run covers whole protocol 23.",
+            mKeysRestoredDuringCatchup.size(), mKeyToRestoredSeq.size());
+    }
+    if (mKeysEvictedDuringCatchup.size() != mKeyToEntries.size())
+    {
+        CLOG_FATAL(
+            Ledger,
+            "Not all corrupted evicted entries were seen during catchup: saw "
+            "{}, expected {}. Make sure catchup run covers whole protocol 23.",
+            mKeysEvictedDuringCatchup.size(), mKeyToEntries.size());
+    }
+}
+
 } // namespace p23_hot_archive_bug
 } // namespace stellar

--- a/src/ledger/P23HotArchiveBug.h
+++ b/src/ledger/P23HotArchiveBug.h
@@ -6,6 +6,9 @@
 
 #include <vector>
 
+#include "util/UnorderedMap.h"
+#include "util/UnorderedSet.h"
+
 #include "xdr/Stellar-ledger-entries.h"
 #include "xdr/Stellar-ledger.h"
 
@@ -13,6 +16,8 @@ namespace stellar
 {
 class Application;
 class AbstractLedgerTxn;
+class Config;
+struct EvictedStateVectors;
 
 namespace p23_hot_archive_bug
 {
@@ -27,11 +32,108 @@ extern const std::array<std::string, P23_CORRUPTED_HOT_ARCHIVE_ENTRIES_COUNT>
     P23_CORRUPTED_HOT_ARCHIVE_ENTRY_CORRECT_STATE;
 } // namespace internal
 
+// Verifier for protocol 23 Hot Archive corruption data.
+// This verifies that the externally provided corruption data file matches the
+// actual corruptions that have occurred during protocol 23, and that the
+// fixes to entries that have never been restored match the expected correct
+// state.
+// This should be used in combination with catchup that spans the whole of
+// protocol 23, as that is when the corruptions and restorations occur.
+//
+// More specifically, this verifies the following:
+// - That every data corruption that occurs during archival exists in the file
+// in the expected state, and that there is no corruption not accounted for.
+// - That every restoration of a corrupted entry is provided in the
+// file with the correct restoration ledger and the expected corrupted state.
+// - That every expected corruption from the file has happened before p24
+// upgrade
+// - That p24 upgrade puts the correct fixes to every entry that was never
+// restored, according to the file
+// - That `P23_CORRUPTED_HOT_ARCHIVE_ENTRIES` and
+// `P23_CORRUPTED_HOT_ARCHIVE_ENTRY_CORRECT_STATE` match the provided file as
+// an additional sanity check.
+struct Protocol23CorruptionDataVerifier
+{
+  public:
+    // Load corruption data from CSV file at given path
+    // The CSV format is: ledgerKey,correctLedgerEntry,corruptedLedgerEntry,
+    // evictedLedgerSeq,restoredLedgerSeq where:
+    // - ledgerKey: base64 XDR encoded LedgerKey
+    // - correctLedgerEntry: base64 XDR encoded LedgerEntry
+    // - corruptedLedgerEntry: base64 XDR encoded LedgerEntry
+    // - evictedLedgerSeq: ledger sequence number where entry was evicted
+    // - restoredLedgerSeq: ledger sequence number where entry was restored
+    //   (or "not-restored" if null)
+    // Returns true on success, false on error
+    bool loadFromFile(std::string const& path);
+
+    // Verifies that the restoration of a corrupted entry matches the expected
+    // data.
+    // This should be called for every restoration that occurs during catchup,
+    // non-corrupted restorations are ignored.
+    // This is thread-safe.
+    void verifyRestorationOfCorruptedEntry(LedgerKey const& restoredKey,
+                                           LedgerEntry const& restoredEntry,
+                                           uint32_t ledgerSeq,
+                                           uint32_t protocolVersion);
+    // Verifies that every corruption during archival is accounted for in the
+    // expected data.
+    // This should be called for every eviction that occurs during catchup,
+    // non-corrupted evictions are ignored.
+    // This is thread-safe.
+    void verifyArchivalOfCorruptedEntry(EvictedStateVectors const& evictedState,
+                                        Application& app, uint32_t ledgerSeq,
+                                        uint32_t protocolVersion);
+    // Verifies that the batch of Hot Archive fixes on protocol 24 upgrade
+    // corresponds to the expected data (i.e. only entries that were never
+    // restored have been fixed, and that the fix comes back to the correct
+    // state).
+    // Also verifies that all the data entries have been exhausted by
+    // verification functions above, which requires the catchup to run for
+    // the whole duration of protocol 23.
+    // This is not thread-safe, which is fine as it shouldn't ever happen during
+    // the transaction application.
+    void verifyEntryFixesOnP24Upgrade(
+        std::vector<LedgerEntry> const& entryBatch) const;
+
+  private:
+    void verifyHardcodedData() const;
+
+    // Parse a single line from the CSV file
+    // Returns true on success, false on error
+    bool parseLine(std::string const& line, size_t lineNumber);
+
+    // Map from evicted ledger sequence to set of ledger keys evicted at that
+    // sequence
+    UnorderedMap<uint32_t, UnorderedSet<LedgerKey>> mEvictedSeqToKeys;
+
+    // Map from ledger key to pair of correct and corrupted ledger entries
+    // pair.first = correct entry, pair.second = corrupted entry
+    UnorderedMap<LedgerKey, std::pair<LedgerEntry, LedgerEntry>> mKeyToEntries;
+
+    // Map from ledger key to restored ledger sequence (only for entries that
+    // were restored)
+    UnorderedMap<LedgerKey, uint32_t> mKeyToRestoredSeq;
+
+    // Set of ledger keys that were not restored
+    UnorderedSet<LedgerKey> mNotRestoredKeys;
+
+    // Keys of the corrupted entries that have been restored during catchup.
+    // This is populated in `verifyRestorationOfCorruptedEntry` calls.
+    UnorderedSet<LedgerKey> mKeysRestoredDuringCatchup;
+    // Keys of the entries that have been evicted during catchup in corrupted
+    // state. This is populated in `verifyArchivalOfCorruptedEntry` calls.
+    UnorderedSet<LedgerKey> mKeysEvictedDuringCatchup;
+
+    std::mutex mMutex;
+};
+
 std::vector<LedgerKey> getP23CorruptedHotArchiveKeys();
 
 void addHotArchiveBatchWithP23HotArchiveFix(
     AbstractLedgerTxn& ltx, Application& app, LedgerHeader header,
     std::vector<LedgerEntry> const& archivedEntries,
     std::vector<LedgerKey> const& restoredEntries);
+
 } // namespace p23_hot_archive_bug
 } // namespace stellar

--- a/src/main/AppConnector.cpp
+++ b/src/main/AppConnector.cpp
@@ -3,6 +3,7 @@
 #include "invariant/InvariantManager.h"
 #include "ledger/LedgerManager.h"
 #include "ledger/LedgerTxn.h"
+#include "ledger/P23HotArchiveBug.h"
 #include "main/Application.h"
 #include "overlay/BanManager.h"
 #include "overlay/OverlayManager.h"
@@ -182,6 +183,12 @@ SearchableSnapshotConstPtr&
 AppConnector::getOverlayThreadSnapshot()
 {
     return mApp.getOverlayManager().getOverlayThreadSnapshot();
+}
+
+std::unique_ptr<p23_hot_archive_bug::Protocol23CorruptionDataVerifier>&
+AppConnector::getProtocol23CorruptionDataVerifier()
+{
+    return mApp.getProtocol23CorruptionDataVerifier();
 }
 
 #ifdef BUILD_TESTS

--- a/src/main/AppConnector.h
+++ b/src/main/AppConnector.h
@@ -76,6 +76,12 @@ class AppConnector
     // only be called from the overlay thread.
     SearchableSnapshotConstPtr& getOverlayThreadSnapshot();
 
+    // Protocol 23 data corruption bug data verifier. This typically is null,
+    // unless a path to a CSV file containing the corruption data was provided
+    // in the config at startup.
+    std::unique_ptr<p23_hot_archive_bug::Protocol23CorruptionDataVerifier>&
+    getProtocol23CorruptionDataVerifier();
+
 #ifdef BUILD_TESTS
     // Access the runtime overlay-only mode flag for testing
     bool getRunInOverlayOnlyMode() const;

--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -22,7 +22,6 @@ class MetricsRegistry;
 
 namespace stellar
 {
-
 class VirtualClock;
 class TmpDirManager;
 class LedgerManager;
@@ -47,6 +46,10 @@ class BasicWork;
 enum class LoadGenMode;
 struct GeneratedLoadConfig;
 class AppConnector;
+namespace p23_hot_archive_bug
+{
+class Protocol23CorruptionDataVerifier;
+} // namespace p23_hot_archive_bug
 
 #ifdef BUILD_TESTS
 class LoadGenerator;
@@ -233,6 +236,13 @@ class Application
     virtual WorkScheduler& getWorkScheduler() = 0;
     virtual BanManager& getBanManager() = 0;
     virtual StatusManager& getStatusManager() = 0;
+
+    // Protocol 23 data corruption bug data verifier. This typically is null,
+    // unless a path to a CSV file containing the corruption data was provided
+    // in the config at startup.
+    virtual std::unique_ptr<
+        p23_hot_archive_bug::Protocol23CorruptionDataVerifier>&
+    getProtocol23CorruptionDataVerifier() = 0;
 
     // Get the worker IO service, served by background threads. Work posted to
     // this io_context will execute in parallel with the calling thread, so use

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -37,6 +37,7 @@
 #include "ledger/LedgerManager.h"
 #include "ledger/LedgerManagerImpl.h"
 #include "ledger/LedgerTxn.h"
+#include "ledger/P23HotArchiveBug.h"
 #include "main/AppConnector.h"
 #include "main/ApplicationUtils.h"
 #include "main/CommandHandler.h"
@@ -264,6 +265,20 @@ ApplicationImpl::initialize(bool createNewDB, bool forceRebuild)
     mWorkScheduler = WorkScheduler::create(*this);
     mBanManager = BanManager::create(*this);
     mStatusManager = std::make_unique<StatusManager>();
+
+    // Load Protocol 23 corruption data if path to CSV is specified
+    if (!mConfig.PATH_TO_PROTOCOL_23_CORRUPTION_FILE.empty())
+    {
+        mProtocol23CorruptionDataVerifier = std::make_unique<
+            p23_hot_archive_bug::Protocol23CorruptionDataVerifier>();
+        if (!mProtocol23CorruptionDataVerifier->loadFromFile(
+                mConfig.PATH_TO_PROTOCOL_23_CORRUPTION_FILE))
+        {
+            throw std::invalid_argument(
+                "Failed to load Protocol 23 corruption file: " +
+                mConfig.PATH_TO_PROTOCOL_23_CORRUPTION_FILE);
+        }
+    }
 
     if (mConfig.ENTRY_CACHE_SIZE < 20000)
     {
@@ -1583,5 +1598,10 @@ AppConnector&
 ApplicationImpl::getAppConnector()
 {
     return *mAppConnector;
+}
+std::unique_ptr<p23_hot_archive_bug::Protocol23CorruptionDataVerifier>&
+ApplicationImpl::getProtocol23CorruptionDataVerifier()
+{
+    return mProtocol23CorruptionDataVerifier;
 }
 }

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -36,6 +36,10 @@ class InMemoryLedgerTxn;
 class InMemoryLedgerTxnRoot;
 class LoadGenerator;
 class AppConnector;
+namespace p23_hot_archive_bug
+{
+class Protocol23CorruptionDataVerifier;
+}
 
 class ApplicationImpl : public Application
 {
@@ -78,6 +82,8 @@ class ApplicationImpl : public Application
     virtual BanManager& getBanManager() override;
     virtual StatusManager& getStatusManager() override;
     virtual AppConnector& getAppConnector() override;
+    std::unique_ptr<p23_hot_archive_bug::Protocol23CorruptionDataVerifier>&
+    getProtocol23CorruptionDataVerifier() override;
 
     virtual asio::io_context& getWorkerIOContext() override;
     virtual asio::io_context& getEvictionIOContext() override;
@@ -191,6 +197,9 @@ class ApplicationImpl : public Application
     std::unique_ptr<StatusManager> mStatusManager;
     std::unique_ptr<AbstractLedgerTxnParent> mLedgerTxnRoot;
     std::unique_ptr<AppConnector> mAppConnector;
+
+    std::unique_ptr<p23_hot_archive_bug::Protocol23CorruptionDataVerifier>
+        mProtocol23CorruptionDataVerifier;
 
     // These two exist for use in MODE_USES_IN_MEMORY_LEDGER only: the
     // mInMemoryLedgerTxnRoot is a _stub_ AbstractLedgerTxnParent that refuses

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -228,6 +228,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
 
     LOG_FILE_PATH = "stellar-core-{datetime:%Y-%m-%d_%H-%M-%S}.log";
     BUCKET_DIR_PATH = "buckets";
+    PATH_TO_PROTOCOL_23_CORRUPTION_FILE = "";
 
     LOG_COLOR = false;
 
@@ -1254,6 +1255,10 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                                  "FILTERED_SOROBAN_KEYS_PATH is "
                                  "deprecated and ignored. Please remove "
                                  "this from config");
+                 }},
+                {"PATH_TO_PROTOCOL_23_CORRUPTION_FILE",
+                 [&]() {
+                     PATH_TO_PROTOCOL_23_CORRUPTION_FILE = readString(item);
                  }},
                 {"NODE_NAMES",
                  [&]() {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -633,6 +633,10 @@ class Config : public std::enable_shared_from_this<Config>
     bool LOG_COLOR;
     std::string BUCKET_DIR_PATH;
 
+    // Path to Protocol 23 corruption CSV file for testing/recovery
+    std::string PATH_TO_PROTOCOL_23_CORRUPTION_FILE;
+
+  public:
     // Ledger protocol version for testing purposes. Defaulted to
     // LEDGER_PROTOCOL_VERSION. Used in the following scenarios: 1. to specify
     // the genesis ledger version (only when USE_CONFIG_FOR_GENESIS is true) 2.

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -27,6 +27,7 @@
 #include "ledger/LedgerTxn.h"
 #include "ledger/LedgerTxnEntry.h"
 #include "ledger/LedgerTypeUtils.h"
+#include "ledger/P23HotArchiveBug.h"
 #include "rust/RustBridge.h"
 #include "transactions/InvokeHostFunctionOpFrame.h"
 #include "transactions/MutableTransactionResult.h"
@@ -1002,6 +1003,17 @@ class InvokeHostFunctionParallelApplyHelper
             auto ttlBuf = toCxxBuf(ttlEntry.data.ttl());
             mTtlEntryCxxBufs.emplace_back(std::move(ttlBuf));
             mAutoRestoredRwEntryIndices.push_back(index);
+
+            // Validate restored entry against Protocol 23 corruption data if
+            // configured. Note that the bug only affects evicted entries, so we
+            // only assert against entries being restored from the hot archive.
+            if (isHotArchiveEntry && mApp.getProtocol23CorruptionDataVerifier())
+            {
+                mApp.getProtocol23CorruptionDataVerifier()
+                    ->verifyRestorationOfCorruptedEntry(
+                        lk, le, mLedgerInfo.getLedgerSeq(),
+                        mLedgerInfo.getLedgerVersion());
+            }
 
             return true;
         }

--- a/src/transactions/RestoreFootprintOpFrame.cpp
+++ b/src/transactions/RestoreFootprintOpFrame.cpp
@@ -8,6 +8,7 @@
 #include "bucket/HotArchiveBucket.h"
 #include "ledger/LedgerManagerImpl.h"
 #include "ledger/LedgerTypeUtils.h"
+#include "ledger/P23HotArchiveBug.h"
 #include "medida/meter.h"
 #include "medida/timer.h"
 #include "transactions/MutableTransactionResult.h"
@@ -152,6 +153,14 @@ class RestoreFootprintApplyHelper : virtual public LedgerAccessHelper
             if (hotArchiveEntryOpt)
             {
                 entry = hotArchiveEntryOpt.value();
+                if (mApp.getProtocol23CorruptionDataVerifier())
+                {
+                    // Validate restored entry against Protocol 23 corruption
+                    // data if configured.
+                    mApp.getProtocol23CorruptionDataVerifier()
+                        ->verifyRestorationOfCorruptedEntry(
+                            lk, entry, ledgerSeq, getLedgerVersion());
+                }
 
                 // Update last modified ledger seq to the current ledger seq
                 // since we're rewriting this entry. ltx will update this for


### PR DESCRIPTION
# Description

Add P23 data corruption verification tool.

This allows specifying an external CSV table that contains the expected p23 Hot Archive corruption data. Then during catchup that covers the whole range of p23 and the upgrade to p24 the file is used to verify that:

- Only the entries from the table are ever incorrectly archived, and that their correct and archived states match those in the table
- Every entry from the table has indeed been incorrectly archived
- The entries that have been marked as restored in the table were indeed restored with the expected corrupted state
- During the protocol 24 upgrade only the entries from the table that have never been restored have been updated, and that the update has brought them back to the correct state

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
