### PR TITLE
Add support for TTL in XDR query utility.

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -577,6 +577,7 @@ exit /b 0
     <ClCompile Include="..\..\src\history\test\HistoryTestsUtils.cpp" />
     <ClCompile Include="..\..\src\history\test\SerializeTests.cpp" />
     <ClCompile Include="..\..\src\invariant\AccountSubEntriesCountIsValid.cpp" />
+    <ClCompile Include="..\..\src\invariant\ArchivedStateConsistency.cpp" />
     <ClCompile Include="..\..\src\invariant\BucketListIsConsistentWithDatabase.cpp" />
     <ClCompile Include="..\..\src\invariant\ConservationOfLumens.cpp" />
     <ClCompile Include="..\..\src\invariant\ConstantProductInvariant.cpp" />
@@ -1043,6 +1044,7 @@ exit /b 0
     <ClInclude Include="..\..\src\history\StateSnapshot.h" />
     <ClInclude Include="..\..\src\history\test\HistoryTestsUtils.h" />
     <ClInclude Include="..\..\src\invariant\AccountSubEntriesCountIsValid.h" />
+    <ClInclude Include="..\..\src\invariant\ArchivedStateConsistency.h" />
     <ClInclude Include="..\..\src\invariant\BucketListIsConsistentWithDatabase.h" />
     <ClInclude Include="..\..\src\invariant\ConservationOfLumens.h" />
     <ClInclude Include="..\..\src\invariant\ConstantProductInvariant.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1426,6 +1426,9 @@
     <ClCompile Include="..\..\src\ledger\P23HotArchiveBugData.cpp">
       <Filter>ledger</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\invariant\ArchivedStateConsistency.cpp">
+      <Filter>invariant</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\util\cpptoml.h">
@@ -2529,6 +2532,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\herder\FilteredEntries.h">
       <Filter>herder</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\invariant\ArchivedStateConsistency.h">
+      <Filter>invariant</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/docs/software/ledger_query_examples.md
+++ b/docs/software/ledger_query_examples.md
@@ -57,6 +57,14 @@ ledger to JSON files for further analysis.
   `./stellar-core dump-ledger --conf ../stellar-core_pubnet.cfg 
    --output-file q8.json --filter-query "entry_size() > 200" --limit 10`
 
+* Output 10 contract entries where TTL (live-until-ledger) is less than 61000000.
+  Note, that for Classic entries TTL is considered to be UINT32_MAX.
+
+  `./stellar-core dump-ledger --conf ../stellar-core_pubnet.cfg 
+   --output-file q9.json --filter-query 
+   "(data.type == 'CONTRACT_DATA' || data.type == 'CONTRACT_CODE') && ttl() < 61000000" 
+   --limit 10`
+
 ## Aggregating ledger entries
 
 The following examples demonstrate how to aggregate parts of the ledger into CSV tables.

--- a/src/bucket/BucketManager.cpp
+++ b/src/bucket/BucketManager.cpp
@@ -1577,18 +1577,18 @@ visitLiveEntriesInBucket(
             if (e.type() == LIVEENTRY || e.type() == INITENTRY)
             {
                 auto const& liveEntry = e.liveEntry();
+                if (!processedEntries
+                         .insert(xdrBlake2(LedgerEntryKey(liveEntry)))
+                         .second)
+                {
+                    continue;
+                }
                 if (minLedger && liveEntry.lastModifiedLedgerSeq < *minLedger)
                 {
                     stopIteration = true;
                     continue;
                 }
                 if (!filterEntry(liveEntry))
-                {
-                    continue;
-                }
-                if (!processedEntries
-                         .insert(xdrBlake2(LedgerEntryKey(liveEntry)))
-                         .second)
                 {
                     continue;
                 }

--- a/src/history/test/SerializeTests.cpp
+++ b/src/history/test/SerializeTests.cpp
@@ -36,7 +36,7 @@ TEST_CASE("Serialization round trip", "[history]")
 
             // Test load
             HistoryArchiveState hasLoad;
-            hasLoad.load(testFilePath);
+            hasLoad.load(testFilePath.string());
             REQUIRE(hasString == hasLoad.toString());
         }
     }

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -301,7 +301,14 @@ class LedgerManager
     // parameter:
     //  * restoreBucketlist indicates whether to restore the bucket list fully,
     //  and restart merges
