### PR TITLE
Misc improvements for apply-load tool.

### DIFF
--- a/Builds/VisualStudio/build_rust.bat
+++ b/Builds/VisualStudio/build_rust.bat
@@ -49,7 +49,7 @@ for /l %%P in (%MIN_P%,1,%MAX_P%) do (
   set "LPATHS=!LPATHS! -L dependency=%out_dir%\soroban-p%%P-target\%2\deps"
 )
 
-echo rem ---- Build latest protocol (passes %features%) ----
+echo rem ---- Build latest protocol (passes --features) ----
 %set_linker_flags% & pushd %project_dir%\src\rust\soroban\p%LATEST_P% & (set RUSTFLAGS=-Cmetadata=p%LATEST_P%) & cargo +%version% build %release_profile% --package soroban-env-host --locked %features% --target-dir %out_dir%\soroban-p%LATEST_P%-target & popd
 
 set "EXTERNS=%EXTERNS% --extern soroban_env_host_p%LATEST_P%=%out_dir%\soroban-p%LATEST_P%-target\%2\libsoroban_env_host.rlib"

--- a/docs/apply-load-for-meta.cfg
+++ b/docs/apply-load-for-meta.cfg
@@ -1,0 +1,138 @@
+# This is the Stellar Core configuration example for using the load generation 
+# (apply-load) tool  while also writing the history and metadata. That allows load
+# testing the metadata ingestion in addition to the Core itself.
+# This is not meant to be used in any production contexts.
+
+# The core with this configuration should be run using 
+# `./stellar-core new-hist local && ./stellar-core apply-load`
+
+# Custom meta path - if not set it will be written to a temp directory and 
+# cleaned up after running the benchmark
+METADATA_OUTPUT_STREAM='meta.xdr'
+
+# Enable load generation
+ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING=true
+
+# Diagnostic events should generally be disabled, but can be enabled for debug
+ENABLE_SOROBAN_DIAGNOSTIC_EVENTS = false
+
+# Network configuration to use during the benchmark
+# The fields here correspond to the network configuration settings.
+APPLY_LOAD_LEDGER_MAX_INSTRUCTIONS = 500000000
+APPLY_LOAD_TX_MAX_INSTRUCTIONS = 100000000
+
+APPLY_LOAD_LEDGER_MAX_DEPENDENT_TX_CLUSTERS = 1
+
+APPLY_LOAD_TX_MAX_FOOTPRINT_SIZE = 200
+
+APPLY_LOAD_LEDGER_MAX_DISK_READ_LEDGER_ENTRIES = 1000
+APPLY_LOAD_TX_MAX_DISK_READ_LEDGER_ENTRIES = 100
+
+APPLY_LOAD_LEDGER_MAX_DISK_READ_BYTES = 200000
+APPLY_LOAD_TX_MAX_DISK_READ_BYTES = 130000
+
+APPLY_LOAD_LEDGER_MAX_WRITE_LEDGER_ENTRIES = 1000
+APPLY_LOAD_TX_MAX_WRITE_LEDGER_ENTRIES = 100
+
+APPLY_LOAD_LEDGER_MAX_WRITE_BYTES = 300000
+APPLY_LOAD_TX_MAX_WRITE_BYTES = 140000
+
+APPLY_LOAD_MAX_LEDGER_TX_SIZE_BYTES = 270000
+APPLY_LOAD_MAX_TX_SIZE_BYTES = 150000
+
+APPLY_LOAD_MAX_CONTRACT_EVENT_SIZE_BYTES = 10000
+APPLY_LOAD_MAX_SOROBAN_TX_COUNT = 1000
+
+# The following section contains various parameters for the generated load.
+
+# Number of ledgers to close for benchmark
+APPLY_LOAD_NUM_LEDGERS = 100
+
+# Generate that many simple Classic payment transactions in every benchmark ledger
+APPLY_LOAD_CLASSIC_TXS_PER_LEDGER = 1000
+
+# Size of every synthetic data entry generated.
+# This setting affects both the size of the pre-generated Bucket List entries,
+# and the size of every entry that a Soroban transaction reads/writes.
+APPLY_LOAD_DATA_ENTRY_SIZE = 300
+
+# Bucket list pre-generation
+
+# The benchmark will pre-generate ledger entries using the simplified ledger
+# close process; the generated ledgers won't be reflected in the meta or
+# history checkpoints.
+
+# Faster settings, more shallow BL (up to level 6)
+# Number of ledgers to close
+APPLY_LOAD_BL_SIMULATED_LEDGERS = 10000
+# Write a batch of entries every that many ledgers
+APPLY_LOAD_BL_WRITE_FREQUENCY = 1000
+# Write that many entries in every batch
+APPLY_LOAD_BL_BATCH_SIZE = 1000
+# Write entry batches in every ledger of this many last ledgers
+APPLY_LOAD_BL_LAST_BATCH_SIZE = 100
+# Write that many entries in every 'last' ledger
+APPLY_LOAD_BL_LAST_BATCH_LEDGERS = 300
+
+# Slower settings, deeper BL (up to level 9)
+#APPLY_LOAD_BL_SIMULATED_LEDGERS = 300000
+#APPLY_LOAD_BL_WRITE_FREQUENCY = 10000
+#APPLY_LOAD_BL_BATCH_SIZE = 10000
+#APPLY_LOAD_BL_LAST_BATCH_LEDGERS = 300
+#APPLY_LOAD_BL_LAST_BATCH_SIZE = 100
+
+# Settings for generated transactions
+# Every setting consists of the list of the possible values and the respective 
+# _DISTRIBUTION list that defines the weight of every value. The values are then
+# sampled from the value list according to the distribution.
+
+# Core will try to pack as many generated transactions as possible,
+# so if it's important to maintain a constant number of transactions per ledger,
+# or to maintain constant utilization of every resources dimension in every
+# ledger, then sampling should be avoided.
+
+# It's generally a good idea to utilize as many dimensions as possible, so
+# the values here should be chosen carefully such that the ratio between the
+# generated value and the respective limit is the roughly same for most of the
+# resources.
+
+# Number of *disk* reads a transaction performs. Every disk read is restoration,
+# so it's also a write (accounted for in NUM_RW_ENTRIES).
+APPLY_LOAD_NUM_DISK_READ_ENTRIES = [1]
+APPLY_LOAD_NUM_DISK_READ_ENTRIES_DISTRIBUTION = [1]
+
+# Number of writes a transaction performs.
+APPLY_LOAD_NUM_RW_ENTRIES = [4]
+APPLY_LOAD_NUM_RW_ENTRIES_DISTRIBUTION = [1]
+
+# Number of events a transaction emits.
+APPLY_LOAD_EVENT_COUNT = [5]
+APPLY_LOAD_EVENT_COUNT_DISTRIBUTION = [1]
+
+# Size of the generated transaction.
+APPLY_LOAD_TX_SIZE_BYTES = [1080]
+APPLY_LOAD_TX_SIZE_BYTES_DISTRIBUTION = [1]
+
+# Number of instructions a transaction will use.
+APPLY_LOAD_INSTRUCTIONS = [2000000]
+APPLY_LOAD_INSTRUCTIONS_DISTRIBUTION = [1]
+
+
+# Minimal core config boilerplate
+
+RUN_STANDALONE=true
+NODE_IS_VALIDATOR=false
+UNSAFE_QUORUM=true
+NETWORK_PASSPHRASE="Standalone Network ; February 2017"
+NODE_SEED="SDQVDISRYN2JXBS7ICL7QJAEKB3HWBJFP2QECXG7GZICAHBK4UNJCWK2 self"
+
+[QUORUM_SET]
+THRESHOLD_PERCENT=100
+VALIDATORS=["$self"]
+
+# Local history configuration to use for catching up to the synthetic
+# ledger state generated before the apply load benchmark is executed.
+[HISTORY.local]
+get="cp -r history/{0} {1}"
+put="cp -r {0} history/{1}"
+mkdir="mkdir -p history/{0}"

