### PR TITLE
Don't populate inner feeCharged in fee bump tx results starting from p25

### DIFF
--- a/src/testdata/ledger-close-meta-enable-classic-events-v2-protocol-25.json
+++ b/src/testdata/ledger-close-meta-enable-classic-events-v2-protocol-25.json
@@ -6,7 +6,7 @@
                 "v": 0
             },
             "ledgerHeader": {
-                "hash": "c36dbcf4cd37a4708bd494ad8259909e0583ccd725bdd37661c411eca23d8e2c",
+                "hash": "5321c8fbac9385389b445d07cf35f1157ba8092fa47779c0df222c68a29450ea",
                 "header": {
                     "ledgerVersion": 25,
                     "previousLedgerHash": "735ce52c69370122eb1a5daeca4600416b916062e10a977098e7a3999c50a8e4",
@@ -22,7 +22,7 @@
                             }
                         }
                     },
-                    "txSetResultHash": "2faeae31b9d73430feb6398a535833e52b512c0822da128266d3327e43928625",
+                    "txSetResultHash": "fd6fb3b06784653ffa2057ae36184c8d9ee185c4ae35f0ba9e076059746fb659",
                     "bucketListHash": "15ceac27d4c9e86c5ebe6e7553deb81e3729660bc4dbf8e6bf37aa29de0ff615",
                     "ledgerSeq": 10,
                     "totalCoins": 1000000000000000000,
