### PR TITLE
Move the Soroban memo check to protocol starting from p25.

### DIFF
--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -493,11 +493,12 @@ TransactionQueue::canAdd(
         }
     }
 
-    if (!tx->validateSorobanMemoForFlooding())
+    if (protocolVersionIsBefore(ledgerVersion, ProtocolVersion::V_25) &&
+        !tx->validateSorobanMemo())
     {
-        diagnosticEvents.pushError(
-            SCE_CONTEXT, SCEC_INVALID_INPUT,
-            "non-source auth Soroban tx uses memo or muxed source account");
+        diagnosticEvents.pushError(SCE_VALUE, SCEC_INVALID_INPUT,
+                                   "Soroban transactions are not allowed to "
+                                   "use memo or muxed source account");
 
         return AddResult(TransactionQueue::AddResultCode::ADD_STATUS_ERROR, *tx,
                          txSOROBAN_INVALID, diagnosticEvents.finalize());

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -469,9 +469,9 @@ FeeBumpTransactionFrame::validateSorobanTxForFlooding(
 }
 
 bool
-FeeBumpTransactionFrame::validateSorobanMemoForFlooding() const
+FeeBumpTransactionFrame::validateSorobanMemo() const
 {
-    return mInnerTx->validateSorobanMemoForFlooding();
+    return mInnerTx->validateSorobanMemo();
 }
 
 int64_t

--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -127,7 +127,7 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
 
     bool validateSorobanTxForFlooding(
         UnorderedSet<LedgerKey> const& keysToFilter) const override;
-    bool validateSorobanMemoForFlooding() const override;
+    bool validateSorobanMemo() const override;
 
     int64_t getFullFee() const override;
     int64_t getInclusionFee() const override;

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -207,7 +207,7 @@ class TransactionFrame : public TransactionFrameBase
 
     bool validateSorobanTxForFlooding(
         UnorderedSet<LedgerKey> const& keysToFilter) const override;
-    bool validateSorobanMemoForFlooding() const override;
+    bool validateSorobanMemo() const override;
 
     int64_t getFullFee() const override;
     int64_t getInclusionFee() const override;

--- a/src/transactions/TransactionFrameBase.h
+++ b/src/transactions/TransactionFrameBase.h
@@ -195,7 +195,7 @@ class TransactionFrameBase
 
     virtual bool validateSorobanTxForFlooding(
         UnorderedSet<LedgerKey> const& keysToFilter) const = 0;
-    virtual bool validateSorobanMemoForFlooding() const = 0;
+    virtual bool validateSorobanMemo() const = 0;
 
     // Returns the total fee of this transaction, including the 'flat',
     // non-market part.

--- a/src/transactions/test/TransactionTestFrame.cpp
+++ b/src/transactions/test/TransactionTestFrame.cpp
@@ -188,9 +188,9 @@ TransactionTestFrame::validateSorobanTxForFlooding(
 }
 
 bool
-TransactionTestFrame::validateSorobanMemoForFlooding() const
+TransactionTestFrame::validateSorobanMemo() const
 {
-    return mTransactionFrame->validateSorobanMemoForFlooding();
+    return mTransactionFrame->validateSorobanMemo();
 }
 
 int64_t

--- a/src/transactions/test/TransactionTestFrame.h
+++ b/src/transactions/test/TransactionTestFrame.h
@@ -94,7 +94,7 @@ class TransactionTestFrame : public TransactionFrameBase
 
     bool validateSorobanTxForFlooding(
         UnorderedSet<LedgerKey> const& keysToFilter) const override;
-    bool validateSorobanMemoForFlooding() const override;
+    bool validateSorobanMemo() const override;
 
     // Returns the total fee of this transaction, including the 'flat',
     // non-market part.


### PR DESCRIPTION
# Description

Move the Soroban memo check to protocol starting from p25.

Also cleaned up the diagnostic event error types a bit for consistency (I doubt anyone actually consumes these, but they still looked a bit weird).

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