--- a/docs/apply-load-max-sac-tps.cfg
+++ b/docs/apply-load-max-sac-tps.cfg
@@ -1,0 +1,41 @@
+# This is the Stellar Core configuration example for using the load generation 
+# (apply-load) tool for testing the theoretical max SAC (Stellar asset contract)
+# transfer TPS via binary search (measured based on apply time only).
+
+# The core with this configuration should run using `./stellar-core apply-load --mode max-sac-tps`
+
+# Enable load generation
+ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING=true
+
+# Diagnostic events should generally be disabled, but can be enabled for debug
+ENABLE_SOROBAN_DIAGNOSTIC_EVENTS = false
+
+# The only relevant network configuration parameter - number of transaction
+# clusters that are then mapped to the transaction execution threads.
+APPLY_LOAD_LEDGER_MAX_DEPENDENT_TX_CLUSTERS = 1
+
+# Number of payments to batch in a single transaction, similarly to how
+# operations are batched for 'classic' transactions.
+APPLY_LOAD_BATCH_SAC_COUNT = 100
+
+# Number of ledgers to close for every iteraiton of search.
+APPLY_LOAD_NUM_LEDGERS = 10
+
+# Disable bucket list pre-generation as it's not necessary for this mode.
+APPLY_LOAD_BL_SIMULATED_LEDGERS = 0
+APPLY_LOAD_BL_WRITE_FREQUENCY = 0
+APPLY_LOAD_BL_BATCH_SIZE = 0
+APPLY_LOAD_BL_LAST_BATCH_SIZE = 0
+APPLY_LOAD_BL_LAST_BATCH_LEDGERS = 0
+
+# Minimal core config boilerplate
+
+RUN_STANDALONE=true
+NODE_IS_VALIDATOR=true
+UNSAFE_QUORUM=true
+NETWORK_PASSPHRASE="Standalone Network ; February 2017"
+NODE_SEED="SDQVDISRYN2JXBS7ICL7QJAEKB3HWBJFP2QECXG7GZICAHBK4UNJCWK2 self"
+
+[QUORUM_SET]
+THRESHOLD_PERCENT=100
+VALIDATORS=["$self"]