@@ -199,7 +199,7 @@
                                 "innerResultPair": {
                                     "transactionHash": "ef356999aea407ce7c1a16e0640065bcf9b1e853ae8f1730a816a5152ceb28e6",
                                     "result": {
-                                        "feeCharged": 200,
+                                        "feeCharged": 0,
                                         "result": {
                                             "code": "txSUCCESS",
                                             "results": [

--- a/src/testdata/ledger-close-meta-enable-classic-events-v2-protocol-26.json
+++ b/src/testdata/ledger-close-meta-enable-classic-events-v2-protocol-26.json
@@ -6,7 +6,7 @@
                 "v": 0
             },
             "ledgerHeader": {
-                "hash": "a271ddb6f63f30cc62db8920b208b9f56e667dec5c25da682a88f6dce13b1cff",
+                "hash": "9dc74e30127db15c9ab287a572608781cb2e526977aea8b2966b8f7ed3008845",
                 "header": {
                     "ledgerVersion": 26,
                     "previousLedgerHash": "90643a66e0ad62f31dbe03ec011b336208246b07ffd8c816d7eab49d8327afb1",
@@ -22,7 +22,7 @@
                             }
                         }
                     },
-                    "txSetResultHash": "7888c59bd2faad45dcefb4ed58d4a392c284c1e4a28395042ea9c061d57c05e5",
+                    "txSetResultHash": "7f284d6f6089dcf4f3b44a28922ac95858dcbfc529cadb03e4ebc4d20a558dea",
                     "bucketListHash": "9171cba98f6a77f4737e16ca99330a8351b03452a98c9c30f3e62c1bc0a65c97",
                     "ledgerSeq": 10,
                     "totalCoins": 1000000000000000000,
@@ -725,7 +725,7 @@
                                 "innerResultPair": {
                                     "transactionHash": "ef356999aea407ce7c1a16e0640065bcf9b1e853ae8f1730a816a5152ceb28e6",
                                     "result": {
-                                        "feeCharged": 200,
+                                        "feeCharged": 0,
                                         "result": {
                                             "code": "txSUCCESS",
                                             "results": [

--- a/src/testdata/ledger-close-meta-v2-protocol-25.json
+++ b/src/testdata/ledger-close-meta-v2-protocol-25.json
@@ -6,7 +6,7 @@
                 "v": 0
             },
             "ledgerHeader": {
-                "hash": "c36dbcf4cd37a4708bd494ad8259909e0583ccd725bdd37661c411eca23d8e2c",
+                "hash": "5321c8fbac9385389b445d07cf35f1157ba8092fa47779c0df222c68a29450ea",
                 "header": {
                     "ledgerVersion": 25,
                     "previousLedgerHash": "735ce52c69370122eb1a5daeca4600416b916062e10a977098e7a3999c50a8e4",
@@ -22,7 +22,7 @@
                             }
                         }
                     },
-                    "txSetResultHash": "2faeae31b9d73430feb6398a535833e52b512c0822da128266d3327e43928625",
+                    "txSetResultHash": "fd6fb3b06784653ffa2057ae36184c8d9ee185c4ae35f0ba9e076059746fb659",
                     "bucketListHash": "15ceac27d4c9e86c5ebe6e7553deb81e3729660bc4dbf8e6bf37aa29de0ff615",
                     "ledgerSeq": 10,
                     "totalCoins": 1000000000000000000,
@@ -199,7 +199,7 @@
                                 "innerResultPair": {
                                     "transactionHash": "ef356999aea407ce7c1a16e0640065bcf9b1e853ae8f1730a816a5152ceb28e6",
                                     "result": {
-                                        "feeCharged": 200,
+                                        "feeCharged": 0,
                                         "result": {
                                             "code": "txSUCCESS",
                                             "results": [

--- a/src/testdata/ledger-close-meta-v2-protocol-26.json
+++ b/src/testdata/ledger-close-meta-v2-protocol-26.json
@@ -6,7 +6,7 @@
                 "v": 0
             },
             "ledgerHeader": {
-                "hash": "a271ddb6f63f30cc62db8920b208b9f56e667dec5c25da682a88f6dce13b1cff",
+                "hash": "9dc74e30127db15c9ab287a572608781cb2e526977aea8b2966b8f7ed3008845",
                 "header": {
                     "ledgerVersion": 26,
                     "previousLedgerHash": "90643a66e0ad62f31dbe03ec011b336208246b07ffd8c816d7eab49d8327afb1",
@@ -22,7 +22,7 @@
                             }
                         }
                     },
-                    "txSetResultHash": "7888c59bd2faad45dcefb4ed58d4a392c284c1e4a28395042ea9c061d57c05e5",
+                    "txSetResultHash": "7f284d6f6089dcf4f3b44a28922ac95858dcbfc529cadb03e4ebc4d20a558dea",
                     "bucketListHash": "9171cba98f6a77f4737e16ca99330a8351b03452a98c9c30f3e62c1bc0a65c97",
                     "ledgerSeq": 10,
                     "totalCoins": 1000000000000000000,
@@ -654,7 +654,7 @@
                                 "innerResultPair": {
                                     "transactionHash": "ef356999aea407ce7c1a16e0640065bcf9b1e853ae8f1730a816a5152ceb28e6",
                                     "result": {
-                                        "feeCharged": 200,
+                                        "feeCharged": 0,
                                         "result": {
                                             "code": "txSUCCESS",
                                             "results": [

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -666,7 +666,11 @@ FeeBumpTransactionFrame::processFeeSeqNum(AbstractLedgerTxn& ltx,
         header.feePool += fee;
     }
 
-    int64_t innerFeeCharged = mInnerTx->getFee(header, baseFee, true);
+    int64_t innerFeeCharged = 0;
+    if (protocolVersionIsBefore(header.ledgerVersion, ProtocolVersion::V_25))
+    {
+        innerFeeCharged = mInnerTx->getFee(header, baseFee, true);
+    }
     return FeeBumpMutableTransactionResult::createSuccess(*mInnerTx, fee,
                                                           innerFeeCharged);
 }

--- a/src/transactions/MutableTransactionResult.cpp
+++ b/src/transactions/MutableTransactionResult.cpp
@@ -430,12 +430,15 @@ FeeBumpMutableTransactionResult::finalizeFeeRefund(uint32_t protocolVersion)
     {
         int64_t refund = mRefundableFeeTracker->getFeeRefund();
         mTxResult.feeCharged -= refund;
-        // This shouldn't be necessary as the inner result should always have 0
-        // fee. However, in fact we do populate the inner `feeCharged` field
-        // for the fee bump transactions and thus we also need to apply the
-        // refund to it.
-        // Changing this is a protocol change.
-        getInnerResult().feeCharged -= refund;
+        if (protocolVersionIsBefore(protocolVersion, ProtocolVersion::V_25))
+        {
+            // This shouldn't be necessary as the inner result should always
+            // have 0 fee. However, in fact we do populate the inner
+            // `feeCharged` field for the fee bump transactions and thus we also
+            // need to apply the refund to it.
+            // This was fixed in protocol 25.
+            getInnerResult().feeCharged -= refund;
+        }
     }
 }
 

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -1999,9 +1999,20 @@ TEST_CASE_VERSIONS("refund is sent to fee-bump source",
         auto const feeCharged =
             afterV20 ? initialFee - expectedRefund : initialFee;
 
-        REQUIRE(
-            r.results.at(0).result.result.innerResultPair().result.feeCharged ==
-            feeCharged - 100);
+        if (protocolVersionIsBefore(test.getLedgerVersion(),
+                                    ProtocolVersion::V_25))
+        {
+            REQUIRE(r.results.at(0)
+                        .result.result.innerResultPair()
+                        .result.feeCharged == feeCharged - 100);
+        }
+        else
+        {
+            REQUIRE(r.results.at(0)
+                        .result.result.innerResultPair()
+                        .result.feeCharged == 0);
+        }
+
         REQUIRE(r.results.at(0).result.feeCharged == feeCharged);
 
         REQUIRE(feeBumper.getBalance() ==


### PR DESCRIPTION
# Description

Resolves https://github.com/stellar/stellar-core/issues/4997

Don't populate inner feeCharged in fee bump tx results starting from p25.

Inner fee being non-zero has never been intentional (this is even documented in the XDR definition), but we actually had a bunch of tests that expected this behavior for some reason.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