-    virtual void loadLastKnownLedger(bool restoreBucketlist) = 0;
+    virtual void loadLastKnownLedger() = 0;
+
+    // Helper for a faster load of the last closed ledger used only for various
+    // diagnostics utils outside of the main application flow. This skips
+    // restoring the bucket list and building in-memory Soroban state.
+    // This should not be used in any context where it's necessary to close the
+    // ledgers.
+    virtual void partiallyLoadLastKnownLedgerForUtils() = 0;
 
     // Forcibly switch the application into catchup mode, treating `toLedger`
     // as the destination ledger number and count as the number of past ledgers

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -410,6 +410,13 @@ class LedgerManagerImpl : public LedgerManager
     void
     advanceLastClosedLedgerState(CompleteConstLedgerStatePtr newLedgerState);
 
+    // Internal helper for loading last known ledger and an option to skip
+    // building the 'full' state (including in-memory Soroban state, module
+    // cache, etc).
+    // Full state building should not be skipped in any flows where new ledgers
+    // have to actually be closed.
+    void loadLastKnownLedgerInternal(bool skipBuildingFullState);
+
   protected:
     // initialLedgerVers must be the ledger version at the start of the ledger
     // and currLedgerVers is the ledger version in the current ltx header. These
@@ -493,7 +500,8 @@ class LedgerManagerImpl : public LedgerManager
 
     void startNewLedger(LedgerHeader const& genesisLedger);
     void startNewLedger() override;
-    void loadLastKnownLedger(bool restoreBucketlist) override;
+    void loadLastKnownLedger() override;
+    void partiallyLoadLastKnownLedgerForUtils() override;
 
     LedgerHeaderHistoryEntry const& getLastClosedLedgerHeader() const override;
 

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -554,7 +554,7 @@ ApplicationImpl::getJsonInfo(bool verbose)
 void
 ApplicationImpl::reportInfo(bool verbose)
 {
-    mLedgerManager->loadLastKnownLedger(/* restoreBucketlist */ false);
+    mLedgerManager->partiallyLoadLastKnownLedgerForUtils();
     LOG_INFO(DEFAULT_LOG, "Reporting application info");
     std::cout << getJsonInfo(verbose).toStyledString() << std::endl;
 }
@@ -826,7 +826,7 @@ ApplicationImpl::start()
     CLOG_INFO(Ledger, "Starting up application");
     mStarted = true;
 
-    mLedgerManager->loadLastKnownLedger(/* restoreBucketlist */ true);
+    mLedgerManager->loadLastKnownLedger();
 
     // Check if we're already on protocol V_24 or later and enable Rust Dalek
     auto const& lcl = mLedgerManager->getLastClosedLedgerHeader();

--- a/src/main/test/ApplicationUtilsTests.cpp
+++ b/src/main/test/ApplicationUtilsTests.cpp
@@ -178,13 +178,13 @@ TEST_CASE("standalone quorum intersection check", "[applicationutils]")
     SECTION("enjoys quorum intersection")
     {
         REQUIRE(checkQuorumIntersectionFromJson(
-            JSON_ROOT / "enjoys-intersection.json", cfg));
+            (JSON_ROOT / "enjoys-intersection.json").string(), cfg));
     }
 
     SECTION("does not enjoy quorum intersection")
     {
         REQUIRE(!checkQuorumIntersectionFromJson(
-            JSON_ROOT / "no-intersection.json", cfg));
+            (JSON_ROOT / "no-intersection.json").string(), cfg));
     }
 
     SECTION("malformed JSON")
@@ -192,18 +192,19 @@ TEST_CASE("standalone quorum intersection check", "[applicationutils]")
         // Test various bad JSON inputs
 
         // Malformed key
-        REQUIRE_THROWS_AS(
-            checkQuorumIntersectionFromJson(JSON_ROOT / "bad-key.json", cfg),
-            KeyUtils::InvalidStrKey);
+        REQUIRE_THROWS_AS(checkQuorumIntersectionFromJson(
+                              (JSON_ROOT / "bad-key.json").string(), cfg),
+                          KeyUtils::InvalidStrKey);
 
         // Wrong datatype
-        REQUIRE_THROWS_AS(checkQuorumIntersectionFromJson(
-                              JSON_ROOT / "bad-threshold-type.json", cfg),
-                          std::runtime_error);
+        REQUIRE_THROWS_AS(
+            checkQuorumIntersectionFromJson(
+                (JSON_ROOT / "bad-threshold-type.json").string(), cfg),
+            std::runtime_error);
 
         // No such file
-        REQUIRE_THROWS_AS(
-            checkQuorumIntersectionFromJson(JSON_ROOT / "no-file.json", cfg),
-            std::runtime_error);
+        REQUIRE_THROWS_AS(checkQuorumIntersectionFromJson(
+                              (JSON_ROOT / "no-file.json").string(), cfg),
+                          std::runtime_error);
     }
 }