--- a/docs/apply-load.cfg
+++ b/docs/apply-load.cfg
@@ -1,0 +1,125 @@
+# This is the Stellar Core configuration example for using the load generation 
+# (apply-load) tool for benchmarking network limits.
+# This is not meant to be used in any production contexts.
+
+# The core with this configuration should be run using `./stellar-core apply-load`
+
+# Enable load generation
+ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING=true
+
+# Diagnostic events should generally be disabled, but can be enabled for debug
+ENABLE_SOROBAN_DIAGNOSTIC_EVENTS = false
+
+# Network configuration to use during the benchmark
+# The fields here correspond to the network configuration settings.
+APPLY_LOAD_LEDGER_MAX_INSTRUCTIONS = 500000000
+APPLY_LOAD_TX_MAX_INSTRUCTIONS = 100000000
+
+APPLY_LOAD_LEDGER_MAX_DEPENDENT_TX_CLUSTERS = 1
+
+APPLY_LOAD_TX_MAX_FOOTPRINT_SIZE = 200
+
+APPLY_LOAD_LEDGER_MAX_DISK_READ_LEDGER_ENTRIES = 1000
+APPLY_LOAD_TX_MAX_DISK_READ_LEDGER_ENTRIES = 100
+
+APPLY_LOAD_LEDGER_MAX_DISK_READ_BYTES = 150000
+APPLY_LOAD_TX_MAX_DISK_READ_BYTES = 130000
+
+APPLY_LOAD_LEDGER_MAX_WRITE_LEDGER_ENTRIES = 1000
+APPLY_LOAD_TX_MAX_WRITE_LEDGER_ENTRIES = 100
+
+APPLY_LOAD_LEDGER_MAX_WRITE_BYTES = 300000
+APPLY_LOAD_TX_MAX_WRITE_BYTES = 140000
+
+APPLY_LOAD_MAX_LEDGER_TX_SIZE_BYTES = 270000
+APPLY_LOAD_MAX_TX_SIZE_BYTES = 150000
+
+APPLY_LOAD_MAX_CONTRACT_EVENT_SIZE_BYTES = 10000
+APPLY_LOAD_MAX_SOROBAN_TX_COUNT = 1000
+
+# The following section contains various parameters for the generated load.
+
+# Number of ledgers to close for benchmark
+APPLY_LOAD_NUM_LEDGERS = 1
+
+# Generate that many simple Classic payment transactions in every benchmark ledger
+APPLY_LOAD_CLASSIC_TXS_PER_LEDGER = 0
+
+# Size of every synthetic data entry generated.
+# This setting affects both the size of the pre-generated Bucket List entries,
+# and the size of every entry that a Soroban transaction reads/writes.
+APPLY_LOAD_DATA_ENTRY_SIZE = 300
+
+# Bucket list pre-generation
+
+# The benchmark will pre-generate ledger entries using the simplified ledger
+# close process; the generated ledgers won't be reflected in the meta or
+# history checkpoints.
+
+# Faster settings, more shallow BL (up to level 6)
+# Number of ledgers to close
+APPLY_LOAD_BL_SIMULATED_LEDGERS = 10000
+# Write a batch of entries every that many ledgers
+APPLY_LOAD_BL_WRITE_FREQUENCY = 1000
+# Write that many entries in every batch
+APPLY_LOAD_BL_BATCH_SIZE = 1000
+# Write entry batches in every ledger of this many last ledgers
+APPLY_LOAD_BL_LAST_BATCH_SIZE = 100
+# Write that many entries in every 'last' ledger
+APPLY_LOAD_BL_LAST_BATCH_LEDGERS = 300
+
+# Slower settings, deeper BL (up to level 9)
+#APPLY_LOAD_BL_SIMULATED_LEDGERS = 300000
+#APPLY_LOAD_BL_WRITE_FREQUENCY = 10000
+#APPLY_LOAD_BL_BATCH_SIZE = 10000
+#APPLY_LOAD_BL_LAST_BATCH_LEDGERS = 300
+#APPLY_LOAD_BL_LAST_BATCH_SIZE = 100
+
+# Settings for generated transactions
+# Every setting consists of the list of the possible values and the respective 
+# _DISTRIBUTION list that defines the weight of every value. The values are then
+# sampled from the value list according to the distribution.
+
+# Core will try to pack as many generated transactions as possible,
+# so if it's important to maintain a constant number of transactions per ledger,
+# or to maintain constant utilization of every resources dimension in every
+# ledger, then sampling should be avoided.
+
+# It's generally a good idea to utilize as many dimensions as possible, so
+# the values here should be chosen carefully such that the ratio between the
+# generated value and the respective limit is the roughly same for most of the
+# resources.
+
+# Number of *disk* reads a transaction performs. Every disk read is restoration,
+# so it's also a write (accounted for in NUM_RW_ENTRIES).
+APPLY_LOAD_NUM_DISK_READ_ENTRIES = [2]
+APPLY_LOAD_NUM_DISK_READ_ENTRIES_DISTRIBUTION = [1]
+
+# Number of writes a transaction performs.
+APPLY_LOAD_NUM_RW_ENTRIES = [4]
+APPLY_LOAD_NUM_RW_ENTRIES_DISTRIBUTION = [1]
+
+# Number of events a transaction emits.
+APPLY_LOAD_EVENT_COUNT = [5]
+APPLY_LOAD_EVENT_COUNT_DISTRIBUTION = [1]
+
+# Size of the generated transaction.
+APPLY_LOAD_TX_SIZE_BYTES = [1080]
+APPLY_LOAD_TX_SIZE_BYTES_DISTRIBUTION = [1]
+
+# Number of instructions a transaction will use.
+APPLY_LOAD_INSTRUCTIONS = [2000000]
+APPLY_LOAD_INSTRUCTIONS_DISTRIBUTION = [1]
+
+
+# Minimal core config boilerplate
+
+RUN_STANDALONE=true
+NODE_IS_VALIDATOR=true
+UNSAFE_QUORUM=true
+NETWORK_PASSPHRASE="Standalone Network ; February 2017"
+NODE_SEED="SDQVDISRYN2JXBS7ICL7QJAEKB3HWBJFP2QECXG7GZICAHBK4UNJCWK2 self"
+
+[QUORUM_SET]
+THRESHOLD_PERCENT=100
+VALIDATORS=["$self"]

--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -19,18 +19,23 @@ Common options can be placed at any place in the command line.
 ## Command line options
 Command options can only by placed after command.
 
-* **apply-load**: Applies Soroban transactions by repeatedly generating transactions and closing
-them directly through the LedgerManager. This command will generate enough transactions to fill up a synthetic transaction queue (it's just a list of transactions with the same limits as the real queue), and then create a transaction set off of that to
-apply.
-
-* At the moment, the Soroban transactions are generated using some of the same config parameters as the **generateload** command. Specifically,
-    `ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING=true`,
-    `LOADGEN_INSTRUCTIONS_FOR_TESTING`, and
-    `LOADGEN_INSTRUCTIONS_DISTRIBUTION_FOR_TESTING`. In addition to those, you must also set the
-    limit related settings - `APPLY_LOAD_LEDGER_MAX_INSTRUCTIONS`, `APPLY_LOAD_TX_MAX_INSTRUCTIONS`, `APPLY_LOAD_LEDGER_MAX_READ_LEDGER_ENTRIES`, `APPLY_LOAD_TX_MAX_READ_LEDGER_ENTRIES`, `APPLY_LOAD_LEDGER_MAX_WRITE_LEDGER_ENTRIES`, `APPLY_LOAD_TX_MAX_WRITE_LEDGER_ENTRIES`, `APPLY_LOAD_LEDGER_MAX_READ_BYTES`, `APPLY_LOAD_TX_MAX_READ_BYTES`, `APPLY_LOAD_LEDGER_MAX_WRITE_BYTES`, `APPLY_LOAD_TX_MAX_WRITE_BYTES`, `APPLY_LOAD_MAX_TX_SIZE_BYTES`, `APPLY_LOAD_MAX_LEDGER_TX_SIZE_BYTES`, `APPLY_LOAD_MAX_CONTRACT_EVENT_SIZE_BYTES`, `APPLY_LOAD_MAX_TX_COUNT`.
-* `apply-load` will also generate a synthetic bucket list using `APPLY_LOAD_BL_SIMULATED_LEDGERS`, `APPLY_LOAD_BL_WRITE_FREQUENCY`, `APPLY_LOAD_BL_BATCH_SIZE`, `APPLY_LOAD_BL_LAST_BATCH_LEDGERS`, `APPLY_LOAD_BL_LAST_BATCH_SIZE`. These have default values set in `Config.h`.
-* There are additional `APPLY_LOAD_*` related config settings that can be used to configure
-`apply-load`, and you can learn more about these from the comments in `Config.h`.
+* **apply-load**: Benchmarks Soroban transaction application time using
+    synthetic transactions. The benchmark is isolated to mostly just executing
+    the transactions and thus it omits a lot of the supporting mechanisms
+    (such as overlay, SCP, mempool etc). This command will generate enough
+    transactions to fill up a synthetic transaction queue (it's just a list of
+    transactions with the same limits as the real queue), and then create a
+    transaction set off of that to apply. This can also be used to record the
+    synthetic ledger close metadata emitted during the benchmark, and then use
+    it for benchmarking the meta consumers.
+  * This can only be used when `ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING=true`
+  * Load generation is configured in the Core config file. The relevant settings
+    all begin with `APPLY_LOAD_`. See full example configurations with
+    per-setting documentation in the `docs` directory
+    (`apply-load.cfg`, `apply-load-for-meta.cfg`).
+  * The command also supports the special mode for determining max apply 'TPS'
+    using SAC transfers. It can be invoked by passing `max-sac-tps` as
+    `apply-load` argument.
 
 * **catchup <DESTINATION-LEDGER/LEDGER-COUNT>**: Perform catchup from history
   archives without connecting to network. For new instances (with empty history

--- a/src/history/HistoryManager.h
+++ b/src/history/HistoryManager.h
@@ -407,6 +407,11 @@ class HistoryManager
     // Return the number of checkpoints that failed publication.
     virtual uint64_t getPublishFailureCount() const = 0;
 
+    // Waits until the currently queued checkpoint publication is complete.
+    // This is only useful in utility scenarios where blocking publication is
+    // necessary - don't use in normal operation.
+    virtual void waitForCheckpointPublish() = 0;
+
 #ifdef BUILD_TESTS
     // Enable or disable history publication, purely a testing interface.
     // History is still queued when publication is disabled.

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -806,6 +806,21 @@ HistoryManagerImpl::setPublicationEnabled(bool enabled)
 }
 #endif
 
+void
+HistoryManagerImpl::waitForCheckpointPublish()
+{
+    // This may only be used for the load testing (apply-load specifically, but
+    // we don't have a separate flag for that).
+    releaseAssert(mApp.getConfig().ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING &&
+                  mApp.getConfig().RUN_STANDALONE);
+    auto& clock = mApp.getClock();
+    while (!clock.getIOContext().stopped() && mPublishWork &&
+           publishQueueLength(mApp.getConfig()) > 0)
+    {
+        clock.crank(true);
+    }
+}
+
 Config const&
 HistoryManagerImpl::getConfig() const
 {

--- a/src/history/HistoryManagerImpl.h
+++ b/src/history/HistoryManagerImpl.h
@@ -79,6 +79,8 @@ class HistoryManagerImpl : public HistoryManager
     uint64_t getPublishSuccessCount() const override;
     uint64_t getPublishFailureCount() const override;
 
+    void waitForCheckpointPublish() override;
+
 #ifdef BUILD_TESTS
     void setPublicationEnabled(bool enabled) override;
     // Throw after inseting ledger `n` into a checkpoint

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -1579,10 +1579,15 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                      LOADGEN_INSTRUCTIONS_DISTRIBUTION_FOR_TESTING =
                          readIntArray<uint32_t>(item);
                  }},
