### PR TITLE
Add apply-load mode for searching ledger limits.

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -756,6 +756,7 @@ exit /b 0
     <ClCompile Include="..\..\src\util\BinaryFuseFilter.cpp" />
     <ClCompile Include="..\..\src\util\DebugMetaUtils.cpp" />
     <ClCompile Include="..\..\src\util\FileSystemException.cpp" />
+    <ClCompile Include="..\..\src\util\MetricsRegistry.cpp" />
     <ClCompile Include="..\..\src\util\ProtocolVersion.cpp" />
     <ClCompile Include="..\..\src\util\LogSlowExecution.cpp" />
     <ClCompile Include="..\..\src\util\RandHasher.cpp" />
@@ -1175,6 +1176,7 @@ exit /b 0
     <ClInclude Include="..\..\src\util\BufferedAsioCerealOutputArchive.h" />
     <ClInclude Include="..\..\src\util\DebugMetaUtils.h" />
     <ClInclude Include="..\..\src\util\Decoder.h" />
+    <ClInclude Include="..\..\src\util\MetricsRegistry.h" />
     <ClInclude Include="..\..\src\util\ProtocolVersion.h" />
     <ClInclude Include="..\..\src\util\numeric128.h" />
     <ClInclude Include="..\..\src\util\RandHasher.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1432,6 +1432,9 @@
     <ClCompile Include="..\..\src\util\SimpleTimer.cpp">
       <Filter>util</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\util\MetricsRegistry.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\util\cpptoml.h">
@@ -2540,6 +2543,9 @@
       <Filter>invariant</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\util\SimpleTimer.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\MetricsRegistry.h">
       <Filter>util</Filter>
     </ClInclude>
   </ItemGroup>