--- a/src/main/test/ConfigTests.cpp
+++ b/src/main/test/ConfigTests.cpp
@@ -147,7 +147,8 @@ TEST_CASE("resolve node id", "[config]")
 TEST_CASE("load validators config", "[config]")
 {
     Config c;
-    c.load(getBuildTestDataPath("stellar-core_example_validators.cfg"));
+    c.load(
+        getBuildTestDataPath("stellar-core_example_validators.cfg").string());
     auto actualS = c.toString(c.QUORUM_SET);
     std::string expected = R"({
    "t" : 4,
@@ -459,7 +460,7 @@ TEST_CASE("load example configs", "[config]")
         auto fnPath = getBuildTestDataPath(fn);
         SECTION("load config " + fnPath.string())
         {
-            c.load(fnPath);
+            c.load(fnPath.string());
         }
     }
 }

--- a/src/overlay/test/OverlayTests.cpp
+++ b/src/overlay/test/OverlayTests.cpp
@@ -2271,9 +2271,8 @@ TEST_CASE("database is purged at overlay start", "[overlay]")
 
     // Herder depends on LM state for close time, so initialize it manually
     // since we aren't actually starting app.
-    LedgerManagerImpl& lm =
-        static_cast<LedgerManagerImpl&>(app->getLedgerManager());
-    lm.loadLastKnownLedger(false);
+    auto& lm = app->getLedgerManager();
+    lm.partiallyLoadLastKnownLedgerForUtils();
     om.start();
 
     // Must wait 2 seconds as `OverlayManagerImpl::start()`

--- a/src/util/xdrquery/XDRQuery.cpp
+++ b/src/util/xdrquery/XDRQuery.cpp
@@ -6,11 +6,14 @@
 
 namespace xdrquery
 {
-XDRMatcher::XDRMatcher(std::string const& query) : mQuery(query)
+XDRMatcher::XDRMatcher(std::string const& query, TTLGetter ttlGetter)
+    : mQuery(query), mTtlGetter(ttlGetter)
 {
 }
 
-XDRFieldExtractor::XDRFieldExtractor(std::string const& query) : mQuery(query)
+XDRFieldExtractor::XDRFieldExtractor(std::string const& query,
+                                     TTLGetter ttlGetter)
+    : mQuery(query), mTtlGetter(ttlGetter)
 {
 }
 
@@ -20,7 +23,8 @@ XDRFieldExtractor::getColumnNames() const
     return mFieldList->getColumnNames();
 }
 
-XDRAccumulator::XDRAccumulator(std::string const& query) : mQuery(query)
+XDRAccumulator::XDRAccumulator(std::string const& query, TTLGetter ttlGetter)
+    : mQuery(query), mTtlGetter(ttlGetter)
 {
 }
 
@@ -28,6 +32,12 @@ std::vector<std::shared_ptr<Accumulator>> const&
 XDRAccumulator::getAccumulators() const
 {
     return mAccumulatorList->getAccumulators();
+}
+
+uint32_t
+noTtlGetter(LedgerKey const&)
+{
+    throw std::runtime_error("TTLGetter not available");
 }
 
 } // namespace xdrquery

--- a/src/util/xdrquery/XDRQuery.h
+++ b/src/util/xdrquery/XDRQuery.h
@@ -4,23 +4,31 @@
 
 #pragma once
 
+#include "ledger/LedgerTypeUtils.h"
 #include "util/xdrquery/XDRFieldResolver.h"
 #include "util/xdrquery/XDRQueryEval.h"
 #include "util/xdrquery/XDRQueryParser.h"
