### PR TITLE
Query Server graceful exit

### DIFF
--- a/lib/http/server.cpp
+++ b/lib/http/server.cpp
@@ -79,10 +79,21 @@ server::do_accept()
     });
 }
 
-server::~server()
+void
+server::shutdown()
 {
+    if (mIsShutdown.exchange(true))
+    {
+        return;
+    }
+
     acceptor_.close();
     connection_manager_.stop_all();
+}
+
+server::~server()
+{
+    shutdown();
 }
 
 void

--- a/lib/http/server.hpp
+++ b/lib/http/server.hpp
@@ -15,9 +15,10 @@
 // else.
 #include "util/asio.h"
 
-#include <string>
-#include <map>
+#include <atomic>
 #include <functional>
+#include <map>
+#include <string>
 #include "connection.hpp"
 #include "connection_manager.hpp"
 
@@ -46,6 +47,9 @@ public:
 
     void handle_request(const request& req, reply& rep);
 
+    /// Shutdown the server
+    void shutdown();
+
     static void parseParams(const std::string& params, std::map<std::string, std::string>& retMap);
 
 private:
@@ -70,6 +74,8 @@ private:
 
     /// The next socket to be accepted.
     asio::ip::tcp::socket socket_;
+
+    std::atomic<bool> mIsShutdown{false};
 
     std::map<std::string, routeHandler> mRoutes;
 };

--- a/lib/httpthreaded/server.hpp
+++ b/lib/httpthreaded/server.hpp
@@ -16,8 +16,10 @@
 #include "util/asio.h"
 
 #include "connection.hpp"
+#include <atomic>
 #include <functional>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -52,6 +54,9 @@ class server
     /// Start the server's io_context loop. Returns PIDs of all worker threads.
     std::vector<std::thread::id> start();
 
+    /// Shutdown the server and join all worker threads
+    void shutdown();
+
     static void parseParams(const std::string& params,
                             std::map<std::string, std::string>& retMap);
     static void
@@ -61,8 +66,6 @@ class server
   private:
     /// Perform an asynchronous accept operation.
     void do_accept();
-
-    void stop();
 
     /// Perform URL-decoding on a string. Returns false if the encoding was
     /// invalid.
@@ -74,10 +77,16 @@ class server
     /// The io_context used to perform asynchronous operations.
     asio::io_context io_context_;
 
+    /// Work guard to keep io_context alive until explicitly stopped
+    std::optional<asio::executor_work_guard<asio::io_context::executor_type>>
+        work_guard_;
+
     /// Acceptor used to listen for incoming connections.
     asio::ip::tcp::acceptor acceptor_;
 
     std::vector<std::thread> worker_threads_{};
+
+    std::atomic<bool> mIsShutdown{false};
 
     std::map<std::string, routeHandler> mRoutes;
 };

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -839,6 +839,10 @@ ApplicationImpl::idempotentShutdown(bool forgetBuckets)
     // idempotent, the extra call is harmless.
     shutdownThread(mLedgerCloseThread, mLedgerCloseWork, "ledger close");
 
+    if (mCommandHandler)
+    {
+        mCommandHandler->shutdown();
+    }
     if (mOverlayManager)
     {
         mOverlayManager->shutdown();

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -140,6 +140,19 @@ CommandHandler::CommandHandler(Application& app) : mApp(app)
 }
 
 void
+CommandHandler::shutdown()
+{
+    if (mServer)
+    {
+        mServer->shutdown();
+    }
+    if (mQueryServer)
+    {
+        mQueryServer->shutdown();
+    }
+}
+
+void
 CommandHandler::addRoute(std::string const& name, HandlerRoute route)
 {
 

--- a/src/main/CommandHandler.h
+++ b/src/main/CommandHandler.h
@@ -43,6 +43,8 @@ class CommandHandler
   public:
     CommandHandler(Application& app);
 
+    void shutdown();
+
     std::string manualCmd(std::string const& cmd);
 
     void fileNotFound(std::string const& params, std::string& retStr);

--- a/src/main/QueryServer.cpp
+++ b/src/main/QueryServer.cpp
@@ -98,6 +98,12 @@ QueryServer::QueryServer(const std::string& address, unsigned short port,
     }
 }
 
+void
+QueryServer::shutdown()
+{
+    mServer.shutdown();
+}
+
 bool
 QueryServer::notFound(std::string const& params, std::string const& body,
                       std::string& retStr)

--- a/src/main/QueryServer.h
+++ b/src/main/QueryServer.h
@@ -62,5 +62,7 @@ class QueryServer
                 bool useMainThreadForTesting = false
 #endif
     );
+
+    void shutdown();
 };
 }


### PR DESCRIPTION
# Description

Fixes a bug in the query server shutdown path and hardens `CommandHandler`.

Previously, the multithreaded HTTP server implementation handled exit signals. This means whenever stellar-core started graceful shutdown, the HTTP server would shut itself down, then the main thread would redundantly try to shutdown the server again, causing it to throw. This removes the signal mask from the HTTP server such that only the main thread is responsible for handling signals and shutting down the server.

Additionally, this adds a `shutdown` function to the `CommandHandler` that gracefully shuts down both its servers explicitly instead of just relying on destructors. 

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