--- a/docs/apply-load-limits-for-model-tx.cfg
+++ b/docs/apply-load-limits-for-model-tx.cfg
@@ -1,0 +1,114 @@
+# This is the Stellar Core configuration example for using the load generation 
+# (apply-load) tool for finding the maximum ledger limits by applying a number
+# of the equivalent 'model' transactions. 
+#
+# The mode will find the maximum value of N, such that closing a ledger 
+# with N 'model' transactions takes less than a certain target time. Then
+# it will find the actual ledger limits by multiplying the 'model' transaction
+# dimensions by N.
+#
+# This is not meant to be used in any production contexts.
+#
+# The core with this configuration should be run using `./stellar-core apply-load --mode limits-for-model-tx`
+
+# Enable load generation
+ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING=true
+
+# Diagnostic events should generally be disabled, but can be enabled for debug
+ENABLE_SOROBAN_DIAGNOSTIC_EVENTS = false
+
+# Target average ledger close time.
+APPLY_LOAD_TARGET_CLOSE_TIME_MS = 600
+
+# Network configuration section
+
+# Most of the network configuration will be inferred automatically from the 'model'
+# transaction (for transaction limits) and from the search itself (for the ledger)
+# limits. Only the following limits need to be set:
+
+# Maximum number of Soroban transactions to apply. This is the upper bound for the
+# search.
+APPLY_LOAD_MAX_SOROBAN_TX_COUNT = 2000
+
+# Number of the transaction clusters and thus apply threads. This will stay constant
+# during the search, unlike all the other ledger limits.
+APPLY_LOAD_LEDGER_MAX_DEPENDENT_TX_CLUSTERS = 8
+
+# The following section contains various parameters for the generated load.
+
+# Number of ledgers to close for benchmarking each iteration of search.
+# The average close time will then be compared to APPLY_LOAD_TARGET_CLOSE_TIME_MS.
+APPLY_LOAD_NUM_LEDGERS = 10
+
+# Generate that many simple Classic payment transactions in every benchmark ledger.
+# Note, that this will affect the close time.
+APPLY_LOAD_CLASSIC_TXS_PER_LEDGER = 0
+
+# Size of every synthetic data entry generated.
+# This setting affects both the size of the pre-generated Bucket List entries,
+# and the size of every entry that a Soroban transaction reads/writes.
+APPLY_LOAD_DATA_ENTRY_SIZE = 250
+
+# Bucket list pre-generation
+
+# The benchmark will pre-generate ledger entries using the simplified ledger
+# close process; the generated ledgers won't be reflected in the meta or
+# history checkpoints.
+
+# Faster settings, more shallow BL (up to level 6)
+# Number of ledgers to close
+APPLY_LOAD_BL_SIMULATED_LEDGERS = 10000
+# Write a batch of entries every that many ledgers
+APPLY_LOAD_BL_WRITE_FREQUENCY = 1000
+# Write that many entries in every batch
+APPLY_LOAD_BL_BATCH_SIZE = 1000
+# Write entry batches in every ledger of this many last ledgers
+APPLY_LOAD_BL_LAST_BATCH_SIZE = 100
+# Write that many entries in every 'last' ledger
+APPLY_LOAD_BL_LAST_BATCH_LEDGERS = 300
+
+# Slower settings, deeper BL (up to level 9)
+#APPLY_LOAD_BL_SIMULATED_LEDGERS = 300000
+#APPLY_LOAD_BL_WRITE_FREQUENCY = 10000
+#APPLY_LOAD_BL_BATCH_SIZE = 10000
+#APPLY_LOAD_BL_LAST_BATCH_LEDGERS = 300
+#APPLY_LOAD_BL_LAST_BATCH_SIZE = 100
+
+# Settings for the generated 'model' transaction.
+# Unlike the 'limit-based' apply-load mode, only a single value
+# with `[1]` as distribution is allowed, thus only a single kind
+# of transaction will be generated.
+
+# Number of *disk* reads a transaction performs. Every disk read is restoration,
+# so it's also a write (accounted for in NUM_RW_ENTRIES).
+APPLY_LOAD_NUM_DISK_READ_ENTRIES = [1]
+APPLY_LOAD_NUM_DISK_READ_ENTRIES_DISTRIBUTION = [1]
+
+# Number of writes a transaction performs.
+APPLY_LOAD_NUM_RW_ENTRIES = [5]
+APPLY_LOAD_NUM_RW_ENTRIES_DISTRIBUTION = [1]
+
+# Number of 80-byte events a transaction emits.
+APPLY_LOAD_EVENT_COUNT = [15]
+APPLY_LOAD_EVENT_COUNT_DISTRIBUTION = [1]
+
+# Size of a generated transaction.
+APPLY_LOAD_TX_SIZE_BYTES = [1650]
+APPLY_LOAD_TX_SIZE_BYTES_DISTRIBUTION = [1]
+
+# Number of instructions a transaction will use.
+APPLY_LOAD_INSTRUCTIONS = [4250000]
+APPLY_LOAD_INSTRUCTIONS_DISTRIBUTION = [1]
+
+
+# Minimal core config boilerplate
+
+RUN_STANDALONE=true
+NODE_IS_VALIDATOR=true
+UNSAFE_QUORUM=true
+NETWORK_PASSPHRASE="Standalone Network ; February 2017"
+NODE_SEED="SDQVDISRYN2JXBS7ICL7QJAEKB3HWBJFP2QECXG7GZICAHBK4UNJCWK2 self"
+
+[QUORUM_SET]
+THRESHOLD_PERCENT=100
+VALIDATORS=["$self"]

--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -29,13 +29,18 @@ Command options can only by placed after command.
     synthetic ledger close metadata emitted during the benchmark, and then use
     it for benchmarking the meta consumers.
   * This can only be used when `ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING=true`
+  * The command supports several modes:
+    - **--mode limit-based**: the default mode that measures the
+      ledger close time for applying transactions.
+    - **--mode max-sac-tps**: determines maximum TPS for the load consisting
+      only of fast SAC transfer
+    - **--mode limits-for-model-tx**: determines maximum ledger limits for the
+      load consisting only of a customizable 'model' transaction.
   * Load generation is configured in the Core config file. The relevant settings
     all begin with `APPLY_LOAD_`. See full example configurations with
     per-setting documentation in the `docs` directory