+#include "xdr/Stellar-ledger.h"
 
 #include <string>
 #include <variant>
 
 namespace xdrquery
 {
+using namespace stellar;
+
+using TTLGetter = std::function<uint32_t(LedgerKey const&)>;
+
+uint32_t noTtlGetter(LedgerKey const&);
 
 // Concrete implementation of DynamicXDRGetter for a given XDR message type T.
 template <typename T>
 class TypedDynamicXDRGetterResolver : public DynamicXDRGetter
 {
   public:
-    TypedDynamicXDRGetterResolver(T const& xdrMessage, bool validate)
-        : mXdrMessage(xdrMessage), mValidate(validate)
+    TypedDynamicXDRGetterResolver(T const& xdrMessage, TTLGetter ttlGetter,
+                                  bool validate)
+        : mXdrMessage(xdrMessage), mTtlGetter(ttlGetter), mValidate(validate)
     {
     }
 
@@ -40,19 +48,43 @@ class TypedDynamicXDRGetterResolver : public DynamicXDRGetter
         return xdr::xdr_size(mXdrMessage);
     }
 
+    uint32_t
+    getLiveUntilLedger() const override
+    {
+        // XDR getter is implemented in generic fashion as it can normally work
+        // for any XDR message. TTL getter is a special case because TTL is
+        // only defined for a few types.
+        // Since we really only process `LedgerEntry` in practice at the
+        // moment, we condition the TTL getter code for ledger entries only.
+        if constexpr (std::is_same_v<T, LedgerEntry>)
+        {
+            if (isSorobanEntry(mXdrMessage.data))
+            {
+                auto ttlKey = getTTLKey(mXdrMessage);
+                return mTtlGetter(ttlKey);
+            }
+            if (mXdrMessage.data.type() == TTL)
+            {
+                return mXdrMessage.data.ttl().liveUntilLedgerSeq;
+            }
+        }
+        return std::numeric_limits<uint32_t>::max();
+    }
+
     ~TypedDynamicXDRGetterResolver() override = default;
 
   private:
     T const& mXdrMessage;
+    TTLGetter mTtlGetter;
     bool mValidate;
 };
 
 template <typename T>
 std::unique_ptr<DynamicXDRGetter>
-createXDRGetter(T const& xdrMessage, bool validate)
+createXDRGetter(T const& xdrMessage, TTLGetter ttlGetter, bool validate)
 {
-    return std::make_unique<TypedDynamicXDRGetterResolver<T>>(xdrMessage,
-                                                              validate);
+    return std::make_unique<TypedDynamicXDRGetterResolver<T>>(
+        xdrMessage, ttlGetter, validate);
 }
 
 // Helper to match multiple XDR messages of the same type using the provided
@@ -64,7 +96,7 @@ createXDRGetter(T const& xdrMessage, bool validate)
 class XDRMatcher
 {
   public:
-    XDRMatcher(std::string const& query);
+    XDRMatcher(std::string const& query, TTLGetter ttlGetter = noTtlGetter);
 
     template <typename T>
     bool
@@ -85,11 +117,13 @@ class XDRMatcher
             }
             mEvalRoot = std::get<std::shared_ptr<BoolEvalNode>>(statement);
         }
-        return mEvalRoot->evalBool(*createXDRGetter(xdrMessage, firstEval));
+        return mEvalRoot->evalBool(
+            *createXDRGetter(xdrMessage, mTtlGetter, firstEval));
     }
 
   private:
     std::string const mQuery;
+    TTLGetter mTtlGetter;
     std::shared_ptr<BoolEvalNode> mEvalRoot;
 };
 
@@ -100,7 +134,8 @@ class XDRMatcher
 class XDRFieldExtractor
 {
   public:
-    XDRFieldExtractor(std::string const& query);
+    XDRFieldExtractor(std::string const& query,
+                      TTLGetter ttlGetter = noTtlGetter);
 
     template <typename T>
     std::vector<ResultType>
@@ -121,7 +156,8 @@ class XDRFieldExtractor
             }
             mFieldList = std::get<std::shared_ptr<ColumnList>>(statement);
         }
-        return mFieldList->getValues(*createXDRGetter(xdrMessage, firstEval));
+        return mFieldList->getValues(
+            *createXDRGetter(xdrMessage, mTtlGetter, firstEval));
     }
 
     // Gets names of the fields from the query.
@@ -129,6 +165,7 @@ class XDRFieldExtractor
 
   private:
     std::string mQuery;
+    TTLGetter mTtlGetter;
     std::shared_ptr<ColumnList> mFieldList;
 };
 
@@ -141,7 +178,7 @@ class XDRFieldExtractor
 class XDRAccumulator
 {
   public:
-    XDRAccumulator(std::string const& query);
+    XDRAccumulator(std::string const& query, TTLGetter ttlGetter = noTtlGetter);
 
     template <typename T>
     void
@@ -164,7 +201,8 @@ class XDRAccumulator
             mAccumulatorList =
                 std::get<std::shared_ptr<AccumulatorList>>(statement);
         }
-        mAccumulatorList->addEntry(*createXDRGetter(xdrMessage, firstEval));
+        mAccumulatorList->addEntry(
+            *createXDRGetter(xdrMessage, mTtlGetter, firstEval));
     }
 
     // Gets the accumulators with aggregated values of each field.
