### PR TITLE
Revert Dockerfile changes to expect DISTRO appended to STELLAR_CORE_VERSION to unstick Jenkins pipeline job

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN /setup
 #install stellar-core
 RUN wget -qO - https://apt.stellar.org/SDF.asc | apt-key add -
 RUN echo "deb https://apt.stellar.org ${DISTRO} unstable" | tee -a /etc/apt/sources.list.d/SDF-unstable.list
-RUN apt-get update && apt-get install -y stellar-core=${STELLAR_CORE_VERSION}.${DISTRO}
+RUN apt-get update && apt-get install -y stellar-core=${STELLAR_CORE_VERSION}
 
 WORKDIR "/etc/stellar"
 ENTRYPOINT ["/usr/bin/stellar-core"]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -7,7 +7,7 @@ BUILD_DATE := $(shell date -u +%FT%TZ)
 # Base image, defaults to ubuntu 24.04 noble
 DISTRO ?= noble
 
-# Deb package version to use. For example "24.1.0-2861.5a7035d49"
+# Deb package version to use. For example "24.1.1-2888.659131984.noble"
 # Not needed for testing builds
 STELLAR_CORE_VERSION ?=
 
@@ -18,7 +18,7 @@ endif
 
 docker-build:
 ifndef STELLAR_CORE_VERSION
-	$(error STELLAR_CORE_VERSION environment variable must be set. For example STELLAR_CORE_VERSION=23.0.2-2724.7b9e6c863)
+	$(error STELLAR_CORE_VERSION environment variable must be set. For example STELLAR_CORE_VERSION=24.1.1-2888.659131984.noble)
 endif
 ifndef TAG
 	TAG = stellar/stellar-core:$(STELLAR_CORE_VERSION)

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,16 +10,15 @@ It uses the official stellar-core deb package for two reasons:
 1. To ensure docker and non-docker environments run the same build
 2. To allow binaries to be cryptographically verified
 
-To build set `STELLAR_CORE_VERSION` to the base deb package version you want installed (without the distro suffix). `DISTRO` will default to Ubuntu 24.04 noble if not passed in.
+To build set `STELLAR_CORE_VERSION` to the base deb package version you want installed (with the distro suffix). 
 For example:
 ```
-export STELLAR_CORE_VERSION=24.1.0-2861.5a7035d49
-export DISTRO=jammy
+export STELLAR_CORE_VERSION=24.1.1-2888.659131984.noble
+export DISTRO=noble
 export TAG=${USER}/stellar-core:${STELLAR_CORE_VERSION}
 make docker-build
 ```
 
-Note: The Dockerfile will automatically append `.${DISTRO}` to the version when installing the package.
 
 ## Dockerfile.testing
 


### PR DESCRIPTION
### what
Dockerfile to expect DISTRO to be already present and appended to STELLAR_CORE_VERSION passed in

### what
Our Jenkins docker pipeline job does append the distro and passes it suffixed to STELLAR_CORE_VERSION so the last change broke the pipeline. Though it was nice to keep them separate but we want to unstick the pipeline job and do this cleanup in future.