### PR TITLE
Add a way to query Hot Archive via dump-ledger.

### DIFF
--- a/docs/software/ledger_query_examples.md
+++ b/docs/software/ledger_query_examples.md
@@ -65,6 +65,12 @@ ledger to JSON files for further analysis.
    "(data.type == 'CONTRACT_DATA' || data.type == 'CONTRACT_CODE') && ttl() < 61000000" 
    --limit 10`
 
+* Output 10 contract code entries from the Hot Archive.
+  `./stellar-core dump-ledger --conf ../stellar-core_pubnet.cfg 
+   --hot-archive --output-file q10.json --filter-query 
+   "data.type == 'CONTRACT_CODE'" 
+   --limit 10`
+
 ## Aggregating ledger entries
 
 The following examples demonstrate how to aggregate parts of the ledger into CSV tables.
@@ -87,4 +93,8 @@ The following examples demonstrate how to aggregate parts of the ledger into CSV
 
 * Find the entry size distribution: 
 
-  `./stellar-core dump-ledger --output-file entry_stats.json --group-by data.type --agg sum(entry_size()),avg(entry_size())`
+  `./stellar-core dump-ledger --output-file entry_stats.csv --group-by data.type --agg sum(entry_size()),avg(entry_size())`
+
+* Find the number of entries in Hot Archive by type:
+
+  `./stellar-core dump-ledger  --hot-archive --output-file hot_archive_stats.csv --group-by data.type --agg count()`

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -443,7 +443,8 @@ class BucketManager : NonMovableOrCopyable
     // equivalent to iterating over `loadCompleteLedgerState`, so the same
     // memory/runtime implications apply.
     void visitLedgerEntries(
-        HistoryArchiveState const& has, std::optional<int64_t> minLedger,
+        bool visitLiveBucketList, HistoryArchiveState const& has,
+        std::optional<uint32_t> minLedger,
         std::function<bool(LedgerEntry const&)> const& filterEntry,
         std::function<bool(LedgerEntry const&)> const& acceptEntry,
         bool includeAllStates);

--- a/src/main/ApplicationUtils.h
+++ b/src/main/ApplicationUtils.h
@@ -33,7 +33,8 @@ int dumpLedger(Config cfg, std::string const& outputFile,
                std::optional<uint32_t> lastModifiedLedgerCount,
                std::optional<uint64_t> limit,
                std::optional<std::string> groupBy,
-               std::optional<std::string> aggregate, bool includeAllStates);
+               std::optional<std::string> aggregate, bool dumpHotArchive,
+               bool includeAllStates);
 void dumpWasmBlob(Config cfg, std::string const& hash, std::string const& dir);
 void showOfflineInfo(Config cfg, bool verbose);
 int reportLastHistoryCheckpoint(Config cfg, std::string const& outputFile);

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -444,6 +444,13 @@ limitParser(std::optional<std::uint64_t>& limit)
 }
 
 clara::Opt
+dumpHotArchiveParser(bool& dumpHotArchive)
+{
+    return clara::Opt{dumpHotArchive}["--hot-archive"](
+        "run query on Hot Archive instead of the Live ledger state");
+}
+
+clara::Opt
 includeAllStatesParser(bool& include)
 {
     return clara::Opt{include}["--include-all-states"](
@@ -1175,6 +1182,7 @@ runDumpLedger(CommandLineArgs const& args)
     std::optional<uint64_t> limit;
     std::optional<std::string> groupBy;
     std::optional<std::string> aggregate;
+    bool dumpHotArchive = false;
     bool includeAllStates = false;
     return runWithHelp(
         args,
@@ -1183,11 +1191,12 @@ runDumpLedger(CommandLineArgs const& args)
          filterQueryParser(filterQuery),
          lastModifiedLedgerCountParser(lastModifiedLedgerCount),
          limitParser(limit), groupByParser(groupBy), aggregateParser(aggregate),
+         dumpHotArchiveParser(dumpHotArchive),
          includeAllStatesParser(includeAllStates)},
         [&] {
             return dumpLedger(configOption.getConfig(), outputFile, filterQuery,
                               lastModifiedLedgerCount, limit, groupBy,
-                              aggregate, includeAllStates);
+                              aggregate, dumpHotArchive, includeAllStates);
         });
 }
 


### PR DESCRIPTION
# Description

Add a way to query Hot Archive via dump-ledger.

When `--hot-archive` flag is specified Hot Archive will be scanned instead of the Live bucket list.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