@@ -172,6 +210,7 @@ class XDRAccumulator
 
   private:
     std::string mQuery;
+    TTLGetter mTtlGetter;
     std::shared_ptr<AccumulatorList> mAccumulatorList;
 };
 } // namespace xdrquery

--- a/src/util/xdrquery/XDRQueryEval.cpp
+++ b/src/util/xdrquery/XDRQueryEval.cpp
@@ -166,6 +166,24 @@ EntrySizeNode::getName() const
 }
 
 ResultType
+TTLNode::eval(DynamicXDRGetter const& xdrGetter) const
+{
+    return xdrGetter.getLiveUntilLedger();
+}
+
+EvalNodeType
+TTLNode::getType() const
+{
+    return EvalNodeType::COLUMN;
+}
+
+std::string
+TTLNode::getName() const
+{
+    return "ttl";
+}
+
+ResultType
 BoolEvalNode::eval(DynamicXDRGetter const& xdrGetter) const
 {
     return evalBool(xdrGetter);

--- a/src/util/xdrquery/XDRQueryEval.h
+++ b/src/util/xdrquery/XDRQueryEval.h
@@ -51,6 +51,10 @@ struct DynamicXDRGetter
     // Gets the serialized XDR size of the entire struct.
     virtual uint64_t getSize() const = 0;
 
+    // Gets the live-until-ledger of the entire entry.
+    // Returns UINT32_MAX for the entries without TTL.
+    virtual uint32_t getLiveUntilLedger() const = 0;
+
     virtual ~DynamicXDRGetter() = default;
 };
 
@@ -122,6 +126,16 @@ struct FieldNode : public ColumnNode
 
 // Node representing the size of an XDR entry in expression.
 struct EntrySizeNode : public ColumnNode
+{
+    ResultType eval(DynamicXDRGetter const& xdrGetter) const override;
+
+    EvalNodeType getType() const override;
+
+    virtual std::string getName() const override;
+};
+
+// Node representing the live-until-ledger of an XDR entry in expression.
+struct TTLNode : public ColumnNode
 {
     ResultType eval(DynamicXDRGetter const& xdrGetter) const override;
 

--- a/src/util/xdrquery/XDRQueryParser.yy
+++ b/src/util/xdrquery/XDRQueryParser.yy
@@ -41,6 +41,7 @@ parseXDRQuery(std::string const& query);
 %token AVG
 %token COUNT
 %token ENTRY_SIZE
+%token TTL
 
 %token AND "&&"
 %token OR "||"
@@ -69,6 +70,7 @@ parseXDRQuery(std::string const& query);
 %type <std::shared_ptr<ColumnNode>> column
 %type <std::shared_ptr<FieldNode>> field
 %type <std::shared_ptr<EntrySizeNode>> entry_size
+%type <std::shared_ptr<TTLNode>> ttl
 
 %type <std::shared_ptr<Accumulator>> accumulator
 %type <std::shared_ptr<AccumulatorList>> accumulator_list
@@ -118,8 +120,10 @@ literal: INT { $$ = std::make_shared<LiteralNode>(LiteralNodeType::INT, $1); }
 
 column: field { $$ = std::move($1); }
       | entry_size { $$ = std::move($1); }
+      | ttl { $$ = std::move($1); }
 
 entry_size: ENTRY_SIZE "(" ")" { $$ = std::make_shared<EntrySizeNode>(); }
+ttl: TTL "(" ")" { $$ = std::make_shared<TTLNode>(); }
 
 field: ID { $$ = std::make_shared<FieldNode>($1); }
      | field "." ID { $1->mFieldPath.push_back($3); $$ = std::move($1); }

--- a/src/util/xdrquery/XDRQueryScanner.ll
+++ b/src/util/xdrquery/XDRQueryScanner.ll
@@ -38,6 +38,7 @@ sum { return xdrquery::XDRQueryParser::make_SUM(); }
 avg { return xdrquery::XDRQueryParser::make_AVG(); }
 count { return xdrquery::XDRQueryParser::make_COUNT(); }
 entry_size { return xdrquery::XDRQueryParser::make_ENTRY_SIZE(); }
+ttl { return xdrquery::XDRQueryParser::make_TTL(); }
 
 {IDENTIFIER}  { return xdrquery::XDRQueryParser::make_ID(yytext); }
 {INT}         { return xdrquery::XDRQueryParser::make_INT(yytext); }


### PR DESCRIPTION
# Description

Add support for TTL in XDR query utility.

This provides a way to filter by TTL of entries with TTL, and also outputs liveUntilLedger for the entries with TTL.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
