### PR TITLE
Test fixes and code hardening in preparation for parallel features

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -936,6 +936,10 @@ HerderImpl::externalizeValue(TxSetXDRFrameConstPtr txSet, uint32_t ledgerSeq,
     StellarValue sv =
         makeStellarValue(txSet->getContentsHash(), closeTime, upgrades, sk);
     getHerderSCPDriver().valueExternalized(ledgerSeq, xdr::xdr_to_opaque(sv));
+    while (mApp.getLedgerManager().getLastClosedLedgerNum() < ledgerSeq)
+    {
+        mApp.getClock().crank(true);
+    }
 }
 
 bool

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -267,7 +267,7 @@ LedgerManagerImpl::ApplyState::getSorobanInMemoryStateSizeForTesting() const
 void
 LedgerManagerImpl::ApplyState::threadInvariant() const
 {
-    if (mAppConnector.getConfig().EXPERIMENTAL_PARALLEL_LEDGER_APPLY)
+    if (mAppConnector.getConfig().parallelLedgerClose())
     {
         releaseAssert(threadIsMain() || mAppConnector.threadIsType(
                                             Application::ThreadType::APPLY));

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -292,8 +292,10 @@ class ApplicationImpl : public Application
     void upgradeToCurrentSchemaAndMaybeRebuildLedger(bool applyBuckets,
                                                      bool forceRebuild);
 
-    void idempotentShutdown();
-    void shutdownThread(std::unique_ptr<std::thread>& threadPtr,
+    // Set `forgetBuckets` to true to clean up unreferenced buckets
+    // Note: this flag requires LM and BM to be fully constructed
+    void idempotentShutdown(bool forgetBuckets);
+    bool shutdownThread(std::unique_ptr<std::thread>& threadPtr,
                         std::unique_ptr<asio::io_context::work>& workPtr,
                         std::string const& threadName);
 };

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -1916,7 +1916,8 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
         {
             std::string msg =
                 "Invalid configuration: EXPERIMENTAL_PARALLEL_LEDGER_APPLY "
-                "does not support SQLite. Either switch to Postgres or set "
+                "does not support SQLite or RUN_STANDALONE mode. Either switch "
+                "to Postgres or set "
                 "EXPERIMENTAL_PARALLEL_LEDGER_APPLY=false";
             throw std::runtime_error(msg);
         }
@@ -2479,8 +2480,10 @@ Config::allBucketsInMemory() const
 bool
 Config::parallelLedgerClose() const
 {
+    // Standalone mode expects synchronous ledger application
     return EXPERIMENTAL_PARALLEL_LEDGER_APPLY &&
-           !(DATABASE.value.find("sqlite3://") != std::string::npos);
+           !(DATABASE.value.find("sqlite3://") != std::string::npos) &&
+           !RUN_STANDALONE;
 }
 
 void

--- a/src/main/test/CommandHandlerTests.cpp
+++ b/src/main/test/CommandHandlerTests.cpp
@@ -198,6 +198,7 @@ TEST_CASE("manualclose", "[commandhandler]")
         auto& commandHandler = app->getCommandHandler();
         std::string retStr;
         issue(commandHandler, retStr);
+        app->gracefulStop();
     };
 
     SECTION("'manualclose' is forbidden if MANUAL_CLOSE is not configured")

--- a/src/overlay/test/OverlayTests.cpp
+++ b/src/overlay/test/OverlayTests.cpp
@@ -2253,8 +2253,10 @@ TEST_CASE("database is purged at overlay start", "[overlay]")
     auto app = createTestApplication(clock, cfg, true, false);
     auto& om = app->getOverlayManager();
     auto& peerManager = om.getPeerManager();
-    auto record = [](size_t numFailures) {
-        return PeerRecord{{}, numFailures, static_cast<int>(PeerType::INBOUND)};
+    auto record = [app](size_t numFailures) {
+        return PeerRecord{
+            VirtualClock::systemPointToTm(app->getClock().system_now()),
+            numFailures, static_cast<int>(PeerType::INBOUND)};
     };
 
     // Need to set max tx size on tests that start OverlayManager without

--- a/src/overlay/test/PeerManagerTests.cpp
+++ b/src/overlay/test/PeerManagerTests.cpp
@@ -513,8 +513,10 @@ TEST_CASE("purge peer table", "[overlay][PeerManager]")
     VirtualClock clock;
     auto app = createTestApplication(clock, getTestConfig());
     auto& peerManager = app->getOverlayManager().getPeerManager();
-    auto record = [](size_t numFailures) {
-        return PeerRecord{{}, numFailures, static_cast<int>(PeerType::INBOUND)};
+    auto record = [&app](size_t numFailures) {
+        return PeerRecord{
+            VirtualClock::systemPointToTm(app->getClock().system_now()),
+            numFailures, static_cast<int>(PeerType::INBOUND)};
     };
 
     peerManager.store(localhost(1), record(1), false);

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -594,10 +594,10 @@ closeLedgerOn(Application& app, uint32 ledgerSeq, TimePoint closeTime,
     }
     app.getHerder().externalizeValue(txSet.first, ledgerSeq, closeTime,
                                      upgrades);
-    // NB: this assert will probably stop being true when background apply is
-    // turned on by default: externalize will have handed the ledger off to
-    // apply but not yet received the results of apply or updated LCL. The fix
-    // should be just to crank here until LCL advances to ledgerSeq.
+    while (app.getLedgerManager().getLastClosedLedgerNum() < ledgerSeq)
+    {
+        app.getClock().crank(true);
+    }
     releaseAssert(app.getLedgerManager().getLastClosedLedgerNum() == ledgerSeq);
     auto& lm = static_cast<LedgerManagerImpl&>(app.getLedgerManager());
     return lm.mLatestTxResultSet;

--- a/src/util/test/TimerTests.cpp
+++ b/src/util/test/TimerTests.cpp
@@ -105,6 +105,7 @@ TEST_CASE("virtual time with background work", "[timer]")
     // is outstanding.
     Config cfg(getTestConfig(0, Config::TESTDB_POSTGRESQL));
     cfg.EXPERIMENTAL_PARALLEL_LEDGER_APPLY = true;
+    cfg.RUN_STANDALONE = false;
 
     VirtualClock clock;
     Application::pointer appPtr = createTestApplication(clock, cfg);

--- a/tsan.supp
+++ b/tsan.supp
@@ -6,3 +6,7 @@
 # This is a false positive - the actual synchronization is handled internally by ASIO
 race:asio::detail::kqueue_reactor::allocate_descriptor_state
 race:asio::detail::kqueue_reactor::run
+
+# ApplicationImpl vptr race
+# vptr race during ApplicationImpl destruction
+race:ApplicationImpl::~ApplicationImpl


### PR DESCRIPTION
As we're planning to enable various parallel features by default, this PR cleans up some test paths and hardens the code. Concrete changes are:
- Crank in tests to support async apply flow
- Harden shutdown paths (avoid calling LM in App destructor - if BM initialization throws, LM is null)
- Don't parallel apply in standalone mode (as it expects immediate result)
- Test fixes to properly work with Postgres (e.g. make timestamps valid to avoid pg complaining)