### PR TITLE
Make state archival startup check opt-in, optimize memory consumption

### DIFF
--- a/src/bucket/BucketListSnapshotBase.h
+++ b/src/bucket/BucketListSnapshotBase.h
@@ -103,12 +103,6 @@ class SearchableBucketListSnapshotBase : public NonMovableOrCopyable
     medida::Meter& mBloomMisses;
     medida::Meter& mBloomLookups;
 
-    // Loops through all buckets, starting with curr at level 0, then snap at
-    // level 0, etc. Calls f on each bucket. Exits early if function
-    // returns Loop::COMPLETE.
-    void loopAllBuckets(std::function<Loop(BucketSnapshotT const&)> f,
-                        BucketListSnapshot<BucketT> const& snapshot) const;
-
     SearchableBucketListSnapshotBase(
         BucketSnapshotManager const& snapshotManager,
         AppConnector const& appConnector, SnapshotPtrT<BucketT>&& snapshot,
@@ -122,6 +116,19 @@ class SearchableBucketListSnapshotBase : public NonMovableOrCopyable
                                     size_t numEntries) const;
 
   public:
+    // Loops through all buckets, starting with curr at level 0, then snap at
+    // level 0, etc. Calls f on each bucket. Exits early if function
+    // returns Loop::COMPLETE.
+    void loopAllBuckets(std::function<Loop(BucketSnapshotT const&)> f,
+                        BucketListSnapshot<BucketT> const& snapshot) const;
+
+    // Overload that uses the internal snapshot
+    void
+    loopAllBuckets(std::function<Loop(BucketSnapshotT const&)> f) const
+    {
+        loopAllBuckets(f, *mSnapshot);
+    }
+
     uint32_t
     getLedgerSeq() const
     {

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -355,6 +355,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     COMMANDS = {};
     REPORT_METRICS = {};
     INVARIANT_CHECKS = {};
+    INVARIANT_EXTRA_CHECKS = false;
 
 #ifdef BUILD_TESTS
     TEST_CASES_ENABLED = false;
@@ -1464,6 +1465,8 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                  [&]() { NETWORK_PASSPHRASE = readString(item); }},
                 {"INVARIANT_CHECKS",
                  [&]() { INVARIANT_CHECKS = readArray<std::string>(item); }},
+                {"INVARIANT_EXTRA_CHECKS",
+                 [&]() { INVARIANT_EXTRA_CHECKS = readBool(item); }},
                 {"ENTRY_CACHE_SIZE",
                  [&]() { ENTRY_CACHE_SIZE = readInt<uint32_t>(item); }},
                 {"PREFETCH_BATCH_SIZE",

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -751,6 +751,11 @@ class Config : public std::enable_shared_from_this<Config>
     // Invariants
     std::vector<std::string> INVARIANT_CHECKS;
 
+    // Enable extra invariant checks that provide additional consistency
+    // verification but may be slow or resource-intensive. The default value is
+    // false.
+    bool INVARIANT_EXTRA_CHECKS;
+
     std::map<std::string, std::string> VALIDATOR_NAMES;
 
     // Information necessary to compute the weight of a validator for leader


### PR DESCRIPTION
This is useful for boxes with low-end memory config - they can still run the invariant, but skip the expensive startup check that requires loading all keys in-memory. The change also improve memory consumption of the startup invariant by traversing the bucketlist iteratively. 