-                {"APPLY_LOAD_DATA_ENTRY_SIZE_FOR_TESTING",
+                {"APPLY_LOAD_DATA_ENTRY_SIZE",
                  [&]() {
-                     APPLY_LOAD_DATA_ENTRY_SIZE_FOR_TESTING =
-                         readInt<uint32_t>(item);
+                     APPLY_LOAD_DATA_ENTRY_SIZE = readInt<uint32_t>(item);
+                     // align to 4 bytes
+                     if (APPLY_LOAD_DATA_ENTRY_SIZE % 4 != 0)
+                     {
+                         APPLY_LOAD_DATA_ENTRY_SIZE +=
+                             4 - (APPLY_LOAD_DATA_ENTRY_SIZE % 4);
+                     }
                  }},
                 {"APPLY_LOAD_BL_SIMULATED_LEDGERS",
                  [&]() {
@@ -1602,34 +1607,50 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                  [&]() {
                      APPLY_LOAD_BL_LAST_BATCH_SIZE = readInt<uint32_t>(item);
                  }},
-                {"APPLY_LOAD_NUM_RO_ENTRIES_FOR_TESTING",
+                {"APPLY_LOAD_INSTRUCTIONS",
                  [&]() {
-                     APPLY_LOAD_NUM_RO_ENTRIES_FOR_TESTING =
+                     APPLY_LOAD_INSTRUCTIONS = readIntArray<uint32>(item);
+                 }},
+                {"APPLY_LOAD_INSTRUCTIONS_DISTRIBUTION",
+                 [&]() {
+                     APPLY_LOAD_INSTRUCTIONS_DISTRIBUTION =
                          readIntArray<uint32>(item);
                  }},
-                {"APPLY_LOAD_NUM_RO_ENTRIES_DISTRIBUTION_FOR_TESTING",
+                {"APPLY_LOAD_TX_SIZE_BYTES",
                  [&]() {
-                     APPLY_LOAD_NUM_RO_ENTRIES_DISTRIBUTION_FOR_TESTING =
+                     APPLY_LOAD_TX_SIZE_BYTES = readIntArray<uint32>(item);
+                 }},
+                {"APPLY_LOAD_TX_SIZE_BYTES_DISTRIBUTION",
+                 [&]() {
+                     APPLY_LOAD_TX_SIZE_BYTES_DISTRIBUTION =
                          readIntArray<uint32>(item);
                  }},
-                {"APPLY_LOAD_NUM_RW_ENTRIES_FOR_TESTING",
+                {"APPLY_LOAD_NUM_DISK_READ_ENTRIES",
                  [&]() {
-                     APPLY_LOAD_NUM_RW_ENTRIES_FOR_TESTING =
+                     APPLY_LOAD_NUM_DISK_READ_ENTRIES =
                          readIntArray<uint32>(item);
                  }},
-                {"APPLY_LOAD_NUM_RW_ENTRIES_DISTRIBUTION_FOR_TESTING",
+                {"APPLY_LOAD_NUM_DISK_READ_ENTRIES_DISTRIBUTION",
                  [&]() {
-                     APPLY_LOAD_NUM_RW_ENTRIES_DISTRIBUTION_FOR_TESTING =
+                     APPLY_LOAD_NUM_DISK_READ_ENTRIES_DISTRIBUTION =
                          readIntArray<uint32>(item);
                  }},
-                {"APPLY_LOAD_EVENT_COUNT_FOR_TESTING",
+                {"APPLY_LOAD_NUM_RW_ENTRIES",
                  [&]() {
-                     APPLY_LOAD_EVENT_COUNT_FOR_TESTING =
+                     APPLY_LOAD_NUM_RW_ENTRIES = readIntArray<uint32>(item);
+                 }},
+                {"APPLY_LOAD_NUM_RW_ENTRIES_DISTRIBUTION",
+                 [&]() {
+                     APPLY_LOAD_NUM_RW_ENTRIES_DISTRIBUTION =
                          readIntArray<uint32>(item);
                  }},
-                {"APPLY_LOAD_EVENT_COUNT_DISTRIBUTION_FOR_TESTING",
+                {"APPLY_LOAD_EVENT_COUNT",
                  [&]() {
-                     APPLY_LOAD_EVENT_COUNT_DISTRIBUTION_FOR_TESTING =
+                     APPLY_LOAD_EVENT_COUNT = readIntArray<uint32>(item);
+                 }},
+                {"APPLY_LOAD_EVENT_COUNT_DISTRIBUTION",
+                 [&]() {
+                     APPLY_LOAD_EVENT_COUNT_DISTRIBUTION =
                          readIntArray<uint32>(item);
                  }},
                 {"APPLY_LOAD_LEDGER_MAX_INSTRUCTIONS",
@@ -1641,15 +1662,19 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                  [&]() {
                      APPLY_LOAD_TX_MAX_INSTRUCTIONS = readInt<uint32_t>(item);
                  }},
-                {"APPLY_LOAD_LEDGER_MAX_READ_LEDGER_ENTRIES",
+                {"APPLY_LOAD_LEDGER_MAX_DISK_READ_LEDGER_ENTRIES",
                  [&]() {
-                     APPLY_LOAD_LEDGER_MAX_READ_LEDGER_ENTRIES =
+                     APPLY_LOAD_LEDGER_MAX_DISK_READ_LEDGER_ENTRIES =
                          readInt<uint32_t>(item);
                  }},
-                {"APPLY_LOAD_TX_MAX_READ_LEDGER_ENTRIES",
+                {"APPLY_LOAD_TX_MAX_DISK_READ_LEDGER_ENTRIES",
                  [&]() {
-                     APPLY_LOAD_TX_MAX_READ_LEDGER_ENTRIES =
+                     APPLY_LOAD_TX_MAX_DISK_READ_LEDGER_ENTRIES =
                          readInt<uint32_t>(item);
+                 }},
+                {"APPLY_LOAD_TX_MAX_FOOTPRINT_SIZE",
+                 [&]() {
+                     APPLY_LOAD_TX_MAX_FOOTPRINT_SIZE = readInt<uint32_t>(item);
                  }},
                 {"APPLY_LOAD_LEDGER_MAX_WRITE_LEDGER_ENTRIES",
                  [&]() {
@@ -1661,13 +1686,15 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                      APPLY_LOAD_TX_MAX_WRITE_LEDGER_ENTRIES =
                          readInt<uint32_t>(item);
                  }},
-                {"APPLY_LOAD_LEDGER_MAX_READ_BYTES",
+                {"APPLY_LOAD_LEDGER_MAX_DISK_READ_BYTES",
                  [&]() {
-                     APPLY_LOAD_LEDGER_MAX_READ_BYTES = readInt<uint32_t>(item);
+                     APPLY_LOAD_LEDGER_MAX_DISK_READ_BYTES =
+                         readInt<uint32_t>(item);
                  }},
-                {"APPLY_LOAD_TX_MAX_READ_BYTES",
+                {"APPLY_LOAD_TX_MAX_DISK_READ_BYTES",
                  [&]() {
-                     APPLY_LOAD_TX_MAX_READ_BYTES = readInt<uint32_t>(item);
+                     APPLY_LOAD_TX_MAX_DISK_READ_BYTES =
+                         readInt<uint32_t>(item);
                  }},
                 {"APPLY_LOAD_LEDGER_MAX_WRITE_BYTES",
                  [&]() {
@@ -1692,15 +1719,20 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                      APPLY_LOAD_MAX_CONTRACT_EVENT_SIZE_BYTES =
                          readInt<uint32_t>(item);
                  }},
-                {"APPLY_LOAD_MAX_TX_COUNT",
-                 [&]() { APPLY_LOAD_MAX_TX_COUNT = readInt<uint32_t>(item); }},
+                {"APPLY_LOAD_MAX_SOROBAN_TX_COUNT",
+                 [&]() {
+                     APPLY_LOAD_MAX_SOROBAN_TX_COUNT = readInt<uint32_t>(item);
+                 }},
+                {"APPLY_LOAD_CLASSIC_TXS_PER_LEDGER",
+                 [&]() {
+                     APPLY_LOAD_CLASSIC_TXS_PER_LEDGER =
+                         readInt<uint32_t>(item);
+                 }},
                 {"APPLY_LOAD_LEDGER_MAX_DEPENDENT_TX_CLUSTERS",
                  [&]() {
                      APPLY_LOAD_LEDGER_MAX_DEPENDENT_TX_CLUSTERS =
                          readInt<uint32_t>(item, 1);
                  }},
-                {"APPLY_LOAD_NUM_ACCOUNTS",
-                 [&]() { APPLY_LOAD_NUM_ACCOUNTS = readInt<uint32_t>(item); }},
                 {"APPLY_LOAD_NUM_LEDGERS",
                  [&]() { APPLY_LOAD_NUM_LEDGERS = readInt<uint32_t>(item); }},
                 {"APPLY_LOAD_MAX_SAC_TPS_TARGET_CLOSE_TIME_MS",
@@ -1883,16 +1915,6 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             std::string msg =
                 "Invalid configuration: PEER_READING_CAPACITY "
                 "must be greater than PEER_FLOOD_READING_CAPACITY";
-            throw std::runtime_error(msg);
-        }
-
-        if (APPLY_LOAD_LEDGER_MAX_WRITE_BYTES <
-            APPLY_LOAD_LEDGER_MAX_READ_BYTES)
-        {
-            std::string msg =
-                "Invalid configuration: APPLY_LOAD_LEDGER_MAX_WRITE_BYTES "
-                "must be greater than or equal to "
-                "APPLY_LOAD_LEDGER_MAX_READ_BYTES";
             throw std::runtime_error(msg);
         }
 

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -331,7 +331,6 @@ class Config : public std::enable_shared_from_this<Config>
 
     // Instructions per transaction for SOROBAN_INVOKE and MIX_CLASSIC_SOROBAN
     // loadgen modes
-    // Also used for configuring apply-load command.
     std::vector<uint32_t> LOADGEN_INSTRUCTIONS_FOR_TESTING;
     std::vector<uint32_t> LOADGEN_INSTRUCTIONS_DISTRIBUTION_FOR_TESTING;
 
@@ -339,7 +338,7 @@ class Config : public std::enable_shared_from_this<Config>
     // Size of the synthetic contract data entries used in apply-load.
     // Currently we generate entries of the equal size for more precise
     // control over the modelled instructions.
-    uint32_t APPLY_LOAD_DATA_ENTRY_SIZE_FOR_TESTING = 0;
+    uint32_t APPLY_LOAD_DATA_ENTRY_SIZE = 0;
 
     // The parameters below control the synthetic bucket list generation in
     // apply-load.
@@ -364,14 +363,16 @@ class Config : public std::enable_shared_from_this<Config>
     uint64_t APPLY_LOAD_LEDGER_MAX_INSTRUCTIONS = 0;
     uint32_t APPLY_LOAD_TX_MAX_INSTRUCTIONS = 0;
 
-    uint32_t APPLY_LOAD_LEDGER_MAX_READ_LEDGER_ENTRIES = 0;
-    uint32_t APPLY_LOAD_TX_MAX_READ_LEDGER_ENTRIES = 0;
+    uint32_t APPLY_LOAD_LEDGER_MAX_DISK_READ_LEDGER_ENTRIES = 0;
+    uint32_t APPLY_LOAD_TX_MAX_DISK_READ_LEDGER_ENTRIES = 0;
+
+    uint32_t APPLY_LOAD_TX_MAX_FOOTPRINT_SIZE = 0;
 
     uint32_t APPLY_LOAD_LEDGER_MAX_WRITE_LEDGER_ENTRIES = 0;
     uint32_t APPLY_LOAD_TX_MAX_WRITE_LEDGER_ENTRIES = 0;
 
-    uint32_t APPLY_LOAD_LEDGER_MAX_READ_BYTES = 0;
-    uint32_t APPLY_LOAD_TX_MAX_READ_BYTES = 0;
+    uint32_t APPLY_LOAD_LEDGER_MAX_DISK_READ_BYTES = 0;
+    uint32_t APPLY_LOAD_TX_MAX_DISK_READ_BYTES = 0;
 
     uint32_t APPLY_LOAD_LEDGER_MAX_WRITE_BYTES = 0;
     uint32_t APPLY_LOAD_TX_MAX_WRITE_BYTES = 0;
@@ -380,24 +381,34 @@ class Config : public std::enable_shared_from_this<Config>
     uint32_t APPLY_LOAD_MAX_LEDGER_TX_SIZE_BYTES = 0;
 
     uint32_t APPLY_LOAD_MAX_CONTRACT_EVENT_SIZE_BYTES = 0;
-    uint32_t APPLY_LOAD_MAX_TX_COUNT = 0;
+    uint32_t APPLY_LOAD_MAX_SOROBAN_TX_COUNT = 0;
 
     uint32_t APPLY_LOAD_LEDGER_MAX_DEPENDENT_TX_CLUSTERS = 1;
-    // A min of APPLY_LOAD_MAX_TX_COUNT * queue size multiplier will be used
-    uint32_t APPLY_LOAD_NUM_ACCOUNTS = 0;
+
     uint32_t APPLY_LOAD_NUM_LEDGERS = 100;
 
-    // Number of read-only and read-write entries in the apply-load
-    // transactions. Every entry will have
-    // `APPLY_LOAD_DATA_ENTRY_SIZE_FOR_TESTING` size.
-    std::vector<uint32_t> APPLY_LOAD_NUM_RO_ENTRIES_FOR_TESTING;
-    std::vector<uint32_t> APPLY_LOAD_NUM_RO_ENTRIES_DISTRIBUTION_FOR_TESTING;
-    std::vector<uint32_t> APPLY_LOAD_NUM_RW_ENTRIES_FOR_TESTING;
-    std::vector<uint32_t> APPLY_LOAD_NUM_RW_ENTRIES_DISTRIBUTION_FOR_TESTING;
+    // Number of classic transactions to include in each ledger in ledger limit
+    // based apply-load mode.
+    uint32_t APPLY_LOAD_CLASSIC_TXS_PER_LEDGER = 0;
+
+    // Number of instructions to generate in the apply-load transactions.
+    std::vector<uint32_t> APPLY_LOAD_INSTRUCTIONS;
+    std::vector<uint32_t> APPLY_LOAD_INSTRUCTIONS_DISTRIBUTION;
+
+    // Transaction size in bytes for the apply-load transactions.
+    std::vector<uint32_t> APPLY_LOAD_TX_SIZE_BYTES;
+    std::vector<uint32_t> APPLY_LOAD_TX_SIZE_BYTES_DISTRIBUTION;
+
+    // Number of disk read-only and read-write entries in the apply-load
+    // transactions. Every entry will have `APPLY_LOAD_DATA_ENTRY_SIZE` size.
+    std::vector<uint32_t> APPLY_LOAD_NUM_DISK_READ_ENTRIES;
+    std::vector<uint32_t> APPLY_LOAD_NUM_DISK_READ_ENTRIES_DISTRIBUTION;
+    std::vector<uint32_t> APPLY_LOAD_NUM_RW_ENTRIES;
+    std::vector<uint32_t> APPLY_LOAD_NUM_RW_ENTRIES_DISTRIBUTION;
 
     // Number of events to generate in the apply-load transactions.
-    std::vector<uint32_t> APPLY_LOAD_EVENT_COUNT_FOR_TESTING;
-    std::vector<uint32_t> APPLY_LOAD_EVENT_COUNT_DISTRIBUTION_FOR_TESTING;
+    std::vector<uint32_t> APPLY_LOAD_EVENT_COUNT;
+    std::vector<uint32_t> APPLY_LOAD_EVENT_COUNT_DISTRIBUTION;
 
     // MAX_SAC_TPS mode specific parameters
     uint32_t APPLY_LOAD_MAX_SAC_TPS_TARGET_CLOSE_TIME_MS = 1000;

--- a/src/main/dumpxdr.cpp
+++ b/src/main/dumpxdr.cpp
@@ -66,7 +66,7 @@ void
 dumpXdrStream(std::string const& filename, bool compact)
 {
     std::regex rx(
-        R"(.*\b(debug-tx-set|(?:(ledger|bucket|transactions|results|meta-debug|scp)-.+))\.xdr(?:\.dirty)?$)");
+        R"(.*\b(debug-tx-set|(?:(ledger|bucket|transactions|results|meta|scp)-?.*))\.xdr(?:\.dirty)?$)");
     std::smatch sm;
     if (std::regex_match(filename, sm, rx))
     {
@@ -96,7 +96,7 @@ dumpXdrStream(std::string const& filename, bool compact)
             {
                 dumpstream<TransactionHistoryResultEntry>(in, compact);
             }
-            else if (m2 == "meta-debug")
+            else if (m2 == "meta")
             {
                 dumpstream<LedgerCloseMeta>(in, compact);
             }

--- a/src/simulation/ApplyLoad.h
+++ b/src/simulation/ApplyLoad.h
@@ -14,16 +14,22 @@ namespace stellar
 
 enum class ApplyLoadMode
 {
-    SOROBAN,
-    CLASSIC,
-    MIX,
+    // Generate load within the configured ledger limits.
+    LIMIT_BASED,
+    // Generate load that only finds max TPS for the cheap operations (SAC
+    // transfers), ignoring ledger limits.
     MAX_SAC_TPS
 };
 
 class ApplyLoad
 {
   public:
-    ApplyLoad(Application& app, ApplyLoadMode mode = ApplyLoadMode::SOROBAN);
+    ApplyLoad(Application& app,
+              ApplyLoadMode mode = ApplyLoadMode::LIMIT_BASED);
+
+    void closeLedger(std::vector<TransactionFrameBasePtr> const& txs,
+                     xdr::xvector<UpgradeType, 6> const& upgrades = {},
+                     bool recordSorobanUtilization = false);
 
     // Fills up a list of transactions with
     // SOROBAN_TRANSACTION_QUEUE_SIZE_MULTIPLIER * the max ledger resources
@@ -52,9 +58,9 @@ class ApplyLoad
     medida::Histogram const& getTxCountUtilization();
     medida::Histogram const& getInstructionUtilization();
     medida::Histogram const& getTxSizeUtilization();
-    medida::Histogram const& getReadByteUtilization();
-    medida::Histogram const& getWriteByteUtilization();
-    medida::Histogram const& getReadEntryUtilization();
+    medida::Histogram const& getDiskReadByteUtilization();
+    medida::Histogram const& getDiskWriteByteUtilization();
+    medida::Histogram const& getDiskReadEntryUtilization();
     medida::Histogram const& getWriteEntryUtilization();
 
     // Returns LedgerKey for pre-populated archived state at the given index.
@@ -62,9 +68,6 @@ class ApplyLoad
     static uint32_t calculateRequiredHotArchiveEntries(Config const& cfg);
 
   private:
-    void closeLedger(std::vector<TransactionFrameBasePtr> const& txs,
-                     xdr::xvector<UpgradeType, 6> const& upgrades = {});
-
     void setup();
 
     void setupAccounts();
@@ -122,9 +125,9 @@ class ApplyLoad
     medida::Histogram& mTxCountUtilization;
     medida::Histogram& mInstructionUtilization;
     medida::Histogram& mTxSizeUtilization;
-    medida::Histogram& mReadByteUtilization;
+    medida::Histogram& mDiskReadByteUtilization;
     medida::Histogram& mWriteByteUtilization;
-    medida::Histogram& mReadEntryUtilization;
+    medida::Histogram& mDiskReadEntryUtilization;
     medida::Histogram& mWriteEntryUtilization;
 
     ApplyLoadMode mMode;

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -792,8 +792,7 @@ LoadGenerator::generateLoad(GeneratedLoadConfig cfg)
                 uint64_t dataEntryCount =
                     appCfg.APPLY_LOAD_BL_BATCH_SIZE *
                     appCfg.APPLY_LOAD_BL_SIMULATED_LEDGERS;
-                size_t dataEntrySize =
-                    appCfg.APPLY_LOAD_DATA_ENTRY_SIZE_FOR_TESTING;
+                size_t dataEntrySize = appCfg.APPLY_LOAD_DATA_ENTRY_SIZE;
 
                 return mTxGenerator.invokeSorobanLoadTransactionV2(
                     ledgerNum, sourceAccountId, instance, dataEntryCount,

--- a/src/simulation/test/LoadGeneratorTests.cpp
+++ b/src/simulation/test/LoadGeneratorTests.cpp
@@ -26,10 +26,10 @@ TEST_CASE("loadgen in overlay-only mode", "[loadgen]")
     Simulation::pointer simulation =
         Topologies::pair(Simulation::OVER_LOOPBACK, networkID, [&](int i) {
             auto cfg = getTestConfig(i);
-            cfg.APPLY_LOAD_NUM_RO_ENTRIES_FOR_TESTING = {10};
-            cfg.APPLY_LOAD_NUM_RO_ENTRIES_DISTRIBUTION_FOR_TESTING = {100};
-            cfg.APPLY_LOAD_NUM_RW_ENTRIES_FOR_TESTING = {5};
-            cfg.APPLY_LOAD_NUM_RW_ENTRIES_DISTRIBUTION_FOR_TESTING = {100};
+            cfg.APPLY_LOAD_NUM_DISK_READ_ENTRIES = {10};
+            cfg.APPLY_LOAD_NUM_DISK_READ_ENTRIES_DISTRIBUTION = {100};
+            cfg.APPLY_LOAD_NUM_RW_ENTRIES = {5};
+            cfg.APPLY_LOAD_NUM_RW_ENTRIES_DISTRIBUTION = {100};
             cfg.LOADGEN_INSTRUCTIONS_FOR_TESTING = {10'000'000, 50'000'000};
             cfg.LOADGEN_INSTRUCTIONS_DISTRIBUTION_FOR_TESTING = {5, 1};
             cfg.ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING = true;
@@ -884,37 +884,44 @@ TEST_CASE("apply load", "[loadgen][applyload][acceptance]")
     cfg.LEDGER_PROTOCOL_VERSION = Config::CURRENT_LEDGER_PROTOCOL_VERSION;
     cfg.MANUAL_CLOSE = true;
 
-    cfg.APPLY_LOAD_DATA_ENTRY_SIZE_FOR_TESTING = 1000;
+    cfg.APPLY_LOAD_CLASSIC_TXS_PER_LEDGER = 100;
 
+    cfg.APPLY_LOAD_DATA_ENTRY_SIZE = 1000;
+
+    // BL generation parameters
     cfg.APPLY_LOAD_BL_SIMULATED_LEDGERS = 10000;
     cfg.APPLY_LOAD_BL_WRITE_FREQUENCY = 1000;
     cfg.APPLY_LOAD_BL_BATCH_SIZE = 1000;
     cfg.APPLY_LOAD_BL_LAST_BATCH_LEDGERS = 300;
     cfg.APPLY_LOAD_BL_LAST_BATCH_SIZE = 100;
 
-    cfg.APPLY_LOAD_NUM_RO_ENTRIES_FOR_TESTING = {5, 10, 30};
-    cfg.APPLY_LOAD_NUM_RO_ENTRIES_DISTRIBUTION_FOR_TESTING = {1, 1, 1};
+    // Load generation parameters
+    cfg.APPLY_LOAD_NUM_DISK_READ_ENTRIES = {0, 1, 2};
+    cfg.APPLY_LOAD_NUM_DISK_READ_ENTRIES_DISTRIBUTION = {3, 2, 1};
 
-    cfg.APPLY_LOAD_NUM_RW_ENTRIES_FOR_TESTING = {1, 5, 10};
-    cfg.APPLY_LOAD_NUM_RW_ENTRIES_DISTRIBUTION_FOR_TESTING = {1, 1, 1};
+    cfg.APPLY_LOAD_NUM_RW_ENTRIES = {1, 5, 10};
+    cfg.APPLY_LOAD_NUM_RW_ENTRIES_DISTRIBUTION = {1, 1, 1};
 
-    cfg.APPLY_LOAD_EVENT_COUNT_FOR_TESTING = {100};
-    cfg.APPLY_LOAD_EVENT_COUNT_DISTRIBUTION_FOR_TESTING = {1};
+    cfg.APPLY_LOAD_EVENT_COUNT = {100};
+    cfg.APPLY_LOAD_EVENT_COUNT_DISTRIBUTION = {1};
 
-    cfg.LOADGEN_TX_SIZE_BYTES_FOR_TESTING = {1'000, 2'000, 5'000};
-    cfg.LOADGEN_TX_SIZE_BYTES_DISTRIBUTION_FOR_TESTING = {3, 2, 1};
+    cfg.APPLY_LOAD_TX_SIZE_BYTES = {1'000, 2'000, 5'000};
+    cfg.APPLY_LOAD_TX_SIZE_BYTES_DISTRIBUTION = {3, 2, 1};
 
-    cfg.LOADGEN_INSTRUCTIONS_FOR_TESTING = {10'000'000, 50'000'000};
-    cfg.LOADGEN_INSTRUCTIONS_DISTRIBUTION_FOR_TESTING = {5, 1};
+    cfg.APPLY_LOAD_INSTRUCTIONS = {10'000'000, 50'000'000};
+    cfg.APPLY_LOAD_INSTRUCTIONS_DISTRIBUTION = {5, 1};
 
+    // Ledger and transaction limits
     cfg.APPLY_LOAD_LEDGER_MAX_INSTRUCTIONS = 500'000'000;
     cfg.APPLY_LOAD_TX_MAX_INSTRUCTIONS = 100'000'000;
+    cfg.APPLY_LOAD_LEDGER_MAX_DEPENDENT_TX_CLUSTERS = 2;
 
-    cfg.APPLY_LOAD_LEDGER_MAX_READ_LEDGER_ENTRIES = 2000;
-    cfg.APPLY_LOAD_TX_MAX_READ_LEDGER_ENTRIES = 100;
+    cfg.APPLY_LOAD_LEDGER_MAX_DISK_READ_LEDGER_ENTRIES = 2000;
+    cfg.APPLY_LOAD_TX_MAX_DISK_READ_LEDGER_ENTRIES = 100;
+    cfg.APPLY_LOAD_TX_MAX_FOOTPRINT_SIZE = 100;
 
-    cfg.APPLY_LOAD_LEDGER_MAX_READ_BYTES = 50'000'000;
-    cfg.APPLY_LOAD_TX_MAX_READ_BYTES = 200'000;
+    cfg.APPLY_LOAD_LEDGER_MAX_DISK_READ_BYTES = 50'000'000;
+    cfg.APPLY_LOAD_TX_MAX_DISK_READ_BYTES = 200'000;
 
     cfg.APPLY_LOAD_LEDGER_MAX_WRITE_LEDGER_ENTRIES = 1250;
     cfg.APPLY_LOAD_TX_MAX_WRITE_LEDGER_ENTRIES = 50;
@@ -926,7 +933,7 @@ TEST_CASE("apply load", "[loadgen][applyload][acceptance]")
     cfg.APPLY_LOAD_MAX_LEDGER_TX_SIZE_BYTES = 800'000;
 
     cfg.APPLY_LOAD_MAX_CONTRACT_EVENT_SIZE_BYTES = 8198;
-    cfg.APPLY_LOAD_MAX_TX_COUNT = 50;
+    cfg.APPLY_LOAD_MAX_SOROBAN_TX_COUNT = 50;
 
     cfg.APPLY_LOAD_NUM_LEDGERS = 100;
 
@@ -1011,11 +1018,11 @@ TEST_CASE("apply load", "[loadgen][applyload][acceptance]")
     CLOG_INFO(Perf, "Tx size utilization {}%",
               al.getTxSizeUtilization().mean() / 1000.0);
     CLOG_INFO(Perf, "Read bytes utilization {}%",
-              al.getReadByteUtilization().mean() / 1000.0);
+              al.getDiskReadByteUtilization().mean() / 1000.0);
     CLOG_INFO(Perf, "Write bytes utilization {}%",
-              al.getWriteByteUtilization().mean() / 1000.0);
+              al.getDiskWriteByteUtilization().mean() / 1000.0);
     CLOG_INFO(Perf, "Read entry utilization {}%",
-              al.getReadEntryUtilization().mean() / 1000.0);
+              al.getDiskReadEntryUtilization().mean() / 1000.0);
     CLOG_INFO(Perf, "Write entry utilization {}%",
               al.getWriteEntryUtilization().mean() / 1000.0);
 }
@@ -1036,7 +1043,6 @@ TEST_CASE("basic MAX_SAC_TPS functionality",
     cfg.APPLY_LOAD_MAX_SAC_TPS_MIN_TPS = 200;
     cfg.APPLY_LOAD_MAX_SAC_TPS_MAX_TPS = 220;
     cfg.APPLY_LOAD_NUM_LEDGERS = 10;
-    cfg.APPLY_LOAD_NUM_ACCOUNTS = 500;
     cfg.APPLY_LOAD_BATCH_SAC_COUNT = 2;
 
     VirtualClock clock(VirtualClock::REAL_TIME);


### PR DESCRIPTION
# Description

This adds some support for the downstream benchmarking, and overhauls the tool for better usability.

- Make a history checkpoint before running the benchmark
- Don't emit meta in the temp directory - when meta is necessary it can be specified explicitly, and we probably don't need meta for SLP benchmarking
- Remove unnecessary modes and consolidate the 'classic' payment mode into the main limit-based mode
- Properly account for the disk read bytes and the data entry size
- Fix how resource utilization is computed (it used be mempool utilization, while we're interested in tx set utilization)
- Update configuration setting names and some settings for consistency
- Add example apply load configuration files with detailed comments

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
