### PR TITLE
Consistently use `struct` for the type of `Protocol23CorruptionDataVerifier`

### DIFF
--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -48,7 +48,7 @@ struct GeneratedLoadConfig;
 class AppConnector;
 namespace p23_hot_archive_bug
 {
-class Protocol23CorruptionDataVerifier;
+struct Protocol23CorruptionDataVerifier;
 } // namespace p23_hot_archive_bug
 
 #ifdef BUILD_TESTS

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -38,7 +38,7 @@ class LoadGenerator;
 class AppConnector;
 namespace p23_hot_archive_bug
 {
-class Protocol23CorruptionDataVerifier;
+struct Protocol23CorruptionDataVerifier;
 }
 
 class ApplicationImpl : public Application


### PR DESCRIPTION
Fixes the following build warning

```
In file included from main/ApplicationImpl.cpp:40:
./ledger/P23HotArchiveBug.h:55:1: warning: 'Protocol23CorruptionDataVerifier' defined as a struct here but previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
   55 | struct Protocol23CorruptionDataVerifier
      | ^
main/ApplicationImpl.h:41:1: note: did you mean struct here?
   41 | class Protocol23CorruptionDataVerifier;
      | ^~~~~
      | struct
./main/Application.h:51:1: note: did you mean struct here?
   51 | class Protocol23CorruptionDataVerifier;
      | ^~~~~
      | struct
```