-    (`apply-load.cfg`, `apply-load-for-meta.cfg`).
-  * The command also supports the special mode for determining max apply 'TPS'
-    using SAC transfers. It can be invoked by passing `max-sac-tps` as
-    `apply-load` argument.
+    (all the `apply-load-*.cfg` files demonstrate different modes and use 
+    cases).
 
 * **calculate-asset-supply**: Calculates total supply of an asset from the live and hot archive bucket lists IF the total supply fits in a 64 bit signed integer. Also validates against totalCoins for the native asset. Uses `--code <CODE>` and `--issuer <ISSUER>` to specify the asset. Uses the native asset if neither `--code` nor `--issuer` is given.
 * **catchup <DESTINATION-LEDGER/LEDGER-COUNT>**: Perform catchup from history

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -1742,19 +1742,18 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                  }},
                 {"APPLY_LOAD_NUM_LEDGERS",
                  [&]() { APPLY_LOAD_NUM_LEDGERS = readInt<uint32_t>(item); }},
-                {"APPLY_LOAD_MAX_SAC_TPS_TARGET_CLOSE_TIME_MS",
+                {"APPLY_LOAD_TARGET_CLOSE_TIME_MS",
                  [&]() {
-                     APPLY_LOAD_MAX_SAC_TPS_TARGET_CLOSE_TIME_MS =
+                     APPLY_LOAD_TARGET_CLOSE_TIME_MS =
                          readInt<uint32_t>(item, 1);
-                     if (APPLY_LOAD_MAX_SAC_TPS_TARGET_CLOSE_TIME_MS %
-                             ApplyLoad::MAX_SAC_TPS_TIME_STEP_MS !=
+                     if (APPLY_LOAD_TARGET_CLOSE_TIME_MS %
+                             ApplyLoad::TARGET_CLOSE_TIME_STEP_MS !=
                          0)
                      {
-                         throw std::invalid_argument(
-                             fmt::format(FMT_STRING("APPLY_LOAD_MAX_SAC_TPS_"
-                                                    "TARGET_CLOSE_TIME_MS must "
-                                                    "be a multiple of {}."),
-                                         ApplyLoad::MAX_SAC_TPS_TIME_STEP_MS));
+                         throw std::invalid_argument(fmt::format(
+                             FMT_STRING("APPLY_LOAD_TARGET_CLOSE_TIME_MS "
+                                        "must be a multiple of {}."),
+                             ApplyLoad::TARGET_CLOSE_TIME_STEP_MS));
                      }
                  }},
                 {"APPLY_LOAD_MAX_SAC_TPS_MIN_TPS",

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -386,7 +386,15 @@ class Config : public std::enable_shared_from_this<Config>
 
     uint32_t APPLY_LOAD_LEDGER_MAX_DEPENDENT_TX_CLUSTERS = 1;
 
+    // Number of ledgers to apply in apply-load.
+    // Depending on the mode this represents either the total number of ledgers
+    // to close for benchmarking, or the number of ledgers to apply per
+    // iteration of binary search for modes that perform search.
     uint32_t APPLY_LOAD_NUM_LEDGERS = 100;
+
+    // Target ledger close time in milliseconds for modes that perform binary
+    // search of TPS or limits.
+    uint32_t APPLY_LOAD_TARGET_CLOSE_TIME_MS = 1000;
 
     // Number of classic transactions to include in each ledger in ledger limit
     // based apply-load mode.
@@ -412,7 +420,6 @@ class Config : public std::enable_shared_from_this<Config>
     std::vector<uint32_t> APPLY_LOAD_EVENT_COUNT_DISTRIBUTION;
 
     // MAX_SAC_TPS mode specific parameters
-    uint32_t APPLY_LOAD_MAX_SAC_TPS_TARGET_CLOSE_TIME_MS = 1000;
     uint32_t APPLY_LOAD_MAX_SAC_TPS_MIN_TPS = 100;
     uint32_t APPLY_LOAD_MAX_SAC_TPS_MAX_TPS = 50000;
 

--- a/src/simulation/ApplyLoad.h
+++ b/src/simulation/ApplyLoad.h
@@ -17,6 +17,8 @@ enum class ApplyLoadMode
 {
     // Generate load within the configured ledger limits.
     LIMIT_BASED,
+    // Generate load that finds max ledger limits for the 'model' transaction.
+    FIND_LIMITS_FOR_MODEL_TX,
     // Generate load that only finds max TPS for the cheap operations (SAC
     // transfers), ignoring ledger limits.
     MAX_SAC_TPS
@@ -25,32 +27,22 @@ enum class ApplyLoadMode
 class ApplyLoad
 {
   public:
-    ApplyLoad(Application& app,
-              ApplyLoadMode mode = ApplyLoadMode::LIMIT_BASED);
+    ApplyLoad(Application& app, ApplyLoadMode mode);
 
-    void closeLedger(std::vector<TransactionFrameBasePtr> const& txs,
-                     xdr::xvector<UpgradeType, 6> const& upgrades = {},
-                     bool recordSorobanUtilization = false);
-
-    // Fills up a list of transactions with
-    // SOROBAN_TRANSACTION_QUEUE_SIZE_MULTIPLIER * the max ledger resources
-    // specified in the ApplyLoad constructor, create a TransactionSet out of
-    // those transactions, and then close a ledger with that TransactionSet. The
-    // generated transactions are generated using the LOADGEN_* config
-    // parameters.
-    void benchmark();
-
-    // Generates SAC transactions and times just the application phase (fee and
-    // sequence number processing, tx execution, and post process, but no disk
-    // writes). This will do a binary search from APPLY_LOAD_MAX_SAC_TPS_MIN_TPS
-    // to APPLY_LOAD_MAX_SAC_TPS_MAX_TPS, attempting to find the largest
-    // transaction set we can execute in under
-    // APPLY_LOAD_MAX_SAC_TPS_TARGET_CLOSE_TIME_MS.
-    void findMaxSacTps();
+    // Execute the benchmark according to the mode specified in the constructor.
+    void execute();
 
     // Returns the % of transactions that succeeded during apply time. The range
     // of values is [0,1.0].
     double successRate();
+
+    // Closes a ledger with the given transactions and optional upgrades.
+    // `recordSorobanUtilization` indicates whether to record utilization of
+    // Soroban resources in transaction set, this should only be necessary for
+    // the benchmark runs.
+    void closeLedger(std::vector<TransactionFrameBasePtr> const& txs,
+                     xdr::xvector<UpgradeType, 6> const& upgrades = {},
+                     bool recordSorobanUtilization = false);
 
     // These metrics track what percentage of available resources were used when
     // creating the list of transactions in benchmark().
@@ -66,11 +58,12 @@ class ApplyLoad
 
     // Returns LedgerKey for pre-populated archived state at the given index.
     static LedgerKey getKeyForArchivedEntry(uint64_t index);
-    static uint32_t calculateRequiredHotArchiveEntries(Config const& cfg);
+    static uint32_t calculateRequiredHotArchiveEntries(ApplyLoadMode mode,
+                                                       Config const& cfg);
 
     // The target time to close a ledger when running in MAX_SAC_TPS mode must
-    // be a multiple of MAX_SAC_TPS_TIME_STEP_MS.
-    static uint32_t const MAX_SAC_TPS_TIME_STEP_MS = 50;
+    // be a multiple of TARGET_CLOSE_TIME_STEP_MS.
+    static uint32_t const TARGET_CLOSE_TIME_STEP_MS = 50;
 
   private:
     void setup();
@@ -82,9 +75,44 @@ class ApplyLoad
     void setupBatchTransferContracts();
     void setupBucketList();
 
+    // Runs for `execute() in `ApplyLoadMode::LIMIT_BASED` mode.
+    // Runs APPLY_LOAD_NUM_LEDGERS iterations of `benchmarkLimitsIteration` and
+    // outputs the measured ledger close time metrics, as well as some other
+    // support metrics.
+    void benchmarkLimits();
+
+    // Runs for `execute() in `ApplyLoadMode::FIND_LIMITS_FOR_MODEL_TX` mode.
+    // Generates transactions according to the 'model' transaction parameters
+    // (specified via the transaction generation config), and does a binary
+    // search for the maximum number of such transactions that can fit into
+    // ledger while not exceeding APPLY_LOAD_TARGET_CLOSE_TIME_MS ledger close
+    // time.
+    // After finding the maximum number of model transactions, outputs the
+    // respective ledger limits.
+    // This also performs some rounding on the ledger limits to make the binary
+    // search faster, and also to produce more readable limits.
+    void findMaxLimitsForModelTransaction();
+
+    // Runs for `execute() in `ApplyLoadMode::MAX_SAC_TPS` mode.
+    // Generates SAC transactions and times just the application phase (fee and
+    // sequence number processing, tx execution, and post process, but no disk
+    // writes). This will do a binary search from APPLY_LOAD_MAX_SAC_TPS_MIN_TPS
+    // to APPLY_LOAD_MAX_SAC_TPS_MAX_TPS, attempting to find the largest
+    // transaction set we can execute in under
+    // APPLY_LOAD_TARGET_CLOSE_TIME_MS.
+    void findMaxSacTps();
+
     // Run iterations at the given TPS. Reports average time over all runs, in
     // milliseconds.
     double benchmarkSacTps(uint32_t targetTps);
+
+    // Fills up a list of transactions with
+    // SOROBAN_TRANSACTION_QUEUE_SIZE_MULTIPLIER * the max ledger resources
+    // specified in the ApplyLoad constructor, create a TransactionSet out of
+    // those transactions, and then close a ledger with that TransactionSet. The
+    // generated transactions are generated using the LOADGEN_* config
+    // parameters.
+    void benchmarkLimitsIteration();
 
     // Generates the given number of native asset SAC payment TXs with no
     // conflicts.
@@ -108,20 +136,17 @@ class ApplyLoad
     // Helper method to apply a config upgrade
     void applyConfigUpgrade(SorobanUpgradeConfig const& upgradeConfig);
 
-    LedgerKey mUpgradeCodeKey;
-    LedgerKey mUpgradeInstanceKey;
-
-    LedgerKey mLoadCodeKey;
-    // Used to generate soroban load transactions
-    TxGenerator::ContractInstance mLoadInstance;
-    // Used to generate XLM payments
-    TxGenerator::ContractInstance mSACInstanceXLM;
-    // Used for batch transfers, one instance for each cluster
-    std::vector<TxGenerator::ContractInstance> mBatchTransferInstances;
-    size_t mDataEntryCount = 0;
-    size_t mDataEntrySize = 0;
+    // Updates the configuration settings such a way to accommodate around
+    // `txsPerLedger` 'model' transactions per ledger for the
+    // `FIND_LIMITS_FOR_MODEL_TX` mode.
+    // Returns the network configuration to use for upgrade and the actual
+    // number of transactions that can fit withing the limits (it may be
+    // slightly lower than `txsPerLedger` due to rounding).
+    std::pair<SorobanUpgradeConfig, uint64_t>
+    updateSettingsForTxCount(uint64_t txsPerLedger);
 
     Application& mApp;
+    ApplyLoadMode mMode;
     TxGenerator::TestAccountPtr mRoot;
 
     uint32_t mNumAccounts;
@@ -135,8 +160,20 @@ class ApplyLoad
     medida::Histogram& mDiskReadEntryUtilization;
     medida::Histogram& mWriteEntryUtilization;
 
-    ApplyLoadMode mMode;
     TxGenerator mTxGenerator;
+
+    LedgerKey mUpgradeCodeKey;
+    LedgerKey mUpgradeInstanceKey;
+
+    LedgerKey mLoadCodeKey;
+    // Used to generate soroban load transactions
+    TxGenerator::ContractInstance mLoadInstance;
+    // Used to generate XLM payments
+    TxGenerator::ContractInstance mSACInstanceXLM;
+    // Used for batch transfers, one instance for each cluster
+    std::vector<TxGenerator::ContractInstance> mBatchTransferInstances;
+    size_t mDataEntryCount = 0;
+    size_t mDataEntrySize = 0;
 
     // Counter for generating unique destination addresses for SAC payments
     uint32_t mDestCounter = 0;

--- a/src/simulation/TxGenerator.cpp
+++ b/src/simulation/TxGenerator.cpp
@@ -559,7 +559,7 @@ TxGenerator::invokeSorobanLoadTransactionV2(
     // functions (maybe with a small constant factor as well).
     uint32_t const baseInstructionCount = 737'119;
     uint32_t const baselineTxSizeBytes = 256;
-    uint32_t const eventSize = 80;
+    uint32_t const eventSize = TxGenerator::SOROBAN_LOAD_V2_EVENT_SIZE_BYTES;
     uint32_t const instructionsPerGuestCycle = 40;
     uint32_t const instructionsPerHostCycle = 4'875;
     uint32_t const instructionsPerAuthByte = 35;
@@ -656,6 +656,9 @@ TxGenerator::invokeSorobanLoadTransactionV2(
     uint32_t targetInstructions =
         sampleDiscrete(appCfg.APPLY_LOAD_INSTRUCTIONS,
                        appCfg.APPLY_LOAD_INSTRUCTIONS_DISTRIBUTION, 0u);
+    resources.instructions = targetInstructions;
+    resources.writeBytes = entriesWriteSize;
+    resources.diskReadBytes = dataEntrySize * archiveEntriesToRestore;
 
     auto numEntries =
         (rwEntries + archiveEntriesToRestore + instance.readOnlyKeys.size());
@@ -707,14 +710,7 @@ TxGenerator::invokeSorobanLoadTransactionV2(
     ihf.invokeContract().args = {makeU32(guestCycles), makeU32(hostCycles),
                                  makeU32(eventCount)};
 
-    resources.writeBytes = entriesWriteSize;
-    resources.diskReadBytes = dataEntrySize * archiveEntriesToRestore;
-
     increaseOpSize(op, paddingBytes);
-
-    resources.instructions = instructionsWithoutCpuLoad +
-                             hostCycles * instructionsPerHostCycle +
-                             guestCycles * instructionsPerGuestCycle;
 
     auto resourceFee =
         sorobanResourceFee(mApp, resources, txOverheadBytes + paddingBytes,

--- a/src/simulation/TxGenerator.h
+++ b/src/simulation/TxGenerator.h
@@ -95,6 +95,7 @@ class TxGenerator
     // Instructions per SAC transaction
     static constexpr uint64_t SAC_TX_INSTRUCTIONS = 250'000;
     static constexpr uint64_t BATCH_TRANSFER_TX_INSTRUCTIONS = 500'000;
+    static constexpr uint32_t SOROBAN_LOAD_V2_EVENT_SIZE_BYTES = 80;
 
     // Special account ID to represent the root account
     static uint64_t const ROOT_ACCOUNT_ID;


### PR DESCRIPTION
# Description

Add apply-load mode for searching ledger limits.

The new mode finds the ledger limits that allow applying the maximum possible TPL that still allows closing ledgers within the configured time limit, e.g. find how many Soroswap-like transactions can be applied within N ms, and what are the respective ledger limits (with some rounding to get nicer numbers).

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
