### PR TITLE
Cleanup changes merged from P24 branch.

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -67,9 +67,9 @@ herder.pending[-soroban]-txs.sum          | counter   | sum of time (millisecond
 herder.pending[-soroban]-txs.count        | counter   | number of transactions to be included in a ledger
 herder.pending[-soroban]-txs.self-sum     | counter   | sum of time (milliseconds) for transactions submitted from this node to be included in a ledger
 herder.pending[-soroban]-txs.self-count   | counter   | number of transactions submitted from this node to be included in a ledger
-herder.pending[-soroban]-txs.evicted-due-too-low-fee-count   | counter   | Count of transactions evicted by higher fee txs when queue is near its capacity.
-herder.pending[-soroban]-txs.evicted-due-too-age-count   | counter   | Count of transactions that had low fee for too long and have not been included into several ledgers in a row.
-herder.pending[-soroban]-txs.not-included-due-too-low-fee-count   | counter   | Count of transactions that were not included into queue because it is at capacity and the fee is too low to replace other txs.
+herder.pending[-soroban]-txs.evicted-due-to-low-fee-count   | counter   | Count of transactions evicted by higher fee txs when queue is near its capacity.
+herder.pending[-soroban]-txs.evicted-due-to-age-count   | counter   | Count of transactions that had low fee for too long and have not been included into several ledgers in a row.
+herder.pending[-soroban]-txs.not-included-due-to-low-fee-count   | counter   | Count of transactions that were not included into queue because it is at capacity and the fee is too low to replace other txs.
 history.check.failure                     | meter     | history archive status checks failed
 history.check.success                     | meter     | history archive status checks succeeded
 history.publish.failure                   | meter     | published failed

--- a/src/bucket/test/BucketTestUtils.cpp
+++ b/src/bucket/test/BucketTestUtils.cpp
@@ -189,7 +189,7 @@ void
 LedgerManagerForBucketTests::finalizeLedgerTxnChanges(
     AbstractLedgerTxn& ltx,
     std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta,
-    LedgerHeader lh, uint32_t initialLedgerVers, bool isP24UpgradeLedger)
+    LedgerHeader lh, uint32_t initialLedgerVers)
 {
     if (mUseTestEntries)
     {
@@ -342,8 +342,8 @@ LedgerManagerForBucketTests::finalizeLedgerTxnChanges(
     }
     else
     {
-        LedgerManagerImpl::finalizeLedgerTxnChanges(
-            ltx, ledgerCloseMeta, lh, initialLedgerVers, isP24UpgradeLedger);
+        LedgerManagerImpl::finalizeLedgerTxnChanges(ltx, ledgerCloseMeta, lh,
+                                                    initialLedgerVers);
     }
 }
 

--- a/src/bucket/test/BucketTestUtils.h
+++ b/src/bucket/test/BucketTestUtils.h
@@ -75,8 +75,7 @@ class LedgerManagerForBucketTests : public LedgerManagerImpl
     void finalizeLedgerTxnChanges(
         AbstractLedgerTxn& ltx,
         std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta,
-        LedgerHeader lh, uint32_t initialLedgerVers,
-        bool isP24UpgradeLedger) override;
+        LedgerHeader lh, uint32_t initialLedgerVers) override;
 
   public:
     void

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -2459,20 +2459,7 @@ HerderImpl::recomputeKeysToFilter(uint32_t protocolVersion) const
         }
         return result;
     };
-    if (protocolVersionStartsFrom(protocolVersion, ProtocolVersion::V_24))
-    {
-
-        return filteredSet(KEYS_TO_FILTER_P24_COUNT, KEYS_TO_FILTER_P24);
-    }
-    else
-    {
-        // Filter all the transactions that interact with any corrupted
-        // entries.
-        // We're past p23 so it's fine to use p23 filter for all
-        // previous protocols.
-        auto keys = p23_hot_archive_bug::getP23CorruptedHotArchiveKeys();
-        return UnorderedSet<LedgerKey>(keys.begin(), keys.end());
-    }
+    return filteredSet(KEYS_TO_FILTER_P24_COUNT, KEYS_TO_FILTER_P24);
 }
 
 void
@@ -2517,9 +2504,9 @@ HerderImpl::updateTransactionQueue(TxSetXDRFrameConstPtr externalizedTxSet,
                     false);
     }
 
