### PR TITLE
Speed up soroban in-memory loading

### DIFF
--- a/src/bucket/BucketSnapshot.cpp
+++ b/src/bucket/BucketSnapshot.cpp
@@ -367,8 +367,16 @@ LiveBucketSnapshot::scanForEntriesOfType(
     stream.seek(range->first);
 
     BucketEntry be;
-    while (stream.pos() < range->second && stream.readOne(be))
+    while (stream.readOne(be))
     {
+        if (!isBucketMetaEntry<LiveBucket>(be))
+        {
+            if (LedgerKey key = getBucketLedgerKey(be); key.type() > type)
+            {
+                break;
+            }
+        }
+
         bool matchesType = false;
         if (be.type() == LIVEENTRY || be.type() == INITENTRY)
         {


### PR DESCRIPTION
For the ~30,000,000 entries loaded for in-memory Soroban state, the overhead of getting the stream position ends up being non-negligible. Running locally, removing this sped up from ~70s to ~24s, and on a dev watcher from ~132 seconds to ~53 seconds.

```
stellar-core catchup 59790335/0 --trusted-hash b3a89d2dcc040e41c58008cb6659ad6c8c89c781096035e481b267c6d231cc62 --console

2025-11-10T22:21:28.796 GBYAB [default INFO] Launching 1 loading and 5 compiling background threads
2025-11-10T22:21:29.138 GBYAB [default INFO] Compiled 717 contracts (13153707 bytes of Wasm) in 342ms real time, 1315ms CPU time
2025-11-10T22:23:40.991 GBYAB [Ledger INFO] Changing state LM_BOOTING_STATE -> LM_CATCHING_UP_STATE

2025-11-10T22:29:20.248 GBYAB [default INFO] Launching 1 loading and 5 compiling background threads
2025-11-10T22:29:20.716 GBYAB [default INFO] Compiled 717 contracts (13153707 bytes of Wasm) in 467ms real time, 1829ms CPU time
2025-11-10T22:30:13.137 GBYAB [Ledger INFO] Changing state LM_BOOTING_STATE -> LM_CATCHING_UP_STATE
```