### PR TITLE
Fix feePool upgrade logic past p24

### DIFF
--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -1240,7 +1240,8 @@ Upgrades::applyVersionUpgrade(Application& app, AbstractLedgerTxn& ltx,
             ltx);
     }
 
-    if (protocolVersionStartsFrom(newVersion, ProtocolVersion::V_24) &&
+    if (protocolVersionEquals(prevVersion, ProtocolVersion::V_23) &&
+        protocolVersionEquals(newVersion, ProtocolVersion::V_24) &&
         gIsProductionNetwork)
     {
         auto header = ltx.loadHeader();

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -2691,7 +2691,8 @@ TEST_CASE("upgrade to version 12", "[upgrades][acceptance]")
     }
 }
 
-TEST_CASE("upgrade to version 24 and check feePool", "[upgrades]")
+TEST_CASE("upgrade to 24 and then latest from 23 and check feePool",
+          "[upgrades]")
 {
     VirtualClock clock;
     auto cfg = getTestConfig();
@@ -2708,7 +2709,13 @@ TEST_CASE("upgrade to version 24 and check feePool", "[upgrades]")
     auto p23feePool = lm.getLastClosedLedgerHeader().header.feePool;
 
     executeUpgrade(*app, makeProtocolVersionUpgrade(24));
+    REQUIRE(lm.getLastClosedLedgerHeader().header.feePool ==
+            p23feePool + 31879035);
 
+    executeUpgrade(*app, makeProtocolVersionUpgrade(
+                             Config::CURRENT_LEDGER_PROTOCOL_VERSION));
+
+    // No change
     REQUIRE(lm.getLastClosedLedgerHeader().header.feePool ==
             p23feePool + 31879035);
 }


### PR DESCRIPTION
# Description

The fee pool upgrade should only be applied for p24.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