-    // Even if we're in protocol 20, still check for number of phases, in case
-    // we're dealing with the upgrade ledger that contains old-style transaction
-    // set
+    // Even if we're in protocol 20, still check for number of phases, in
+    // case we're dealing with the upgrade ledger that contains old-style
+    // transaction set
     if (mSorobanTransactionQueue != nullptr &&
         txsPerPhase.size() > static_cast<size_t>(TxSetPhase::SOROBAN))
     {
@@ -2533,12 +2520,12 @@ void
 HerderImpl::herderOutOfSync()
 {
     ZoneScoped;
-    // State switch from "tracking" to "out of sync" should only happen if there
-    // are no ledgers queued to be applied. If there are ledgers queued, it's
-    // possible the rest of the network is waiting for this node to vote. In
-    // this case we should _still_ remain in tracking and emit nomination; If
-    // the node does not hear anything from the network after that, then node
-    // can go into out of sync recovery.
+    // State switch from "tracking" to "out of sync" should only happen if
+    // there are no ledgers queued to be applied. If there are ledgers
+    // queued, it's possible the rest of the network is waiting for this
+    // node to vote. In this case we should _still_ remain in tracking and
+    // emit nomination; If the node does not hear anything from the network
+    // after that, then node can go into out of sync recovery.
     releaseAssert(threadIsMain());
     releaseAssert(!mLedgerManager.isApplying());
 

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -136,11 +136,11 @@ ClassicTransactionQueue::ClassicTransactionQueue(Application& app,
         app.getMetrics().NewCounter({"herder", "pending-txs", "self-sum"}),
         app.getMetrics().NewCounter({"herder", "pending-txs", "self-count"}),
         app.getMetrics().NewCounter(
-            {"herder", "pending-txs", "evicted-due-too-low-fee-count"}),
+            {"herder", "pending-txs", "evicted-due-to-low-fee-count"}),
         app.getMetrics().NewCounter(
-            {"herder", "pending-txs", "evicted-due-too-age-count"}),
+            {"herder", "pending-txs", "evicted-due-to-age-count"}),
         app.getMetrics().NewCounter(
-            {"herder", "pending-txs", "not-included-due-too-low-fee-count"}),
+            {"herder", "pending-txs", "not-included-due-to-low-fee-count"}),
         app.getMetrics().NewCounter(
             {"herder", "pending-txs", "filtered-due-to-fp-keys"}));
     mBroadcastOpCarryover.resize(1,
@@ -1094,11 +1094,11 @@ SorobanTransactionQueue::SorobanTransactionQueue(
         app.getMetrics().NewCounter(
             {"herder", "pending-soroban-txs", "self-count"}),
         app.getMetrics().NewCounter(
-            {"herder", "pending-soroban-txs", "evicted-due-too-low-fee-count"}),
+            {"herder", "pending-soroban-txs", "evicted-due-to-low-fee-count"}),
         app.getMetrics().NewCounter(
-            {"herder", "pending-soroban-txs", "evicted-due-too-age-count"}),
+            {"herder", "pending-soroban-txs", "evicted-due-to-age-count"}),
         app.getMetrics().NewCounter({"herder", "pending-soroban-txs",
-                                     "not-included-due-too-low-fee-count"}),
+                                     "not-included-due-to-low-fee-count"}),
         app.getMetrics().NewCounter(
             {"herder", "pending-soroban-txs", "filtered-due-to-fp-keys"}));
     mBroadcastOpCarryover.resize(1, Resource::makeEmptySoroban());

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -308,8 +308,6 @@ class SorobanTransactionQueue : public TransactionQueue
 {
   public:
     SorobanTransactionQueue(Application& app, uint32 pendingDepth,
-                            uint32 banDepth, uint32 poolLedgerMultiplier);
-    SorobanTransactionQueue(Application& app, uint32 pendingDepth,
                             uint32 banDepth, uint32 poolLedgerMultiplier,
                             UnorderedSet<LedgerKey> const& keysToFilter);
     int

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -377,7 +377,7 @@ class LedgerManagerImpl : public LedgerManager
     CompleteConstLedgerStatePtr sealLedgerTxnAndStoreInBucketsAndDB(
         AbstractLedgerTxn& ltx,
         std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta,
-        uint32_t initialLedgerVers, bool isP24UpgradeLedger);
+        uint32_t initialLedgerVers);
 
     HistoryArchiveState
     storePersistentStateAndLedgerHeaderInDB(LedgerHeader const& header,
@@ -420,7 +420,7 @@ class LedgerManagerImpl : public LedgerManager
     virtual void finalizeLedgerTxnChanges(
         AbstractLedgerTxn& ltx,
         std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta,
-        LedgerHeader lh, uint32_t initialLedgerVers, bool isP24UpgradeLedger);
+        LedgerHeader lh, uint32_t initialLedgerVers);
 
     // Update bucket list snapshot, and construct LedgerState return
     // value, which contains all information relevant to ledger state (HAS,

--- a/src/ledger/P23HotArchiveBug.h
+++ b/src/ledger/P23HotArchiveBug.h
@@ -52,7 +52,7 @@ extern const std::array<std::string, P23_CORRUPTED_HOT_ARCHIVE_ENTRIES_COUNT>
 // - That `P23_CORRUPTED_HOT_ARCHIVE_ENTRIES` and
 // `P23_CORRUPTED_HOT_ARCHIVE_ENTRY_CORRECT_STATE` match the provided file as
 // an additional sanity check.
-struct Protocol23CorruptionDataVerifier
+class Protocol23CorruptionDataVerifier
 {
   public:
     // Load corruption data from CSV file at given path
@@ -127,8 +127,6 @@ struct Protocol23CorruptionDataVerifier
 
     std::mutex mMutex;
 };
-
-std::vector<LedgerKey> getP23CorruptedHotArchiveKeys();
 
 void addHotArchiveBatchWithP23HotArchiveFix(
     AbstractLedgerTxn& ltx, Application& app, LedgerHeader header,

--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -48,7 +48,7 @@ struct GeneratedLoadConfig;
 class AppConnector;
 namespace p23_hot_archive_bug
 {
-struct Protocol23CorruptionDataVerifier;
+class Protocol23CorruptionDataVerifier;
 } // namespace p23_hot_archive_bug
 
 #ifdef BUILD_TESTS

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -38,7 +38,7 @@ class LoadGenerator;
 class AppConnector;
 namespace p23_hot_archive_bug
 {
-struct Protocol23CorruptionDataVerifier;
+class Protocol23CorruptionDataVerifier;
 }
 
 class ApplicationImpl : public Application


### PR DESCRIPTION
# Description

Cleanup changes merged from P24 branch.

- Remove p23-related logic for filtering transactions that interact with keys affected by the data corruption issue
- Get rid of `isP24UpgradeLedger` flag
- Make some checks for p24 upgrade hot archive fixes more strict, now that the upgrade has actually happened
- Fix typos in the metric names (that's actually not from p24 branch, but has been noticed in the merge PR)

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
