### PR TITLE
Remove deprecated Clang-Format style options and setting BreakAfterReturnType to ExceptShortType

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -14,9 +14,7 @@ AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
-AlwaysBreakAfterReturnType: AllDefinitions
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: false
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
@@ -38,18 +36,17 @@ BraceWrapping:
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
+BreakAfterReturnType: ExceptShortType
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Custom
-BreakBeforeInheritanceComma: false
 BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: true
 BreakConstructorInitializers: BeforeComma
-BreakAfterJavaFieldAnnotations: false
+BreakInheritanceList: AfterComma
 BreakStringLiterals: true
+BreakTemplateDeclarations: Leave
 ColumnLimit:     80
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
@@ -78,7 +75,10 @@ IndentWidth:     4
 IndentWrappedFunctionNames: false
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: true
+KeepEmptyLines:
+  AtStartOfBlock: false
+  AtStartOfFile: false
+  AtEndOfFile: false
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
@@ -86,6 +86,7 @@ NamespaceIndentation: None
 ObjCBlockIndentWidth: 2
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
+PackConstructorInitializers: NextLine
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
@@ -101,14 +102,12 @@ SpaceAfterCStyleCast: false
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements
-SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
 SpacesInAngles:  false
 SpacesInContainerLiterals: true
-SpacesInCStyleCastParentheses: false
-SpacesInParentheses: false
+SpacesInParens: Never
 SpacesInSquareBrackets: false
-Standard:        Cpp11
+Standard:        c++17
 TabWidth:        8
 UseTab:          Never
 UseCRLF: false

--- a/src/bucket/BucketApplicator.cpp
+++ b/src/bucket/BucketApplicator.cpp
@@ -57,8 +57,7 @@ BucketApplicator::BucketApplicator(Application& app,
     }
 }
 
-BucketApplicator::
-operator bool() const
+BucketApplicator::operator bool() const
 {
     // There is more work to do (i.e. (bool) *this == true) iff:
     // 1. The underlying bucket iterator is not EOF and
@@ -66,20 +65,17 @@ operator bool() const
     return static_cast<bool>(mBucketIter) && mOffersRemaining;
 }
 
-size_t
-BucketApplicator::pos()
+size_t BucketApplicator::pos()
 {
     return mBucketIter.pos();
 }
 
-size_t
-BucketApplicator::size() const
+size_t BucketApplicator::size() const
 {
     return mBucketIter.size();
 }
 
-static bool
-shouldApplyEntry(BucketEntry const& e)
+static bool shouldApplyEntry(BucketEntry const& e)
 {
     if (e.type() == LIVEENTRY || e.type() == INITENTRY)
     {
@@ -94,8 +90,7 @@ shouldApplyEntry(BucketEntry const& e)
     return LiveBucketIndex::typeNotSupported(e.deadEntry().type());
 }
 
-size_t
-BucketApplicator::advance(BucketApplicator::Counters& counters)
+size_t BucketApplicator::advance(BucketApplicator::Counters& counters)
 {
     size_t count = 0;
 
@@ -217,8 +212,7 @@ BucketApplicator::Counters::Counters(VirtualClock::time_point now)
     reset(now);
 }
 
-void
-BucketApplicator::Counters::reset(VirtualClock::time_point now)
+void BucketApplicator::Counters::reset(VirtualClock::time_point now)
 {
     mStarted = now;
     for (auto let : xdr::xdr_traits<LedgerEntryType>::enum_values())
@@ -228,8 +222,7 @@ BucketApplicator::Counters::reset(VirtualClock::time_point now)
     }
 }
 
-void
-BucketApplicator::Counters::getRates(
+void BucketApplicator::Counters::getRates(
     VirtualClock::time_point now,
     std::map<LedgerEntryType, CounterEntry>& sec_counters, uint64_t& T_sec,
     uint64_t& total)
@@ -248,8 +241,7 @@ BucketApplicator::Counters::getRates(
     T_sec = (total * 1000000) / usecs;
 }
 
-std::string
-BucketApplicator::Counters::logStr(
+std::string BucketApplicator::Counters::logStr(
     uint64_t total, uint64_t level, std::string const& bucketName,
     std::map<LedgerEntryType, CounterEntry> const& counters)
 {
@@ -266,10 +258,9 @@ BucketApplicator::Counters::logStr(
     return str;
 }
 
-void
-BucketApplicator::Counters::logInfo(std::string const& bucketName,
-                                    uint32_t level,
-                                    VirtualClock::time_point now)
+void BucketApplicator::Counters::logInfo(std::string const& bucketName,
+                                         uint32_t level,
+                                         VirtualClock::time_point now)
 {
     uint64_t T_sec, total;
     std::map<LedgerEntryType, CounterEntry> sec_counters;
@@ -280,10 +271,9 @@ BucketApplicator::Counters::logInfo(std::string const& bucketName,
               logStr(total, level, bucketName, mCounters));
 }
 
-void
-BucketApplicator::Counters::logDebug(std::string const& bucketName,
-                                     uint32_t level,
-                                     VirtualClock::time_point now)
+void BucketApplicator::Counters::logDebug(std::string const& bucketName,
+                                          uint32_t level,
+                                          VirtualClock::time_point now)
 {
     uint64_t T_sec, total;
     std::map<LedgerEntryType, CounterEntry> sec_counters;
@@ -292,8 +282,7 @@ BucketApplicator::Counters::logDebug(std::string const& bucketName,
                logStr(total, level, bucketName, sec_counters), T_sec);
 }
 
-void
-BucketApplicator::Counters::mark(BucketEntry const& e)
+void BucketApplicator::Counters::mark(BucketEntry const& e)
 {
     if (e.type() == LIVEENTRY || e.type() == INITENTRY)
     {

--- a/src/bucket/BucketBase.cpp
+++ b/src/bucket/BucketBase.cpp
@@ -32,8 +32,7 @@ namespace stellar
 {
 
 template <class BucketT, class IndexT>
-IndexT const&
-BucketBase<BucketT, IndexT>::getIndex() const
+IndexT const& BucketBase<BucketT, IndexT>::getIndex() const
 {
     ZoneScoped;
     releaseAssertOrThrow(!mFilename.empty());
@@ -42,15 +41,14 @@ BucketBase<BucketT, IndexT>::getIndex() const
 }
 
 template <class BucketT, class IndexT>
-bool
-BucketBase<BucketT, IndexT>::isIndexed() const
+bool BucketBase<BucketT, IndexT>::isIndexed() const
 {
     return static_cast<bool>(mIndex);
 }
 
 template <class BucketT, class IndexT>
-void
-BucketBase<BucketT, IndexT>::setIndex(std::unique_ptr<IndexT const>&& index)
+void BucketBase<BucketT, IndexT>::setIndex(
+    std::unique_ptr<IndexT const>&& index)
 {
     releaseAssertOrThrow(!mIndex);
     mIndex = std::move(index);
@@ -76,29 +74,25 @@ template <class BucketT, class IndexT> BucketBase<BucketT, IndexT>::BucketBase()
 }
 
 template <class BucketT, class IndexT>
-Hash const&
-BucketBase<BucketT, IndexT>::getHash() const
+Hash const& BucketBase<BucketT, IndexT>::getHash() const
 {
     return mHash;
 }
 
 template <class BucketT, class IndexT>
-std::filesystem::path const&
-BucketBase<BucketT, IndexT>::getFilename() const
+std::filesystem::path const& BucketBase<BucketT, IndexT>::getFilename() const
 {
     return mFilename;
 }
 
 template <class BucketT, class IndexT>
-size_t
-BucketBase<BucketT, IndexT>::getSize() const
+size_t BucketBase<BucketT, IndexT>::getSize() const
 {
     return mSize;
 }
 
 template <class BucketT, class IndexT>
-bool
-BucketBase<BucketT, IndexT>::isEmpty() const
+bool BucketBase<BucketT, IndexT>::isEmpty() const
 {
     if (mFilename.empty() || isZero(mHash))
     {
@@ -110,8 +104,7 @@ BucketBase<BucketT, IndexT>::isEmpty() const
 }
 
 template <class BucketT, class IndexT>
-void
-BucketBase<BucketT, IndexT>::freeIndex()
+void BucketBase<BucketT, IndexT>::freeIndex()
 {
     mIndex.reset(nullptr);
 }
@@ -182,8 +175,7 @@ BucketBase<BucketT, IndexT>::randomBucketIndexName(std::string const& tmpDir)
 // bucket enters the youngest level. At least one new bucket is in every merge's
 // shadows from then on in, so they all upgrade (and preserve lifecycle events).
 template <class BucketT, class IndexT>
-static void
-calculateMergeProtocolVersion(
+static void calculateMergeProtocolVersion(
     MergeCounters& mc, uint32_t maxProtocolVersion,
     BucketInputIterator<BucketT> const& oi,
     BucketInputIterator<BucketT> const& ni,
@@ -238,8 +230,7 @@ calculateMergeProtocolVersion(
 // not scrutinizing the entry type further.
 template <class BucketT, class IndexT, typename InputSource,
           typename... ShadowParams>
-static bool
-mergeCasesWithDefaultAcceptance(
+static bool mergeCasesWithDefaultAcceptance(
     BucketEntryIdCmp<BucketT> const& cmp, MergeCounters& mc,
     InputSource& inputSource,
     std::function<void(typename BucketT::EntryT const&)> putFunc,
@@ -285,8 +276,7 @@ mergeCasesWithDefaultAcceptance(
 
 template <class BucketT, class IndexT>
 template <typename InputSource, typename PutFuncT, typename... ShadowParams>
-void
-BucketBase<BucketT, IndexT>::mergeInternal(
+void BucketBase<BucketT, IndexT>::mergeInternal(
     BucketManager& bucketManager, InputSource& inputSource, PutFuncT putFunc,
     uint32_t protocolVersion, MergeCounters& mc, ShadowParams&&... shadowParams)
 {
@@ -337,8 +327,7 @@ BucketBase<BucketT, IndexT>::mergeInternal(
 }
 
 template <class BucketT, class IndexT>
-std::shared_ptr<BucketT>
-BucketBase<BucketT, IndexT>::merge(
+std::shared_ptr<BucketT> BucketBase<BucketT, IndexT>::merge(
     BucketManager& bucketManager, uint32_t maxProtocolVersion,
     std::shared_ptr<BucketT> const& oldBucket,
     std::shared_ptr<BucketT> const& newBucket,

--- a/src/bucket/BucketBase.h
+++ b/src/bucket/BucketBase.h
@@ -148,8 +148,7 @@ class BucketBase : public NonMovableOrCopyable
     static std::string randomBucketIndexName(std::string const& tmpDir);
 
 #ifdef BUILD_TESTS
-    IndexT const&
-    getIndexForTesting() const
+    IndexT const& getIndexForTesting() const
     {
         return getIndex();
     }

--- a/src/bucket/BucketIndexUtils.cpp
+++ b/src/bucket/BucketIndexUtils.cpp
@@ -16,8 +16,7 @@
 namespace stellar
 {
 
-std::streamoff
-getPageSizeFromConfig(Config const& cfg)
+std::streamoff getPageSizeFromConfig(Config const& cfg)
 {
     if (cfg.BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT == 0)
     {

--- a/src/bucket/BucketIndexUtils.h
+++ b/src/bucket/BucketIndexUtils.h
@@ -71,20 +71,17 @@ class IndexReturnT
     {
     }
 
-    IndexReturnState
-    getState() const
+    IndexReturnState getState() const
     {
         return mState;
     }
-    IndexPtrT
-    cacheHit() const
+    IndexPtrT cacheHit() const
     {
         releaseAssertOrThrow(mState == IndexReturnState::CACHE_HIT);
         releaseAssertOrThrow(std::holds_alternative<IndexPtrT>(mPayload));
         return std::get<IndexPtrT>(mPayload);
     }
-    std::streamoff
-    fileOffset() const
+    std::streamoff fileOffset() const
     {
         releaseAssertOrThrow(mState == IndexReturnState::FILE_OFFSET);
         releaseAssertOrThrow(std::holds_alternative<std::streamoff>(mPayload));

--- a/src/bucket/BucketInputIterator.cpp
+++ b/src/bucket/BucketInputIterator.cpp
@@ -15,9 +15,7 @@ namespace stellar
  * Helper class that reads from the file underlying a bucket, keeping the bucket
  * alive for the duration of its existence.
  */
-template <typename BucketT>
-void
-BucketInputIterator<BucketT>::loadEntry()
+template <typename BucketT> void BucketInputIterator<BucketT>::loadEntry()
 {
     ZoneScoped;
     if (mIn.readOne(mEntry))
@@ -84,16 +82,12 @@ BucketInputIterator<BucketT>::loadEntry()
     }
 }
 
-template <typename BucketT>
-std::streamoff
-BucketInputIterator<BucketT>::pos()
+template <typename BucketT> std::streamoff BucketInputIterator<BucketT>::pos()
 {
     return mIn.pos();
 }
 
-template <typename BucketT>
-size_t
-BucketInputIterator<BucketT>::size() const
+template <typename BucketT> size_t BucketInputIterator<BucketT>::size() const
 {
     return mIn.size();
 }
@@ -104,22 +98,19 @@ template <typename BucketT> BucketInputIterator<BucketT>::operator bool() const
 }
 
 template <typename BucketT>
-typename BucketT::EntryT const&
-BucketInputIterator<BucketT>::operator*()
+typename BucketT::EntryT const& BucketInputIterator<BucketT>::operator*()
 {
     return *mEntryPtr;
 }
 
 template <typename BucketT>
-bool
-BucketInputIterator<BucketT>::seenMetadata() const
+bool BucketInputIterator<BucketT>::seenMetadata() const
 {
     return mSeenMetadata;
 }
 
 template <typename BucketT>
-BucketMetadata const&
-BucketInputIterator<BucketT>::getMetadata() const
+BucketMetadata const& BucketInputIterator<BucketT>::getMetadata() const
 {
     return mMetadata;
 }
@@ -151,8 +142,7 @@ template <typename BucketT> BucketInputIterator<BucketT>::~BucketInputIterator()
 }
 
 template <typename BucketT>
-BucketInputIterator<BucketT>&
-BucketInputIterator<BucketT>::operator++()
+BucketInputIterator<BucketT>& BucketInputIterator<BucketT>::operator++()
 {
     if (mIn)
     {
@@ -166,8 +156,7 @@ BucketInputIterator<BucketT>::operator++()
 }
 
 template <typename BucketT>
-void
-BucketInputIterator<BucketT>::seek(std::streamoff offset)
+void BucketInputIterator<BucketT>::seek(std::streamoff offset)
 {
     mIn.seek(offset);
     loadEntry();

--- a/src/bucket/BucketListBase.cpp
+++ b/src/bucket/BucketListBase.cpp
@@ -31,9 +31,7 @@ BucketLevel<BucketT>::BucketLevel(uint32_t i)
 {
 }
 
-template <typename BucketT>
-uint256
-BucketLevel<BucketT>::getHash() const
+template <typename BucketT> uint256 BucketLevel<BucketT>::getHash() const
 {
     SHA256 hsh;
     hsh.add(mCurr->getHash());
@@ -42,61 +40,52 @@ BucketLevel<BucketT>::getHash() const
 }
 
 template <typename BucketT>
-FutureBucket<BucketT> const&
-BucketLevel<BucketT>::getNext() const
+FutureBucket<BucketT> const& BucketLevel<BucketT>::getNext() const
 {
     releaseAssert(!hasInMemoryMerge());
     return std::get<FutureBucket<BucketT>>(mNextCurr);
 }
 
 template <typename BucketT>
-FutureBucket<BucketT>&
-BucketLevel<BucketT>::getNext()
+FutureBucket<BucketT>& BucketLevel<BucketT>::getNext()
 {
     releaseAssert(!hasInMemoryMerge());
     return std::get<FutureBucket<BucketT>>(mNextCurr);
 }
 
 template <typename BucketT>
-void
-BucketLevel<BucketT>::setNext(FutureBucket<BucketT> const& fb)
+void BucketLevel<BucketT>::setNext(FutureBucket<BucketT> const& fb)
 {
     releaseAssertOrThrow(!hasInMemoryMerge());
     mNextCurr = fb;
 }
 
 template <typename BucketT>
-void
-BucketLevel<BucketT>::setNextInMemory(std::shared_ptr<BucketT>&& bucket)
+void BucketLevel<BucketT>::setNextInMemory(std::shared_ptr<BucketT>&& bucket)
 {
     releaseAssertOrThrow(!hasInProgressMerge());
     mNextCurr = std::move(bucket);
 }
 
-template <typename BucketT>
-void
-BucketLevel<BucketT>::clearNext()
+template <typename BucketT> void BucketLevel<BucketT>::clearNext()
 {
     mNextCurr = FutureBucket<BucketT>();
 }
 
 template <typename BucketT>
-std::shared_ptr<BucketT>
-BucketLevel<BucketT>::getCurr() const
+std::shared_ptr<BucketT> BucketLevel<BucketT>::getCurr() const
 {
     return mCurr;
 }
 
 template <typename BucketT>
-std::shared_ptr<BucketT>
-BucketLevel<BucketT>::getSnap() const
+std::shared_ptr<BucketT> BucketLevel<BucketT>::getSnap() const
 {
     return mSnap;
 }
 
 template <typename BucketT>
-void
-BucketLevel<BucketT>::setCurr(std::shared_ptr<BucketT> b)
+void BucketLevel<BucketT>::setCurr(std::shared_ptr<BucketT> b)
 {
     clearNext();
     mCurr = b;
@@ -107,11 +96,9 @@ template <typename BucketT> BucketListBase<BucketT>::~BucketListBase()
 }
 
 template <typename BucketT>
-bool
-BucketListBase<BucketT>::shouldMergeWithEmptyCurr(uint32_t ledger,
-                                                  uint32_t level)
+bool BucketListBase<BucketT>::shouldMergeWithEmptyCurr(uint32_t ledger,
+                                                       uint32_t level)
 {
-
     if (level != 0)
     {
         // Round down the current ledger to when the merge was started, and
@@ -136,37 +123,30 @@ BucketListBase<BucketT>::shouldMergeWithEmptyCurr(uint32_t ledger,
 }
 
 template <typename BucketT>
-void
-BucketLevel<BucketT>::setSnap(std::shared_ptr<BucketT> b)
+void BucketLevel<BucketT>::setSnap(std::shared_ptr<BucketT> b)
 {
     releaseAssert(threadIsMain());
     mSnap = b;
 }
 
-template <typename BucketT>
-bool
-BucketLevel<BucketT>::hasInMemoryMerge() const
+template <typename BucketT> bool BucketLevel<BucketT>::hasInMemoryMerge() const
 {
     return std::holds_alternative<std::shared_ptr<BucketT>>(mNextCurr);
 }
 
 template <typename BucketT>
-bool
-BucketLevel<BucketT>::hasFutureBucketMerge() const
+bool BucketLevel<BucketT>::hasFutureBucketMerge() const
 {
     return std::holds_alternative<FutureBucket<BucketT>>(mNextCurr);
 }
 
 template <typename BucketT>
-bool
-BucketLevel<BucketT>::hasInProgressMerge() const
+bool BucketLevel<BucketT>::hasInProgressMerge() const
 {
     return hasInMemoryMerge() || getNext().isMerging();
 }
 
-template <typename BucketT>
-void
-BucketLevel<BucketT>::commit()
+template <typename BucketT> void BucketLevel<BucketT>::commit()
 {
     std::visit(
         [this](auto&& arg) {
@@ -192,12 +172,9 @@ BucketLevel<BucketT>::commit()
 
 template <>
 template <typename... VectorT>
-void
-BucketLevel<LiveBucket>::prepareFirstLevel(Application& app,
-                                           uint32_t currLedger,
-                                           uint32_t currLedgerProtocol,
-                                           bool countMergeEvents, bool doFsync,
-                                           VectorT const&... inputVectors)
+void BucketLevel<LiveBucket>::prepareFirstLevel(
+    Application& app, uint32_t currLedger, uint32_t currLedgerProtocol,
+    bool countMergeEvents, bool doFsync, VectorT const&... inputVectors)
 {
     ZoneScoped;
 
@@ -239,8 +216,7 @@ BucketLevel<LiveBucket>::prepareFirstLevel(Application& app,
 
 template <>
 template <typename... VectorT>
-void
-BucketLevel<HotArchiveBucket>::prepareFirstLevel(
+void BucketLevel<HotArchiveBucket>::prepareFirstLevel(
     Application& app, uint32_t currLedger, uint32_t currLedgerProtocol,
     bool countMergeEvents, bool doFsync, VectorT const&... inputVectors)
 {
@@ -288,8 +264,7 @@ BucketLevel<HotArchiveBucket>::prepareFirstLevel(
 // ...
 // clang-format on
 template <typename BucketT>
-void
-BucketLevel<BucketT>::prepare(
+void BucketLevel<BucketT>::prepare(
     Application& app, uint32_t currLedger, uint32_t currLedgerProtocol,
     std::shared_ptr<BucketT> snap,
     std::vector<std::shared_ptr<BucketT>> const& shadows, bool countMergeEvents)
@@ -316,8 +291,7 @@ BucketLevel<BucketT>::prepare(
 }
 
 template <typename BucketT>
-std::shared_ptr<BucketT>
-BucketLevel<BucketT>::snap()
+std::shared_ptr<BucketT> BucketLevel<BucketT>::snap()
 {
     mSnap = mCurr;
     mCurr = std::make_shared<BucketT>();
@@ -328,15 +302,13 @@ BucketListDepth::BucketListDepth(uint32_t numLevels) : mNumLevels(numLevels)
 {
 }
 
-BucketListDepth&
-BucketListDepth::operator=(uint32_t numLevels)
+BucketListDepth& BucketListDepth::operator=(uint32_t numLevels)
 {
     mNumLevels = numLevels;
     return *this;
 }
 
-BucketListDepth::
-operator uint32_t() const
+BucketListDepth::operator uint32_t() const
 {
     return mNumLevels;
 }
@@ -357,8 +329,7 @@ operator uint32_t() const
 // levelSize(9)  = 1048576=0x100000
 // levelSize(10) = 4194304=0x400000
 template <typename BucketT>
-uint32_t
-BucketListBase<BucketT>::levelSize(uint32_t level)
+uint32_t BucketListBase<BucketT>::levelSize(uint32_t level)
 {
     releaseAssert(level < kNumLevels);
     return 1UL << (2 * (level + 1));
@@ -380,15 +351,13 @@ BucketListBase<BucketT>::levelSize(uint32_t level)
 // levelHalf(9)  =  524288=0x080000
 // levelHalf(10) = 2097152=0x200000
 template <typename BucketT>
-uint32_t
-BucketListBase<BucketT>::levelHalf(uint32_t level)
+uint32_t BucketListBase<BucketT>::levelHalf(uint32_t level)
 {
     return levelSize(level) >> 1;
 }
 
 template <typename BucketT>
-uint32_t
-BucketListBase<BucketT>::sizeOfCurr(uint32_t ledger, uint32_t level)
+uint32_t BucketListBase<BucketT>::sizeOfCurr(uint32_t ledger, uint32_t level)
 {
     releaseAssert(ledger != 0);
     releaseAssert(level < kNumLevels);
@@ -437,8 +406,7 @@ BucketListBase<BucketT>::sizeOfCurr(uint32_t ledger, uint32_t level)
 }
 
 template <typename BucketT>
-uint32_t
-BucketListBase<BucketT>::sizeOfSnap(uint32_t ledger, uint32_t level)
+uint32_t BucketListBase<BucketT>::sizeOfSnap(uint32_t ledger, uint32_t level)
 {
     releaseAssert(ledger != 0);
     releaseAssert(level < kNumLevels);
@@ -464,8 +432,8 @@ BucketListBase<BucketT>::sizeOfSnap(uint32_t ledger, uint32_t level)
 }
 
 template <typename BucketT>
-uint32_t
-BucketListBase<BucketT>::oldestLedgerInCurr(uint32_t ledger, uint32_t level)
+uint32_t BucketListBase<BucketT>::oldestLedgerInCurr(uint32_t ledger,
+                                                     uint32_t level)
 {
     releaseAssert(ledger != 0);
     releaseAssert(level < kNumLevels);
@@ -485,8 +453,8 @@ BucketListBase<BucketT>::oldestLedgerInCurr(uint32_t ledger, uint32_t level)
 }
 
 template <typename BucketT>
-uint32_t
-BucketListBase<BucketT>::oldestLedgerInSnap(uint32_t ledger, uint32_t level)
+uint32_t BucketListBase<BucketT>::oldestLedgerInSnap(uint32_t ledger,
+                                                     uint32_t level)
 {
     releaseAssert(ledger != 0);
     releaseAssert(level < kNumLevels);
@@ -504,9 +472,7 @@ BucketListBase<BucketT>::oldestLedgerInSnap(uint32_t ledger, uint32_t level)
     return count + 1;
 }
 
-template <typename BucketT>
-uint256
-BucketListBase<BucketT>::getHash() const
+template <typename BucketT> uint256 BucketListBase<BucketT>::getHash() const
 {
     ZoneScoped;
     SHA256 hsh;
@@ -537,8 +503,7 @@ BucketListBase<BucketT>::getHash() const
 // clang-format on
 
 template <typename BucketT>
-bool
-BucketListBase<BucketT>::levelShouldSpill(uint32_t ledger, uint32_t level)
+bool BucketListBase<BucketT>::levelShouldSpill(uint32_t ledger, uint32_t level)
 {
     if (level == kNumLevels - 1)
     {
@@ -556,8 +521,8 @@ BucketListBase<BucketT>::levelShouldSpill(uint32_t ledger, uint32_t level)
 // incoming_spill_frequency(i) = 2^(2i - 1) for i > 0
 // incoming_spill_frequency(0) = 1
 template <typename BucketT>
-uint32_t
-BucketListBase<BucketT>::bucketUpdatePeriod(uint32_t level, bool isCurr)
+uint32_t BucketListBase<BucketT>::bucketUpdatePeriod(uint32_t level,
+                                                     bool isCurr)
 {
     if (!isCurr)
     {
@@ -575,30 +540,25 @@ BucketListBase<BucketT>::bucketUpdatePeriod(uint32_t level, bool isCurr)
 }
 
 template <typename BucketT>
-bool
-BucketListBase<BucketT>::keepTombstoneEntries(uint32_t level)
+bool BucketListBase<BucketT>::keepTombstoneEntries(uint32_t level)
 {
     return level < BucketListBase<BucketT>::kNumLevels - 1;
 }
 
 template <typename BucketT>
-BucketLevel<BucketT> const&
-BucketListBase<BucketT>::getLevel(uint32_t i) const
+BucketLevel<BucketT> const& BucketListBase<BucketT>::getLevel(uint32_t i) const
 {
     return mLevels.at(i);
 }
 
 template <typename BucketT>
-BucketLevel<BucketT>&
-BucketListBase<BucketT>::getLevel(uint32_t i)
+BucketLevel<BucketT>& BucketListBase<BucketT>::getLevel(uint32_t i)
 {
     return mLevels.at(i);
 }
 
 #ifdef BUILD_TESTS
-template <typename BucketT>
-void
-BucketListBase<BucketT>::resolveAllFutures()
+template <typename BucketT> void BucketListBase<BucketT>::resolveAllFutures()
 {
     ZoneScoped;
     for (auto& level : mLevels)
@@ -612,8 +572,7 @@ BucketListBase<BucketT>::resolveAllFutures()
 #endif
 
 template <typename BucketT>
-void
-BucketListBase<BucketT>::resolveAnyReadyFutures()
+void BucketListBase<BucketT>::resolveAnyReadyFutures()
 {
     ZoneScoped;
     for (auto& level : mLevels)
@@ -626,8 +585,7 @@ BucketListBase<BucketT>::resolveAnyReadyFutures()
 }
 
 template <typename BucketT>
-bool
-BucketListBase<BucketT>::futuresAllResolved(uint32_t maxLevel) const
+bool BucketListBase<BucketT>::futuresAllResolved(uint32_t maxLevel) const
 {
     ZoneScoped;
     releaseAssert(maxLevel < mLevels.size());
@@ -643,8 +601,7 @@ BucketListBase<BucketT>::futuresAllResolved(uint32_t maxLevel) const
 }
 
 template <typename BucketT>
-uint32_t
-BucketListBase<BucketT>::getMaxMergeLevel(uint32_t currLedger) const
+uint32_t BucketListBase<BucketT>::getMaxMergeLevel(uint32_t currLedger) const
 {
     uint32_t i = 0;
     for (; i < static_cast<uint32_t>(mLevels.size()) - 1; ++i)
@@ -657,9 +614,7 @@ BucketListBase<BucketT>::getMaxMergeLevel(uint32_t currLedger) const
     return i;
 }
 
-template <typename BucketT>
-uint64_t
-BucketListBase<BucketT>::getSize() const
+template <typename BucketT> uint64_t BucketListBase<BucketT>::getSize() const
 {
     uint64_t sum = 0;
     for (auto const& lev : mLevels)
@@ -680,10 +635,10 @@ BucketListBase<BucketT>::getSize() const
 
 template <typename BucketT>
 template <typename... VectorT>
-void
-BucketListBase<BucketT>::addBatchInternal(Application& app, uint32_t currLedger,
-                                          uint32_t currLedgerProtocol,
-                                          VectorT const&... inputVectors)
+void BucketListBase<BucketT>::addBatchInternal(Application& app,
+                                               uint32_t currLedger,
+                                               uint32_t currLedgerProtocol,
+                                               VectorT const&... inputVectors)
 {
     ZoneScoped;
     releaseAssert(currLedger > 0);
@@ -797,10 +752,9 @@ BucketListBase<BucketT>::addBatchInternal(Application& app, uint32_t currLedger,
 }
 
 template <typename BucketT>
-void
-BucketListBase<BucketT>::restartMerges(Application& app,
-                                       uint32_t maxProtocolVersion,
-                                       uint32_t ledger)
+void BucketListBase<BucketT>::restartMerges(Application& app,
+                                            uint32_t maxProtocolVersion,
+                                            uint32_t ledger)
 {
     ZoneScoped;
     for (uint32_t i = 0; i < static_cast<uint32>(mLevels.size()); i++)

--- a/src/bucket/BucketListSnapshotBase.cpp
+++ b/src/bucket/BucketListSnapshotBase.cpp
@@ -43,8 +43,7 @@ BucketListSnapshot<BucketT>::getLevels() const
 }
 
 template <class BucketT>
-uint32_t
-BucketListSnapshot<BucketT>::getLedgerSeq() const
+uint32_t BucketListSnapshot<BucketT>::getLedgerSeq() const
 {
     return mHeader.ledgerSeq;
 }
@@ -58,8 +57,7 @@ SearchableBucketListSnapshotBase<BucketT>::getLedgerHeader() const
 }
 
 template <class BucketT>
-void
-SearchableBucketListSnapshotBase<BucketT>::loopAllBuckets(
+void SearchableBucketListSnapshotBase<BucketT>::loopAllBuckets(
     std::function<Loop(BucketSnapshotT const&)> f,
     BucketListSnapshot<BucketT> const& snapshot) const
 {
@@ -215,8 +213,7 @@ SearchableBucketListSnapshotBase<BucketT>::~SearchableBucketListSnapshotBase()
 }
 
 template <class BucketT>
-medida::Timer&
-SearchableBucketListSnapshotBase<BucketT>::getBulkLoadTimer(
+medida::Timer& SearchableBucketListSnapshotBase<BucketT>::getBulkLoadTimer(
     std::string const& label, size_t numEntries) const
 {
     if (numEntries != 0)

--- a/src/bucket/BucketListSnapshotBase.h
+++ b/src/bucket/BucketListSnapshotBase.h
@@ -57,8 +57,7 @@ template <class BucketT> class BucketListSnapshot : public NonMovable
 
     std::vector<BucketLevelSnapshot<BucketT>> const& getLevels() const;
     uint32_t getLedgerSeq() const;
-    LedgerHeader const&
-    getLedgerHeader() const
+    LedgerHeader const& getLedgerHeader() const
     {
         return mHeader;
     }
@@ -123,14 +122,12 @@ class SearchableBucketListSnapshotBase : public NonMovableOrCopyable
                         BucketListSnapshot<BucketT> const& snapshot) const;
 
     // Overload that uses the internal snapshot
-    void
-    loopAllBuckets(std::function<Loop(BucketSnapshotT const&)> f) const
+    void loopAllBuckets(std::function<Loop(BucketSnapshotT const&)> f) const
     {
         loopAllBuckets(f, *mSnapshot);
     }
 
-    uint32_t
-    getLedgerSeq() const
+    uint32_t getLedgerSeq() const
     {
         return mSnapshot->getLedgerSeq();
     }

--- a/src/bucket/BucketManager.cpp
+++ b/src/bucket/BucketManager.cpp
@@ -53,8 +53,7 @@
 namespace stellar
 {
 
-std::unique_ptr<BucketManager>
-BucketManager::create(AppConnector& app)
+std::unique_ptr<BucketManager> BucketManager::create(AppConnector& app)
 {
     auto bucketManagerPtr =
         std::unique_ptr<BucketManager>(new BucketManager(app));
@@ -62,8 +61,7 @@ BucketManager::create(AppConnector& app)
     return bucketManagerPtr;
 }
 
-void
-BucketManager::initialize()
+void BucketManager::initialize()
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -119,16 +117,14 @@ BucketManager::initialize()
     HistoryManager::createPublishQueueDir(mConfig);
 }
 
-void
-BucketManager::dropAll()
+void BucketManager::dropAll()
 {
     ZoneScoped;
     deleteEntireBucketDir();
     initialize();
 }
 
-TmpDirManager&
-BucketManager::getTmpDirManager()
+TmpDirManager& BucketManager::getTmpDirManager()
 {
     return *mTmpDirManager;
 }
@@ -189,56 +185,48 @@ const std::string BucketManager::kLockFilename = "stellar-core.lock";
 
 namespace
 {
-std::string
-bucketBasename(std::string const& bucketHexHash)
+std::string bucketBasename(std::string const& bucketHexHash)
 {
     return "bucket-" + bucketHexHash + ".xdr";
 }
 
-bool
-isBucketFile(std::string const& name)
+bool isBucketFile(std::string const& name)
 {
     static std::regex re("^bucket-[a-z0-9]{64}\\.xdr(\\.gz)?$");
     return std::regex_match(name, re);
 };
 
-uint256
-extractFromFilename(std::string const& name)
+uint256 extractFromFilename(std::string const& name)
 {
     return hexToBin256(name.substr(7, 64));
 };
 }
 
-void
-BucketManager::updateSharedBucketSize()
+void BucketManager::updateSharedBucketSize()
 {
     mSharedBucketsSize.set_count(mSharedHotArchiveBuckets.size() +
                                  mSharedLiveBuckets.size());
 }
 
-std::string
-BucketManager::bucketFilename(std::string const& bucketHexHash)
+std::string BucketManager::bucketFilename(std::string const& bucketHexHash)
 {
     std::string basename = bucketBasename(bucketHexHash);
     return getBucketDir() + "/" + basename;
 }
 
-std::string
-BucketManager::bucketFilename(Hash const& hash)
+std::string BucketManager::bucketFilename(Hash const& hash)
 {
     return bucketFilename(binToHex(hash));
 }
 
-std::string
-BucketManager::bucketIndexFilename(Hash const& hash) const
+std::string BucketManager::bucketIndexFilename(Hash const& hash) const
 {
     auto hashStr = binToHex(hash);
     auto basename = "bucket-" + hashStr + ".index";
     return getBucketDir() + "/" + basename;
 }
 
-std::string const&
-BucketManager::getTmpDir()
+std::string const& BucketManager::getTmpDir()
 {
     ZoneScoped;
     RecursiveMutexLocker lock(mBucketMutex);
@@ -250,20 +238,17 @@ BucketManager::getTmpDir()
     return mWorkDir->getName();
 }
 
-std::string const&
-BucketManager::getBucketDir() const
+std::string const& BucketManager::getBucketDir() const
 {
     return *(mLockedBucketDir);
 }
 
 BucketManager::~BucketManager()
 {
-
     deleteTmpDirAndUnlockBucketDir();
 }
 
-void
-BucketManager::deleteEntireBucketDir()
+void BucketManager::deleteEntireBucketDir()
 {
     ZoneScoped;
     std::string d = mConfig.BUCKET_DIR_PATH;
@@ -281,8 +266,7 @@ BucketManager::deleteEntireBucketDir()
     }
 }
 
-void
-BucketManager::deleteTmpDirAndUnlockBucketDir()
+void BucketManager::deleteTmpDirAndUnlockBucketDir()
 {
     ZoneScoped;
 
@@ -307,34 +291,28 @@ BucketManager::deleteTmpDirAndUnlockBucketDir()
     }
 }
 
-LiveBucketList&
-BucketManager::getLiveBucketList()
+LiveBucketList& BucketManager::getLiveBucketList()
 {
     return *mLiveBucketList;
 }
 
-HotArchiveBucketList&
-BucketManager::getHotArchiveBucketList()
+HotArchiveBucketList& BucketManager::getHotArchiveBucketList()
 {
     return *mHotArchiveBucketList;
 }
 
-BucketSnapshotManager&
-BucketManager::getBucketSnapshotManager() const
+BucketSnapshotManager& BucketManager::getBucketSnapshotManager() const
 {
     releaseAssert(mSnapshotManager);
     return *mSnapshotManager;
 }
 
-medida::Timer&
-BucketManager::getMergeTimer()
+medida::Timer& BucketManager::getMergeTimer()
 {
     return mBucketSnapMerge;
 }
 
-template <class BucketT>
-medida::Meter&
-BucketManager::getBloomMissMeter() const
+template <class BucketT> medida::Meter& BucketManager::getBloomMissMeter() const
 {
     BUCKET_TYPE_ASSERT(BucketT);
     return mAppConnector.getMetrics().NewMeter(
@@ -342,28 +320,24 @@ BucketManager::getBloomMissMeter() const
 }
 
 template <class BucketT>
-medida::Meter&
-BucketManager::getBloomLookupMeter() const
+medida::Meter& BucketManager::getBloomLookupMeter() const
 {
     BUCKET_TYPE_ASSERT(BucketT);
     return mAppConnector.getMetrics().NewMeter(
         {BucketT::METRIC_STRING, "bloom", "lookups"}, "bloom");
 }
 
-medida::Meter&
-BucketManager::getCacheHitMeter() const
+medida::Meter& BucketManager::getCacheHitMeter() const
 {
     return mCacheHitMeter;
 }
 
-medida::Meter&
-BucketManager::getCacheMissMeter() const
+medida::Meter& BucketManager::getCacheMissMeter() const
 {
     return mCacheMissMeter;
 }
 
-void
-BucketManager::reportLiveBucketIndexCacheMetrics()
+void BucketManager::reportLiveBucketIndexCacheMetrics()
 {
     size_t totalCacheEntries = 0;
     size_t totalEstimatedBytes = 0;
@@ -408,41 +382,35 @@ BucketManager::reportLiveBucketIndexCacheMetrics()
               static_cast<int64_t>(totalEstimatedBytes));
 }
 
-template <>
-MergeCounters
-BucketManager::readMergeCounters<LiveBucket>()
+template <> MergeCounters BucketManager::readMergeCounters<LiveBucket>()
 {
     RecursiveMutexLocker lock(mBucketMutex);
     return mLiveMergeCounters;
 }
 
-template <>
-MergeCounters
-BucketManager::readMergeCounters<HotArchiveBucket>()
+template <> MergeCounters BucketManager::readMergeCounters<HotArchiveBucket>()
 {
     RecursiveMutexLocker lock(mBucketMutex);
     return mHotArchiveMergeCounters;
 }
 
 template <>
-void
-BucketManager::incrMergeCounters<LiveBucket>(MergeCounters const& delta)
+void BucketManager::incrMergeCounters<LiveBucket>(MergeCounters const& delta)
 {
     RecursiveMutexLocker lock(mBucketMutex);
     mLiveMergeCounters += delta;
 }
 
 template <>
-void
-BucketManager::incrMergeCounters<HotArchiveBucket>(MergeCounters const& delta)
+void BucketManager::incrMergeCounters<HotArchiveBucket>(
+    MergeCounters const& delta)
 {
     RecursiveMutexLocker lock(mBucketMutex);
     mHotArchiveMergeCounters += delta;
 }
 
-bool
-BucketManager::renameBucketDirFile(std::filesystem::path const& src,
-                                   std::filesystem::path const& dst)
+bool BucketManager::renameBucketDirFile(std::filesystem::path const& src,
+                                        std::filesystem::path const& dst)
 {
     ZoneScoped;
     if (mConfig.DISABLE_XDR_FSYNC)
@@ -456,8 +424,7 @@ BucketManager::renameBucketDirFile(std::filesystem::path const& src,
 }
 
 template <>
-std::shared_ptr<LiveBucket>
-BucketManager::adoptFileAsBucket(
+std::shared_ptr<LiveBucket> BucketManager::adoptFileAsBucket(
     std::string const& filename, uint256 const& hash, MergeKey* mergeKey,
     std::unique_ptr<LiveBucket::IndexT const> index)
 {
@@ -467,8 +434,7 @@ BucketManager::adoptFileAsBucket(
 }
 
 template <>
-std::shared_ptr<HotArchiveBucket>
-BucketManager::adoptFileAsBucket(
+std::shared_ptr<HotArchiveBucket> BucketManager::adoptFileAsBucket(
     std::string const& filename, uint256 const& hash, MergeKey* mergeKey,
     std::unique_ptr<HotArchiveBucket::IndexT const> index)
 {
@@ -479,8 +445,7 @@ BucketManager::adoptFileAsBucket(
 }
 
 template <typename BucketT>
-std::shared_ptr<BucketT>
-BucketManager::adoptFileAsBucketInternal(
+std::shared_ptr<BucketT> BucketManager::adoptFileAsBucketInternal(
     std::string const& filename, uint256 const& hash, MergeKey* mergeKey,
     std::unique_ptr<typename BucketT::IndexT const> index,
     BucketMapT<BucketT>& bucketMap, FutureMapT<BucketT>& futureMap)
@@ -558,25 +523,23 @@ BucketManager::adoptFileAsBucketInternal(
 }
 
 template <>
-void
-BucketManager::noteEmptyMergeOutput<LiveBucket>(MergeKey const& mergeKey)
+void BucketManager::noteEmptyMergeOutput<LiveBucket>(MergeKey const& mergeKey)
 {
     RecursiveMutexLocker lock(mBucketMutex);
     noteEmptyMergeOutputInternal(mergeKey, mLiveBucketFutures);
 }
 
 template <>
-void
-BucketManager::noteEmptyMergeOutput<HotArchiveBucket>(MergeKey const& mergeKey)
+void BucketManager::noteEmptyMergeOutput<HotArchiveBucket>(
+    MergeKey const& mergeKey)
 {
     RecursiveMutexLocker lock(mBucketMutex);
     noteEmptyMergeOutputInternal(mergeKey, mHotArchiveBucketFutures);
 }
 
 template <class BucketT>
-void
-BucketManager::noteEmptyMergeOutputInternal(MergeKey const& mergeKey,
-                                            FutureMapT<BucketT>& futureMap)
+void BucketManager::noteEmptyMergeOutputInternal(MergeKey const& mergeKey,
+                                                 FutureMapT<BucketT>& futureMap)
 {
     BUCKET_TYPE_ASSERT(BucketT);
 
@@ -610,8 +573,7 @@ BucketManager::getBucketIfExists(uint256 const& hash)
 }
 
 template <class BucketT>
-std::shared_ptr<BucketT>
-BucketManager::getBucketIfExistsInternal(
+std::shared_ptr<BucketT> BucketManager::getBucketIfExistsInternal(
     uint256 const& hash, BucketMapT<BucketT> const& bucketMap) const
 {
     BUCKET_TYPE_ASSERT(BucketT);
@@ -629,8 +591,7 @@ BucketManager::getBucketIfExistsInternal(
 }
 
 template <>
-std::shared_ptr<LiveBucket>
-BucketManager::getBucketByHash(uint256 const& hash)
+std::shared_ptr<LiveBucket> BucketManager::getBucketByHash(uint256 const& hash)
 {
     RecursiveMutexLocker lock(mBucketMutex);
     return getBucketByHashInternal(hash, mSharedLiveBuckets);
@@ -742,8 +703,7 @@ BucketManager::getMergeFutureInternal(MergeKey const& key,
 }
 
 template <>
-void
-BucketManager::putMergeFuture(
+void BucketManager::putMergeFuture(
     MergeKey const& key, std::shared_future<std::shared_ptr<LiveBucket>> future)
 {
     RecursiveMutexLocker lock(mBucketMutex);
@@ -751,8 +711,7 @@ BucketManager::putMergeFuture(
 }
 
 template <>
-void
-BucketManager::putMergeFuture(
+void BucketManager::putMergeFuture(
     MergeKey const& key,
     std::shared_future<std::shared_ptr<HotArchiveBucket>> future)
 {
@@ -761,8 +720,7 @@ BucketManager::putMergeFuture(
 }
 
 template <class BucketT>
-void
-BucketManager::putMergeFutureInternal(
+void BucketManager::putMergeFutureInternal(
     MergeKey const& key, std::shared_future<std::shared_ptr<BucketT>> future,
     FutureMapT<BucketT>& futureMap)
 {
@@ -776,24 +734,21 @@ BucketManager::putMergeFutureInternal(
 }
 
 #ifdef BUILD_TESTS
-void
-BucketManager::clearMergeFuturesForTesting()
+void BucketManager::clearMergeFuturesForTesting()
 {
     RecursiveMutexLocker lock(mBucketMutex);
     mLiveBucketFutures.clear();
     mHotArchiveBucketFutures.clear();
 }
 
-void
-BucketManager::enableDelayedMergesForTesting()
+void BucketManager::enableDelayedMergesForTesting()
 {
     releaseAssertOrThrow(!mDelayMergesForTesting);
     mDelayMergesForTesting = true;
 }
 #endif
 
-std::set<Hash>
-BucketManager::getBucketListReferencedBuckets() const
+std::set<Hash> BucketManager::getBucketListReferencedBuckets() const
 {
     ZoneScoped;
     std::set<Hash> referenced;
@@ -873,8 +828,7 @@ BucketManager::getAllReferencedBuckets(HistoryArchiveState const& has,
     return referenced;
 }
 
-void
-BucketManager::cleanupStaleFiles(HistoryArchiveState const& has)
+void BucketManager::cleanupStaleFiles(HistoryArchiveState const& has)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -917,8 +871,7 @@ BucketManager::cleanupStaleFiles(HistoryArchiveState const& has)
     }
 }
 
-void
-BucketManager::forgetUnreferencedBuckets(HistoryArchiveState const& has)
+void BucketManager::forgetUnreferencedBuckets(HistoryArchiveState const& has)
 {
     ZoneScoped;
     RecursiveMutexLocker lock(mBucketMutex);
@@ -1018,11 +971,10 @@ BucketManager::forgetUnreferencedBuckets(HistoryArchiveState const& has)
     updateSharedBucketSize();
 }
 
-void
-BucketManager::addLiveBatch(Application& app, LedgerHeader header,
-                            std::vector<LedgerEntry> const& initEntries,
-                            std::vector<LedgerEntry> const& liveEntries,
-                            std::vector<LedgerKey> const& deadEntries)
+void BucketManager::addLiveBatch(Application& app, LedgerHeader header,
+                                 std::vector<LedgerEntry> const& initEntries,
+                                 std::vector<LedgerEntry> const& liveEntries,
+                                 std::vector<LedgerKey> const& deadEntries)
 {
     ZoneScoped;
 #ifdef BUILD_TESTS
@@ -1041,8 +993,7 @@ BucketManager::addLiveBatch(Application& app, LedgerHeader header,
     reportLiveBucketIndexCacheMetrics();
 }
 
-void
-BucketManager::addHotArchiveBatch(
+void BucketManager::addHotArchiveBatch(
     Application& app, LedgerHeader header,
     std::vector<LedgerEntry> const& archivedEntries,
     std::vector<LedgerKey> const& restoredEntries)
@@ -1069,17 +1020,15 @@ BucketManager::addHotArchiveBatch(
 }
 
 #ifdef BUILD_TESTS
-void
-BucketManager::setNextCloseVersionAndHashForTesting(uint32_t protocolVers,
-                                                    uint256 const& hash)
+void BucketManager::setNextCloseVersionAndHashForTesting(uint32_t protocolVers,
+                                                         uint256 const& hash)
 {
     mUseFakeTestValuesForNextClose = true;
     mFakeTestProtocolVersion = protocolVers;
     mFakeTestBucketListHash = hash;
 }
 
-std::set<Hash>
-BucketManager::getBucketHashesInBucketDirForTesting() const
+std::set<Hash> BucketManager::getBucketHashesInBucketDirForTesting() const
 {
     std::set<Hash> hashes;
     for (auto f : fs::findfiles(getBucketDir(), isBucketFile))
@@ -1089,8 +1038,7 @@ BucketManager::getBucketHashesInBucketDirForTesting() const
     return hashes;
 }
 
-medida::Counter&
-BucketManager::getEntriesEvictedCounter() const
+medida::Counter& BucketManager::getEntriesEvictedCounter() const
 {
     return mBucketListEvictionCounters.entriesEvicted;
 }
@@ -1098,8 +1046,7 @@ BucketManager::getEntriesEvictedCounter() const
 
 // updates the given LedgerHeader to reflect the current state of the bucket
 // list
-void
-BucketManager::snapshotLedger(LedgerHeader& currentHeader)
+void BucketManager::snapshotLedger(LedgerHeader& currentHeader)
 {
     ZoneScoped;
     Hash hash;
@@ -1130,8 +1077,7 @@ BucketManager::snapshotLedger(LedgerHeader& currentHeader)
 }
 
 template <class BucketT>
-void
-BucketManager::maybeSetIndex(
+void BucketManager::maybeSetIndex(
     std::shared_ptr<BucketT> b,
     std::unique_ptr<typename BucketT::IndexT const>&& index)
 {
@@ -1143,10 +1089,9 @@ BucketManager::maybeSetIndex(
     }
 }
 
-void
-BucketManager::startBackgroundEvictionScan(uint32_t ledgerSeq,
-                                           uint32_t ledgerVers,
-                                           SorobanNetworkConfig const& cfg)
+void BucketManager::startBackgroundEvictionScan(uint32_t ledgerSeq,
+                                                uint32_t ledgerVers,
+                                                SorobanNetworkConfig const& cfg)
 {
     releaseAssert(mSnapshotManager);
     releaseAssert(!mEvictionFuture.valid());
@@ -1177,8 +1122,7 @@ BucketManager::startBackgroundEvictionScan(uint32_t ledgerSeq,
         "SearchableLiveBucketListSnapshot: eviction scan");
 }
 
-EvictedStateVectors
-BucketManager::resolveBackgroundEvictionScan(
+EvictedStateVectors BucketManager::resolveBackgroundEvictionScan(
     AbstractLedgerTxn& ltx, uint32_t ledgerSeq,
     LedgerKeySet const& modifiedKeys, uint32_t ledgerVers,
     SorobanNetworkConfig const& networkConfig)
@@ -1267,10 +1211,8 @@ BucketManager::resolveBackgroundEvictionScan(
     return EvictedStateVectors{deletedKeys, archivedEntries};
 }
 
-void
-BucketManager::calculateSkipValues(LedgerHeader& currentHeader)
+void BucketManager::calculateSkipValues(LedgerHeader& currentHeader)
 {
-
     if ((currentHeader.ledgerSeq % SKIP_1) == 0)
     {
         int v = currentHeader.ledgerSeq - SKIP_1;
@@ -1282,7 +1224,6 @@ BucketManager::calculateSkipValues(LedgerHeader& currentHeader)
                 v = currentHeader.ledgerSeq - SKIP_3 - SKIP_2 - SKIP_1;
                 if (v > 0 && (v % SKIP_4) == 0)
                 {
-
                     currentHeader.skipList[3] = currentHeader.skipList[2];
                 }
                 currentHeader.skipList[2] = currentHeader.skipList[1];
@@ -1308,9 +1249,9 @@ BucketManager::checkForMissingBucketsFiles(HistoryArchiveState const& has)
     return result;
 }
 
-void
-BucketManager::assumeState(Application& app, HistoryArchiveState const& has,
-                           uint32_t maxProtocolVersion, bool restartMerges)
+void BucketManager::assumeState(Application& app,
+                                HistoryArchiveState const& has,
+                                uint32_t maxProtocolVersion, bool restartMerges)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -1380,14 +1321,12 @@ BucketManager::assumeState(Application& app, HistoryArchiveState const& has,
     cleanupStaleFiles(has);
 }
 
-void
-BucketManager::shutdown()
+void BucketManager::shutdown()
 {
     mIsShutdown = true;
 }
 
-bool
-BucketManager::isShutdown() const
+bool BucketManager::isShutdown() const
 {
     return mIsShutdown;
 }
@@ -1395,9 +1334,9 @@ BucketManager::isShutdown() const
 // Loads a single bucket worth of entries into `map`, deleting dead entries and
 // inserting live or init entries. Should be called in a loop over a BL, from
 // old to new.
-static void
-loadEntriesFromBucket(std::shared_ptr<LiveBucket> b, std::string const& name,
-                      std::map<LedgerKey, LedgerEntry>& map)
+static void loadEntriesFromBucket(std::shared_ptr<LiveBucket> b,
+                                  std::string const& name,
+                                  std::map<LedgerKey, LedgerEntry>& map)
 {
     ZoneScoped;
 
@@ -1658,8 +1597,7 @@ visitBucketEntries(bool visitShadowedEntries, std::shared_ptr<BucketT const> b,
     return !stopIteration;
 }
 
-void
-BucketManager::visitLedgerEntries(
+void BucketManager::visitLedgerEntries(
     bool visitLiveBucketList, HistoryArchiveState const& has,
     std::optional<uint32_t> minLedger,
     std::function<bool(LedgerEntry const&)> const& filterEntry,
@@ -1745,8 +1683,7 @@ BucketManager::visitLedgerEntries(
               std::chrono::duration_cast<std::chrono::milliseconds>(ns));
 }
 
-std::shared_ptr<BasicWork>
-BucketManager::scheduleVerifyReferencedBucketsWork(
+std::shared_ptr<BasicWork> BucketManager::scheduleVerifyReferencedBucketsWork(
     Application& app, HistoryArchiveState const& has)
 {
     releaseAssert(threadIsMain());
@@ -1806,14 +1743,12 @@ BucketManager::scheduleVerifyReferencedBucketsWork(
         "verify-referenced-buckets", seq);
 }
 
-Config const&
-BucketManager::getConfig() const
+Config const& BucketManager::getConfig() const
 {
     return mConfig;
 }
 
-void
-BucketManager::reportBucketEntryCountMetrics()
+void BucketManager::reportBucketEntryCountMetrics()
 {
     auto bucketEntryCounters = mLiveBucketList->sumBucketEntryCounters();
     for (auto [type, count] : bucketEntryCounters.entryTypeCounts)

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -181,11 +181,10 @@ class BucketManager : NonMovableOrCopyable
         REQUIRES(mBucketMutex);
 
     template <class BucketT>
-    void
-    putMergeFutureInternal(MergeKey const& key,
-                           std::shared_future<std::shared_ptr<BucketT>> future,
-                           FutureMapT<BucketT>& futureMap)
-        REQUIRES(mBucketMutex);
+    void putMergeFutureInternal(
+        MergeKey const& key,
+        std::shared_future<std::shared_ptr<BucketT>> future,
+        FutureMapT<BucketT>& futureMap) REQUIRES(mBucketMutex);
 
     template <class BucketT>
     void noteEmptyMergeOutputInternal(MergeKey const& mergeKey,
@@ -373,8 +372,7 @@ class BucketManager : NonMovableOrCopyable
 
     // Enable merge delays for testing bucket reattachment
     void enableDelayedMergesForTesting();
-    bool
-    shouldDelayMergesForTesting() const
+    bool shouldDelayMergesForTesting() const
     {
         return mDelayMergesForTesting;
     }
@@ -383,8 +381,7 @@ class BucketManager : NonMovableOrCopyable
     // Return the set of buckets referenced by the BucketList
     std::set<Hash> getBucketListReferencedBuckets() const;
 
-    std::set<Hash>
-    getAllReferencedBuckets(HistoryArchiveState const& has) const
+    std::set<Hash> getAllReferencedBuckets(HistoryArchiveState const& has) const
         LOCKS_EXCLUDED(mBucketMutex)
     {
         RecursiveMutexLocker lock(mBucketMutex);

--- a/src/bucket/BucketMergeAdapter.h
+++ b/src/bucket/BucketMergeAdapter.h
@@ -53,51 +53,43 @@ template <class BucketT> class FileMergeInput : public MergeInput<BucketT>
     {
     }
 
-    bool
-    isDone() const override
+    bool isDone() const override
     {
         return !mOldIter && !mNewIter;
     }
 
-    bool
-    oldFirst() const override
+    bool oldFirst() const override
     {
         return !mNewIter || (mOldIter && mCmp(*mOldIter, *mNewIter));
     }
 
-    bool
-    newFirst() const override
+    bool newFirst() const override
     {
         return !mOldIter || (mNewIter && mCmp(*mNewIter, *mOldIter));
     }
 
-    bool
-    equalKeys() const override
+    bool equalKeys() const override
     {
         return mOldIter && mNewIter && !mCmp(*mOldIter, *mNewIter) &&
                !mCmp(*mNewIter, *mOldIter);
     }
 
-    typename BucketT::EntryT const&
-    getOldEntry() override
+    typename BucketT::EntryT const& getOldEntry() override
     {
         return *mOldIter;
     }
 
-    typename BucketT::EntryT const&
-    getNewEntry() override
+    typename BucketT::EntryT const& getNewEntry() override
     {
         return *mNewIter;
     }
 
-    void
-    advanceOld() override
+    void advanceOld() override
     {
         ++mOldIter;
     }
 
-    void
-    advanceNew() override
+    void advanceNew() override
     {
         ++mNewIter;
     }
@@ -119,56 +111,48 @@ template <class BucketT> class MemoryMergeInput : public MergeInput<BucketT>
     {
     }
 
-    bool
-    isDone() const override
+    bool isDone() const override
     {
         return mOldIdx >= mOldEntries.size() && mNewIdx >= mNewEntries.size();
     }
 
-    bool
-    oldFirst() const override
+    bool oldFirst() const override
     {
         return mNewIdx >= mNewEntries.size() ||
                (mOldIdx < mOldEntries.size() &&
                 mCmp(mOldEntries.at(mOldIdx), mNewEntries.at(mNewIdx)));
     }
 
-    bool
-    newFirst() const override
+    bool newFirst() const override
     {
         return mOldIdx >= mOldEntries.size() ||
                (mNewIdx < mNewEntries.size() &&
                 mCmp(mNewEntries.at(mNewIdx), mOldEntries.at(mOldIdx)));
     }
 
-    bool
-    equalKeys() const override
+    bool equalKeys() const override
     {
         return mOldIdx < mOldEntries.size() && mNewIdx < mNewEntries.size() &&
                !mCmp(mOldEntries.at(mOldIdx), mNewEntries.at(mNewIdx)) &&
                !mCmp(mNewEntries.at(mNewIdx), mOldEntries.at(mOldIdx));
     }
 
-    typename BucketT::EntryT const&
-    getOldEntry() override
+    typename BucketT::EntryT const& getOldEntry() override
     {
         return mOldEntries.at(mOldIdx);
     }
 
-    typename BucketT::EntryT const&
-    getNewEntry() override
+    typename BucketT::EntryT const& getNewEntry() override
     {
         return mNewEntries.at(mNewIdx);
     }
 
-    void
-    advanceOld() override
+    void advanceOld() override
     {
         ++mOldIdx;
     }
 
-    void
-    advanceNew() override
+    void advanceNew() override
     {
         ++mNewIdx;
     }

--- a/src/bucket/BucketMergeMap.cpp
+++ b/src/bucket/BucketMergeMap.cpp
@@ -28,8 +28,7 @@ getMergeKeyHashes(stellar::MergeKey const& key)
 namespace stellar
 {
 
-void
-BucketMergeMap::recordMerge(MergeKey const& input, Hash const& output)
+void BucketMergeMap::recordMerge(MergeKey const& input, Hash const& output)
 {
     ZoneScoped;
     mMergeKeyToOutput.emplace(input, output);
@@ -103,8 +102,7 @@ BucketMergeMap::forgetAllMergesProducing(Hash const& outputBeingDropped)
     return ret;
 }
 
-bool
-BucketMergeMap::findMergeFor(MergeKey const& input, Hash& output)
+bool BucketMergeMap::findMergeFor(MergeKey const& input, Hash& output)
 {
     ZoneScoped;
     auto i = mMergeKeyToOutput.find(input);
@@ -116,9 +114,8 @@ BucketMergeMap::findMergeFor(MergeKey const& input, Hash& output)
     return false;
 }
 
-void
-BucketMergeMap::getOutputsUsingInput(Hash const& input,
-                                     std::set<Hash>& outputs) const
+void BucketMergeMap::getOutputsUsingInput(Hash const& input,
+                                          std::set<Hash>& outputs) const
 {
     ZoneScoped;
     auto pair = mInputToOutput.equal_range(input);

--- a/src/bucket/BucketOutputIterator.cpp
+++ b/src/bucket/BucketOutputIterator.cpp
@@ -46,7 +46,6 @@ BucketOutputIterator<BucketT>::BucketOutputIterator(std::string const& tmpDir,
             meta.ledgerVersion,
             LiveBucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY))
     {
-
         if constexpr (std::is_same_v<BucketT, LiveBucket>)
         {
             BucketEntry bme;
@@ -74,8 +73,7 @@ BucketOutputIterator<BucketT>::BucketOutputIterator(std::string const& tmpDir,
 }
 
 template <typename BucketT>
-void
-BucketOutputIterator<BucketT>::put(typename BucketT::EntryT const& e)
+void BucketOutputIterator<BucketT>::put(typename BucketT::EntryT const& e)
 {
     ZoneScoped;
 
@@ -165,8 +163,7 @@ BucketOutputIterator<BucketT>::put(typename BucketT::EntryT const& e)
 }
 
 template <typename BucketT>
-std::shared_ptr<BucketT>
-BucketOutputIterator<BucketT>::getBucket(
+std::shared_ptr<BucketT> BucketOutputIterator<BucketT>::getBucket(
     BucketManager& bucketManager, MergeKey* mergeKey,
     std::optional<std::vector<typename BucketT::EntryT>> inMemoryState)
 {

--- a/src/bucket/BucketSnapshot.cpp
+++ b/src/bucket/BucketSnapshot.cpp
@@ -33,9 +33,7 @@ BucketSnapshotBase<BucketT>::BucketSnapshotBase(
     releaseAssert(mBucket);
 }
 
-template <class BucketT>
-bool
-BucketSnapshotBase<BucketT>::isEmpty() const
+template <class BucketT> bool BucketSnapshotBase<BucketT>::isEmpty() const
 {
     releaseAssert(mBucket);
     return mBucket->isEmpty();
@@ -105,8 +103,7 @@ BucketSnapshotBase<BucketT>::getBucketEntry(LedgerKey const& k) const
 // do not load shadowed entries. If we don't find the entry, we do not remove it
 // from keys so that it will be searched for again at a lower level.
 template <class BucketT>
-void
-BucketSnapshotBase<BucketT>::loadKeys(
+void BucketSnapshotBase<BucketT>::loadKeys(
     std::set<LedgerKey, LedgerEntryIdCmp>& keys,
     std::vector<typename BucketT::LoadT>& result) const
 {
@@ -130,7 +127,6 @@ BucketSnapshotBase<BucketT>::loadKeys(
         std::shared_ptr<typename BucketT::EntryT const> entryOp;
         switch (indexRes.getState())
         {
-
         // Index had entry in cache
         case IndexReturnState::CACHE_HIT:
             if constexpr (std::is_same_v<BucketT, LiveBucket>)
@@ -200,8 +196,7 @@ LiveBucketSnapshot::getPoolIDsByAsset(Asset const& asset) const
 // Note: evicatbleKeys and keysInEvictableEntries both reference the same
 // entries. evictableEntries in order of eviction, keysInEvictableEntries in an
 // unordered but searchable set.
-Loop
-LiveBucketSnapshot::scanForEviction(
+Loop LiveBucketSnapshot::scanForEviction(
     EvictionIterator& iter, uint32_t& bytesToScan, uint32_t ledgerSeq,
     std::list<EvictionResultEntry>& evictableEntries,
     SearchableLiveBucketListSnapshot const& bl, uint32_t ledgerVers,
@@ -346,8 +341,7 @@ LiveBucketSnapshot::scanForEviction(
 }
 
 // Scans entries of the specified type in the bucket.
-Loop
-LiveBucketSnapshot::scanForEntriesOfType(
+Loop LiveBucketSnapshot::scanForEntriesOfType(
     LedgerEntryType type,
     std::function<Loop(BucketEntry const&)> callback) const
 {
@@ -399,8 +393,7 @@ LiveBucketSnapshot::scanForEntriesOfType(
 }
 
 template <class BucketT>
-XDRInputFileStream&
-BucketSnapshotBase<BucketT>::getStream() const
+XDRInputFileStream& BucketSnapshotBase<BucketT>::getStream() const
 {
     releaseAssertOrThrow(!isEmpty());
     if (!mStream)
@@ -412,8 +405,7 @@ BucketSnapshotBase<BucketT>::getStream() const
 }
 
 template <class BucketT>
-std::shared_ptr<BucketT const>
-BucketSnapshotBase<BucketT>::getRawBucket() const
+std::shared_ptr<BucketT const> BucketSnapshotBase<BucketT>::getRawBucket() const
 {
     return mBucket;
 }

--- a/src/bucket/BucketSnapshotManager.cpp
+++ b/src/bucket/BucketSnapshotManager.cpp
@@ -21,8 +21,7 @@ namespace stellar
 namespace
 {
 template <class BucketT>
-std::map<uint32_t, SnapshotPtrT<BucketT>>
-copyHistoricalSnapshots(
+std::map<uint32_t, SnapshotPtrT<BucketT>> copyHistoricalSnapshots(
     std::map<uint32_t, SnapshotPtrT<BucketT>> const& snapshots)
 {
     std::map<uint32_t, SnapshotPtrT<BucketT>> copiedSnapshots;
@@ -99,16 +98,14 @@ BucketSnapshotManager::copySearchableHotArchiveBucketListSnapshot(
 namespace
 {
 template <typename T, typename U>
-bool
-needsUpdate(std::shared_ptr<T const> const& snapshot,
-            SnapshotPtrT<U> const& curr)
+bool needsUpdate(std::shared_ptr<T const> const& snapshot,
+                 SnapshotPtrT<U> const& curr)
 {
     return !snapshot || snapshot->getLedgerSeq() < curr->getLedgerSeq();
 }
 }
 
-void
-BucketSnapshotManager::maybeCopySearchableBucketListSnapshot(
+void BucketSnapshotManager::maybeCopySearchableBucketListSnapshot(
     SearchableSnapshotConstPtr& snapshot)
 {
     // The canonical snapshot held by the BucketSnapshotManager is not being
@@ -121,8 +118,7 @@ BucketSnapshotManager::maybeCopySearchableBucketListSnapshot(
     }
 }
 
-void
-BucketSnapshotManager::maybeCopySearchableHotArchiveBucketListSnapshot(
+void BucketSnapshotManager::maybeCopySearchableHotArchiveBucketListSnapshot(
     SearchableHotArchiveSnapshotConstPtr& snapshot)
 {
     // The canonical snapshot held by the BucketSnapshotManager is not being
@@ -135,8 +131,7 @@ BucketSnapshotManager::maybeCopySearchableHotArchiveBucketListSnapshot(
     }
 }
 
-void
-BucketSnapshotManager::maybeCopyLiveAndHotArchiveSnapshots(
+void BucketSnapshotManager::maybeCopyLiveAndHotArchiveSnapshots(
     SearchableSnapshotConstPtr& liveSnapshot,
     SearchableHotArchiveSnapshotConstPtr& hotArchiveSnapshot)
 {
@@ -156,8 +151,7 @@ BucketSnapshotManager::maybeCopyLiveAndHotArchiveSnapshots(
     }
 }
 
-void
-BucketSnapshotManager::updateCurrentSnapshot(
+void BucketSnapshotManager::updateCurrentSnapshot(
     SnapshotPtrT<LiveBucket>&& liveSnapshot,
     SnapshotPtrT<HotArchiveBucket>&& hotArchiveSnapshot)
 {

--- a/src/bucket/BucketSnapshotManager.h
+++ b/src/bucket/BucketSnapshotManager.h
@@ -66,9 +66,9 @@ class BucketSnapshotManager : NonMovableOrCopyable
   public:
     // Called by main thread to update snapshots whenever the BucketList
     // is updated
-    void
-    updateCurrentSnapshot(SnapshotPtrT<LiveBucket>&& liveSnapshot,
-                          SnapshotPtrT<HotArchiveBucket>&& hotArchiveSnapshot)
+    void updateCurrentSnapshot(
+        SnapshotPtrT<LiveBucket>&& liveSnapshot,
+        SnapshotPtrT<HotArchiveBucket>&& hotArchiveSnapshot)
         LOCKS_EXCLUDED(mSnapshotMutex);
 
     // numHistoricalLedgers is the number of historical snapshots that the
@@ -103,9 +103,8 @@ class BucketSnapshotManager : NonMovableOrCopyable
     // `maybeCopy` interface refreshes `snapshot` if a newer snapshot is
     // available. It's a no-op otherwise. This is useful to avoid unnecessary
     // copying.
-    void
-    maybeCopySearchableBucketListSnapshot(SearchableSnapshotConstPtr& snapshot)
-        LOCKS_EXCLUDED(mSnapshotMutex);
+    void maybeCopySearchableBucketListSnapshot(
+        SearchableSnapshotConstPtr& snapshot) LOCKS_EXCLUDED(mSnapshotMutex);
     void maybeCopySearchableHotArchiveBucketListSnapshot(
         SearchableHotArchiveSnapshotConstPtr& snapshot)
         LOCKS_EXCLUDED(mSnapshotMutex);

--- a/src/bucket/BucketUtils.cpp
+++ b/src/bucket/BucketUtils.cpp
@@ -17,8 +17,7 @@
 namespace stellar
 {
 
-std::string
-toString(LedgerEntryTypeAndDurability const type)
+std::string toString(LedgerEntryTypeAndDurability const type)
 {
     switch (type)
     {
@@ -51,8 +50,7 @@ toString(LedgerEntryTypeAndDurability const type)
     }
 }
 
-MergeCounters&
-MergeCounters::operator+=(MergeCounters const& delta)
+MergeCounters& MergeCounters::operator+=(MergeCounters const& delta)
 {
     mPreInitEntryProtocolMerges += delta.mPreInitEntryProtocolMerges;
     mPostInitEntryProtocolMerges += delta.mPostInitEntryProtocolMerges;
@@ -92,8 +90,7 @@ MergeCounters::operator+=(MergeCounters const& delta)
     return *this;
 }
 
-bool
-MergeCounters::operator==(MergeCounters const& other) const
+bool MergeCounters::operator==(MergeCounters const& other) const
 {
     return (
         mPreInitEntryProtocolMerges == other.mPreInitEntryProtocolMerges &&
@@ -141,10 +138,9 @@ MergeCounters::operator==(MergeCounters const& other) const
 
 // Check that eviction scan is based off of current ledger snapshot and that
 // archival settings have not changed
-bool
-EvictionResultCandidates::isValid(uint32_t currLedgerSeq,
-                                  uint32_t currLedgerVers,
-                                  StateArchivalSettings const& currSas) const
+bool EvictionResultCandidates::isValid(
+    uint32_t currLedgerSeq, uint32_t currLedgerVers,
+    StateArchivalSettings const& currSas) const
 {
     // If the eviction scan started before a protocol upgrade, and the protocol
     // upgrade changes eviction scan behavior during the scan, we need
@@ -182,17 +178,15 @@ EvictionCounters::EvictionCounters(AppConnector& app)
 {
 }
 
-void
-EvictionStatistics::recordEvictedEntry(uint64_t age)
+void EvictionStatistics::recordEvictedEntry(uint64_t age)
 {
     std::lock_guard l(mLock);
     ++mNumEntriesEvicted;
     mEvictedEntriesAgeSum += age;
 }
 
-void
-EvictionStatistics::submitMetricsAndRestartCycle(uint32_t currLedgerSeq,
-                                                 EvictionCounters& counters)
+void EvictionStatistics::submitMetricsAndRestartCycle(
+    uint32_t currLedgerSeq, EvictionCounters& counters)
 {
     std::lock_guard l(mLock);
 
@@ -305,22 +299,18 @@ bucketEntryToLedgerEntryAndDurabilityType<HotArchiveBucket>(
 }
 
 template <>
-bool
-isBucketMetaEntry<HotArchiveBucket>(HotArchiveBucket::EntryT const& be)
+bool isBucketMetaEntry<HotArchiveBucket>(HotArchiveBucket::EntryT const& be)
 {
     return be.type() == HOT_ARCHIVE_METAENTRY;
 }
 
-template <>
-bool
-isBucketMetaEntry<LiveBucket>(LiveBucket::EntryT const& be)
+template <> bool isBucketMetaEntry<LiveBucket>(LiveBucket::EntryT const& be)
 {
     return be.type() == METAENTRY;
 }
 
 template <class BucketT>
-void
-BucketEntryCounters::count(typename BucketT::EntryT const& be)
+void BucketEntryCounters::count(typename BucketT::EntryT const& be)
 {
     if (isBucketMetaEntry<BucketT>(be))
     {
@@ -346,21 +336,18 @@ BucketEntryCounters::operator+=(BucketEntryCounters const& other)
     return *this;
 }
 
-bool
-BucketEntryCounters::operator==(BucketEntryCounters const& other) const
+bool BucketEntryCounters::operator==(BucketEntryCounters const& other) const
 {
     return this->entryTypeCounts == other.entryTypeCounts &&
            this->entryTypeSizes == other.entryTypeSizes;
 }
 
-bool
-BucketEntryCounters::operator!=(BucketEntryCounters const& other) const
+bool BucketEntryCounters::operator!=(BucketEntryCounters const& other) const
 {
     return !(*this == other);
 }
 
-size_t
-BucketEntryCounters::numEntries() const
+size_t BucketEntryCounters::numEntries() const
 {
     size_t num = 0;
     for (auto const& [_, count] : entryTypeCounts)
@@ -387,8 +374,7 @@ BucketEntryCounters::count<LiveBucket>(LiveBucket::EntryT const& be);
 template void BucketEntryCounters::count<HotArchiveBucket>(
     HotArchiveBucket::EntryT const& be);
 
-void
-updateTypeBoundaries(
+void updateTypeBoundaries(
     LedgerEntryType currentType, std::streamoff position,
     std::map<LedgerEntryType, std::streamoff>& typeStartOffsets,
     std::map<LedgerEntryType, std::streamoff>& typeEndOffsets,

--- a/src/bucket/BucketUtils.h
+++ b/src/bucket/BucketUtils.h
@@ -211,9 +211,7 @@ struct BucketEntryCounters
     bool operator!=(BucketEntryCounters const& other) const;
     size_t numEntries() const;
 
-    template <class Archive>
-    void
-    serialize(Archive& ar)
+    template <class Archive> void serialize(Archive& ar)
     {
         ar(entryTypeCounts, entryTypeSizes);
     }

--- a/src/bucket/DiskIndex.cpp
+++ b/src/bucket/DiskIndex.cpp
@@ -27,8 +27,7 @@ namespace
 // Returns true if the key is not contained within the given IndexEntry.
 // Range index: check if key is outside range of indexEntry
 // Individual index: check if key does not match indexEntry key
-bool
-keyNotInIndexEntry(LedgerKey const& key, RangeEntry const& indexEntry)
+bool keyNotInIndexEntry(LedgerKey const& key, RangeEntry const& indexEntry)
 {
     return key < indexEntry.lowerBound || indexEntry.upperBound < key;
 }
@@ -38,8 +37,8 @@ keyNotInIndexEntry(LedgerKey const& key, RangeEntry const& indexEntry)
 // If key is too small for indexEntry bounds: return false
 // If key is contained within indexEntry bounds: return false
 // If key is too large for indexEntry bounds: return true
-bool
-lower_bound_pred(RangeIndex::value_type const& indexEntry, LedgerKey const& key)
+bool lower_bound_pred(RangeIndex::value_type const& indexEntry,
+                      LedgerKey const& key)
 {
     return indexEntry.first.upperBound < key;
 }
@@ -49,8 +48,8 @@ lower_bound_pred(RangeIndex::value_type const& indexEntry, LedgerKey const& key)
 // If key is too small for indexEntry bounds: return true
 // If key is contained within indexEntry bounds: return false
 // If key is too large for indexEntry bounds: return false
-bool
-upper_bound_pred(LedgerKey const& key, RangeIndex::value_type const& indexEntry)
+bool upper_bound_pred(LedgerKey const& key,
+                      RangeIndex::value_type const& indexEntry)
 {
     return key < indexEntry.first.lowerBound;
 }
@@ -321,9 +320,8 @@ DiskIndex<BucketT>::DiskIndex(Archive& ar, BucketManager const& bm,
 }
 
 template <class BucketT>
-void
-DiskIndex<BucketT>::saveToDisk(BucketManager& bm, Hash const& hash,
-                               asio::io_context& ctx) const
+void DiskIndex<BucketT>::saveToDisk(BucketManager& bm, Hash const& hash,
+                                    asio::io_context& ctx) const
 {
     ZoneScoped;
     releaseAssert(bm.getConfig().BUCKETLIST_DB_PERSIST_INDEX);
@@ -371,17 +369,14 @@ DiskIndex<BucketT>::saveToDisk(BucketManager& bm, Hash const& hash,
     }
 }
 
-template <class BucketT>
-void
-DiskIndex<BucketT>::markBloomMiss() const
+template <class BucketT> void DiskIndex<BucketT>::markBloomMiss() const
 {
     mBloomMissMeter.Mark();
 }
 
 #ifdef BUILD_TESTS
 template <class BucketT>
-bool
-DiskIndex<BucketT>::operator==(DiskIndex<BucketT> const& in) const
+bool DiskIndex<BucketT>::operator==(DiskIndex<BucketT> const& in) const
 {
     if (getPageSize() != in.getPageSize())
     {

--- a/src/bucket/DiskIndex.h
+++ b/src/bucket/DiskIndex.h
@@ -47,15 +47,12 @@ struct RangeEntry
         releaseAssert(low < high || low == high);
     }
 
-    inline bool
-    operator==(RangeEntry const& in) const
+    inline bool operator==(RangeEntry const& in) const
     {
         return lowerBound == in.lowerBound && upperBound == in.upperBound;
     }
 
-    template <class Archive>
-    void
-    serialize(Archive& ar)
+    template <class Archive> void serialize(Archive& ar)
     {
         ar(lowerBound, upperBound);
     }
@@ -85,9 +82,7 @@ template <class BucketT> class DiskIndex : public NonMovableOrCopyable
         std::map<LedgerEntryType, std::pair<std::streamoff, std::streamoff>>
             typeRanges;
 
-        template <class Archive>
-        void
-        save(Archive& ar) const
+        template <class Archive> void save(Archive& ar) const
         {
             auto version = BucketT::IndexT::BUCKET_INDEX_VERSION;
             ar(version, pageSize, keysToOffset, filter, assetToPoolID, counters,
@@ -100,9 +95,7 @@ template <class BucketT> class DiskIndex : public NonMovableOrCopyable
         // not match the expected values, it indicates an upgrade has occurred
         // since serialization. The on-disk version is outdated and must be
         // replaced by a newly created index.
-        template <class Archive>
-        void
-        load(Archive& ar)
+        template <class Archive> void load(Archive& ar)
         {
             ar(keysToOffset, filter, assetToPoolID, counters, typeRanges);
         }
@@ -146,26 +139,22 @@ template <class BucketT> class DiskIndex : public NonMovableOrCopyable
     getRangeForType(LedgerEntryType type) const;
 
     // Returns page size for index
-    std::streamoff
-    getPageSize() const
+    std::streamoff getPageSize() const
     {
         return mData.pageSize;
     }
 
-    BucketEntryCounters const&
-    getBucketEntryCounters() const
+    BucketEntryCounters const& getBucketEntryCounters() const
     {
         return mData.counters;
     }
 
-    IterT
-    begin() const
+    IterT begin() const
     {
         return mData.keysToOffset.begin();
     }
 
-    IterT
-    end() const
+    IterT end() const
     {
         return mData.keysToOffset.end();
     }
@@ -174,8 +163,8 @@ template <class BucketT> class DiskIndex : public NonMovableOrCopyable
     // called before DiskIndex(Archive& ar, std::streamoff pageSize) to properly
     // deserialize index.
     template <class Archive>
-    static void
-    preLoad(Archive& ar, uint32_t& version, std::streamoff& pageSize)
+    static void preLoad(Archive& ar, uint32_t& version,
+                        std::streamoff& pageSize)
     {
         ar(version, pageSize);
     }
@@ -184,8 +173,7 @@ template <class BucketT> class DiskIndex : public NonMovableOrCopyable
     // when BucketT == LiveBucket
     template <int..., typename T = BucketT,
               std::enable_if_t<std::is_same_v<T, LiveBucket>, bool> = true>
-    AssetPoolIDMap const&
-    getAssetPoolIDMap() const
+    AssetPoolIDMap const& getAssetPoolIDMap() const
     {
         static_assert(std::is_same_v<T, LiveBucket>);
         releaseAssert(mData.assetToPoolID);

--- a/src/bucket/FutureBucket.cpp
+++ b/src/bucket/FutureBucket.cpp
@@ -84,8 +84,7 @@ FutureBucket<BucketT>::FutureBucket(
 }
 
 template <class BucketT>
-void
-FutureBucket<BucketT>::setLiveOutput(std::shared_ptr<BucketT> output)
+void FutureBucket<BucketT>::setLiveOutput(std::shared_ptr<BucketT> output)
 {
     ZoneScoped;
     mState = FB_LIVE_OUTPUT;
@@ -95,15 +94,12 @@ FutureBucket<BucketT>::setLiveOutput(std::shared_ptr<BucketT> output)
 }
 
 template <class BucketT>
-static void
-checkHashEq(std::shared_ptr<BucketT> const& b, std::string const& h)
+static void checkHashEq(std::shared_ptr<BucketT> const& b, std::string const& h)
 {
     releaseAssert(b->getHash() == hexToBin256(h));
 }
 
-template <class BucketT>
-void
-FutureBucket<BucketT>::checkHashesMatch() const
+template <class BucketT> void FutureBucket<BucketT>::checkHashesMatch() const
 {
     ZoneScoped;
     if (!mInputShadowBuckets.empty())
@@ -136,9 +132,7 @@ FutureBucket<BucketT>::checkHashesMatch() const
  * the different hash-only states are mutually exclusive with each other and
  * with live values.
  */
-template <class BucketT>
-void
-FutureBucket<BucketT>::checkState() const
+template <class BucketT> void FutureBucket<BucketT>::checkState() const
 {
     switch (mState)
     {
@@ -197,9 +191,7 @@ FutureBucket<BucketT>::checkState() const
     }
 }
 
-template <class BucketT>
-void
-FutureBucket<BucketT>::clearInputs()
+template <class BucketT> void FutureBucket<BucketT>::clearInputs()
 {
     mInputShadowBuckets.clear();
     mInputSnapBucket.reset();
@@ -210,9 +202,7 @@ FutureBucket<BucketT>::clearInputs()
     mInputCurrBucketHash.clear();
 }
 
-template <class BucketT>
-void
-FutureBucket<BucketT>::clearOutput()
+template <class BucketT> void FutureBucket<BucketT>::clearOutput()
 {
     // NB: MSVC future<> implementation doesn't purge the task lambda (and
     // its captures) on invalidation (due to get()); must explicitly reset.
@@ -221,46 +211,34 @@ FutureBucket<BucketT>::clearOutput()
     mOutputBucket.reset();
 }
 
-template <class BucketT>
-void
-FutureBucket<BucketT>::clear()
+template <class BucketT> void FutureBucket<BucketT>::clear()
 {
     mState = FB_CLEAR;
     clearInputs();
     clearOutput();
 }
 
-template <class BucketT>
-bool
-FutureBucket<BucketT>::isLive() const
+template <class BucketT> bool FutureBucket<BucketT>::isLive() const
 {
     return (mState == FB_LIVE_INPUTS || mState == FB_LIVE_OUTPUT);
 }
 
-template <class BucketT>
-bool
-FutureBucket<BucketT>::isMerging() const
+template <class BucketT> bool FutureBucket<BucketT>::isMerging() const
 {
     return mState == FB_LIVE_INPUTS;
 }
 
-template <class BucketT>
-bool
-FutureBucket<BucketT>::hasHashes() const
+template <class BucketT> bool FutureBucket<BucketT>::hasHashes() const
 {
     return (mState == FB_HASH_INPUTS || mState == FB_HASH_OUTPUT);
 }
 
-template <class BucketT>
-bool
-FutureBucket<BucketT>::isClear() const
+template <class BucketT> bool FutureBucket<BucketT>::isClear() const
 {
     return mState == FB_CLEAR;
 }
 
-template <class BucketT>
-bool
-FutureBucket<BucketT>::mergeComplete() const
+template <class BucketT> bool FutureBucket<BucketT>::mergeComplete() const
 {
     ZoneScoped;
     releaseAssert(isLive());
@@ -273,8 +251,7 @@ FutureBucket<BucketT>::mergeComplete() const
 }
 
 template <class BucketT>
-std::shared_ptr<BucketT>
-FutureBucket<BucketT>::resolve()
+std::shared_ptr<BucketT> FutureBucket<BucketT>::resolve()
 {
     ZoneScoped;
     checkState();
@@ -304,9 +281,7 @@ FutureBucket<BucketT>::resolve()
     return mOutputBucket;
 }
 
-template <class BucketT>
-bool
-FutureBucket<BucketT>::hasOutputHash() const
+template <class BucketT> bool FutureBucket<BucketT>::hasOutputHash() const
 {
     if (mState == FB_LIVE_OUTPUT || mState == FB_HASH_OUTPUT)
     {
@@ -317,8 +292,7 @@ FutureBucket<BucketT>::hasOutputHash() const
 }
 
 template <class BucketT>
-std::string const&
-FutureBucket<BucketT>::getOutputHash() const
+std::string const& FutureBucket<BucketT>::getOutputHash() const
 {
     releaseAssert(mState == FB_LIVE_OUTPUT || mState == FB_HASH_OUTPUT);
     releaseAssert(!mOutputBucketHash.empty());
@@ -326,8 +300,8 @@ FutureBucket<BucketT>::getOutputHash() const
 }
 
 template <class BucketT>
-static std::chrono::seconds
-getAvailableTimeForMerge(Application& app, uint32_t level)
+static std::chrono::seconds getAvailableTimeForMerge(Application& app,
+                                                     uint32_t level)
 {
     // FutureBucket is managed by a background thread that is not related to the
     // rest of the core state machine such that getting the current value of a
@@ -344,9 +318,9 @@ getAvailableTimeForMerge(Application& app, uint32_t level)
 }
 
 template <class BucketT>
-void
-FutureBucket<BucketT>::startMerge(Application& app, uint32_t maxProtocolVersion,
-                                  bool countMergeEvents, uint32_t level)
+void FutureBucket<BucketT>::startMerge(Application& app,
+                                       uint32_t maxProtocolVersion,
+                                       bool countMergeEvents, uint32_t level)
 {
     ZoneScoped;
     // NB: startMerge starts with FutureBucket in a half-valid state; the inputs
@@ -462,9 +436,9 @@ FutureBucket<BucketT>::startMerge(Application& app, uint32_t maxProtocolVersion,
 }
 
 template <class BucketT>
-void
-FutureBucket<BucketT>::makeLive(Application& app, uint32_t maxProtocolVersion,
-                                uint32_t level)
+void FutureBucket<BucketT>::makeLive(Application& app,
+                                     uint32_t maxProtocolVersion,
+                                     uint32_t level)
 {
     ZoneScoped;
     checkState();
@@ -501,8 +475,7 @@ FutureBucket<BucketT>::makeLive(Application& app, uint32_t maxProtocolVersion,
 }
 
 template <class BucketT>
-std::vector<std::string>
-FutureBucket<BucketT>::getHashes() const
+std::vector<std::string> FutureBucket<BucketT>::getHashes() const
 {
     ZoneScoped;
     std::vector<std::string> hashes;

--- a/src/bucket/FutureBucket.h
+++ b/src/bucket/FutureBucket.h
@@ -133,9 +133,7 @@ template <class BucketT> class FutureBucket
     // Return all hashes referenced by this future.
     std::vector<std::string> getHashes() const;
 
-    template <class Archive>
-    void
-    load(Archive& ar)
+    template <class Archive> void load(Archive& ar)
     {
         clear();
         ar(cereal::make_nvp("state", mState));
@@ -159,9 +157,7 @@ template <class BucketT> class FutureBucket
         checkState();
     }
 
-    template <class Archive>
-    void
-    save(Archive& ar) const
+    template <class Archive> void save(Archive& ar) const
     {
         checkState();
         switch (mState)

--- a/src/bucket/HotArchiveBucket.cpp
+++ b/src/bucket/HotArchiveBucket.cpp
@@ -43,8 +43,7 @@ HotArchiveBucket::fresh(BucketManager& bucketManager, uint32_t protocolVersion,
     return out.getBucket(bucketManager);
 }
 
-std::vector<HotArchiveBucketEntry>
-HotArchiveBucket::convertToBucketEntry(
+std::vector<HotArchiveBucketEntry> HotArchiveBucket::convertToBucketEntry(
     std::vector<LedgerEntry> const& archivedEntries,
     std::vector<LedgerKey> const& restoredEntries)
 {
@@ -76,8 +75,7 @@ HotArchiveBucket::convertToBucketEntry(
     return bucket;
 }
 
-void
-HotArchiveBucket::maybePut(
+void HotArchiveBucket::maybePut(
     std::function<void(HotArchiveBucketEntry const&)> putFunc,
     HotArchiveBucketEntry const& entry, MergeCounters& mc)
 {
@@ -85,8 +83,7 @@ HotArchiveBucket::maybePut(
 }
 
 template <typename InputSource>
-void
-HotArchiveBucket::mergeCasesWithEqualKeys(
+void HotArchiveBucket::mergeCasesWithEqualKeys(
     MergeCounters& mc, InputSource& inputSource,
     std::function<void(HotArchiveBucketEntry const&)> putFunc,
     uint32_t protocolVersion)
@@ -97,8 +94,7 @@ HotArchiveBucket::mergeCasesWithEqualKeys(
     inputSource.advanceOld();
 }
 
-uint32_t
-HotArchiveBucket::getBucketVersion() const
+uint32_t HotArchiveBucket::getBucketVersion() const
 {
     HotArchiveBucketInputIterator it(shared_from_this());
     return it.getMetadata().ledgerVersion;
@@ -115,8 +111,7 @@ HotArchiveBucket::HotArchiveBucket() : BucketBase()
 {
 }
 
-bool
-HotArchiveBucket::isTombstoneEntry(HotArchiveBucketEntry const& e)
+bool HotArchiveBucket::isTombstoneEntry(HotArchiveBucketEntry const& e)
 {
     return e.type() == HOT_ARCHIVE_LIVE;
 }

--- a/src/bucket/HotArchiveBucket.h
+++ b/src/bucket/HotArchiveBucket.h
@@ -65,19 +65,18 @@ class HotArchiveBucket
              HotArchiveBucketEntry const& entry, MergeCounters& mc);
 
     // For now, we only count LiveBucket merge events
-    static void
-    countOldEntryType(MergeCounters& mc, HotArchiveBucketEntry const& e)
+    static void countOldEntryType(MergeCounters& mc,
+                                  HotArchiveBucketEntry const& e)
     {
     }
 
-    static void
-    countNewEntryType(MergeCounters& mc, HotArchiveBucketEntry const& e)
+    static void countNewEntryType(MergeCounters& mc,
+                                  HotArchiveBucketEntry const& e)
     {
     }
 
-    static void
-    checkProtocolLegality(HotArchiveBucketEntry const& entry,
-                          uint32_t protocolVersion)
+    static void checkProtocolLegality(HotArchiveBucketEntry const& entry,
+                                      uint32_t protocolVersion)
     {
     }
 

--- a/src/bucket/HotArchiveBucketIndex.cpp
+++ b/src/bucket/HotArchiveBucketIndex.cpp
@@ -28,8 +28,8 @@ HotArchiveBucketIndex::HotArchiveBucketIndex(
                mDiskIndex.getPageSize(), filename);
 }
 
-std::streamoff
-HotArchiveBucketIndex::getPageSize(Config const& cfg, size_t bucketSize)
+std::streamoff HotArchiveBucketIndex::getPageSize(Config const& cfg,
+                                                  size_t bucketSize)
 {
     auto ret = getPageSizeFromConfig(cfg);
     if (ret == 0)
@@ -59,8 +59,7 @@ HotArchiveBucketIndex::scan(IterT start, LedgerKey const& k) const
 }
 
 #ifdef BUILD_TESTS
-bool
-HotArchiveBucketIndex::operator==(HotArchiveBucketIndex const& in) const
+bool HotArchiveBucketIndex::operator==(HotArchiveBucketIndex const& in) const
 {
     if (!(mDiskIndex == in.mDiskIndex))
     {

--- a/src/bucket/HotArchiveBucketIndex.h
+++ b/src/bucket/HotArchiveBucketIndex.h
@@ -69,48 +69,41 @@ class HotArchiveBucketIndex : public NonMovableOrCopyable
     // LiveBucketIndex.
     static std::streamoff getPageSize(Config const& cfg, size_t bucketSize);
 
-    IndexReturnT
-    lookup(LedgerKey const& k) const
+    IndexReturnT lookup(LedgerKey const& k) const
     {
         return mDiskIndex.scan(mDiskIndex.begin(), k).first;
     }
 
     // Hot Archive does not support the cache, so define empty function for
     // consistency with LiveBucketIndex
-    void
-    maybeAddToCache(
+    void maybeAddToCache(
         std::shared_ptr<HotArchiveBucketEntry const> const& entry) const
     {
     }
 
     std::pair<IndexReturnT, IterT> scan(IterT start, LedgerKey const& k) const;
 
-    BucketEntryCounters const&
-    getBucketEntryCounters() const
+    BucketEntryCounters const& getBucketEntryCounters() const
     {
         return mDiskIndex.getBucketEntryCounters();
     }
 
-    uint32_t
-    getPageSize() const
+    uint32_t getPageSize() const
     {
         return static_cast<uint32_t>(mDiskIndex.getPageSize());
     }
 
-    IterT
-    begin() const
+    IterT begin() const
     {
         return mDiskIndex.begin();
     }
 
-    IterT
-    end() const
+    IterT end() const
     {
         return mDiskIndex.end();
     }
 
-    void
-    markBloomMiss() const
+    void markBloomMiss() const
     {
         mDiskIndex.markBloomMiss();
     }

--- a/src/bucket/HotArchiveBucketList.cpp
+++ b/src/bucket/HotArchiveBucketList.cpp
@@ -8,11 +8,10 @@
 namespace stellar
 {
 
-void
-HotArchiveBucketList::addBatch(Application& app, uint32_t currLedger,
-                               uint32_t currLedgerProtocol,
-                               std::vector<LedgerEntry> const& archiveEntries,
-                               std::vector<LedgerKey> const& restoredEntries)
+void HotArchiveBucketList::addBatch(
+    Application& app, uint32_t currLedger, uint32_t currLedgerProtocol,
+    std::vector<LedgerEntry> const& archiveEntries,
+    std::vector<LedgerKey> const& restoredEntries)
 {
     ZoneScoped;
     releaseAssertOrThrow(protocolVersionStartsFrom(

--- a/src/bucket/InMemoryIndex.cpp
+++ b/src/bucket/InMemoryIndex.cpp
@@ -18,13 +18,12 @@ namespace
 {
 // Helper function to process a single bucket entry for InMemoryIndex
 // construction
-void
-processEntry(BucketEntry const& be, InMemoryBucketState& inMemoryState,
-             AssetPoolIDMap& assetPoolIDMap, BucketEntryCounters& counters,
-             std::streamoff& lastOffset,
-             std::map<LedgerEntryType, std::streamoff>& typeStartOffsets,
-             std::map<LedgerEntryType, std::streamoff>& typeEndOffsets,
-             std::optional<LedgerEntryType>& lastTypeSeen)
+void processEntry(BucketEntry const& be, InMemoryBucketState& inMemoryState,
+                  AssetPoolIDMap& assetPoolIDMap, BucketEntryCounters& counters,
+                  std::streamoff& lastOffset,
+                  std::map<LedgerEntryType, std::streamoff>& typeStartOffsets,
+                  std::map<LedgerEntryType, std::streamoff>& typeEndOffsets,
+                  std::optional<LedgerEntryType>& lastTypeSeen)
 {
     counters.template count<LiveBucket>(be);
 
@@ -51,8 +50,7 @@ processEntry(BucketEntry const& be, InMemoryBucketState& inMemoryState,
 }
 }
 
-void
-InMemoryBucketState::insert(BucketEntry const& be)
+void InMemoryBucketState::insert(BucketEntry const& be)
 {
     auto [_, inserted] = mEntries.insert(
         InternalInMemoryBucketEntry(std::make_shared<BucketEntry const>(be)));
@@ -162,8 +160,7 @@ InMemoryIndex::getRangeForType(LedgerEntryType type) const
 }
 
 #ifdef BUILD_TESTS
-bool
-InMemoryIndex::operator==(InMemoryIndex const& in) const
+bool InMemoryIndex::operator==(InMemoryIndex const& in) const
 {
     return mInMemoryState == in.mInMemoryState &&
            mAssetPoolIDMap == in.mAssetPoolIDMap &&

--- a/src/bucket/InMemoryIndex.h
+++ b/src/bucket/InMemoryIndex.h
@@ -33,8 +33,7 @@ class InternalInMemoryBucketEntry
         virtual size_t hash() const = 0;
         virtual IndexPtrT const& get() const = 0;
 
-        virtual bool
-        operator==(const AbstractEntry& other) const
+        virtual bool operator==(const AbstractEntry& other) const
         {
             return copyKey() == other.copyKey();
         }
@@ -51,20 +50,17 @@ class InternalInMemoryBucketEntry
         {
         }
 
-        LedgerKey
-        copyKey() const override
+        LedgerKey copyKey() const override
         {
             return getBucketLedgerKey(*entry);
         }
 
-        size_t
-        hash() const override
+        size_t hash() const override
         {
             return std::hash<LedgerKey>{}(getBucketLedgerKey(*entry));
         }
 
-        IndexPtrT const&
-        get() const override
+        IndexPtrT const& get() const override
         {
             return entry;
         }
@@ -81,20 +77,17 @@ class InternalInMemoryBucketEntry
         {
         }
 
-        LedgerKey
-        copyKey() const override
+        LedgerKey copyKey() const override
         {
             return ledgerKey;
         }
 
-        size_t
-        hash() const override
+        size_t hash() const override
         {
             return std::hash<LedgerKey>{}(ledgerKey);
         }
 
-        IndexPtrT const&
-        get() const override
+        IndexPtrT const& get() const override
         {
             throw std::runtime_error("Called get() on QueryKey");
         }
@@ -113,20 +106,17 @@ class InternalInMemoryBucketEntry
     {
     }
 
-    size_t
-    hash() const
+    size_t hash() const
     {
         return impl->hash();
     }
 
-    bool
-    operator==(InternalInMemoryBucketEntry const& other) const
+    bool operator==(InternalInMemoryBucketEntry const& other) const
     {
         return impl->operator==(*other.impl);
     }
 
-    IndexPtrT const&
-    get() const
+    IndexPtrT const& get() const
     {
         return impl->get();
     }
@@ -134,8 +124,7 @@ class InternalInMemoryBucketEntry
 
 struct InternalInMemoryBucketEntryHash
 {
-    size_t
-    operator()(InternalInMemoryBucketEntry const& entry) const
+    size_t operator()(InternalInMemoryBucketEntry const& entry) const
     {
         return entry.hash();
     }
@@ -163,20 +152,17 @@ class InMemoryBucketState : public NonMovableOrCopyable
     std::pair<IndexReturnT, IterT> scan(IterT start,
                                         LedgerKey const& searchKey) const;
 
-    IterT
-    begin() const
+    IterT begin() const
     {
         return mEntries.begin();
     }
-    IterT
-    end() const
+    IterT end() const
     {
         return mEntries.end();
     }
 
 #ifdef BUILD_TESTS
-    bool
-    operator==(InMemoryBucketState const& in) const
+    bool operator==(InMemoryBucketState const& in) const
     {
         return mEntries == in.mEntries;
     }
@@ -202,31 +188,27 @@ class InMemoryIndex
                   std::vector<BucketEntry> const& inMemoryState,
                   BucketMetadata const& metadata);
 
-    IterT
-    begin() const
+    IterT begin() const
     {
         return mInMemoryState.begin();
     }
-    IterT
-    end() const
+    IterT end() const
     {
         return mInMemoryState.end();
     }
 
-    AssetPoolIDMap const&
-    getAssetPoolIDMap() const
+    AssetPoolIDMap const& getAssetPoolIDMap() const
     {
         return mAssetPoolIDMap;
     }
 
-    BucketEntryCounters const&
-    getBucketEntryCounters() const
+    BucketEntryCounters const& getBucketEntryCounters() const
     {
         return mCounters;
     }
 
-    std::pair<IndexReturnT, IterT>
-    scan(IterT start, LedgerKey const& searchKey) const
+    std::pair<IndexReturnT, IterT> scan(IterT start,
+                                        LedgerKey const& searchKey) const
     {
         return mInMemoryState.scan(start, searchKey);
     }

--- a/src/bucket/LedgerCmp.h
+++ b/src/bucket/LedgerCmp.h
@@ -15,16 +15,13 @@ namespace stellar
 class HotArchiveBucket;
 class LiveBucket;
 
-template <typename T>
-bool
-lexCompare(T&& lhs1, T&& rhs1)
+template <typename T> bool lexCompare(T&& lhs1, T&& rhs1)
 {
     return lhs1 < rhs1;
 }
 
 template <typename T, typename... U>
-bool
-lexCompare(T&& lhs1, T&& rhs1, U&&... args)
+bool lexCompare(T&& lhs1, T&& rhs1, U&&... args)
 {
     if (lhs1 < rhs1)
     {
@@ -55,8 +52,7 @@ lexCompare(T&& lhs1, T&& rhs1, U&&... args)
 struct LedgerEntryIdCmp
 {
     template <typename T, typename U>
-    auto
-    operator()(T const& a, U const& b) const
+    auto operator()(T const& a, U const& b) const
         -> decltype(a.type(), b.type(), bool())
     {
         LedgerEntryType aty = a.type();
@@ -132,9 +128,8 @@ template <typename BucketT> struct BucketEntryIdCmp
 {
     BUCKET_TYPE_ASSERT(BucketT);
 
-    bool
-    compareHotArchive(HotArchiveBucketEntry const& a,
-                      HotArchiveBucketEntry const& b) const
+    bool compareHotArchive(HotArchiveBucketEntry const& a,
+                           HotArchiveBucketEntry const& b) const
     {
         HotArchiveBucketEntryType aty = a.type();
         HotArchiveBucketEntryType bty = b.type();
@@ -186,8 +181,7 @@ template <typename BucketT> struct BucketEntryIdCmp
         }
     }
 
-    bool
-    compareLive(BucketEntry const& a, BucketEntry const& b) const
+    bool compareLive(BucketEntry const& a, BucketEntry const& b) const
     {
         BucketEntryType aty = a.type();
         BucketEntryType bty = b.type();
@@ -238,9 +232,8 @@ template <typename BucketT> struct BucketEntryIdCmp
         }
     }
 
-    bool
-    operator()(typename BucketT::EntryT const& a,
-               typename BucketT::EntryT const& b) const
+    bool operator()(typename BucketT::EntryT const& a,
+                    typename BucketT::EntryT const& b) const
     {
         if constexpr (std::is_same_v<BucketT, LiveBucket>)
         {

--- a/src/bucket/LiveBucket.cpp
+++ b/src/bucket/LiveBucket.cpp
@@ -16,8 +16,7 @@ namespace stellar
 {
 namespace
 {
-void
-countShadowedEntryType(MergeCounters& mc, BucketEntry const& e)
+void countShadowedEntryType(MergeCounters& mc, BucketEntry const& e)
 {
     switch (e.type())
     {
@@ -37,8 +36,7 @@ countShadowedEntryType(MergeCounters& mc, BucketEntry const& e)
 }
 }
 
-void
-LiveBucket::countNewEntryType(MergeCounters& mc, BucketEntry const& e)
+void LiveBucket::countNewEntryType(MergeCounters& mc, BucketEntry const& e)
 {
     switch (e.type())
     {
@@ -56,8 +54,7 @@ LiveBucket::countNewEntryType(MergeCounters& mc, BucketEntry const& e)
         break;
     }
 }
-void
-LiveBucket::countOldEntryType(MergeCounters& mc, BucketEntry const& e)
+void LiveBucket::countOldEntryType(MergeCounters& mc, BucketEntry const& e)
 {
     switch (e.type())
     {
@@ -76,8 +73,7 @@ LiveBucket::countOldEntryType(MergeCounters& mc, BucketEntry const& e)
     }
 }
 
-bool
-LiveBucket::updateMergeCountersForProtocolVersion(
+bool LiveBucket::updateMergeCountersForProtocolVersion(
     MergeCounters& mc, uint32_t protocolVersion,
     std::vector<LiveBucketInputIterator> const& shadowIterators)
 {
@@ -112,11 +108,10 @@ LiveBucket::updateMergeCountersForProtocolVersion(
     return keepShadowedLifecycleEntries;
 }
 
-void
-LiveBucket::maybePut(std::function<void(BucketEntry const&)> putFunc,
-                     BucketEntry const& entry, MergeCounters& mc,
-                     std::vector<LiveBucketInputIterator>& shadowIterators,
-                     bool keepShadowedLifecycleEntries)
+void LiveBucket::maybePut(std::function<void(BucketEntry const&)> putFunc,
+                          BucketEntry const& entry, MergeCounters& mc,
+                          std::vector<LiveBucketInputIterator>& shadowIterators,
+                          bool keepShadowedLifecycleEntries)
 {
     // In ledgers before protocol 11, keepShadowedLifecycleEntries will be
     // `false` and we will drop all shadowed entries here.
@@ -188,8 +183,7 @@ LiveBucket::maybePut(std::function<void(BucketEntry const&)> putFunc,
 }
 
 template <typename InputSource>
-void
-LiveBucket::mergeCasesWithEqualKeys(
+void LiveBucket::mergeCasesWithEqualKeys(
     MergeCounters& mc, InputSource& inputSource,
     std::function<void(BucketEntry const&)> putFunc, uint32_t protocolVersion,
     std::vector<LiveBucketInputIterator>& shadowIterators,
@@ -311,8 +305,7 @@ LiveBucket::mergeCasesWithEqualKeys(
     inputSource.advanceNew();
 }
 
-bool
-LiveBucket::containsBucketIdentity(BucketEntry const& id) const
+bool LiveBucket::containsBucketIdentity(BucketEntry const& id) const
 {
     BucketEntryIdCmp<LiveBucket> cmp;
     LiveBucketInputIterator iter(shared_from_this());
@@ -327,8 +320,7 @@ LiveBucket::containsBucketIdentity(BucketEntry const& id) const
     return false;
 }
 
-size_t
-LiveBucket::getIndexCacheSize() const
+size_t LiveBucket::getIndexCacheSize() const
 {
     if (mIndex)
     {
@@ -338,8 +330,7 @@ LiveBucket::getIndexCacheSize() const
 }
 
 #ifdef BUILD_TESTS
-void
-LiveBucket::apply(Application& app) const
+void LiveBucket::apply(Application& app) const
 {
     ZoneScoped;
     std::unordered_set<LedgerKey> emptySet;
@@ -358,8 +349,7 @@ LiveBucket::apply(Application& app) const
     counters.logInfo("direct", 0, app.getClock().now());
 }
 
-size_t
-LiveBucket::getMaxCacheSize() const
+size_t LiveBucket::getMaxCacheSize() const
 {
     if (!isEmpty())
     {
@@ -463,13 +453,11 @@ LiveBucket::fresh(BucketManager& bucketManager, uint32_t protocolVersion,
     return out.getBucket(bucketManager);
 }
 
-std::shared_ptr<LiveBucket>
-LiveBucket::freshInMemoryOnly(BucketManager& bucketManager,
-                              uint32_t protocolVersion,
-                              std::vector<LedgerEntry> const& initEntries,
-                              std::vector<LedgerEntry> const& liveEntries,
-                              std::vector<LedgerKey> const& deadEntries,
-                              bool countMergeEvents)
+std::shared_ptr<LiveBucket> LiveBucket::freshInMemoryOnly(
+    BucketManager& bucketManager, uint32_t protocolVersion,
+    std::vector<LedgerEntry> const& initEntries,
+    std::vector<LedgerEntry> const& liveEntries,
+    std::vector<LedgerKey> const& deadEntries, bool countMergeEvents)
 {
     ZoneScoped;
     // When building fresh buckets after protocol version 10 (i.e. version
@@ -498,9 +486,8 @@ LiveBucket::freshInMemoryOnly(BucketManager& bucketManager,
     return b;
 }
 
-void
-LiveBucket::checkProtocolLegality(BucketEntry const& entry,
-                                  uint32_t protocolVersion)
+void LiveBucket::checkProtocolLegality(BucketEntry const& entry,
+                                       uint32_t protocolVersion)
 {
     if (protocolVersionIsBefore(
             protocolVersion,
@@ -525,28 +512,24 @@ LiveBucket::LiveBucket() : BucketBase()
     mEntries = std::vector<BucketEntry>();
 }
 
-uint32_t
-LiveBucket::getBucketVersion() const
+uint32_t LiveBucket::getBucketVersion() const
 {
     LiveBucketInputIterator it(shared_from_this());
     return it.getMetadata().ledgerVersion;
 }
 
-void
-LiveBucket::maybeInitializeCache(size_t totalBucketListAccountsSizeBytes,
-                                 Config const& cfg) const
+void LiveBucket::maybeInitializeCache(size_t totalBucketListAccountsSizeBytes,
+                                      Config const& cfg) const
 {
     releaseAssert(mIndex);
     mIndex->maybeInitializeCache(totalBucketListAccountsSizeBytes, cfg);
 }
 
-std::shared_ptr<LiveBucket>
-LiveBucket::mergeInMemory(BucketManager& bucketManager,
-                          uint32_t maxProtocolVersion,
-                          std::shared_ptr<LiveBucket> const& oldBucket,
-                          std::shared_ptr<LiveBucket> const& newBucket,
-                          bool countMergeEvents, asio::io_context& ctx,
-                          bool doFsync)
+std::shared_ptr<LiveBucket> LiveBucket::mergeInMemory(
+    BucketManager& bucketManager, uint32_t maxProtocolVersion,
+    std::shared_ptr<LiveBucket> const& oldBucket,
+    std::shared_ptr<LiveBucket> const& newBucket, bool countMergeEvents,
+    asio::io_context& ctx, bool doFsync)
 {
     ZoneScoped;
     releaseAssertOrThrow(oldBucket->hasInMemoryEntries());
@@ -604,15 +587,13 @@ LiveBucket::mergeInMemory(BucketManager& bucketManager,
     return out.getBucket(bucketManager, nullptr, std::move(mergedEntries));
 }
 
-BucketEntryCounters const&
-LiveBucket::getBucketEntryCounters() const
+BucketEntryCounters const& LiveBucket::getBucketEntryCounters() const
 {
     releaseAssert(mIndex);
     return mIndex->getBucketEntryCounters();
 }
 
-bool
-LiveBucket::isTombstoneEntry(BucketEntry const& e)
+bool LiveBucket::isTombstoneEntry(BucketEntry const& e)
 {
     return e.type() == DEADENTRY;
 }

--- a/src/bucket/LiveBucket.h
+++ b/src/bucket/LiveBucket.h
@@ -160,20 +160,17 @@ class LiveBucket : public BucketBase<LiveBucket, LiveBucketIndex>,
 
     uint32_t getBucketVersion() const;
 
-    bool
-    hasInMemoryEntries() const
+    bool hasInMemoryEntries() const
     {
         return mEntries.has_value();
     }
 
-    void
-    setInMemoryEntries(std::vector<BucketEntry>&& entries)
+    void setInMemoryEntries(std::vector<BucketEntry>&& entries)
     {
         mEntries = std::move(entries);
     }
 
-    std::vector<BucketEntry> const&
-    getInMemoryEntries() const
+    std::vector<BucketEntry> const& getInMemoryEntries() const
     {
         releaseAssertOrThrow(mEntries.has_value());
         return *mEntries;

--- a/src/bucket/LiveBucketIndex.cpp
+++ b/src/bucket/LiveBucketIndex.cpp
@@ -19,14 +19,13 @@
 namespace stellar
 {
 
-bool
-LiveBucketIndex::typeNotSupported(LedgerEntryType t)
+bool LiveBucketIndex::typeNotSupported(LedgerEntryType t)
 {
     return t == OFFER;
 }
 
-std::streamoff
-LiveBucketIndex::getPageSize(Config const& cfg, size_t bucketSize)
+std::streamoff LiveBucketIndex::getPageSize(Config const& cfg,
+                                            size_t bucketSize)
 {
     // Convert cfg param from MB to bytes
     if (auto cutoff = cfg.BUCKETLIST_DB_INDEX_CUTOFF * 1024 * 1024;
@@ -51,7 +50,6 @@ LiveBucketIndex::LiveBucketIndex(BucketManager& bm,
     auto pageSize = getPageSize(bm.getConfig(), fs::size(filename.string()));
     if (pageSize == 0)
     {
-
         CLOG_DEBUG(Bucket,
                    "LiveBucketIndex::createIndex() using in-memory index for "
                    "bucket {}",
@@ -91,9 +89,8 @@ LiveBucketIndex::LiveBucketIndex(BucketManager& bm,
 {
 }
 
-void
-LiveBucketIndex::maybeInitializeCache(size_t totalBucketListAccountsSizeBytes,
-                                      Config const& cfg) const
+void LiveBucketIndex::maybeInitializeCache(
+    size_t totalBucketListAccountsSizeBytes, Config const& cfg) const
 {
     // Everything is already in memory, no need for a redundant cache.
     if (mInMemoryIndex)
@@ -162,8 +159,7 @@ LiveBucketIndex::maybeInitializeCache(size_t totalBucketListAccountsSizeBytes,
     }
 }
 
-LiveBucketIndex::IterT
-LiveBucketIndex::begin() const
+LiveBucketIndex::IterT LiveBucketIndex::begin() const
 {
     if (mDiskIndex)
     {
@@ -176,8 +172,7 @@ LiveBucketIndex::begin() const
     }
 }
 
-LiveBucketIndex::IterT
-LiveBucketIndex::end() const
+LiveBucketIndex::IterT LiveBucketIndex::end() const
 {
     if (mDiskIndex)
     {
@@ -190,8 +185,7 @@ LiveBucketIndex::end() const
     }
 }
 
-void
-LiveBucketIndex::markBloomMiss() const
+void LiveBucketIndex::markBloomMiss() const
 {
     releaseAssertOrThrow(mDiskIndex);
     mDiskIndex->markBloomMiss();
@@ -220,8 +214,7 @@ LiveBucketIndex::getCachedEntry(LedgerKey const& k) const
     return nullptr;
 }
 
-IndexReturnT
-LiveBucketIndex::lookup(LedgerKey const& k) const
+IndexReturnT LiveBucketIndex::lookup(LedgerKey const& k) const
 {
     if (mDiskIndex)
     {
@@ -294,8 +287,7 @@ LiveBucketIndex::getRangeForType(LedgerEntryType type) const
     return mInMemoryIndex->getRangeForType(type);
 }
 
-uint32_t
-LiveBucketIndex::getPageSize() const
+uint32_t LiveBucketIndex::getPageSize() const
 {
     if (mDiskIndex)
     {
@@ -306,8 +298,7 @@ LiveBucketIndex::getPageSize() const
     return 0;
 }
 
-BucketEntryCounters const&
-LiveBucketIndex::getBucketEntryCounters() const
+BucketEntryCounters const& LiveBucketIndex::getBucketEntryCounters() const
 {
     if (mDiskIndex)
     {
@@ -318,8 +309,7 @@ LiveBucketIndex::getBucketEntryCounters() const
     return mInMemoryIndex->getBucketEntryCounters();
 }
 
-bool
-LiveBucketIndex::shouldUseCache() const
+bool LiveBucketIndex::shouldUseCache() const
 {
     if (mDiskIndex)
     {
@@ -330,14 +320,12 @@ LiveBucketIndex::shouldUseCache() const
     return false;
 }
 
-bool
-LiveBucketIndex::isCachedType(LedgerKey const& lk)
+bool LiveBucketIndex::isCachedType(LedgerKey const& lk)
 {
     return lk.type() == ACCOUNT;
 }
 
-void
-LiveBucketIndex::maybeAddToCache(
+void LiveBucketIndex::maybeAddToCache(
     std::shared_ptr<BucketEntry const> const& entry) const
 {
     if (shouldUseCache())
@@ -359,8 +347,7 @@ LiveBucketIndex::maybeAddToCache(
 }
 
 #ifdef BUILD_TESTS
-bool
-LiveBucketIndex::operator==(LiveBucketIndex const& in) const
+bool LiveBucketIndex::operator==(LiveBucketIndex const& in) const
 {
     if (mDiskIndex)
     {
@@ -387,8 +374,7 @@ LiveBucketIndex::operator==(LiveBucketIndex const& in) const
     return true;
 }
 
-size_t
-LiveBucketIndex::getMaxCacheSize() const
+size_t LiveBucketIndex::getMaxCacheSize() const
 {
     if (shouldUseCache())
     {
@@ -400,8 +386,7 @@ LiveBucketIndex::getMaxCacheSize() const
 }
 #endif
 
-size_t
-LiveBucketIndex::getCurrentCacheSize() const
+size_t LiveBucketIndex::getCurrentCacheSize() const
 {
     if (shouldUseCache())
     {

--- a/src/bucket/LiveBucketIndex.h
+++ b/src/bucket/LiveBucketIndex.h
@@ -71,14 +71,12 @@ class LiveBucketIndex : public NonMovableOrCopyable
     medida::Meter& mCacheHitMeter;
     medida::Meter& mCacheMissMeter;
 
-    static inline DiskIndex<LiveBucket>::IterT
-    getDiskIter(IterT const& iter)
+    static inline DiskIndex<LiveBucket>::IterT getDiskIter(IterT const& iter)
     {
         return std::get<DiskIndex<LiveBucket>::IterT>(iter);
     }
 
-    static inline InMemoryIndex::IterT
-    getInMemoryIter(IterT const& iter)
+    static inline InMemoryIndex::IterT getInMemoryIter(IterT const& iter)
     {
         return std::get<InMemoryIndex::IterT>(iter);
     }

--- a/src/bucket/LiveBucketList.cpp
+++ b/src/bucket/LiveBucketList.cpp
@@ -11,12 +11,11 @@
 namespace stellar
 {
 
-void
-LiveBucketList::addBatch(Application& app, uint32_t currLedger,
-                         uint32_t currLedgerProtocol,
-                         std::vector<LedgerEntry> const& initEntries,
-                         std::vector<LedgerEntry> const& liveEntries,
-                         std::vector<LedgerKey> const& deadEntries)
+void LiveBucketList::addBatch(Application& app, uint32_t currLedger,
+                              uint32_t currLedgerProtocol,
+                              std::vector<LedgerEntry> const& initEntries,
+                              std::vector<LedgerEntry> const& liveEntries,
+                              std::vector<LedgerKey> const& deadEntries)
 {
     ZoneScoped;
     addBatchInternal(app, currLedger, currLedgerProtocol, initEntries,
@@ -26,8 +25,7 @@ LiveBucketList::addBatch(Application& app, uint32_t currLedger,
     maybeInitializeCaches(app.getConfig());
 }
 
-BucketEntryCounters
-LiveBucketList::sumBucketEntryCounters() const
+BucketEntryCounters LiveBucketList::sumBucketEntryCounters() const
 {
     BucketEntryCounters counters;
     for (auto const& lev : mLevels)
@@ -44,8 +42,7 @@ LiveBucketList::sumBucketEntryCounters() const
     return counters;
 }
 
-void
-LiveBucketList::maybeInitializeCaches(Config const& cfg) const
+void LiveBucketList::maybeInitializeCaches(Config const& cfg) const
 {
     auto blCounters = sumBucketEntryCounters();
     size_t totalAccountsSize =
@@ -67,10 +64,9 @@ LiveBucketList::maybeInitializeCaches(Config const& cfg) const
     }
 }
 
-void
-LiveBucketList::updateStartingEvictionIterator(EvictionIterator& iter,
-                                               uint32_t firstScanLevel,
-                                               uint32_t ledgerSeq)
+void LiveBucketList::updateStartingEvictionIterator(EvictionIterator& iter,
+                                                    uint32_t firstScanLevel,
+                                                    uint32_t ledgerSeq)
 {
     // Check if an upgrade has changed the starting scan level to below the
     // current iterator level
@@ -111,8 +107,7 @@ LiveBucketList::updateStartingEvictionIterator(EvictionIterator& iter,
     }
 }
 
-bool
-LiveBucketList::updateEvictionIterAndRecordStats(
+bool LiveBucketList::updateEvictionIterAndRecordStats(
     EvictionIterator& iter, EvictionIterator startIter,
     uint32_t configFirstScanLevel, uint32_t ledgerSeq,
     std::shared_ptr<EvictionStatistics> stats, EvictionCounters& counters)
@@ -154,11 +149,9 @@ LiveBucketList::updateEvictionIterAndRecordStats(
     return false;
 }
 
-void
-LiveBucketList::checkIfEvictionScanIsStuck(EvictionIterator const& evictionIter,
-                                           uint32_t scanSize,
-                                           std::shared_ptr<LiveBucket const> b,
-                                           EvictionCounters& counters)
+void LiveBucketList::checkIfEvictionScanIsStuck(
+    EvictionIterator const& evictionIter, uint32_t scanSize,
+    std::shared_ptr<LiveBucket const> b, EvictionCounters& counters)
 {
     // Check to see if we can finish scanning the new bucket before it
     // receives an update

--- a/src/bucket/MergeKey.cpp
+++ b/src/bucket/MergeKey.cpp
@@ -19,8 +19,7 @@ MergeKey::MergeKey(bool keepTombstoneEntries, Hash const& currHash,
 {
 }
 
-bool
-MergeKey::operator==(MergeKey const& other) const
+bool MergeKey::operator==(MergeKey const& other) const
 {
     return mKeepTombstoneEntries == other.mKeepTombstoneEntries &&
            mInputCurrBucket == other.mInputCurrBucket &&
@@ -28,8 +27,7 @@ MergeKey::operator==(MergeKey const& other) const
            mInputShadowBuckets == other.mInputShadowBuckets;
 }
 
-std::ostream&
-operator<<(std::ostream& out, MergeKey const& b)
+std::ostream& operator<<(std::ostream& out, MergeKey const& b)
 {
     out << "[curr=" << hexAbbrev(b.mInputCurrBucket)
         << ", snap=" << hexAbbrev(b.mInputSnapBucket) << ", shadows=[";
@@ -47,8 +45,7 @@ operator<<(std::ostream& out, MergeKey const& b)
     return out;
 }
 
-std::string
-format_as(MergeKey const& k)
+std::string format_as(MergeKey const& k)
 {
     std::stringstream ss;
     ss << k;

--- a/src/bucket/SearchableBucketList.cpp
+++ b/src/bucket/SearchableBucketList.cpp
@@ -78,8 +78,7 @@ SearchableLiveBucketListSnapshot::scanForEviction(
     return result;
 }
 
-void
-SearchableLiveBucketListSnapshot::scanForEntriesOfType(
+void SearchableLiveBucketListSnapshot::scanForEntriesOfType(
     LedgerEntryType type,
     std::function<Loop(BucketEntry const&)> callback) const
 {
@@ -195,7 +194,6 @@ SearchableLiveBucketListSnapshot::loadInflationWinners(size_t maxWinners,
     // Check if we need to sort the voteCount by number of votes
     if (voteCount.size() > maxWinners)
     {
-
         // Sort Inflation winners by vote count in descending order
         std::map<int64_t, UnorderedMap<AccountID, int64_t>::const_iterator,
                  std::greater<int64_t>>
@@ -228,8 +226,7 @@ SearchableLiveBucketListSnapshot::loadInflationWinners(size_t maxWinners,
     return winners;
 }
 
-std::vector<LedgerEntry>
-SearchableLiveBucketListSnapshot::loadKeys(
+std::vector<LedgerEntry> SearchableLiveBucketListSnapshot::loadKeys(
     std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys,
     std::string const& label) const
 {

--- a/src/bucket/test/BucketIndexTests.cpp
+++ b/src/bucket/test/BucketIndexTests.cpp
@@ -64,9 +64,8 @@ class BucketIndexTest
         }
     }
 
-    void
-    buildBucketList(std::function<void(std::vector<LedgerEntry>&)> f,
-                    bool isCacheTest = false, bool sorobanOnly = false)
+    void buildBucketList(std::function<void(std::vector<LedgerEntry>&)> f,
+                         bool isCacheTest = false, bool sorobanOnly = false)
     {
         releaseAssertOrThrow(!(isCacheTest && sorobanOnly));
 
@@ -89,7 +88,6 @@ class BucketIndexTest
             }
             else if (sorobanOnly)
             {
-
                 entries =
                     LedgerTestUtils::generateValidUniqueLedgerEntriesWithTypes(
                         {CONTRACT_DATA, CONTRACT_CODE}, 10, mGeneratedKeys);
@@ -146,32 +144,27 @@ class BucketIndexTest
     {
     }
 
-    BucketManager&
-    getBM() const
+    BucketManager& getBM() const
     {
         return mApp->getBucketManager();
     }
 
-    Application&
-    getApp() const
+    Application& getApp() const
     {
         return *mApp;
     }
 
-    UnorderedMap<LedgerKey, LedgerEntry> const&
-    getContractCodeEntries() const
+    UnorderedMap<LedgerKey, LedgerEntry> const& getContractCodeEntries() const
     {
         return mContractCodeEntries;
     }
 
-    UnorderedMap<LedgerKey, LedgerEntry> const&
-    getContractDataEntries() const
+    UnorderedMap<LedgerKey, LedgerEntry> const& getContractDataEntries() const
     {
         return mContractDataEntries;
     }
 
-    virtual void
-    buildGeneralTest(bool isCacheTest = false)
+    virtual void buildGeneralTest(bool isCacheTest = false)
     {
         auto f = [&](std::vector<LedgerEntry> const& entries) {
             // Sample ~4% of entries if not a cache test
@@ -193,8 +186,7 @@ class BucketIndexTest
         buildBucketList(f, isCacheTest);
     }
 
-    void
-    runHistoricalSnapshotTest()
+    void runHistoricalSnapshotTest()
     {
         uint32_t ledger = 0;
 
@@ -247,8 +239,7 @@ class BucketIndexTest
         }
     }
 
-    virtual void
-    buildMultiVersionTest(bool sorobanOnly = false)
+    virtual void buildMultiVersionTest(bool sorobanOnly = false)
     {
         std::vector<LedgerKey> toDestroy;
         std::vector<LedgerEntry> toUpdate;
@@ -359,8 +350,7 @@ class BucketIndexTest
         buildBucketList(f, /*isCacheTest=*/false, sorobanOnly);
     }
 
-    void
-    insertSimilarContractDataKeys()
+    void insertSimilarContractDataKeys()
     {
         auto templateEntry =
             LedgerTestUtils::generateValidUniqueLedgerEntriesWithTypes(
@@ -410,8 +400,7 @@ class BucketIndexTest
         closeLedger(*mApp);
     }
 
-    virtual void
-    run(std::optional<double> expectedHitRate = std::nullopt)
+    virtual void run(std::optional<double> expectedHitRate = std::nullopt)
     {
         auto searchableBL = getBM()
                                 .getBucketSnapshotManager()
@@ -541,8 +530,7 @@ class BucketIndexTest
     }
 
     // Do many lookups with subsets of sampled entries
-    virtual void
-    runPerf(size_t n)
+    virtual void runPerf(size_t n)
     {
         auto searchableBL = getBM()
                                 .getBucketSnapshotManager()
@@ -582,8 +570,7 @@ class BucketIndexTest
         }
     }
 
-    void
-    testInvalidKeys()
+    void testInvalidKeys()
     {
         auto searchableBL = getBM()
                                 .getBucketSnapshotManager()
@@ -607,8 +594,7 @@ class BucketIndexTest
         }
     }
 
-    void
-    restartWithConfig(Config const& cfg)
+    void restartWithConfig(Config const& cfg)
     {
         mApp->gracefulStop();
         while (mClock->crank(false))
@@ -631,8 +617,7 @@ class BucketIndexPoolShareTest : public BucketIndexTest
     Asset mAsset2;
     Asset mAsset3;
 
-    static LedgerEntry
-    generateTrustline(AccountEntry a, LiquidityPoolEntry p)
+    static LedgerEntry generateTrustline(AccountEntry a, LiquidityPoolEntry p)
     {
         LedgerEntry t;
         t.data.type(TRUSTLINE);
@@ -642,8 +627,7 @@ class BucketIndexPoolShareTest : public BucketIndexTest
         return t;
     }
 
-    void
-    buildTest(bool shouldMultiVersion)
+    void buildTest(bool shouldMultiVersion)
     {
         auto f = [&](std::vector<LedgerEntry>& entries) {
             std::vector<LedgerEntry> poolEntries;
@@ -741,14 +725,12 @@ class BucketIndexPoolShareTest : public BucketIndexTest
         strToAssetCode(mAsset3.alphaNum4().assetCode, "ast2");
     }
 
-    virtual void
-    buildGeneralTest(bool isCacheTest = false) override
+    virtual void buildGeneralTest(bool isCacheTest = false) override
     {
         buildTest(false);
     }
 
-    virtual void
-    buildMultiVersionTest(bool ignored = false) override
+    virtual void buildMultiVersionTest(bool ignored = false) override
     {
         buildTest(true);
     }
@@ -766,8 +748,7 @@ class BucketIndexPoolShareTest : public BucketIndexTest
     }
 };
 
-static void
-testAllIndexTypes(std::function<void(Config&)> f)
+static void testAllIndexTypes(std::function<void(Config&)> f)
 {
     SECTION("individual index only")
     {

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -44,35 +44,29 @@ using namespace BucketTestUtils;
 namespace BucketListTests
 {
 
-uint32_t
-size(uint32_t level)
+uint32_t size(uint32_t level)
 {
     return 1 << (2 * (level + 1));
 }
-uint32_t
-half(uint32_t level)
+uint32_t half(uint32_t level)
 {
     return size(level) >> 1;
 }
-uint32_t
-prev(uint32_t level)
+uint32_t prev(uint32_t level)
 {
     return size(level - 1);
 }
-uint32_t
-lowBoundExclusive(uint32_t level, uint32_t ledger)
+uint32_t lowBoundExclusive(uint32_t level, uint32_t ledger)
 {
     return roundDown(ledger, size(level));
 }
-uint32_t
-highBoundInclusive(uint32_t level, uint32_t ledger)
+uint32_t highBoundInclusive(uint32_t level, uint32_t ledger)
 {
     return roundDown(ledger, prev(level));
 }
 
-void
-checkBucketSizeAndBounds(LiveBucketList& bl, uint32_t ledgerSeq, uint32_t level,
-                         bool isCurr)
+void checkBucketSizeAndBounds(LiveBucketList& bl, uint32_t ledgerSeq,
+                              uint32_t level, bool isCurr)
 {
     std::shared_ptr<LiveBucket> bucket;
     uint32_t sizeOfBucket = 0;
@@ -111,9 +105,8 @@ checkBucketSizeAndBounds(LiveBucketList& bl, uint32_t ledgerSeq, uint32_t level,
 
 // If pred is false for ledger < L and true for ledger >= L then
 // binarySearchForLedger will return L.
-uint32_t
-binarySearchForLedger(uint32_t lbound, uint32_t ubound,
-                      const std::function<uint32_t(uint32_t)>& pred)
+uint32_t binarySearchForLedger(uint32_t lbound, uint32_t ubound,
+                               const std::function<uint32_t(uint32_t)>& pred)
 {
     while (lbound + 1 != ubound)
     {
@@ -133,9 +126,7 @@ binarySearchForLedger(uint32_t lbound, uint32_t ubound,
 
 using namespace BucketListTests;
 
-template <class BucketListT>
-static void
-basicBucketListTest()
+template <class BucketListT> static void basicBucketListTest()
 {
     VirtualClock clock;
     Config const& cfg = getTestConfig();
@@ -221,9 +212,7 @@ TEST_CASE_VERSIONS("bucket list", "[bucket][bucketlist]")
     }
 }
 
-template <class BucketListT>
-static void
-updatePeriodTest()
+template <class BucketListT> static void updatePeriodTest()
 {
     std::map<uint32_t, uint32_t> currCalculatedUpdatePeriods;
     std::map<uint32_t, uint32_t> snapCalculatedUpdatePeriods;
@@ -754,9 +743,7 @@ TEST_CASE_VERSIONS("single entry bubbling up",
     }
 }
 
-template <class BucketListT>
-static void
-sizeOfTests()
+template <class BucketListT> static void sizeOfTests()
 {
     stellar::uniform_int_distribution<uint32_t> dist;
     for (uint32_t i = 0; i < 1000; ++i)
@@ -801,9 +788,7 @@ TEST_CASE("BucketList sizeOf and oldestLedgerIn relations",
     }
 }
 
-template <class BucketListT>
-static void
-snapSteadyStateTest()
+template <class BucketListT> static void snapSteadyStateTest()
 {
     // Deliberately exclude deepest level since snap on the deepest level
     // is always empty.
@@ -847,9 +832,7 @@ TEST_CASE("BucketList snap reaches steady state", "[bucket][bucketlist][count]")
     }
 }
 
-template <class BucketListT>
-static void
-deepestCurrTest()
+template <class BucketListT> static void deepestCurrTest()
 {
     uint32_t const deepest = BucketListT::kNumLevels - 1;
     // Use binary search to find the first ledger where the deepest curr
@@ -893,9 +876,7 @@ TEST_CASE("BucketList deepest curr accumulates", "[bucket][bucketlist][count]")
     }
 }
 
-template <class BucketListT>
-static void
-blSizesAtLedger1Test()
+template <class BucketListT> static void blSizesAtLedger1Test()
 {
     REQUIRE(BucketListT::sizeOfCurr(1, 0) == 1);
     REQUIRE(BucketListT::sizeOfSnap(1, 0) == 0);
@@ -1733,16 +1714,14 @@ TEST_CASE_VERSIONS("Searchable BucketListDB snapshots", "[bucketlist]")
     }
 }
 
-static std::string
-formatX32(uint32_t v)
+static std::string formatX32(uint32_t v)
 {
     std::ostringstream oss;
     oss << "0x" << std::hex << std::setw(8) << std::setfill('0') << v;
     return oss.str();
 }
 
-static std::string
-formatU32(uint32_t v)
+static std::string formatU32(uint32_t v)
 {
     std::ostringstream oss;
     oss << std::dec << std::setw(8) << std::setfill(' ') << v << "="
@@ -1750,8 +1729,7 @@ formatU32(uint32_t v)
     return oss.str();
 }
 
-static std::string
-formatLedgerList(std::vector<uint32_t> const& ledgers)
+static std::string formatLedgerList(std::vector<uint32_t> const& ledgers)
 {
     std::ostringstream oss;
     bool first = true;

--- a/src/bucket/test/BucketManagerTests.cpp
+++ b/src/bucket/test/BucketManagerTests.cpp
@@ -43,10 +43,8 @@ using namespace BucketTestUtils;
 namespace BucketManagerTests
 {
 
-static void
-clearFutures(Application::pointer app, LiveBucketList& bl)
+static void clearFutures(Application::pointer app, LiveBucketList& bl)
 {
-
     // First go through the BL and mop up all the FutureBuckets.
     for (uint32_t i = 0; i < LiveBucketList::kNumLevels; ++i)
     {
@@ -108,8 +106,7 @@ TEST_CASE("skip list", "[bucket][bucketmanager]")
             : BucketManager(app.getAppConnector())
         {
         }
-        void
-        test()
+        void test()
         {
             Hash h0;
             Hash h1 = HashUtils::pseudoRandomForTesting();
@@ -843,9 +840,7 @@ TEST_CASE_VERSIONS(
 // 2048).
 class StopAndRestartBucketMergesTest
 {
-    template <class BucketListT>
-    static void
-    resolveAllMerges(BucketListT& bl)
+    template <class BucketListT> static void resolveAllMerges(BucketListT& bl)
     {
         for (uint32 i = 0; i < BucketListT::kNumLevels; ++i)
         {
@@ -868,8 +863,7 @@ class StopAndRestartBucketMergesTest
         MergeCounters mLiveMergeCounters;
         MergeCounters mHotArchiveMergeCounters;
 
-        void
-        checkEmptyHotArchiveMetrics() const
+        void checkEmptyHotArchiveMetrics() const
         {
             // If before p23, check that all hot archive metrics are zero
             CHECK(mHotArchiveMergeCounters.mPreInitEntryProtocolMerges == 0);
@@ -906,9 +900,8 @@ class StopAndRestartBucketMergesTest
             CHECK(mHotArchiveMergeCounters.mOutputIteratorActualWrites == 0);
         }
 
-        void
-        dumpMergeCounters(std::string const& label, uint32_t level,
-                          uint32_t protocol) const
+        void dumpMergeCounters(std::string const& label, uint32_t level,
+                               uint32_t protocol) const
         {
             auto dumpCounters = [&](std::string const& label, uint32_t level,
                                     MergeCounters const& counters) {
@@ -981,8 +974,7 @@ class StopAndRestartBucketMergesTest
             }
         }
 
-        void
-        checkSensiblePostInitEntryMergeCounters(uint32_t protocol) const
+        void checkSensiblePostInitEntryMergeCounters(uint32_t protocol) const
         {
             // Check live merge counters
             CHECK(mLiveMergeCounters.mPostInitEntryProtocolMerges != 0);
@@ -1089,8 +1081,7 @@ class StopAndRestartBucketMergesTest
             }
         }
 
-        void
-        checkSensiblePreInitEntryMergeCounters(uint32_t protocol) const
+        void checkSensiblePreInitEntryMergeCounters(uint32_t protocol) const
         {
             CHECK(mLiveMergeCounters.mPreInitEntryProtocolMerges != 0);
             CHECK(mLiveMergeCounters.mPreShadowRemovalProtocolMerges != 0);
@@ -1124,8 +1115,7 @@ class StopAndRestartBucketMergesTest
                   mLiveMergeCounters.mOutputIteratorActualWrites);
         }
 
-        void
-        checkEqualMergeCounters(Survey const& other) const
+        void checkEqualMergeCounters(Survey const& other) const
         {
             auto checkCountersEqual = [](auto const& counters,
                                          auto const& other) {
@@ -1189,8 +1179,7 @@ class StopAndRestartBucketMergesTest
                                other.mHotArchiveMergeCounters);
         }
 
-        void
-        checkEqual(Survey const& other) const
+        void checkEqual(Survey const& other) const
         {
             CHECK(mCurrBucketHash == other.mCurrBucketHash);
             CHECK(mSnapBucketHash == other.mSnapBucketHash);
@@ -1241,10 +1230,9 @@ class StopAndRestartBucketMergesTest
     // for Hot Archive
     std::vector<LedgerKey> mHotArchiveInitialBatch;
 
-    void
-    collectLedgerEntries(Application& app,
-                         std::map<LedgerKey, LedgerEntry>& liveEntries,
-                         std::map<LedgerKey, LedgerEntry>& archiveEntries)
+    void collectLedgerEntries(Application& app,
+                              std::map<LedgerKey, LedgerEntry>& liveEntries,
+                              std::map<LedgerKey, LedgerEntry>& archiveEntries)
     {
         auto bl = app.getBucketManager().getLiveBucketList();
         for (uint32_t i = LiveBucketList::kNumLevels; i > 0; --i)
@@ -1299,8 +1287,7 @@ class StopAndRestartBucketMergesTest
         }
     }
 
-    void
-    collectFinalLedgerEntries(Application& app)
+    void collectFinalLedgerEntries(Application& app)
     {
         collectLedgerEntries(app, mFinalEntries, mFinalArchiveEntries);
         CLOG_INFO(Bucket,
@@ -1309,8 +1296,7 @@ class StopAndRestartBucketMergesTest
                   mFinalEntries.size(), mFinalArchiveEntries.size());
     }
 
-    void
-    checkAgainstFinalLedgerEntries(Application& app)
+    void checkAgainstFinalLedgerEntries(Application& app)
     {
         std::map<LedgerKey, LedgerEntry> testEntries;
         std::map<LedgerKey, LedgerEntry> testArchiveEntries;
@@ -1331,8 +1317,7 @@ class StopAndRestartBucketMergesTest
         }
     }
 
-    void
-    calculateDesignatedLedgers()
+    void calculateDesignatedLedgers()
     {
         uint32_t spillFreq = LiveBucketList::levelHalf(mDesignatedLevel);
         uint32_t prepFreq =
@@ -1379,8 +1364,7 @@ class StopAndRestartBucketMergesTest
 
     // Designated ledgers are where stop/restart events will occur. We further
     // _survey_ ledgers +/- 1 on each side of _designated_ ledgers.
-    bool
-    shouldSurveyLedger(uint32_t ledger)
+    bool shouldSurveyLedger(uint32_t ledger)
     {
         if (mDesignatedLedgers.find(ledger + 1) != mDesignatedLedgers.end())
         {
@@ -1398,8 +1382,7 @@ class StopAndRestartBucketMergesTest
         return false;
     }
 
-    void
-    collectControlSurveys()
+    void collectControlSurveys()
     {
         VirtualClock clock;
         Config cfg(getTestConfig(0, Config::TESTDB_BUCKET_DB_PERSISTENT));
@@ -1563,8 +1546,7 @@ class StopAndRestartBucketMergesTest
         collectFinalLedgerEntries(*app);
     }
 
-    void
-    runStopAndRestartTest(uint32_t firstProtocol, uint32_t secondProtocol)
+    void runStopAndRestartTest(uint32_t firstProtocol, uint32_t secondProtocol)
     {
         std::unique_ptr<VirtualClock> clock = std::make_unique<VirtualClock>();
         Config cfg(getTestConfig(0, Config::TESTDB_BUCKET_DB_PERSISTENT));
@@ -1745,8 +1727,7 @@ class StopAndRestartBucketMergesTest
     {
     }
 
-    void
-    run()
+    void run()
     {
         calculateDesignatedLedgers();
         collectControlSurveys();

--- a/src/bucket/test/BucketTestUtils.cpp
+++ b/src/bucket/test/BucketTestUtils.cpp
@@ -21,24 +21,21 @@ namespace stellar
 namespace BucketTestUtils
 {
 
-uint32_t
-getAppLedgerVersion(Application& app)
+uint32_t getAppLedgerVersion(Application& app)
 {
     auto const& lcl = app.getLedgerManager().getLastClosedLedgerHeader();
     return lcl.header.ledgerVersion;
 }
 
-uint32_t
-getAppLedgerVersion(Application::pointer app)
+uint32_t getAppLedgerVersion(Application::pointer app)
 {
     return getAppLedgerVersion(*app);
 }
 
-void
-addLiveBatchAndUpdateSnapshot(Application& app, LedgerHeader header,
-                              std::vector<LedgerEntry> const& initEntries,
-                              std::vector<LedgerEntry> const& liveEntries,
-                              std::vector<LedgerKey> const& deadEntries)
+void addLiveBatchAndUpdateSnapshot(Application& app, LedgerHeader header,
+                                   std::vector<LedgerEntry> const& initEntries,
+                                   std::vector<LedgerEntry> const& liveEntries,
+                                   std::vector<LedgerKey> const& deadEntries)
 {
     auto& liveBl = app.getBucketManager().getLiveBucketList();
     liveBl.addBatch(app, header.ledgerSeq, header.ledgerVersion, initEntries,
@@ -54,8 +51,7 @@ addLiveBatchAndUpdateSnapshot(Application& app, LedgerHeader header,
         std::move(liveSnapshot), std::move(hotArchiveSnapshot));
 }
 
-void
-addHotArchiveBatchAndUpdateSnapshot(
+void addHotArchiveBatchAndUpdateSnapshot(
     Application& app, LedgerHeader header,
     std::vector<LedgerEntry> const& archiveEntries,
     std::vector<LedgerKey> const& restoredEntries)
@@ -73,8 +69,7 @@ addHotArchiveBatchAndUpdateSnapshot(
         std::move(liveSnapshot), std::move(hotArchiveSnapshot));
 }
 
-void
-for_versions_with_differing_bucket_logic(
+void for_versions_with_differing_bucket_logic(
     Config const& cfg, std::function<void(Config const&)> const& f)
 {
     for_versions(
@@ -89,9 +84,8 @@ for_versions_with_differing_bucket_logic(
         cfg, f);
 }
 
-Hash
-closeLedger(Application& app, std::optional<SecretKey> skToSignValue,
-            xdr::xvector<UpgradeType, 6> upgrades)
+Hash closeLedger(Application& app, std::optional<SecretKey> skToSignValue,
+                 xdr::xvector<UpgradeType, 6> upgrades)
 {
     auto& lm = app.getLedgerManager();
     auto lcl = lm.getLastClosedLedgerHeader();
@@ -110,8 +104,7 @@ closeLedger(Application& app, std::optional<SecretKey> skToSignValue,
     return lm.getLastClosedLedgerHeader().hash;
 }
 
-Hash
-closeLedger(Application& app)
+Hash closeLedger(Application& app)
 {
     return closeLedger(app, std::nullopt);
 }
@@ -174,9 +167,7 @@ EntryCounts<HotArchiveBucket>::EntryCounts(
     }
 }
 
-template <class BucketT>
-size_t
-countEntries(std::shared_ptr<BucketT> bucket)
+template <class BucketT> size_t countEntries(std::shared_ptr<BucketT> bucket)
 {
     EntryCounts e(bucket);
     return e.sum();
@@ -185,8 +176,7 @@ countEntries(std::shared_ptr<BucketT> bucket)
 template size_t countEntries(std::shared_ptr<LiveBucket> bucket);
 template size_t countEntries(std::shared_ptr<HotArchiveBucket> bucket);
 
-void
-LedgerManagerForBucketTests::finalizeLedgerTxnChanges(
+void LedgerManagerForBucketTests::finalizeLedgerTxnChanges(
     SearchableSnapshotConstPtr lclSnapshot,
     SearchableHotArchiveSnapshotConstPtr lclHotArchiveSnapshot,
     AbstractLedgerTxn& ltx,
@@ -352,8 +342,7 @@ LedgerManagerForBucketTests::finalizeLedgerTxnChanges(
     }
 }
 
-LedgerManagerForBucketTests&
-BucketTestApplication::getLedgerManager()
+LedgerManagerForBucketTests& BucketTestApplication::getLedgerManager()
 {
     auto& lm = ApplicationImpl::getLedgerManager();
     return static_cast<LedgerManagerForBucketTests&>(lm);

--- a/src/bucket/test/BucketTestUtils.h
+++ b/src/bucket/test/BucketTestUtils.h
@@ -37,13 +37,11 @@ template <class BucketT> struct EntryCounts
     size_t nInitOrArchived{0};
     size_t nLive{0};
     size_t nDead{0};
-    size_t
-    sum() const
+    size_t sum() const
     {
         return nLive + nInitOrArchived + nDead;
     }
-    size_t
-    sumIncludingMeta() const
+    size_t sumIncludingMeta() const
     {
         return nLive + nInitOrArchived + nDead + nMeta;
     }
@@ -80,8 +78,7 @@ class LedgerManagerForBucketTests : public LedgerManagerImpl
         LedgerHeader lh, uint32_t initialLedgerVers) override;
 
   public:
-    void
-    setNextLedgerEntryBatchForBucketTesting(
+    void setNextLedgerEntryBatchForBucketTesting(
         std::vector<LedgerEntry> const& initEntries,
         std::vector<LedgerEntry> const& liveEntries,
         std::vector<LedgerKey> const& deadEntries,
@@ -94,8 +91,7 @@ class LedgerManagerForBucketTests : public LedgerManagerImpl
         mTestDeadEntries = deadEntries;
     }
 
-    void
-    setNextArchiveBatchForBucketTesting(
+    void setNextArchiveBatchForBucketTesting(
         std::vector<LedgerEntry> const& archiveEntries,
         std::vector<LedgerKey> const& restoredEntries)
     {
@@ -120,8 +116,7 @@ class BucketTestApplication : public TestApplication
     virtual LedgerManagerForBucketTests& getLedgerManager() override;
 
   private:
-    virtual std::unique_ptr<LedgerManager>
-    createLedgerManager() override
+    virtual std::unique_ptr<LedgerManager> createLedgerManager() override
     {
         return std::make_unique<LedgerManagerForBucketTests>(*this);
     }

--- a/src/bucket/test/BucketTests.cpp
+++ b/src/bucket/test/BucketTests.cpp
@@ -33,8 +33,7 @@
 using namespace stellar;
 using namespace BucketTestUtils;
 
-static std::ifstream::pos_type
-fileSize(std::string const& name)
+static std::ifstream::pos_type fileSize(std::string const& name)
 {
     assert(fs::exists(name));
     std::ifstream in(name, std::ifstream::ate | std::ifstream::binary);
@@ -43,8 +42,7 @@ fileSize(std::string const& name)
     return in.tellg();
 }
 
-static void
-for_versions_with_differing_initentry_logic(
+static void for_versions_with_differing_initentry_logic(
     Config const& cfg, std::function<void(Config const&)> const& f)
 {
     for_versions(
@@ -373,8 +371,7 @@ TEST_CASE_VERSIONS("merging hot archive bucket entries", "[bucket][archival]")
     });
 }
 
-static LedgerEntry
-generateAccount()
+static LedgerEntry generateAccount()
 {
     LedgerEntry e;
     e.data.type(ACCOUNT);

--- a/src/catchup/ApplyBucketsWork.cpp
+++ b/src/catchup/ApplyBucketsWork.cpp
@@ -30,8 +30,7 @@ class TempLedgerVersionSetter : NonMovableOrCopyable
     Application& mApp;
     uint32 mOldVersion;
 
-    void
-    setVersion(uint32 ver)
+    void setVersion(uint32 ver)
     {
         LedgerTxn ltx(mApp.getLedgerTxnRoot());
         auto header = ltx.loadHeader();
@@ -67,8 +66,7 @@ ApplyBucketsWork::ApplyBucketsWork(
 {
 }
 
-std::shared_ptr<LiveBucket>
-ApplyBucketsWork::getBucket(std::string const& hash)
+std::shared_ptr<LiveBucket> ApplyBucketsWork::getBucket(std::string const& hash)
 {
     auto i = mBuckets.find(hash);
     auto b = (i != mBuckets.end())
@@ -79,8 +77,7 @@ ApplyBucketsWork::getBucket(std::string const& hash)
     return b;
 }
 
-void
-ApplyBucketsWork::doReset()
+void ApplyBucketsWork::doReset()
 {
     ZoneScoped;
     CLOG_INFO(History, "Applying buckets");
@@ -137,14 +134,12 @@ ApplyBucketsWork::doReset()
     }
 }
 
-bool
-ApplyBucketsWork::appliedAllBuckets() const
+bool ApplyBucketsWork::appliedAllBuckets() const
 {
     return mBucketToApplyIndex == mBucketsToApply.size();
 }
 
-void
-ApplyBucketsWork::startBucket()
+void ApplyBucketsWork::startBucket()
 {
     ZoneScoped;
     auto bucket = mBucketsToApply.at(mBucketToApplyIndex);
@@ -164,8 +159,7 @@ ApplyBucketsWork::startBucket()
         mSeenKeys);
 }
 
-void
-ApplyBucketsWork::prepareForNextBucket()
+void ApplyBucketsWork::prepareForNextBucket()
 {
     ZoneScoped;
     mBucketApplicator.reset();
@@ -185,8 +179,7 @@ ApplyBucketsWork::prepareForNextBucket()
 // allows us to perform a single write to the DB and ensure that only the newest
 // version is written.
 //
-BasicWork::State
-ApplyBucketsWork::doWork()
+BasicWork::State ApplyBucketsWork::doWork()
 {
     ZoneScoped;
 
@@ -256,9 +249,8 @@ ApplyBucketsWork::doWork()
     return checkChildrenStatus();
 }
 
-void
-ApplyBucketsWork::advance(std::string const& bucketName,
-                          BucketApplicator& applicator)
+void ApplyBucketsWork::advance(std::string const& bucketName,
+                               BucketApplicator& applicator)
 {
     ZoneScoped;
     releaseAssert(applicator);
@@ -299,8 +291,7 @@ ApplyBucketsWork::advance(std::string const& bucketName,
     }
 }
 
-std::string
-ApplyBucketsWork::getStatus() const
+std::string ApplyBucketsWork::getStatus() const
 {
     // This status string only applies to step 2 when we actually apply the
     // buckets.

--- a/src/catchup/ApplyBufferedLedgersWork.cpp
+++ b/src/catchup/ApplyBufferedLedgersWork.cpp
@@ -19,14 +19,12 @@ ApplyBufferedLedgersWork::ApplyBufferedLedgersWork(Application& app)
 {
 }
 
-void
-ApplyBufferedLedgersWork::onReset()
+void ApplyBufferedLedgersWork::onReset()
 {
     mConditionalWork.reset();
 }
 
-BasicWork::State
-ApplyBufferedLedgersWork::onRun()
+BasicWork::State ApplyBufferedLedgersWork::onRun()
 {
     ZoneScoped;
     if (mConditionalWork)
@@ -78,16 +76,14 @@ ApplyBufferedLedgersWork::onRun()
     return State::WORK_RUNNING;
 }
 
-std::string
-ApplyBufferedLedgersWork::getStatus() const
+std::string ApplyBufferedLedgersWork::getStatus() const
 {
     return fmt::format(FMT_STRING("Applying buffered ledgers: {}"),
                        mConditionalWork ? mConditionalWork->getStatus()
                                         : BasicWork::getStatus());
 }
 
-void
-ApplyBufferedLedgersWork::shutdown()
+void ApplyBufferedLedgersWork::shutdown()
 {
     ZoneScoped;
     if (mConditionalWork)
@@ -97,8 +93,7 @@ ApplyBufferedLedgersWork::shutdown()
     BasicWork::shutdown();
 }
 
-bool
-ApplyBufferedLedgersWork::onAbort()
+bool ApplyBufferedLedgersWork::onAbort()
 {
     ZoneScoped;
     if (mConditionalWork && !mConditionalWork->isDone())

--- a/src/catchup/ApplyCheckpointWork.cpp
+++ b/src/catchup/ApplyCheckpointWork.cpp
@@ -51,8 +51,7 @@ ApplyCheckpointWork::ApplyCheckpointWork(Application& app,
     }
 }
 
-std::string
-ApplyCheckpointWork::getStatus() const
+std::string ApplyCheckpointWork::getStatus() const
 {
     if (getState() == State::WORK_RUNNING)
     {
@@ -62,23 +61,20 @@ ApplyCheckpointWork::getStatus() const
     return BasicWork::getStatus();
 }
 
-void
-ApplyCheckpointWork::closeFiles()
+void ApplyCheckpointWork::closeFiles()
 {
     mHdrIn.close();
     mTxIn.close();
     mFilesOpen = false;
 }
 
-void
-ApplyCheckpointWork::onReset()
+void ApplyCheckpointWork::onReset()
 {
     mConditionalWork.reset();
     closeFiles();
 }
 
-void
-ApplyCheckpointWork::openInputFiles()
+void ApplyCheckpointWork::openInputFiles()
 {
     ZoneScoped;
     mHdrIn.close();
@@ -133,8 +129,7 @@ ApplyCheckpointWork::openInputFiles()
     mFilesOpen = true;
 }
 
-TxSetXDRFrameConstPtr
-ApplyCheckpointWork::getCurrentTxSet()
+TxSetXDRFrameConstPtr ApplyCheckpointWork::getCurrentTxSet()
 {
     ZoneScoped;
     auto& lm = mApp.getLedgerManager();
@@ -162,8 +157,7 @@ ApplyCheckpointWork::getCurrentTxSet()
 }
 
 #ifdef BUILD_TESTS
-std::optional<TransactionResultSet>
-ApplyCheckpointWork::getCurrentTxResultSet()
+std::optional<TransactionResultSet> ApplyCheckpointWork::getCurrentTxResultSet()
 {
     ZoneScoped;
     auto& lm = mApp.getLedgerManager();
@@ -187,8 +181,7 @@ ApplyCheckpointWork::getCurrentTxResultSet()
 }
 #endif // BUILD_TESTS
 
-std::shared_ptr<LedgerCloseData>
-ApplyCheckpointWork::getNextLedgerCloseData()
+std::shared_ptr<LedgerCloseData> ApplyCheckpointWork::getNextLedgerCloseData()
 {
     ZoneScoped;
     if (!mHdrIn || !mHdrIn.readOne(mHeaderHistoryEntry))
@@ -309,8 +302,7 @@ ApplyCheckpointWork::getNextLedgerCloseData()
 #endif
 }
 
-BasicWork::State
-ApplyCheckpointWork::onRun()
+BasicWork::State ApplyCheckpointWork::onRun()
 {
     ZoneScoped;
     if (mConditionalWork)
@@ -386,8 +378,7 @@ ApplyCheckpointWork::onRun()
     return State::WORK_RUNNING;
 }
 
-void
-ApplyCheckpointWork::shutdown()
+void ApplyCheckpointWork::shutdown()
 {
     ZoneScoped;
     if (mConditionalWork)
@@ -397,8 +388,7 @@ ApplyCheckpointWork::shutdown()
     BasicWork::shutdown();
 }
 
-bool
-ApplyCheckpointWork::onAbort()
+bool ApplyCheckpointWork::onAbort()
 {
     ZoneScoped;
     if (mConditionalWork && !mConditionalWork->isDone())
@@ -409,8 +399,7 @@ ApplyCheckpointWork::onAbort()
     return true;
 }
 
-void
-ApplyCheckpointWork::onFailureRaise()
+void ApplyCheckpointWork::onFailureRaise()
 {
     if (mOnFailure)
     {

--- a/src/catchup/ApplyLedgerWork.cpp
+++ b/src/catchup/ApplyLedgerWork.cpp
@@ -19,8 +19,7 @@ ApplyLedgerWork::ApplyLedgerWork(Application& app,
 {
 }
 
-BasicWork::State
-ApplyLedgerWork::onRun()
+BasicWork::State ApplyLedgerWork::onRun()
 {
     ZoneScoped;
     mApp.getLedgerManager().applyLedger(mLedgerCloseData,
@@ -28,14 +27,12 @@ ApplyLedgerWork::onRun()
     return BasicWork::State::WORK_SUCCESS;
 }
 
-bool
-ApplyLedgerWork::onAbort()
+bool ApplyLedgerWork::onAbort()
 {
     return true;
 }
 
-std::string
-ApplyLedgerWork::getStatus() const
+std::string ApplyLedgerWork::getStatus() const
 {
     return fmt::format(FMT_STRING("apply ledger {:d}"),
                        mLedgerCloseData.getLedgerSeq());

--- a/src/catchup/AssumeStateWork.cpp
+++ b/src/catchup/AssumeStateWork.cpp
@@ -72,8 +72,7 @@ AssumeStateWork::AssumeStateWork(Application& app,
     }
 }
 
-BasicWork::State
-AssumeStateWork::doWork()
+BasicWork::State AssumeStateWork::doWork()
 {
     if (!mWorkSpawned)
     {
@@ -118,8 +117,7 @@ AssumeStateWork::doWork()
     return checkChildrenStatus();
 }
 
-void
-AssumeStateWork::doReset()
+void AssumeStateWork::doReset()
 {
     mWorkSpawned = false;
 }

--- a/src/catchup/CatchupConfiguration.cpp
+++ b/src/catchup/CatchupConfiguration.cpp
@@ -34,8 +34,7 @@ CatchupConfiguration::resolve(uint32_t remoteCheckpoint) const
     return cfg;
 }
 
-uint32_t
-parseLedger(std::string const& str)
+uint32_t parseLedger(std::string const& str)
 {
     if (str == "current")
     {
@@ -53,8 +52,7 @@ parseLedger(std::string const& str)
     return result;
 }
 
-uint32_t
-parseLedgerCount(std::string const& str)
+uint32_t parseLedgerCount(std::string const& str)
 {
     if (str == "max")
     {

--- a/src/catchup/CatchupConfiguration.h
+++ b/src/catchup/CatchupConfiguration.h
@@ -62,38 +62,32 @@ class CatchupConfiguration
      */
     CatchupConfiguration resolve(uint32_t remoteCheckpoint) const;
 
-    uint32_t
-    toLedger() const
+    uint32_t toLedger() const
     {
         return mLedgerHashPair.first;
     }
 
-    uint32_t
-    count() const
+    uint32_t count() const
     {
         return mCount;
     }
 
-    std::optional<Hash>
-    hash() const
+    std::optional<Hash> hash() const
     {
         return mLedgerHashPair.second;
     }
 
-    Mode
-    mode() const
+    Mode mode() const
     {
         return mMode;
     }
 
-    bool
-    offline() const
+    bool offline() const
     {
         return mMode == Mode::OFFLINE_BASIC || mMode == Mode::OFFLINE_COMPLETE;
     }
 
-    bool
-    online() const
+    bool online() const
     {
         return mMode == Mode::ONLINE;
     }

--- a/src/catchup/CatchupRange.cpp
+++ b/src/catchup/CatchupRange.cpp
@@ -13,9 +13,8 @@
 namespace
 {
 using namespace stellar;
-void
-checkCatchupPreconditions(uint32_t lastClosedLedger,
-                          CatchupConfiguration const& configuration)
+void checkCatchupPreconditions(uint32_t lastClosedLedger,
+                               CatchupConfiguration const& configuration)
 {
     if (lastClosedLedger < LedgerManager::GENESIS_LEDGER_SEQ)
     {
@@ -41,9 +40,9 @@ checkCatchupPreconditions(uint32_t lastClosedLedger,
     }
 }
 
-CatchupRange
-calculateCatchupRange(uint32_t lcl, CatchupConfiguration const& cfg,
-                      HistoryManager const& hm)
+CatchupRange calculateCatchupRange(uint32_t lcl,
+                                   CatchupConfiguration const& cfg,
+                                   HistoryManager const& hm)
 {
     checkCatchupPreconditions(lcl, cfg);
     const uint32_t init = LedgerManager::GENESIS_LEDGER_SEQ;
@@ -129,8 +128,7 @@ CatchupRange::CatchupRange(uint32_t lastClosedLedger,
     checkInvariants();
 }
 
-void
-CatchupRange::checkInvariants()
+void CatchupRange::checkInvariants()
 {
     // Must be applying buckets and/or replaying.
     releaseAssert(applyBuckets() || replayLedgers());

--- a/src/catchup/CatchupRange.h
+++ b/src/catchup/CatchupRange.h
@@ -50,8 +50,7 @@ class CatchupRange
   public:
     // Return a LedgerRange spanning both the apply-buckets phase (if it
     // exists) and the replay phase.
-    LedgerRange
-    getFullRangeIncludingBucketApply() const
+    LedgerRange getFullRangeIncludingBucketApply() const
     {
         if (mApplyBuckets)
         {
@@ -63,8 +62,7 @@ class CatchupRange
         }
     }
 
-    uint32_t
-    count() const
+    uint32_t count() const
     {
         if (mApplyBuckets)
         {
@@ -73,8 +71,7 @@ class CatchupRange
         return mReplayRange.mCount;
     }
 
-    uint32_t
-    first() const
+    uint32_t first() const
     {
         if (mApplyBuckets)
         {
@@ -86,8 +83,7 @@ class CatchupRange
         }
     }
 
-    uint32_t
-    last() const
+    uint32_t last() const
     {
         if (mReplayRange.mCount != 0)
         {
@@ -104,54 +100,46 @@ class CatchupRange
 
     // Return the LedgerRange that covers the ledger-replay part of this
     // catchup.
-    LedgerRange
-    getReplayRange() const
+    LedgerRange getReplayRange() const
     {
         return mReplayRange;
     }
 
-    bool
-    replayLedgers() const
+    bool replayLedgers() const
     {
         return mReplayRange.mCount > 0;
     }
 
-    uint32_t
-    getReplayFirst() const
+    uint32_t getReplayFirst() const
     {
         return mReplayRange.mFirst;
     }
 
-    uint32_t
-    getReplayCount() const
+    uint32_t getReplayCount() const
     {
         return mReplayRange.mCount;
     }
 
     // Return first+count, which is one-past-the-last ledger to replay.
     // Best to use this in a loop header to properly handle count=0.
-    uint32_t
-    getReplayLimit() const
+    uint32_t getReplayLimit() const
     {
         return mReplayRange.limit();
     }
 
     // Return first+count-1 which is the last ledger to replay, but
     // throw if count==0. Use only in rare "inclusive range" cases.
-    uint32_t
-    getReplayLast() const
+    uint32_t getReplayLast() const
     {
         return mReplayRange.last();
     }
 
-    bool
-    applyBuckets() const
+    bool applyBuckets() const
     {
         return mApplyBuckets;
     }
 
-    uint32_t
-    getBucketApplyLedger() const
+    uint32_t getBucketApplyLedger() const
     {
         if (!mApplyBuckets)
         {

--- a/src/catchup/CatchupWork.cpp
+++ b/src/catchup/CatchupWork.cpp
@@ -53,8 +53,8 @@ getHistoryEntryForLedger(uint32_t ledgerSeq, FileTransferInfo const& ft)
     return nullptr;
 }
 
-static bool
-setHerderStateTo(FileTransferInfo const& ft, uint32_t ledger, Application& app)
+static bool setHerderStateTo(FileTransferInfo const& ft, uint32_t ledger,
+                             Application& app)
 {
     auto entry = getHistoryEntryForLedger(ledger, ft);
     if (!entry)
@@ -94,8 +94,7 @@ CatchupWork::~CatchupWork()
 {
 }
 
-std::string
-CatchupWork::getStatus() const
+std::string CatchupWork::getStatus() const
 {
     std::string toLedger;
     if (mCatchupConfiguration.toLedger() == CatchupConfiguration::CURRENT)
@@ -118,8 +117,7 @@ CatchupWork::getStatus() const
                                     : Work::getStatus());
 }
 
-void
-CatchupWork::doReset()
+void CatchupWork::doReset()
 {
     ZoneScoped;
     mBucketsAppliedEmitted = false;
@@ -144,9 +142,8 @@ CatchupWork::doReset()
     mBucketHAS.reset();
 }
 
-void
-CatchupWork::downloadVerifyLedgerChain(CatchupRange const& catchupRange,
-                                       LedgerNumHashPair rangeEnd)
+void CatchupWork::downloadVerifyLedgerChain(CatchupRange const& catchupRange,
+                                            LedgerNumHashPair rangeEnd)
 {
     ZoneScoped;
     auto verifyRange = catchupRange.getFullRangeIncludingBucketApply();
@@ -177,8 +174,7 @@ CatchupWork::downloadVerifyLedgerChain(CatchupRange const& catchupRange,
     mCurrentWork = mDownloadVerifyLedgersSeq;
 }
 
-void
-CatchupWork::downloadVerifyTxResults(CatchupRange const& catchupRange)
+void CatchupWork::downloadVerifyTxResults(CatchupRange const& catchupRange)
 {
     ZoneScoped;
     auto range = catchupRange.getReplayRange();
@@ -187,15 +183,14 @@ CatchupWork::downloadVerifyTxResults(CatchupRange const& catchupRange)
         mApp, checkpointRange, *mDownloadDir);
 }
 
-bool
-CatchupWork::alreadyHaveBucketsHistoryArchiveState(uint32_t atCheckpoint) const
+bool CatchupWork::alreadyHaveBucketsHistoryArchiveState(
+    uint32_t atCheckpoint) const
 {
     return atCheckpoint ==
            mGetHistoryArchiveStateWork->getHistoryArchiveState().currentLedger;
 }
 
-WorkSeqPtr
-CatchupWork::downloadApplyBuckets()
+WorkSeqPtr CatchupWork::downloadApplyBuckets()
 {
     ZoneScoped;
 
@@ -239,8 +234,7 @@ CatchupWork::downloadApplyBuckets()
                                           seq, RETRY_NEVER);
 }
 
-void
-CatchupWork::assertBucketState()
+void CatchupWork::assertBucketState()
 {
     releaseAssert(mBucketHAS);
     releaseAssert(mBucketHAS->currentLedger >
@@ -273,8 +267,7 @@ CatchupWork::assertBucketState()
     }
 }
 
-void
-CatchupWork::downloadApplyTransactions(CatchupRange const& catchupRange)
+void CatchupWork::downloadApplyTransactions(CatchupRange const& catchupRange)
 {
     ZoneScoped;
     auto waitForPublish = mCatchupConfiguration.offline();
@@ -283,8 +276,7 @@ CatchupWork::downloadApplyTransactions(CatchupRange const& catchupRange)
         mApp, *mDownloadDir, range, mLastApplied, waitForPublish, mArchive);
 }
 
-BasicWork::State
-CatchupWork::getAndMaybeSetHistoryArchiveState()
+BasicWork::State CatchupWork::getAndMaybeSetHistoryArchiveState()
 {
     // First, retrieve the HAS
     if (!mGetHistoryArchiveStateWork)
@@ -392,8 +384,7 @@ CatchupWork::getAndMaybeSetBucketHistoryArchiveState(uint32_t applyBucketsAt)
     return State::WORK_SUCCESS;
 }
 
-BasicWork::State
-CatchupWork::runCatchupStep()
+BasicWork::State CatchupWork::runCatchupStep()
 {
     ZoneScoped;
 
@@ -597,8 +588,7 @@ CatchupWork::runCatchupStep()
     return State::WORK_RUNNING;
 }
 
-BasicWork::State
-CatchupWork::doWork()
+BasicWork::State CatchupWork::doWork()
 {
     ZoneScoped;
     auto nextState = runCatchupStep();
@@ -613,15 +603,13 @@ CatchupWork::doWork()
     return nextState;
 }
 
-void
-CatchupWork::onFailureRaise()
+void CatchupWork::onFailureRaise()
 {
     CLOG_WARNING(History, "Catchup failed");
     Work::onFailureRaise();
 }
 
-void
-CatchupWork::onSuccess()
+void CatchupWork::onSuccess()
 {
     CLOG_INFO(History, "Catchup finished");
     Work::onSuccess();

--- a/src/catchup/CatchupWork.h
+++ b/src/catchup/CatchupWork.h
@@ -70,14 +70,12 @@ class CatchupWork : public Work
     virtual ~CatchupWork();
     std::string getStatus() const override;
 
-    CatchupConfiguration const&
-    getCatchupConfiguration() const
+    CatchupConfiguration const& getCatchupConfiguration() const
     {
         return mCatchupConfiguration;
     }
 
-    bool
-    fatalFailure()
+    bool fatalFailure()
     {
         if (futureIsReady(mFatalFailureFuture))
         {

--- a/src/catchup/DownloadApplyTxsWork.cpp
+++ b/src/catchup/DownloadApplyTxsWork.cpp
@@ -35,8 +35,7 @@ DownloadApplyTxsWork::DownloadApplyTxsWork(
 {
 }
 
-std::shared_ptr<BasicWork>
-DownloadApplyTxsWork::yieldMoreWork()
+std::shared_ptr<BasicWork> DownloadApplyTxsWork::yieldMoreWork()
 {
     ZoneScoped;
     if (!hasNext())
@@ -219,8 +218,7 @@ DownloadApplyTxsWork::yieldMoreWork()
     return nextWork;
 }
 
-void
-DownloadApplyTxsWork::resetIter()
+void DownloadApplyTxsWork::resetIter()
 {
     mCheckpointToQueue = HistoryManager::checkpointContainingLedger(
         mRange.mFirst, mApp.getConfig());
@@ -228,8 +226,7 @@ DownloadApplyTxsWork::resetIter()
     mLastApplied = mApp.getLedgerManager().getLastClosedLedgerHeader();
 }
 
-bool
-DownloadApplyTxsWork::hasNext() const
+bool DownloadApplyTxsWork::hasNext() const
 {
     if (mRange.mCount == 0)
     {
@@ -240,14 +237,12 @@ DownloadApplyTxsWork::hasNext() const
     return mCheckpointToQueue <= last;
 }
 
-void
-DownloadApplyTxsWork::onSuccess()
+void DownloadApplyTxsWork::onSuccess()
 {
     mLastApplied = mApp.getLedgerManager().getLastClosedLedgerHeader();
 }
 
-std::string
-DownloadApplyTxsWork::getStatus() const
+std::string DownloadApplyTxsWork::getStatus() const
 {
     auto first = HistoryManager::checkpointContainingLedger(mRange.mFirst,
                                                             mApp.getConfig());

--- a/src/catchup/IndexBucketsWork.cpp
+++ b/src/catchup/IndexBucketsWork.cpp
@@ -21,8 +21,7 @@ IndexBucketsWork<BucketT>::IndexWork::IndexWork(Application& app,
 }
 
 template <class BucketT>
-BasicWork::State
-IndexBucketsWork<BucketT>::IndexWork::onRun()
+BasicWork::State IndexBucketsWork<BucketT>::IndexWork::onRun()
 {
     if (mState == State::WORK_WAITING)
     {
@@ -32,23 +31,17 @@ IndexBucketsWork<BucketT>::IndexWork::onRun()
     return mState;
 }
 
-template <class BucketT>
-bool
-IndexBucketsWork<BucketT>::IndexWork::onAbort()
+template <class BucketT> bool IndexBucketsWork<BucketT>::IndexWork::onAbort()
 {
     return true;
 };
 
-template <class BucketT>
-void
-IndexBucketsWork<BucketT>::IndexWork::onReset()
+template <class BucketT> void IndexBucketsWork<BucketT>::IndexWork::onReset()
 {
     mState = BasicWork::State::WORK_WAITING;
 }
 
-template <class BucketT>
-void
-IndexBucketsWork<BucketT>::IndexWork::postWork()
+template <class BucketT> void IndexBucketsWork<BucketT>::IndexWork::postWork()
 {
     Application& app = this->mApp;
     asio::io_context& ctx = app.getWorkerIOContext();
@@ -138,9 +131,7 @@ IndexBucketsWork<BucketT>::IndexBucketsWork(
 {
 }
 
-template <class BucketT>
-BasicWork::State
-IndexBucketsWork<BucketT>::doWork()
+template <class BucketT> BasicWork::State IndexBucketsWork<BucketT>::doWork()
 {
     if (!mWorkSpawned)
     {
@@ -150,16 +141,12 @@ IndexBucketsWork<BucketT>::doWork()
     return checkChildrenStatus();
 }
 
-template <class BucketT>
-void
-IndexBucketsWork<BucketT>::doReset()
+template <class BucketT> void IndexBucketsWork<BucketT>::doReset()
 {
     mWorkSpawned = false;
 }
 
-template <class BucketT>
-void
-IndexBucketsWork<BucketT>::spawnWork()
+template <class BucketT> void IndexBucketsWork<BucketT>::spawnWork()
 {
     UnorderedSet<Hash> indexedBuckets;
     auto spawnIndexWork = [&](auto const& b) {

--- a/src/catchup/LedgerApplyManagerImpl.cpp
+++ b/src/catchup/LedgerApplyManagerImpl.cpp
@@ -71,8 +71,7 @@ operator-(LedgerApplyManager::CatchupMetrics const& x,
 }
 
 template <typename T>
-T
-findFirstCheckpoint(T begin, T end, HistoryManager const& hm)
+T findFirstCheckpoint(T begin, T end, HistoryManager const& hm)
 {
     return std::find_if(begin, end,
                         [&hm](std::pair<uint32_t, LedgerCloseData> const& kvp) {
@@ -81,8 +80,7 @@ findFirstCheckpoint(T begin, T end, HistoryManager const& hm)
                         });
 }
 
-std::unique_ptr<LedgerApplyManager>
-LedgerApplyManager::create(Application& app)
+std::unique_ptr<LedgerApplyManager> LedgerApplyManager::create(Application& app)
 {
     return std::make_unique<LedgerApplyManagerImpl>(app);
 }
@@ -101,8 +99,7 @@ LedgerApplyManagerImpl::~LedgerApplyManagerImpl()
 {
 }
 
-uint32_t
-LedgerApplyManagerImpl::getCatchupCount()
+uint32_t LedgerApplyManagerImpl::getCatchupCount()
 {
     releaseAssert(threadIsMain());
     return mApp.getConfig().CATCHUP_COMPLETE
@@ -268,9 +265,8 @@ LedgerApplyManagerImpl::processLedger(LedgerCloseData const& ledgerData,
     return ProcessLedgerResult::WAIT_TO_APPLY_BUFFERED_OR_CATCHUP;
 }
 
-void
-LedgerApplyManagerImpl::startCatchup(CatchupConfiguration configuration,
-                                     std::shared_ptr<HistoryArchive> archive)
+void LedgerApplyManagerImpl::startCatchup(
+    CatchupConfiguration configuration, std::shared_ptr<HistoryArchive> archive)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -296,38 +292,33 @@ LedgerApplyManagerImpl::startCatchup(CatchupConfiguration configuration,
         configuration, archive);
 }
 
-std::string
-LedgerApplyManagerImpl::getStatus() const
+std::string LedgerApplyManagerImpl::getStatus() const
 {
     releaseAssert(threadIsMain());
     return mCatchupWork ? mCatchupWork->getStatus() : std::string{};
 }
 
-BasicWork::State
-LedgerApplyManagerImpl::getCatchupWorkState() const
+BasicWork::State LedgerApplyManagerImpl::getCatchupWorkState() const
 {
     releaseAssert(threadIsMain());
     releaseAssert(mCatchupWork);
     return mCatchupWork->getState();
 }
 
-bool
-LedgerApplyManagerImpl::catchupWorkIsDone() const
+bool LedgerApplyManagerImpl::catchupWorkIsDone() const
 {
     releaseAssert(threadIsMain());
     return mCatchupWork && mCatchupWork->isDone();
 }
 
-bool
-LedgerApplyManagerImpl::isCatchupInitialized() const
+bool LedgerApplyManagerImpl::isCatchupInitialized() const
 {
     releaseAssert(threadIsMain());
     return mCatchupWork != nullptr;
 }
 
-void
-LedgerApplyManagerImpl::logAndUpdateCatchupStatus(bool contiguous,
-                                                  std::string const& message)
+void LedgerApplyManagerImpl::logAndUpdateCatchupStatus(
+    bool contiguous, std::string const& message)
 {
     releaseAssert(threadIsMain());
     if (!message.empty())
@@ -351,8 +342,7 @@ LedgerApplyManagerImpl::logAndUpdateCatchupStatus(bool contiguous,
     }
 }
 
-void
-LedgerApplyManagerImpl::logAndUpdateCatchupStatus(bool contiguous)
+void LedgerApplyManagerImpl::logAndUpdateCatchupStatus(bool contiguous)
 {
     releaseAssert(threadIsMain());
     logAndUpdateCatchupStatus(contiguous, getStatus());
@@ -393,30 +383,26 @@ LedgerApplyManagerImpl::maybeGetLargestBufferedLedger()
     }
 }
 
-uint32_t
-LedgerApplyManagerImpl::getLargestLedgerSeqHeard() const
+uint32_t LedgerApplyManagerImpl::getLargestLedgerSeqHeard() const
 {
     releaseAssert(threadIsMain());
     return mLargestLedgerSeqHeard;
 }
 
-uint32_t
-LedgerApplyManagerImpl::getMaxQueuedToApply()
+uint32_t LedgerApplyManagerImpl::getMaxQueuedToApply()
 {
     releaseAssert(threadIsMain());
     updateLastQueuedToApply();
     return *mLastQueuedToApply;
 }
 
-void
-LedgerApplyManagerImpl::syncMetrics()
+void LedgerApplyManagerImpl::syncMetrics()
 {
     releaseAssert(threadIsMain());
     mSyncingLedgersSize.set_count(mSyncingLedgers.size());
 }
 
-void
-LedgerApplyManagerImpl::updateLastQueuedToApply()
+void LedgerApplyManagerImpl::updateLastQueuedToApply()
 {
     releaseAssert(threadIsMain());
     if (!mLastQueuedToApply)
@@ -431,8 +417,7 @@ LedgerApplyManagerImpl::updateLastQueuedToApply()
     }
 }
 
-void
-LedgerApplyManagerImpl::startOnlineCatchup()
+void LedgerApplyManagerImpl::startOnlineCatchup()
 {
     releaseAssert(threadIsMain());
     releaseAssert(mSyncingLedgers.size() > 1);
@@ -448,8 +433,7 @@ LedgerApplyManagerImpl::startOnlineCatchup()
                  nullptr);
 }
 
-void
-LedgerApplyManagerImpl::trimSyncingLedgers()
+void LedgerApplyManagerImpl::trimSyncingLedgers()
 {
     releaseAssert(threadIsMain());
     auto removeLedgersLessThan = [&](uint32_t ledger) {
@@ -489,8 +473,7 @@ LedgerApplyManagerImpl::trimSyncingLedgers()
     }
 }
 
-void
-LedgerApplyManagerImpl::tryApplySyncingLedgers()
+void LedgerApplyManagerImpl::tryApplySyncingLedgers()
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -551,42 +534,36 @@ LedgerApplyManagerImpl::tryApplySyncingLedgers()
     mSyncingLedgers.erase(mSyncingLedgers.cbegin(), it);
 }
 
-void
-LedgerApplyManagerImpl::historyArchiveStatesDownloaded(uint32_t num)
+void LedgerApplyManagerImpl::historyArchiveStatesDownloaded(uint32_t num)
 {
     releaseAssert(threadIsMain());
     mMetrics.mHistoryArchiveStatesDownloaded += num;
 }
 
-void
-LedgerApplyManagerImpl::ledgersVerified(uint32_t num)
+void LedgerApplyManagerImpl::ledgersVerified(uint32_t num)
 {
     releaseAssert(threadIsMain());
     mMetrics.mLedgersVerified += num;
 }
 
-void
-LedgerApplyManagerImpl::ledgerChainsVerificationFailed(uint32_t num)
+void LedgerApplyManagerImpl::ledgerChainsVerificationFailed(uint32_t num)
 {
     releaseAssert(threadIsMain());
     mMetrics.mLedgerChainsVerificationFailed += num;
 }
 
-void
-LedgerApplyManagerImpl::bucketsApplied(uint32_t num)
+void LedgerApplyManagerImpl::bucketsApplied(uint32_t num)
 {
     releaseAssert(threadIsMain());
     mMetrics.mBucketsApplied += num;
 }
-void
-LedgerApplyManagerImpl::txSetsApplied(uint32_t num)
+void LedgerApplyManagerImpl::txSetsApplied(uint32_t num)
 {
     releaseAssert(threadIsMain());
     mMetrics.mTxSetsApplied += num;
 }
 
-void
-LedgerApplyManagerImpl::fileDownloaded(FileType type, uint32_t num)
+void LedgerApplyManagerImpl::fileDownloaded(FileType type, uint32_t num)
 {
     releaseAssert(threadIsMain());
     if (type == FileType::HISTORY_FILE_TYPE_BUCKET)

--- a/src/catchup/LedgerApplyManagerImpl.h
+++ b/src/catchup/LedgerApplyManagerImpl.h
@@ -94,8 +94,7 @@ class LedgerApplyManagerImpl : public LedgerApplyManager
 
     void syncMetrics() override;
 
-    CatchupMetrics const&
-    getCatchupMetrics() override
+    CatchupMetrics const& getCatchupMetrics() override
     {
         return mMetrics;
     }
@@ -108,27 +107,23 @@ class LedgerApplyManagerImpl : public LedgerApplyManager
     void fileDownloaded(FileType type, uint32_t num) override;
 
 #ifdef BUILD_TESTS
-    std::map<uint32_t, LedgerCloseData> const&
-    getBufferedLedgers() const
+    std::map<uint32_t, LedgerCloseData> const& getBufferedLedgers() const
     {
         return mSyncingLedgers;
     }
 
-    std::shared_ptr<CatchupWork>
-    getCatchupWork() const
+    std::shared_ptr<CatchupWork> getCatchupWork() const
     {
         return mCatchupWork;
     }
 
-    bool
-    getCatchupFatalFailure() const
+    bool getCatchupFatalFailure() const
     {
         return mCatchupFatalFailure;
     }
 
     std::optional<uint32_t> mMaxExternalizeApplyBuffer;
-    uint32_t
-    getMaxExternalizeApplyBuffer()
+    uint32_t getMaxExternalizeApplyBuffer()
     {
         return mMaxExternalizeApplyBuffer ? *mMaxExternalizeApplyBuffer
                                           : MAX_EXTERNALIZE_LEDGER_APPLY_DRIFT;

--- a/src/catchup/ReplayDebugMetaWork.cpp
+++ b/src/catchup/ReplayDebugMetaWork.cpp
@@ -42,16 +42,14 @@ class ApplyLedgersFromMetaWork : public Work
     virtual ~ApplyLedgersFromMetaWork() = default;
 
   protected:
-    void
-    doReset() override
+    void doReset() override
     {
         mMetaIn.close();
         mFileOpen = false;
         mApplyLedgerWork.reset();
     }
 
-    State
-    doWork() override
+    State doWork() override
     {
         if (!mFileOpen)
         {
@@ -144,8 +142,7 @@ class ApplyLedgersFromMetaWork : public Work
         return BasicWork::State::WORK_RUNNING;
     }
 
-    void
-    onSuccess() override
+    void onSuccess() override
     {
         // Close the stream just in case Work is kept alive for some time before
         // it's garbage-collected
@@ -164,8 +161,7 @@ ReplayDebugMetaWork::ReplayDebugMetaWork(Application& app,
     mNextToApply = mFiles.cbegin();
 }
 
-BasicWork::State
-ReplayDebugMetaWork::applyLastLedger()
+BasicWork::State ReplayDebugMetaWork::applyLastLedger()
 {
     StoredDebugTransactionSet debugTxSet;
     {
@@ -196,8 +192,7 @@ ReplayDebugMetaWork::applyLastLedger()
     return BasicWork::State::WORK_SUCCESS;
 }
 
-BasicWork::State
-ReplayDebugMetaWork::doWork()
+BasicWork::State ReplayDebugMetaWork::doWork()
 {
     if (mCurrentWorkSequence)
     {
@@ -263,8 +258,7 @@ ReplayDebugMetaWork::doWork()
     return BasicWork::State::WORK_RUNNING;
 }
 
-void
-ReplayDebugMetaWork::doReset()
+void ReplayDebugMetaWork::doReset()
 {
     mNextToApply = mFiles.cbegin();
     mCurrentWorkSequence.reset();

--- a/src/catchup/VerifyLedgerChainWork.cpp
+++ b/src/catchup/VerifyLedgerChainWork.cpp
@@ -84,9 +84,7 @@ verifyLastLedgerInCheckpoint(LedgerHeaderHistoryEntry const& ledger,
     return HistoryManager::VERIFY_STATUS_OK;
 }
 
-template <typename T>
-void
-trySetFuture(std::promise<T>& promise, T value)
+template <typename T> void trySetFuture(std::promise<T>& promise, T value)
 {
     try
     {
@@ -130,8 +128,7 @@ VerifyLedgerChainWork::VerifyLedgerChainWork(
     releaseAssert(lastClosedLedger.second);
 }
 
-std::string
-VerifyLedgerChainWork::getStatus() const
+std::string VerifyLedgerChainWork::getStatus() const
 {
     if (!isDone() && !isAborting() && mRange.mCount != 0)
     {
@@ -142,8 +139,7 @@ VerifyLedgerChainWork::getStatus() const
     return BasicWork::getStatus();
 }
 
-void
-VerifyLedgerChainWork::onReset()
+void VerifyLedgerChainWork::onReset()
 {
     CLOG_INFO(History, "Verifying ledgers {}", mRange.toString());
 
@@ -425,8 +421,7 @@ VerifyLedgerChainWork::verifyHistoryOfSingleCheckpoint()
     return HistoryManager::VERIFY_STATUS_OK;
 }
 
-void
-VerifyLedgerChainWork::onSuccess()
+void VerifyLedgerChainWork::onSuccess()
 {
     trySetFuture<bool>(mFatalFailurePromise,
                        mChainDisagreesWithLocalState && mHasTrustedHash);
@@ -446,15 +441,13 @@ VerifyLedgerChainWork::onSuccess()
     }
 }
 
-void
-VerifyLedgerChainWork::onFailureRaise()
+void VerifyLedgerChainWork::onFailureRaise()
 {
     trySetFuture<bool>(mFatalFailurePromise,
                        mChainDisagreesWithLocalState && mHasTrustedHash);
 }
 
-BasicWork::State
-VerifyLedgerChainWork::onRun()
+BasicWork::State VerifyLedgerChainWork::onRun()
 {
     ZoneScoped;
     if (mRange.mCount == 0)

--- a/src/catchup/VerifyLedgerChainWork.h
+++ b/src/catchup/VerifyLedgerChainWork.h
@@ -89,14 +89,12 @@ class VerifyLedgerChainWork : public BasicWork
     ~VerifyLedgerChainWork() override = default;
     std::string getStatus() const override;
 
-    std::shared_future<LedgerNumHashPair>
-    getVerifiedMinLedgerPrev() const
+    std::shared_future<LedgerNumHashPair> getVerifiedMinLedgerPrev() const
     {
         return mVerifiedMinLedgerPrevFuture;
     }
 
-    LedgerHeaderHistoryEntry
-    getMaxVerifiedLedgerOfMinCheckpoint()
+    LedgerHeaderHistoryEntry getMaxVerifiedLedgerOfMinCheckpoint()
     {
         return mMaxVerifiedLedgerOfMinCheckpoint;
     }
@@ -107,8 +105,7 @@ class VerifyLedgerChainWork : public BasicWork
     BasicWork::State onRun() override;
     void onSuccess() override;
     void onFailureRaise() override;
-    bool
-    onAbort() override
+    bool onAbort() override
     {
         return true;
     };

--- a/src/crypto/BLAKE2.cpp
+++ b/src/crypto/BLAKE2.cpp
@@ -13,8 +13,7 @@ namespace stellar
 {
 
 // Plain BLAKE2 (a.k.a. BLAKE2b)
-uint256
-blake2(ByteSlice const& bin)
+uint256 blake2(ByteSlice const& bin)
 {
     static_assert(crypto_generichash_BYTES == sizeof(uint256),
                   "unexpected crypto_generichash_BYTES");
@@ -33,8 +32,7 @@ BLAKE2::BLAKE2()
     reset();
 }
 
-void
-BLAKE2::reset()
+void BLAKE2::reset()
 {
     if (crypto_generichash_init(&mState, nullptr, 0,
                                 crypto_generichash_BYTES) != 0)
@@ -44,8 +42,7 @@ BLAKE2::reset()
     mFinished = false;
 }
 
-void
-BLAKE2::add(ByteSlice const& bin)
+void BLAKE2::add(ByteSlice const& bin)
 {
     ZoneScoped;
     if (mFinished)
@@ -58,8 +55,7 @@ BLAKE2::add(ByteSlice const& bin)
     }
 }
 
-uint256
-BLAKE2::finish()
+uint256 BLAKE2::finish()
 {
     uint256 out;
     if (mFinished)

--- a/src/crypto/BLAKE2.h
+++ b/src/crypto/BLAKE2.h
@@ -33,8 +33,7 @@ class BLAKE2
 struct XDRBLAKE2 : XDRHasher<XDRBLAKE2>
 {
     BLAKE2 state;
-    void
-    hashBytes(unsigned char const* bytes, size_t size)
+    void hashBytes(unsigned char const* bytes, size_t size)
     {
         state.add(ByteSlice(bytes, size));
     }
@@ -46,9 +45,7 @@ struct XDRBLAKE2 : XDRHasher<XDRBLAKE2>
 // NB: This is not an overload of `blake2` to avoid ambiguity when called
 // with xdrpp-provided types like opaque_vec, which will convert to a ByteSlice
 // if demanded, but can also be passed to XDRBLAKE2.
-template <typename T>
-uint256
-xdrBlake2(T const& t)
+template <typename T> uint256 xdrBlake2(T const& t)
 {
     XDRBLAKE2 xb;
     xdr::archive(xb, t);

--- a/src/crypto/ByteSlice.h
+++ b/src/crypto/ByteSlice.h
@@ -24,35 +24,29 @@ class ByteSlice
     size_t const mSize;
 
   public:
-    unsigned char const*
-    data() const
+    unsigned char const* data() const
     {
         return static_cast<unsigned char const*>(mData);
     }
-    unsigned char const*
-    begin() const
+    unsigned char const* begin() const
     {
         return data();
     }
-    unsigned char const*
-    end() const
+    unsigned char const* end() const
     {
         return data() + size();
     }
-    unsigned char
-    operator[](size_t i) const
+    unsigned char operator[](size_t i) const
     {
         if (i >= mSize)
             throw std::range_error("ByteSlice index out of bounds");
         return data()[i];
     }
-    size_t
-    size() const
+    size_t size() const
     {
         return mSize;
     }
-    bool
-    empty() const
+    bool empty() const
     {
         return mSize == 0;
     }

--- a/src/crypto/Curve25519.cpp
+++ b/src/crypto/Curve25519.cpp
@@ -16,8 +16,7 @@
 namespace stellar
 {
 
-Curve25519Secret
-curve25519RandomSecret()
+Curve25519Secret curve25519RandomSecret()
 {
     Curve25519Secret out;
     randombytes_buf(out.key.data(), out.key.size());
@@ -27,8 +26,7 @@ curve25519RandomSecret()
     return out;
 }
 
-Curve25519Public
-curve25519DerivePublic(Curve25519Secret const& sec)
+Curve25519Public curve25519DerivePublic(Curve25519Secret const& sec)
 {
     ZoneScoped;
     Curve25519Public out;
@@ -39,18 +37,17 @@ curve25519DerivePublic(Curve25519Secret const& sec)
     return out;
 }
 
-void
-clearCurve25519Keys(Curve25519Public& localPublic,
-                    Curve25519Secret& localSecret)
+void clearCurve25519Keys(Curve25519Public& localPublic,
+                         Curve25519Secret& localSecret)
 {
     sodium_memzero(localPublic.key.data(), localPublic.key.size());
     sodium_memzero(localSecret.key.data(), localSecret.key.size());
 }
 
-HmacSha256Key
-curve25519DeriveSharedKey(Curve25519Secret const& localSecret,
-                          Curve25519Public const& localPublic,
-                          Curve25519Public const& remotePublic, bool localFirst)
+HmacSha256Key curve25519DeriveSharedKey(Curve25519Secret const& localSecret,
+                                        Curve25519Public const& localPublic,
+                                        Curve25519Public const& remotePublic,
+                                        bool localFirst)
 {
     ZoneScoped;
     auto const& publicA = localFirst ? localPublic : remotePublic;
@@ -74,10 +71,9 @@ curve25519DeriveSharedKey(Curve25519Secret const& localSecret,
     return hkdfExtract(buf);
 }
 
-xdr::opaque_vec<>
-curve25519Decrypt(Curve25519Secret const& localSecret,
-                  Curve25519Public const& localPublic,
-                  ByteSlice const& encrypted)
+xdr::opaque_vec<> curve25519Decrypt(Curve25519Secret const& localSecret,
+                                    Curve25519Public const& localPublic,
+                                    ByteSlice const& encrypted)
 {
     ZoneScoped;
     if (encrypted.size() < crypto_box_SEALBYTES)
@@ -102,8 +98,7 @@ curve25519Decrypt(Curve25519Secret const& localSecret,
 
 namespace std
 {
-size_t
-hash<stellar::Curve25519Public>::operator()(
+size_t hash<stellar::Curve25519Public>::operator()(
     stellar::Curve25519Public const& k) const noexcept
 {
     return std::hash<stellar::uint256>()(k.key);

--- a/src/crypto/Curve25519.h
+++ b/src/crypto/Curve25519.h
@@ -52,8 +52,8 @@ xdr::opaque_vec<> curve25519Decrypt(Curve25519Secret const& localSecret,
                                     ByteSlice const& encrypted);
 
 template <uint32_t N>
-xdr::opaque_vec<N>
-curve25519Encrypt(Curve25519Public const& remotePublic, ByteSlice const& bin)
+xdr::opaque_vec<N> curve25519Encrypt(Curve25519Public const& remotePublic,
+                                     ByteSlice const& bin)
 {
     const uint64_t CIPHERTEXT_LEN = crypto_box_SEALBYTES + bin.size();
     if (CIPHERTEXT_LEN > N)

--- a/src/crypto/Hex.cpp
+++ b/src/crypto/Hex.cpp
@@ -8,8 +8,7 @@
 namespace stellar
 {
 
-std::string
-binToHex(ByteSlice const& bin)
+std::string binToHex(ByteSlice const& bin)
 {
     // NB: C++ standard says we can't go modifying the contents of a std::string
     // just by const_cast'ing away const on .data(), so we use a vector<char> to
@@ -26,8 +25,7 @@ binToHex(ByteSlice const& bin)
     return std::string(hex.begin(), hex.end() - 1);
 }
 
-std::string
-hexAbbrev(ByteSlice const& bin)
+std::string hexAbbrev(ByteSlice const& bin)
 {
     size_t sz = bin.size();
     if (sz > 3)
@@ -37,8 +35,7 @@ hexAbbrev(ByteSlice const& bin)
     return binToHex(ByteSlice(bin.data(), sz));
 }
 
-std::vector<uint8_t>
-hexToBin(std::string const& hex)
+std::vector<uint8_t> hexToBin(std::string const& hex)
 {
     std::vector<uint8_t> bin(hex.size() / 2, 0);
     if (!hex.empty())
@@ -52,8 +49,7 @@ hexToBin(std::string const& hex)
     return bin;
 }
 
-uint256
-hexToBin256(std::string const& hex)
+uint256 hexToBin256(std::string const& hex)
 {
     uint256 out;
     auto bin = hexToBin(hex);

--- a/src/crypto/KeyUtils.cpp
+++ b/src/crypto/KeyUtils.cpp
@@ -9,8 +9,7 @@
 namespace stellar
 {
 
-size_t
-KeyUtils::getKeyVersionSize(strKey::StrKeyVersionByte keyVersion)
+size_t KeyUtils::getKeyVersionSize(strKey::StrKeyVersionByte keyVersion)
 {
     switch (keyVersion)
     {

--- a/src/crypto/KeyUtils.h
+++ b/src/crypto/KeyUtils.h
@@ -81,9 +81,7 @@ struct InvalidStrKey : public std::invalid_argument
     using std::invalid_argument::invalid_argument;
 };
 
-template <typename T>
-T
-fromStrKey(std::string const& s)
+template <typename T> T fromStrKey(std::string const& s)
 {
     T key;
     uint8_t verByte;
@@ -110,17 +108,13 @@ fromStrKey(std::string const& s)
     return key;
 }
 
-template <typename T, typename F>
-bool
-canConvert(F const& fromKey)
+template <typename T, typename F> bool canConvert(F const& fromKey)
 {
     return KeyFunctions<T>::getKeyVersionIsSupported(
         KeyFunctions<F>::toKeyVersion(fromKey.type()));
 }
 
-template <typename T, typename F>
-T
-convertKey(F const& fromKey)
+template <typename T, typename F> T convertKey(F const& fromKey)
 {
     T toKey;
     toKey.type(KeyFunctions<T>::toKeyType(

--- a/src/crypto/Random.cpp
+++ b/src/crypto/Random.cpp
@@ -13,8 +13,7 @@
 #include <sanitizer/msan_interface.h>
 #endif
 
-std::vector<uint8_t>
-randomBytes(size_t length)
+std::vector<uint8_t> randomBytes(size_t length)
 {
     std::vector<uint8_t> vec(length);
 

--- a/src/crypto/SHA.cpp
+++ b/src/crypto/SHA.cpp
@@ -14,8 +14,7 @@ namespace stellar
 {
 
 // Plain SHA256
-uint256
-sha256(ByteSlice const& bin)
+uint256 sha256(ByteSlice const& bin)
 {
     ZoneScoped;
     uint256 out;
@@ -26,8 +25,7 @@ sha256(ByteSlice const& bin)
     return out;
 }
 
-Hash
-subSha256(ByteSlice const& seed, uint64_t counter)
+Hash subSha256(ByteSlice const& seed, uint64_t counter)
 {
     SHA256 sha;
     sha.add(seed);
@@ -40,8 +38,7 @@ SHA256::SHA256()
     reset();
 }
 
-void
-SHA256::reset()
+void SHA256::reset()
 {
     if (crypto_hash_sha256_init(&mState) != 0)
     {
@@ -50,8 +47,7 @@ SHA256::reset()
     mFinished = false;
 }
 
-void
-SHA256::add(ByteSlice const& bin)
+void SHA256::add(ByteSlice const& bin)
 {
     ZoneScoped;
     if (mFinished)
@@ -64,8 +60,7 @@ SHA256::add(ByteSlice const& bin)
     }
 }
 
-uint256
-SHA256::finish()
+uint256 SHA256::finish()
 {
     uint256 out;
     static_assert(sizeof(out) == crypto_hash_sha256_BYTES,
@@ -83,8 +78,7 @@ SHA256::finish()
 }
 
 // HMAC-SHA256
-HmacSha256Mac
-hmacSha256(HmacSha256Key const& key, ByteSlice const& bin)
+HmacSha256Mac hmacSha256(HmacSha256Key const& key, ByteSlice const& bin)
 {
     ZoneScoped;
     HmacSha256Mac out;
@@ -96,9 +90,8 @@ hmacSha256(HmacSha256Key const& key, ByteSlice const& bin)
     return out;
 }
 
-bool
-hmacSha256Verify(HmacSha256Mac const& hmac, HmacSha256Key const& key,
-                 ByteSlice const& bin)
+bool hmacSha256Verify(HmacSha256Mac const& hmac, HmacSha256Key const& key,
+                      ByteSlice const& bin)
 {
     ZoneScoped;
     return 0 == crypto_auth_hmacsha256_verify(hmac.mac.data(), bin.data(),
@@ -106,8 +99,7 @@ hmacSha256Verify(HmacSha256Mac const& hmac, HmacSha256Key const& key,
 }
 
 // Unsalted HKDF-extract(bytes) == HMAC(<zero>,bytes)
-HmacSha256Key
-hkdfExtract(ByteSlice const& bin)
+HmacSha256Key hkdfExtract(ByteSlice const& bin)
 {
     ZoneScoped;
     HmacSha256Key zerosalt;
@@ -118,8 +110,7 @@ hkdfExtract(ByteSlice const& bin)
 }
 
 // Single-step HKDF-expand(key,bytes) == HMAC(key,bytes|0x1)
-HmacSha256Key
-hkdfExpand(HmacSha256Key const& key, ByteSlice const& bin)
+HmacSha256Key hkdfExpand(HmacSha256Key const& key, ByteSlice const& bin)
 {
     ZoneScoped;
     std::vector<uint8_t> bytes(bin.begin(), bin.end());

--- a/src/crypto/SHA.h
+++ b/src/crypto/SHA.h
@@ -37,8 +37,7 @@ class SHA256
 struct XDRSHA256 : XDRHasher<XDRSHA256>
 {
     SHA256 state;
-    void
-    hashBytes(unsigned char const* bytes, size_t size)
+    void hashBytes(unsigned char const* bytes, size_t size)
     {
         state.add(ByteSlice(bytes, size));
     }
@@ -50,9 +49,7 @@ struct XDRSHA256 : XDRHasher<XDRSHA256>
 // NB: This is not an overload of `sha256` to avoid ambiguity when called
 // with xdrpp-provided types like opaque_vec, which will convert to a ByteSlice
 // if demanded, but can also be passed to XDRSHA256.
-template <typename T>
-uint256
-xdrSha256(T const& t)
+template <typename T> uint256 xdrSha256(T const& t)
 {
     XDRSHA256 xs;
     xdr::archive(xs, t);

--- a/src/crypto/SecretKey.cpp
+++ b/src/crypto/SecretKey.cpp
@@ -52,9 +52,8 @@ static uint64_t gVerifyCacheMiss = 0;
 // Protected by gVerifySigCacheMutex
 static bool gUseRustDalekVerify = false;
 
-static Hash
-verifySigCacheKey(PublicKey const& key, Signature const& signature,
-                  ByteSlice const& bin)
+static Hash verifySigCacheKey(PublicKey const& key, Signature const& signature,
+                              ByteSlice const& bin)
 {
     releaseAssert(key.type() == PUBLIC_KEY_TYPE_ED25519);
 
@@ -87,14 +86,12 @@ SecretKey::Seed::~Seed()
     std::memset(mSeed.data(), 0, mSeed.size());
 }
 
-PublicKey const&
-SecretKey::getPublicKey() const
+PublicKey const& SecretKey::getPublicKey() const
 {
     return mPublicKey;
 }
 
-SecretKey::Seed
-SecretKey::getSeed() const
+SecretKey::Seed SecretKey::getSeed() const
 {
     releaseAssert(mKeyType == PUBLIC_KEY_TYPE_ED25519);
 
@@ -108,22 +105,19 @@ SecretKey::getSeed() const
     return seed;
 }
 
-SecretValue
-SecretKey::getStrKeySeed() const
+SecretValue SecretKey::getStrKeySeed() const
 {
     releaseAssert(mKeyType == PUBLIC_KEY_TYPE_ED25519);
 
     return strKey::toStrKey(strKey::STRKEY_SEED_ED25519, getSeed().mSeed);
 }
 
-std::string
-SecretKey::getStrKeyPublic() const
+std::string SecretKey::getStrKeyPublic() const
 {
     return KeyUtils::toStrKey(getPublicKey());
 }
 
-bool
-SecretKey::isZero() const
+bool SecretKey::isZero() const
 {
     for (auto i : mSecretKey)
     {
@@ -135,8 +129,7 @@ SecretKey::isZero() const
     return true;
 }
 
-Signature
-SecretKey::sign(ByteSlice const& bin) const
+Signature SecretKey::sign(ByteSlice const& bin) const
 {
     ZoneScoped;
     releaseAssert(mKeyType == PUBLIC_KEY_TYPE_ED25519);
@@ -150,8 +143,7 @@ SecretKey::sign(ByteSlice const& bin) const
     return out;
 }
 
-SecretKey
-SecretKey::random()
+SecretKey SecretKey::random()
 {
     SecretKey sk;
     releaseAssert(sk.mKeyType == PUBLIC_KEY_TYPE_ED25519);
@@ -171,21 +163,18 @@ struct SignVerifyTestcase
     SecretKey key;
     std::vector<uint8_t> msg;
     Signature sig;
-    void
-    sign()
+    void sign()
     {
         sig = key.sign(msg);
     }
-    void
-    verify()
+    void verify()
     {
         if (!PubKeyUtils::verifySig(key.getPublicKey(), sig, msg).valid)
         {
             throw std::runtime_error("verify failed");
         }
     }
-    static SignVerifyTestcase
-    create()
+    static SignVerifyTestcase create()
     {
         SignVerifyTestcase st;
         st.key = SecretKey::random();
@@ -194,9 +183,9 @@ struct SignVerifyTestcase
     }
 };
 
-void
-SecretKey::benchmarkOpsPerSecond(size_t& sign, size_t& verify,
-                                 size_t iterations, size_t cachedVerifyPasses)
+void SecretKey::benchmarkOpsPerSecond(size_t& sign, size_t& verify,
+                                      size_t iterations,
+                                      size_t cachedVerifyPasses)
 {
     namespace ch = std::chrono;
     using clock = ch::high_resolution_clock;
@@ -240,8 +229,7 @@ SecretKey::benchmarkOpsPerSecond(size_t& sign, size_t& verify,
 
 #ifdef BUILD_TESTS
 template <typename Rng>
-static std::vector<uint8_t>
-getPRNGBytes(size_t n, Rng& engine)
+static std::vector<uint8_t> getPRNGBytes(size_t n, Rng& engine)
 {
     std::vector<uint8_t> bytes;
     for (size_t i = 0; i < n; ++i)
@@ -252,14 +240,12 @@ getPRNGBytes(size_t n, Rng& engine)
 }
 
 template <typename Rng>
-static SecretKey
-pseudoRandomForTestingFromPRNG(Rng& engine)
+static SecretKey pseudoRandomForTestingFromPRNG(Rng& engine)
 {
     return SecretKey::fromSeed(getPRNGBytes(crypto_sign_SEEDBYTES, engine));
 }
 
-SecretKey
-SecretKey::pseudoRandomForTesting()
+SecretKey SecretKey::pseudoRandomForTesting()
 {
     // Reminder: this is not cryptographic randomness or even particularly hard
     // to guess PRNG-ness. It's intended for _deterministic_ use, when you want
@@ -267,8 +253,7 @@ SecretKey::pseudoRandomForTesting()
     return pseudoRandomForTestingFromPRNG(Catch::rng());
 }
 
-SecretKey
-SecretKey::pseudoRandomForTestingFromSeed(unsigned int seed)
+SecretKey SecretKey::pseudoRandomForTestingFromSeed(unsigned int seed)
 {
     // Reminder: this is not cryptographic randomness or even particularly hard
     // to guess PRNG-ness. It's intended for _deterministic_ use, when you want
@@ -278,8 +263,7 @@ SecretKey::pseudoRandomForTestingFromSeed(unsigned int seed)
 }
 #endif
 
-SecretKey
-SecretKey::fromSeed(ByteSlice const& seed)
+SecretKey SecretKey::fromSeed(ByteSlice const& seed)
 {
     SecretKey sk;
     releaseAssert(sk.mKeyType == PUBLIC_KEY_TYPE_ED25519);
@@ -296,8 +280,7 @@ SecretKey::fromSeed(ByteSlice const& seed)
     return sk;
 }
 
-SecretKey
-SecretKey::fromStrKeySeed(std::string const& strKeySeed)
+SecretKey SecretKey::fromStrKeySeed(std::string const& strKeySeed)
 {
     uint8_t ver;
     std::vector<uint8_t> seed;
@@ -319,29 +302,25 @@ SecretKey::fromStrKeySeed(std::string const& strKeySeed)
     return sk;
 }
 
-void
-PubKeyUtils::clearVerifySigCache()
+void PubKeyUtils::clearVerifySigCache()
 {
     std::lock_guard<std::mutex> guard(gVerifySigCacheMutex);
     gVerifySigCache.clear();
 }
 
-void
-PubKeyUtils::enableRustDalekVerify()
+void PubKeyUtils::enableRustDalekVerify()
 {
     std::lock_guard<std::mutex> guard(gVerifySigCacheMutex);
     gUseRustDalekVerify = true;
 }
 
-void
-PubKeyUtils::seedVerifySigCache(unsigned int seed)
+void PubKeyUtils::seedVerifySigCache(unsigned int seed)
 {
     std::lock_guard<std::mutex> guard(gVerifySigCacheMutex);
     gVerifySigCache.seed(seed);
 }
 
-void
-PubKeyUtils::flushVerifySigCacheCounts(uint64_t& hits, uint64_t& misses)
+void PubKeyUtils::flushVerifySigCacheCounts(uint64_t& hits, uint64_t& misses)
 {
     std::lock_guard<std::mutex> guard(gVerifySigCacheMutex);
     hits = gVerifyCacheHit;
@@ -350,14 +329,12 @@ PubKeyUtils::flushVerifySigCacheCounts(uint64_t& hits, uint64_t& misses)
     gVerifyCacheMiss = 0;
 }
 
-std::string
-KeyFunctions<PublicKey>::getKeyTypeName()
+std::string KeyFunctions<PublicKey>::getKeyTypeName()
 {
     return "public key";
 }
 
-bool
-KeyFunctions<PublicKey>::getKeyVersionIsSupported(
+bool KeyFunctions<PublicKey>::getKeyVersionIsSupported(
     strKey::StrKeyVersionByte keyVersion)
 {
     switch (keyVersion)
@@ -369,8 +346,7 @@ KeyFunctions<PublicKey>::getKeyVersionIsSupported(
     }
 }
 
-bool
-KeyFunctions<PublicKey>::getKeyVersionIsVariableLength(
+bool KeyFunctions<PublicKey>::getKeyVersionIsVariableLength(
     strKey::StrKeyVersionByte keyVersion)
 {
     return false;
@@ -400,8 +376,7 @@ KeyFunctions<PublicKey>::toKeyVersion(PublicKeyType keyType)
     }
 }
 
-uint256&
-KeyFunctions<PublicKey>::getEd25519Value(PublicKey& key)
+uint256& KeyFunctions<PublicKey>::getEd25519Value(PublicKey& key)
 {
     switch (key.type())
     {
@@ -412,8 +387,7 @@ KeyFunctions<PublicKey>::getEd25519Value(PublicKey& key)
     }
 }
 
-uint256 const&
-KeyFunctions<PublicKey>::getEd25519Value(PublicKey const& key)
+uint256 const& KeyFunctions<PublicKey>::getEd25519Value(PublicKey const& key)
 {
     switch (key.type())
     {
@@ -424,15 +398,13 @@ KeyFunctions<PublicKey>::getEd25519Value(PublicKey const& key)
     }
 }
 
-std::vector<uint8_t>
-KeyFunctions<PublicKey>::getKeyValue(PublicKey const& key)
+std::vector<uint8_t> KeyFunctions<PublicKey>::getKeyValue(PublicKey const& key)
 {
     return xdr::xdr_to_opaque(getEd25519Value(key));
 }
 
-void
-KeyFunctions<PublicKey>::setKeyValue(PublicKey& key,
-                                     std::vector<uint8_t> const& data)
+void KeyFunctions<PublicKey>::setKeyValue(PublicKey& key,
+                                          std::vector<uint8_t> const& data)
 {
     switch (key.type())
     {
@@ -444,9 +416,9 @@ KeyFunctions<PublicKey>::setKeyValue(PublicKey& key,
     }
 }
 
-PubKeyUtils::VerifySigResult
-PubKeyUtils::verifySig(PublicKey const& key, Signature const& signature,
-                       ByteSlice const& bin)
+PubKeyUtils::VerifySigResult PubKeyUtils::verifySig(PublicKey const& key,
+                                                    Signature const& signature,
+                                                    ByteSlice const& bin)
 {
     ZoneScoped;
     releaseAssert(key.type() == PUBLIC_KEY_TYPE_ED25519);
@@ -494,8 +466,7 @@ PubKeyUtils::verifySig(PublicKey const& key, Signature const& signature,
     return {ok, VerifySigCacheLookupResult::MISS};
 }
 
-PublicKey
-PubKeyUtils::random()
+PublicKey PubKeyUtils::random()
 {
     PublicKey pk;
     pk.type(PUBLIC_KEY_TYPE_ED25519);
@@ -505,33 +476,28 @@ PubKeyUtils::random()
 }
 
 #ifdef BUILD_TESTS
-PublicKey
-PubKeyUtils::pseudoRandomForTesting()
+PublicKey PubKeyUtils::pseudoRandomForTesting()
 {
     return SecretKey::pseudoRandomForTesting().getPublicKey();
 }
 #endif
 
-static void
-logPublicKey(std::ostream& s, PublicKey const& pk)
+static void logPublicKey(std::ostream& s, PublicKey const& pk)
 {
     s << "PublicKey:" << std::endl
       << "  strKey: " << KeyUtils::toStrKey(pk) << std::endl
       << "  hex: " << binToHex(pk.ed25519()) << std::endl;
 }
 
-static void
-logSecretKey(std::ostream& s, SecretKey const& sk)
+static void logSecretKey(std::ostream& s, SecretKey const& sk)
 {
     s << "Seed:" << std::endl
       << "  strKey: " << sk.getStrKeySeed().value << std::endl;
     logPublicKey(s, sk.getPublicKey());
 }
 
-void
-StrKeyUtils::logKey(std::ostream& s, std::string const& key)
+void StrKeyUtils::logKey(std::ostream& s, std::string const& key)
 {
-
     // see if it's a public key
     try
     {
@@ -632,8 +598,7 @@ StrKeyUtils::logKey(std::ostream& s, std::string const& key)
     s << "Unknown key type" << std::endl;
 }
 
-Hash
-HashUtils::random()
+Hash HashUtils::random()
 {
     Hash res;
     randombytes_buf(res.data(), res.size());
@@ -641,8 +606,7 @@ HashUtils::random()
 }
 
 #ifdef BUILD_TESTS
-Hash
-HashUtils::pseudoRandomForTesting()
+Hash HashUtils::pseudoRandomForTesting()
 {
     Hash res;
     auto bytes = getPRNGBytes(res.size(), getGlobalRandomEngine());

--- a/src/crypto/SecretKey.h
+++ b/src/crypto/SecretKey.h
@@ -78,8 +78,7 @@ class SecretKey
 
     // Decode a secret key from a provided StrKey seed value.
     static SecretKey fromStrKeySeed(std::string const& strKeySeed);
-    static SecretKey
-    fromStrKeySeed(std::string&& strKeySeed)
+    static SecretKey fromStrKeySeed(std::string&& strKeySeed)
     {
         SecretKey ret = fromStrKeySeed(strKeySeed);
         for (std::size_t i = 0; i < strKeySeed.size(); ++i)
@@ -90,14 +89,12 @@ class SecretKey
     // Decode a secret key from a binary seed value.
     static SecretKey fromSeed(ByteSlice const& seed);
 
-    bool
-    operator==(SecretKey const& rh) const
+    bool operator==(SecretKey const& rh) const
     {
         return (mKeyType == rh.mKeyType) && (mSecretKey == rh.mSecretKey);
     }
 
-    bool
-    operator<(SecretKey const& rh) const
+    bool operator<(SecretKey const& rh) const
     {
         if (mKeyType < rh.mKeyType)
         {

--- a/src/crypto/ShortHash.cpp
+++ b/src/crypto/ShortHash.cpp
@@ -18,15 +18,13 @@ static bool gHaveHashed{false};
 static unsigned int gExplicitSeed{0};
 #endif
 
-void
-initialize()
+void initialize()
 {
     std::lock_guard<std::mutex> guard(gKeyMutex);
     crypto_shorthash_keygen(gKey);
 }
 
-std::array<unsigned char, crypto_shorthash_KEYBYTES>
-getShortHashInitKey()
+std::array<unsigned char, crypto_shorthash_KEYBYTES> getShortHashInitKey()
 {
     std::lock_guard<std::mutex> guard(gKeyMutex);
     std::array<unsigned char, crypto_shorthash_KEYBYTES> arr;
@@ -35,8 +33,7 @@ getShortHashInitKey()
 }
 
 #ifdef BUILD_TESTS
-void
-seed(unsigned int s)
+void seed(unsigned int s)
 {
     std::lock_guard<std::mutex> guard(gKeyMutex);
     if (gHaveHashed)
@@ -58,8 +55,7 @@ seed(unsigned int s)
     }
 }
 #endif
-uint64_t
-computeHash(stellar::ByteSlice const& b)
+uint64_t computeHash(stellar::ByteSlice const& b)
 {
     std::lock_guard<std::mutex> guard(gKeyMutex);
     gHaveHashed = true;
@@ -78,8 +74,7 @@ XDRShortHasher::XDRShortHasher() : state(gKey)
     state = SipHash24(gKey);
 }
 
-void
-XDRShortHasher::hashBytes(unsigned char const* bytes, size_t len)
+void XDRShortHasher::hashBytes(unsigned char const* bytes, size_t len)
 {
     state.update(bytes, len);
 }

--- a/src/crypto/ShortHash.h
+++ b/src/crypto/ShortHash.h
@@ -44,9 +44,7 @@ struct XDRShortHasher : XDRHasher<XDRShortHasher>
 // (ByteSlice case). This difference isn't a security feature or anything
 // (SipHash integrates length into the hash) but it's a source of potential
 // bugs, so we avoid it by using a different function name.
-template <typename T>
-uint64_t
-xdrComputeHash(T const& t)
+template <typename T> uint64_t xdrComputeHash(T const& t)
 {
     XDRShortHasher xsh;
     xdr::archive(xsh, t);

--- a/src/crypto/SignerKey.cpp
+++ b/src/crypto/SignerKey.cpp
@@ -13,14 +13,12 @@
 namespace stellar
 {
 
-std::string
-KeyFunctions<SignerKey>::getKeyTypeName()
+std::string KeyFunctions<SignerKey>::getKeyTypeName()
 {
     return "signer key";
 }
 
-bool
-KeyFunctions<SignerKey>::getKeyVersionIsSupported(
+bool KeyFunctions<SignerKey>::getKeyVersionIsSupported(
     strKey::StrKeyVersionByte keyVersion)
 {
     switch (keyVersion)
@@ -38,8 +36,7 @@ KeyFunctions<SignerKey>::getKeyVersionIsSupported(
     }
 }
 
-bool
-KeyFunctions<SignerKey>::getKeyVersionIsVariableLength(
+bool KeyFunctions<SignerKey>::getKeyVersionIsVariableLength(
     strKey::StrKeyVersionByte keyVersion)
 {
     switch (keyVersion)
@@ -93,8 +90,7 @@ KeyFunctions<SignerKey>::toKeyVersion(SignerKeyType keyType)
     }
 }
 
-uint256&
-KeyFunctions<SignerKey>::getEd25519Value(SignerKey& key)
+uint256& KeyFunctions<SignerKey>::getEd25519Value(SignerKey& key)
 {
     switch (key.type())
     {
@@ -105,8 +101,7 @@ KeyFunctions<SignerKey>::getEd25519Value(SignerKey& key)
     }
 }
 
-uint256 const&
-KeyFunctions<SignerKey>::getEd25519Value(SignerKey const& key)
+uint256 const& KeyFunctions<SignerKey>::getEd25519Value(SignerKey const& key)
 {
     switch (key.type())
     {
@@ -117,8 +112,7 @@ KeyFunctions<SignerKey>::getEd25519Value(SignerKey const& key)
     }
 }
 
-std::vector<uint8_t>
-KeyFunctions<SignerKey>::getKeyValue(SignerKey const& key)
+std::vector<uint8_t> KeyFunctions<SignerKey>::getKeyValue(SignerKey const& key)
 {
     switch (key.type())
     {
@@ -135,9 +129,8 @@ KeyFunctions<SignerKey>::getKeyValue(SignerKey const& key)
     }
 }
 
-void
-KeyFunctions<SignerKey>::setKeyValue(SignerKey& key,
-                                     std::vector<uint8_t> const& data)
+void KeyFunctions<SignerKey>::setKeyValue(SignerKey& key,
+                                          std::vector<uint8_t> const& data)
 {
     switch (key.type())
     {

--- a/src/crypto/SignerKeyUtils.cpp
+++ b/src/crypto/SignerKeyUtils.cpp
@@ -14,8 +14,7 @@ namespace stellar
 namespace SignerKeyUtils
 {
 
-SignerKey
-preAuthTxKey(TransactionFrame const& tx)
+SignerKey preAuthTxKey(TransactionFrame const& tx)
 {
     SignerKey sk;
     sk.type(SIGNER_KEY_TYPE_PRE_AUTH_TX);
@@ -23,8 +22,7 @@ preAuthTxKey(TransactionFrame const& tx)
     return sk;
 }
 
-SignerKey
-preAuthTxKey(FeeBumpTransactionFrame const& tx)
+SignerKey preAuthTxKey(FeeBumpTransactionFrame const& tx)
 {
     SignerKey sk;
     sk.type(SIGNER_KEY_TYPE_PRE_AUTH_TX);
@@ -32,8 +30,7 @@ preAuthTxKey(FeeBumpTransactionFrame const& tx)
     return sk;
 }
 
-SignerKey
-hashXKey(ByteSlice const& bs)
+SignerKey hashXKey(ByteSlice const& bs)
 {
     SignerKey sk;
     sk.type(SIGNER_KEY_TYPE_HASH_X);
@@ -41,8 +38,8 @@ hashXKey(ByteSlice const& bs)
     return sk;
 }
 
-SignerKey
-ed25519PayloadKey(uint256 const& ed25519, xdr::opaque_vec<64> const& payload)
+SignerKey ed25519PayloadKey(uint256 const& ed25519,
+                            xdr::opaque_vec<64> const& payload)
 {
     SignerKey sk;
     sk.type(SIGNER_KEY_TYPE_ED25519_SIGNED_PAYLOAD);

--- a/src/crypto/StrKey.cpp
+++ b/src/crypto/StrKey.cpp
@@ -13,8 +13,7 @@ namespace stellar
 namespace strKey
 {
 // Encode a version byte and ByteSlice into StrKey
-SecretValue
-toStrKey(uint8_t ver, ByteSlice const& bin)
+SecretValue toStrKey(uint8_t ver, ByteSlice const& bin)
 {
     ZoneScoped;
     ver <<= 3; // promote to 8 bits
@@ -33,16 +32,14 @@ toStrKey(uint8_t ver, ByteSlice const& bin)
     return SecretValue{res};
 }
 
-size_t
-getStrKeySize(size_t dataSize)
+size_t getStrKeySize(size_t dataSize)
 {
     dataSize += 3; // version and crc
     return decoder::encoded_size32(dataSize);
 }
 
-bool
-fromStrKey(std::string const& strKey, uint8_t& outVersion,
-           std::vector<uint8_t>& decoded)
+bool fromStrKey(std::string const& strKey, uint8_t& outVersion,
+                std::vector<uint8_t>& decoded)
 {
     ZoneScoped;
     // check that there is no trailing data

--- a/src/crypto/XDRHasher.h
+++ b/src/crypto/XDRHasher.h
@@ -18,13 +18,11 @@ template <typename Derived> struct XDRHasher
     // Buffer and batch calls to underlying hasher a _little_ bit.
     unsigned char mBuf[256] = {0};
     size_t mLen = 0;
-    size_t
-    available() const
+    size_t available() const
     {
         return sizeof(mBuf) - mLen;
     }
-    void
-    queueOrHash(unsigned char const* u, size_t sz)
+    void queueOrHash(unsigned char const* u, size_t sz)
     {
         if (u == nullptr)
         {
@@ -47,8 +45,7 @@ template <typename Derived> struct XDRHasher
         memcpy(mBuf + mLen, u, sz);
         mLen += sz;
     }
-    void
-    flush()
+    void flush()
     {
         if (mLen != 0)
         {

--- a/src/database/Database.h
+++ b/src/database/Database.h
@@ -59,8 +59,7 @@ class StatementContext : NonCopyable
             mStmt->clean_up(false);
         }
     }
-    soci::statement&
-    statement()
+    soci::statement& statement()
     {
         return *mStmt;
     }
@@ -81,13 +80,11 @@ class SessionWrapper : NonCopyable
     {
     }
 
-    soci::session&
-    session()
+    soci::session& session()
     {
         return mSession;
     }
-    std::string const&
-    getSessionName() const
+    std::string const& getSessionName() const
     {
         return mSessionName;
     }
@@ -224,9 +221,8 @@ class Database : NonMovableOrCopyable
 };
 
 template <typename T>
-T
-doDatabaseTypeSpecificOperation(soci::session& session,
-                                DatabaseTypeSpecificOperation<T>& op)
+T doDatabaseTypeSpecificOperation(soci::session& session,
+                                  DatabaseTypeSpecificOperation<T>& op)
 {
     auto b = session.get_backend();
     if (auto sq = dynamic_cast<soci::sqlite3_session_backend*>(b))
@@ -247,16 +243,13 @@ doDatabaseTypeSpecificOperation(soci::session& session,
 }
 
 template <typename T>
-T
-Database::doDatabaseTypeSpecificOperation(SessionWrapper& session,
-                                          DatabaseTypeSpecificOperation<T>& op)
+T Database::doDatabaseTypeSpecificOperation(
+    SessionWrapper& session, DatabaseTypeSpecificOperation<T>& op)
 {
     return stellar::doDatabaseTypeSpecificOperation(session.session(), op);
 }
 
-template <typename T>
-void
-decodeOpaqueXDR(std::string const& in, T& out)
+template <typename T> void decodeOpaqueXDR(std::string const& in, T& out)
 {
     std::vector<uint8_t> opaque;
     decoder::decode_b64(in, opaque);
@@ -264,8 +257,7 @@ decodeOpaqueXDR(std::string const& in, T& out)
 }
 
 template <typename T>
-void
-decodeOpaqueXDR(std::string const& in, soci::indicator const& ind, T& out)
+void decodeOpaqueXDR(std::string const& in, soci::indicator const& ind, T& out)
 {
     if (ind == soci::i_ok)
     {

--- a/src/database/DatabaseConnectionString.cpp
+++ b/src/database/DatabaseConnectionString.cpp
@@ -8,8 +8,7 @@
 
 namespace stellar
 {
-std::string
-removePasswordFromConnectionString(std::string connectionString)
+std::string removePasswordFromConnectionString(std::string connectionString)
 {
     std::string escapedSingleQuotePat("\\\\'");
     std::string nonSingleQuotePat("[^']");

--- a/src/database/DatabaseUtils.cpp
+++ b/src/database/DatabaseUtils.cpp
@@ -8,10 +8,9 @@ namespace stellar
 {
 namespace DatabaseUtils
 {
-void
-deleteOldEntriesHelper(soci::session& sess, uint32_t ledgerSeq, uint32_t count,
-                       std::string const& tableName,
-                       std::string const& ledgerSeqColumn)
+void deleteOldEntriesHelper(soci::session& sess, uint32_t ledgerSeq,
+                            uint32_t count, std::string const& tableName,
+                            std::string const& ledgerSeqColumn)
 {
     uint32_t curMin = 0;
     soci::indicator gotMin;

--- a/src/database/test/DatabaseTests.cpp
+++ b/src/database/test/DatabaseTests.cpp
@@ -25,8 +25,7 @@
 
 using namespace stellar;
 
-void
-transactionTest(Application::pointer app)
+void transactionTest(Application::pointer app)
 {
     int a = 10, b = 0;
     int a0 = a + 1;
@@ -88,10 +87,8 @@ TEST_CASE("database on-disk smoketest", "[db]")
     transactionTest(app);
 }
 
-void
-checkMVCCIsolation(Application::pointer app)
+void checkMVCCIsolation(Application::pointer app)
 {
-
     int v0 = 1;
 
     // Values we insert/update in different txs

--- a/src/herder/Herder.cpp
+++ b/src/herder/Herder.cpp
@@ -1,4 +1,3 @@
-
 #include "herder/Herder.h"
 
 namespace stellar

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -53,8 +53,7 @@ class HerderImpl : public Herder
     TimePoint trackingConsensusCloseTime() const;
 
     // the ledger index that we expect to externalize next
-    uint32
-    nextConsensusLedgerIndex() const
+    uint32 nextConsensusLedgerIndex() const
     {
         return trackingConsensusLedgerIndex() + 1;
     }
@@ -79,14 +78,12 @@ class HerderImpl : public Herder
                                    bool queueRebuildNeeded) override;
 
     SCP& getSCP();
-    HerderSCPDriver&
-    getHerderSCPDriver()
+    HerderSCPDriver& getHerderSCPDriver()
     {
         return mHerderSCPDriver;
     }
 
-    bool
-    isTracking() const override
+    bool isTracking() const override
     {
         return mState == State::HERDER_TRACKING_NETWORK_STATE;
     }
@@ -121,8 +118,7 @@ class HerderImpl : public Herder
                           xdr::xvector<UpgradeType, 6> const& upgrades,
                           std::optional<SecretKey> skToSignValue) override;
 
-    VirtualTimer const&
-    getTriggerTimer() const override
+    VirtualTimer const& getTriggerTimer() const override
     {
         return mTriggerTimer;
     }
@@ -131,19 +127,16 @@ class HerderImpl : public Herder
 
     std::optional<uint32_t> mMaxClassicTxSize;
     std::optional<uint32_t> mMaxTxSizeOverride;
-    void
-    setMaxClassicTxSize(uint32 bytes) override
+    void setMaxClassicTxSize(uint32 bytes) override
     {
         mMaxClassicTxSize = std::make_optional<uint32_t>(bytes);
     }
-    void
-    setMaxTxSize(uint32 bytes) override
+    void setMaxTxSize(uint32 bytes) override
     {
         mMaxTxSizeOverride = bytes;
     }
     std::optional<uint32_t> mFlowControlExtraBuffer;
-    void
-    setFlowControlExtraBufferSize(uint32 bytes) override
+    void setFlowControlExtraBufferSize(uint32 bytes) override
     {
         mFlowControlExtraBuffer = std::make_optional<uint32_t>(bytes);
     }
@@ -162,8 +155,7 @@ class HerderImpl : public Herder
     uint32_t getMaxClassicTxSize() const override;
     uint32_t getFlowControlExtraBuffer() const override;
 
-    uint32_t
-    getMaxTxSize() const override
+    uint32_t getMaxTxSize() const override
     {
 #ifdef BUILD_TESTS
         if (mMaxTxSizeOverride)

--- a/src/herder/HerderPersistenceImpl.cpp
+++ b/src/herder/HerderPersistenceImpl.cpp
@@ -20,8 +20,7 @@
 namespace stellar
 {
 
-std::unique_ptr<HerderPersistence>
-HerderPersistence::create(Application& app)
+std::unique_ptr<HerderPersistence> HerderPersistence::create(Application& app)
 {
     return std::make_unique<HerderPersistenceImpl>(app);
 }
@@ -34,10 +33,9 @@ HerderPersistenceImpl::~HerderPersistenceImpl()
 {
 }
 
-void
-HerderPersistenceImpl::saveSCPHistory(uint32_t seq,
-                                      std::vector<SCPEnvelope> const& envs,
-                                      QuorumTracker::QuorumMap const& qmap)
+void HerderPersistenceImpl::saveSCPHistory(uint32_t seq,
+                                           std::vector<SCPEnvelope> const& envs,
+                                           QuorumTracker::QuorumMap const& qmap)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -229,11 +227,9 @@ HerderPersistenceImpl::saveSCPHistory(uint32_t seq,
     txscope.commit();
 }
 
-size_t
-HerderPersistence::copySCPHistoryToStream(soci::session& sess,
-                                          uint32_t ledgerSeq,
-                                          uint32_t ledgerCount,
-                                          XDROutputFileStream& scpHistory)
+size_t HerderPersistence::copySCPHistoryToStream(
+    soci::session& sess, uint32_t ledgerSeq, uint32_t ledgerCount,
+    XDROutputFileStream& scpHistory)
 {
     ZoneScoped;
     // Subtle: changing these queries may cause conflicts with main thread
@@ -318,8 +314,8 @@ HerderPersistence::copySCPHistoryToStream(soci::session& sess,
     return n;
 }
 
-std::optional<Hash>
-HerderPersistence::getNodeQuorumSet(soci::session& sess, NodeID const& nodeID)
+std::optional<Hash> HerderPersistence::getNodeQuorumSet(soci::session& sess,
+                                                        NodeID const& nodeID)
 {
     ZoneScoped;
     std::string nodeIDStrKey = KeyUtils::toStrKey(nodeID);
@@ -343,8 +339,8 @@ HerderPersistence::getNodeQuorumSet(soci::session& sess, NodeID const& nodeID)
     }
 }
 
-SCPQuorumSetPtr
-HerderPersistence::getQuorumSet(soci::session& sess, Hash const& qSetHash)
+SCPQuorumSetPtr HerderPersistence::getQuorumSet(soci::session& sess,
+                                                Hash const& qSetHash)
 {
     ZoneScoped;
     SCPQuorumSetPtr res;
@@ -375,8 +371,7 @@ HerderPersistence::getQuorumSet(soci::session& sess, Hash const& qSetHash)
     }
 }
 
-void
-HerderPersistence::dropAll(Database& db)
+void HerderPersistence::dropAll(Database& db)
 {
     ZoneScoped;
     db.getRawSession() << "DROP TABLE IF EXISTS scphistory";
@@ -409,9 +404,8 @@ HerderPersistence::dropAll(Database& db)
                           "PRIMARY KEY (nodeid))";
 }
 
-void
-HerderPersistence::deleteOldEntries(soci::session& sess, uint32_t ledgerSeq,
-                                    uint32_t count)
+void HerderPersistence::deleteOldEntries(soci::session& sess,
+                                         uint32_t ledgerSeq, uint32_t count)
 {
     ZoneScoped;
     DatabaseUtils::deleteOldEntriesHelper(sess, ledgerSeq, count, "scphistory",

--- a/src/herder/HerderPersistenceImpl.h
+++ b/src/herder/HerderPersistenceImpl.h
@@ -12,7 +12,6 @@ class Application;
 
 class HerderPersistenceImpl : public HerderPersistence
 {
-
   public:
     HerderPersistenceImpl(Application& app);
     ~HerderPersistenceImpl();

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -38,8 +38,8 @@ namespace stellar
 
 uint32_t const TXSETVALID_CACHE_SIZE = 1000;
 
-Hash
-HerderSCPDriver::getHashOf(std::vector<xdr::opaque_vec<>> const& vals) const
+Hash HerderSCPDriver::getHashOf(
+    std::vector<xdr::opaque_vec<>> const& vals) const
 {
     SHA256 hasher;
     for (auto const& v : vals)
@@ -94,14 +94,12 @@ HerderSCPDriver::~HerderSCPDriver()
 {
 }
 
-void
-HerderSCPDriver::stateChanged()
+void HerderSCPDriver::stateChanged()
 {
     mApp.syncOwnMetrics();
 }
 
-void
-HerderSCPDriver::bootstrap()
+void HerderSCPDriver::bootstrap()
 {
     stateChanged();
     clearSCPExecutionEvents();
@@ -149,23 +147,20 @@ class SCPHerderEnvelopeWrapper : public SCPEnvelopeWrapper
     }
 };
 
-SCPEnvelopeWrapperPtr
-HerderSCPDriver::wrapEnvelope(SCPEnvelope const& envelope)
+SCPEnvelopeWrapperPtr HerderSCPDriver::wrapEnvelope(SCPEnvelope const& envelope)
 {
     auto r = std::make_shared<SCPHerderEnvelopeWrapper>(envelope, mHerder);
     return r;
 }
 
-void
-HerderSCPDriver::signEnvelope(SCPEnvelope& envelope)
+void HerderSCPDriver::signEnvelope(SCPEnvelope& envelope)
 {
     ZoneScoped;
     mSCPMetrics.mEnvelopeSign.Mark();
     mHerder.signEnvelope(mApp.getConfig().NODE_SEED, envelope);
 }
 
-void
-HerderSCPDriver::emitEnvelope(SCPEnvelope const& envelope)
+void HerderSCPDriver::emitEnvelope(SCPEnvelope const& envelope)
 {
     ZoneScoped;
     mHerder.emitEnvelope(envelope);
@@ -173,9 +168,8 @@ HerderSCPDriver::emitEnvelope(SCPEnvelope const& envelope)
 
 // value validation
 
-bool
-HerderSCPDriver::checkCloseTime(uint64_t slotIndex, uint64_t lastCloseTime,
-                                StellarValue const& b) const
+bool HerderSCPDriver::checkCloseTime(uint64_t slotIndex, uint64_t lastCloseTime,
+                                     StellarValue const& b) const
 {
     // Check closeTime (not too old)
     if (b.closeTime <= lastCloseTime)
@@ -197,8 +191,7 @@ HerderSCPDriver::checkCloseTime(uint64_t slotIndex, uint64_t lastCloseTime,
     return true;
 }
 
-SCPDriver::ValidationLevel
-HerderSCPDriver::validatePastOrFutureValue(
+SCPDriver::ValidationLevel HerderSCPDriver::validatePastOrFutureValue(
     uint64_t slotIndex, StellarValue const& b,
     LedgerHeaderHistoryEntry const& lcl) const
 {
@@ -275,10 +268,8 @@ HerderSCPDriver::validatePastOrFutureValue(
     return SCPDriver::kMaybeValidValue;
 }
 
-SCPDriver::ValidationLevel
-HerderSCPDriver::validateValueAgainstLocalState(uint64_t slotIndex,
-                                                StellarValue const& b,
-                                                bool nomination) const
+SCPDriver::ValidationLevel HerderSCPDriver::validateValueAgainstLocalState(
+    uint64_t slotIndex, StellarValue const& b, bool nomination) const
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -332,9 +323,9 @@ HerderSCPDriver::validateValueAgainstLocalState(uint64_t slotIndex,
     return res;
 }
 
-SCPDriver::ValidationLevel
-HerderSCPDriver::validateValue(uint64_t slotIndex, Value const& value,
-                               bool nomination)
+SCPDriver::ValidationLevel HerderSCPDriver::validateValue(uint64_t slotIndex,
+                                                          Value const& value,
+                                                          bool nomination)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -412,8 +403,8 @@ HerderSCPDriver::validateValue(uint64_t slotIndex, Value const& value,
     return res;
 }
 
-ValueWrapperPtr
-HerderSCPDriver::extractValidValue(uint64_t slotIndex, Value const& value)
+ValueWrapperPtr HerderSCPDriver::extractValidValue(uint64_t slotIndex,
+                                                   Value const& value)
 {
     ZoneScoped;
     StellarValue b;
@@ -451,14 +442,12 @@ HerderSCPDriver::extractValidValue(uint64_t slotIndex, Value const& value)
 
 // value marshaling
 
-std::string
-HerderSCPDriver::toShortString(NodeID const& pk) const
+std::string HerderSCPDriver::toShortString(NodeID const& pk) const
 {
     return mApp.getConfig().toShortString(pk);
 }
 
-std::string
-HerderSCPDriver::getValueString(Value const& v) const
+std::string HerderSCPDriver::getValueString(Value const& v) const
 {
     StellarValue b;
     if (v.empty())
@@ -479,9 +468,8 @@ HerderSCPDriver::getValueString(Value const& v) const
 }
 
 // timer handling
-void
-HerderSCPDriver::timerCallbackWrapper(uint64_t slotIndex, int timerID,
-                                      std::function<void()> cb)
+void HerderSCPDriver::timerCallbackWrapper(uint64_t slotIndex, int timerID,
+                                           std::function<void()> cb)
 {
     // reschedule timers for future slots when tracking
     if (mHerder.isTracking() && mHerder.nextConsensusLedgerIndex() != slotIndex)
@@ -518,10 +506,9 @@ HerderSCPDriver::timerCallbackWrapper(uint64_t slotIndex, int timerID,
     }
 }
 
-void
-HerderSCPDriver::setupTimer(uint64_t slotIndex, int timerID,
-                            std::chrono::milliseconds timeout,
-                            std::function<void()> cb)
+void HerderSCPDriver::setupTimer(uint64_t slotIndex, int timerID,
+                                 std::chrono::milliseconds timeout,
+                                 std::function<void()> cb)
 {
     // don't setup timers for old slots
     if (slotIndex <= mApp.getHerder().trackingConsensusLedgerIndex())
@@ -549,10 +536,8 @@ HerderSCPDriver::setupTimer(uint64_t slotIndex, int timerID,
     }
 }
 
-void
-HerderSCPDriver::stopTimer(uint64 slotIndex, int timerID)
+void HerderSCPDriver::stopTimer(uint64 slotIndex, int timerID)
 {
-
     auto timersIt = mSCPTimers.find(slotIndex);
     if (timersIt == mSCPTimers.end())
     {
@@ -570,8 +555,8 @@ HerderSCPDriver::stopTimer(uint64 slotIndex, int timerID)
 
 static const uint32_t MAX_TIMEOUT_MS = (30 * 60) * 1000;
 
-std::chrono::milliseconds
-HerderSCPDriver::computeTimeout(uint32 roundNumber, bool isNomination)
+std::chrono::milliseconds HerderSCPDriver::computeTimeout(uint32 roundNumber,
+                                                          bool isNomination)
 {
     releaseAssertOrThrow(roundNumber > 0);
 
@@ -610,10 +595,11 @@ HerderSCPDriver::computeTimeout(uint32 roundNumber, bool isNomination)
 
 // returns true if l < r
 // lh, rh are the hashes of l,h
-static bool
-compareTxSets(ApplicableTxSetFrame const& l, ApplicableTxSetFrame const& r,
-              Hash const& lh, Hash const& rh, size_t lEncodedSize,
-              size_t rEncodedSize, LedgerHeader const& header, Hash const& s)
+static bool compareTxSets(ApplicableTxSetFrame const& l,
+                          ApplicableTxSetFrame const& r, Hash const& lh,
+                          Hash const& rh, size_t lEncodedSize,
+                          size_t rEncodedSize, LedgerHeader const& header,
+                          Hash const& s)
 {
     auto lSize = l.size(header);
     auto rSize = r.size(header);
@@ -764,7 +750,6 @@ HerderSCPDriver::combineCandidates(uint64_t slotIndex,
             releaseAssert(cApplicableTxSet);
             if (cTxSet->previousLedgerHash() == lcl.hash)
             {
-
                 if (!highestTxSet ||
                     compareTxSets(*highestApplicableTxSet, *cApplicableTxSet,
                                   highest->txSetHash, sv.txSetHash,
@@ -796,8 +781,7 @@ HerderSCPDriver::combineCandidates(uint64_t slotIndex,
     return res;
 }
 
-bool
-HerderSCPDriver::toStellarValue(Value const& v, StellarValue& sv)
+bool HerderSCPDriver::toStellarValue(Value const& v, StellarValue& sv)
 {
     try
     {
@@ -810,8 +794,7 @@ HerderSCPDriver::toStellarValue(Value const& v, StellarValue& sv)
     return true;
 }
 
-void
-HerderSCPDriver::valueExternalized(uint64_t slotIndex, Value const& value)
+void HerderSCPDriver::valueExternalized(uint64_t slotIndex, Value const& value)
 {
     ZoneScoped;
     auto it = mSCPTimers.begin(); // cancel all timers below this slot
@@ -889,8 +872,7 @@ HerderSCPDriver::valueExternalized(uint64_t slotIndex, Value const& value)
     }
 }
 
-void
-HerderSCPDriver::logQuorumInformationAndUpdateMetrics(uint64_t index)
+void HerderSCPDriver::logQuorumInformationAndUpdateMetrics(uint64_t index)
 {
     std::string res;
     auto v = mApp.getHerder().getJsonQuorumInfo(mSCP.getLocalNodeID(), true,
@@ -930,10 +912,9 @@ HerderSCPDriver::logQuorumInformationAndUpdateMetrics(uint64_t index)
                           std::inserter(mMissingNodes, mMissingNodes.begin()));
 }
 
-void
-HerderSCPDriver::nominate(uint64_t slotIndex, StellarValue const& value,
-                          TxSetXDRFrameConstPtr proposedSet,
-                          StellarValue const& previousValue)
+void HerderSCPDriver::nominate(uint64_t slotIndex, StellarValue const& value,
+                               TxSetXDRFrameConstPtr proposedSet,
+                               StellarValue const& previousValue)
 {
     ZoneScoped;
     mCurrentValue = wrapStellarValue(value);
@@ -951,49 +932,43 @@ HerderSCPDriver::nominate(uint64_t slotIndex, StellarValue const& value,
     mSCP.nominate(slotIndex, mCurrentValue, prevValue);
 }
 
-SCPQuorumSetPtr
-HerderSCPDriver::getQSet(Hash const& qSetHash)
+SCPQuorumSetPtr HerderSCPDriver::getQSet(Hash const& qSetHash)
 {
     return mPendingEnvelopes.getQSet(qSetHash);
 }
 
-void
-HerderSCPDriver::ballotDidHearFromQuorum(uint64_t, SCPBallot const&)
+void HerderSCPDriver::ballotDidHearFromQuorum(uint64_t, SCPBallot const&)
 {
 }
 
-void
-HerderSCPDriver::nominatingValue(uint64_t slotIndex, Value const& value)
+void HerderSCPDriver::nominatingValue(uint64_t slotIndex, Value const& value)
 {
     CLOG_DEBUG(Herder, "nominatingValue i:{} v: {}", slotIndex,
                getValueString(value));
 }
 
-void
-HerderSCPDriver::updatedCandidateValue(uint64_t slotIndex, Value const& value)
+void HerderSCPDriver::updatedCandidateValue(uint64_t slotIndex,
+                                            Value const& value)
 {
 }
 
-void
-HerderSCPDriver::startedBallotProtocol(uint64_t slotIndex,
-                                       SCPBallot const& ballot)
+void HerderSCPDriver::startedBallotProtocol(uint64_t slotIndex,
+                                            SCPBallot const& ballot)
 {
     recordSCPEvent(slotIndex, false);
 }
-void
-HerderSCPDriver::acceptedBallotPrepared(uint64_t slotIndex,
-                                        SCPBallot const& ballot)
+void HerderSCPDriver::acceptedBallotPrepared(uint64_t slotIndex,
+                                             SCPBallot const& ballot)
 {
 }
 
-void
-HerderSCPDriver::confirmedBallotPrepared(uint64_t slotIndex,
-                                         SCPBallot const& ballot)
+void HerderSCPDriver::confirmedBallotPrepared(uint64_t slotIndex,
+                                              SCPBallot const& ballot)
 {
 }
 
-void
-HerderSCPDriver::acceptedCommit(uint64_t slotIndex, SCPBallot const& ballot)
+void HerderSCPDriver::acceptedCommit(uint64_t slotIndex,
+                                     SCPBallot const& ballot)
 {
 }
 
@@ -1009,8 +984,7 @@ HerderSCPDriver::getPrepareStart(uint64_t slotIndex)
     return res;
 }
 
-Json::Value
-HerderSCPDriver::getQsetLagInfo(bool summary, bool fullKeys)
+Json::Value HerderSCPDriver::getQsetLagInfo(bool summary, bool fullKeys)
 {
     Json::Value ret;
     double totalLag = 0;
@@ -1043,8 +1017,7 @@ HerderSCPDriver::getQsetLagInfo(bool summary, bool fullKeys)
     return ret;
 }
 
-Json::Value
-HerderSCPDriver::getMaybeDeadNodes(bool fullKeys)
+Json::Value HerderSCPDriver::getMaybeDeadNodes(bool fullKeys)
 {
     Json::Value maybeDeadNodes(Json::arrayValue);
     for (const auto& node : mDeadNodes)
@@ -1054,8 +1027,7 @@ HerderSCPDriver::getMaybeDeadNodes(bool fullKeys)
     return maybeDeadNodes;
 }
 
-void
-HerderSCPDriver::startCheckForDeadNodesInterval()
+void HerderSCPDriver::startCheckForDeadNodesInterval()
 {
     mDeadNodes = std::move(mMissingNodes);
     mMissingNodes.clear();
@@ -1066,8 +1038,7 @@ HerderSCPDriver::startCheckForDeadNodesInterval()
                            });
 }
 
-double
-HerderSCPDriver::getExternalizeLag(NodeID const& id) const
+double HerderSCPDriver::getExternalizeLag(NodeID const& id) const
 {
     auto n = mQSetLag.find(id);
 
@@ -1079,10 +1050,8 @@ HerderSCPDriver::getExternalizeLag(NodeID const& id) const
     return n->second.GetSnapshot().get75thPercentile();
 }
 
-void
-HerderSCPDriver::recordSCPEvent(uint64_t slotIndex, bool isNomination)
+void HerderSCPDriver::recordSCPEvent(uint64_t slotIndex, bool isNomination)
 {
-
     auto& timing = mSCPExecutionTimes[slotIndex];
     VirtualClock::time_point start = mApp.getClock().now();
 
@@ -1098,9 +1067,9 @@ HerderSCPDriver::recordSCPEvent(uint64_t slotIndex, bool isNomination)
     }
 }
 
-void
-HerderSCPDriver::recordSCPExternalizeEvent(uint64_t slotIndex, NodeID const& id,
-                                           bool forceUpdateSelf)
+void HerderSCPDriver::recordSCPExternalizeEvent(uint64_t slotIndex,
+                                                NodeID const& id,
+                                                bool forceUpdateSelf)
 {
     auto& timing = mSCPExecutionTimes[slotIndex];
     auto now = mApp.getClock().now();
@@ -1162,13 +1131,12 @@ HerderSCPDriver::recordSCPExternalizeEvent(uint64_t slotIndex, NodeID const& id,
     }
 }
 
-void
-HerderSCPDriver::recordLogTiming(VirtualClock::time_point start,
-                                 VirtualClock::time_point end,
-                                 medida::Timer& timer,
-                                 std::string const& logStr,
-                                 std::chrono::nanoseconds threshold,
-                                 uint64_t slotIndex)
+void HerderSCPDriver::recordLogTiming(VirtualClock::time_point start,
+                                      VirtualClock::time_point end,
+                                      medida::Timer& timer,
+                                      std::string const& logStr,
+                                      std::chrono::nanoseconds threshold,
+                                      uint64_t slotIndex)
 {
     auto delta =
         std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
@@ -1181,8 +1149,7 @@ HerderSCPDriver::recordLogTiming(VirtualClock::time_point start,
     }
 };
 
-void
-HerderSCPDriver::recordSCPExecutionMetrics(uint64_t slotIndex)
+void HerderSCPDriver::recordSCPExecutionMetrics(uint64_t slotIndex)
 {
     auto externalizeStart = mApp.getClock().now();
 
@@ -1239,8 +1206,7 @@ HerderSCPDriver::recordSCPExecutionMetrics(uint64_t slotIndex)
     }
 }
 
-void
-HerderSCPDriver::purgeSlots(uint64_t maxSlotIndex, uint64 slotToKeep)
+void HerderSCPDriver::purgeSlots(uint64_t maxSlotIndex, uint64 slotToKeep)
 {
     // Clean up timings map
     auto it = mSCPExecutionTimes.begin();
@@ -1259,8 +1225,7 @@ HerderSCPDriver::purgeSlots(uint64_t maxSlotIndex, uint64 slotToKeep)
     getSCP().purgeSlots(maxSlotIndex, slotToKeep);
 }
 
-void
-HerderSCPDriver::clearSCPExecutionEvents()
+void HerderSCPDriver::clearSCPExecutionEvents()
 {
     mSCPExecutionTimes.clear();
 }
@@ -1288,8 +1253,7 @@ class SCPHerderValueWrapper : public ValueWrapper
     }
 };
 
-ValueWrapperPtr
-HerderSCPDriver::wrapValue(Value const& val)
+ValueWrapperPtr HerderSCPDriver::wrapValue(Value const& val)
 {
     StellarValue sv;
     auto b = mHerder.getHerderSCPDriver().toStellarValue(val, sv);
@@ -1303,18 +1267,16 @@ HerderSCPDriver::wrapValue(Value const& val)
     return res;
 }
 
-ValueWrapperPtr
-HerderSCPDriver::wrapStellarValue(StellarValue const& sv)
+ValueWrapperPtr HerderSCPDriver::wrapStellarValue(StellarValue const& sv)
 {
     auto val = xdr::xdr_to_opaque(sv);
     auto res = std::make_shared<SCPHerderValueWrapper>(sv, val, mHerder);
     return res;
 }
 
-void
-HerderSCPDriver::cacheValidTxSet(ApplicableTxSetFrame const& txSet,
-                                 LedgerHeaderHistoryEntry const& lcl,
-                                 uint64_t closeTimeOffset) const
+void HerderSCPDriver::cacheValidTxSet(ApplicableTxSetFrame const& txSet,
+                                      LedgerHeaderHistoryEntry const& lcl,
+                                      uint64_t closeTimeOffset) const
 {
     auto key = TxSetValidityKey{lcl.hash, txSet.getContentsHash(),
                                 closeTimeOffset, closeTimeOffset};
@@ -1337,10 +1299,9 @@ HerderSCPDriver::cacheValidTxSet(ApplicableTxSetFrame const& txSet,
     }
 }
 
-bool
-HerderSCPDriver::checkAndCacheTxSetValid(TxSetXDRFrame const& txSet,
-                                         LedgerHeaderHistoryEntry const& lcl,
-                                         uint64_t closeTimeOffset) const
+bool HerderSCPDriver::checkAndCacheTxSetValid(
+    TxSetXDRFrame const& txSet, LedgerHeaderHistoryEntry const& lcl,
+    uint64_t closeTimeOffset) const
 {
     auto key = TxSetValidityKey{lcl.hash, txSet.getContentsHash(),
                                 closeTimeOffset, closeTimeOffset};
@@ -1381,11 +1342,9 @@ HerderSCPDriver::checkAndCacheTxSetValid(TxSetXDRFrame const& txSet,
         return *pRes;
     }
 }
-size_t
-HerderSCPDriver::TxSetValidityKeyHash::operator()(
+size_t HerderSCPDriver::TxSetValidityKeyHash::operator()(
     TxSetValidityKey const& key) const
 {
-
     size_t res = std::hash<Hash>()(std::get<0>(key));
     hashMix(res, std::hash<Hash>()(std::get<1>(key)));
     hashMix(res, std::get<2>(key));
@@ -1393,9 +1352,9 @@ HerderSCPDriver::TxSetValidityKeyHash::operator()(
     return res;
 }
 
-uint64
-HerderSCPDriver::getNodeWeight(NodeID const& nodeID, SCPQuorumSet const& qset,
-                               bool const isLocalNode) const
+uint64 HerderSCPDriver::getNodeWeight(NodeID const& nodeID,
+                                      SCPQuorumSet const& qset,
+                                      bool const isLocalNode) const
 {
     releaseAssert(!mLedgerManager.isApplying());
     Config const& cfg = mApp.getConfig();

--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -49,8 +49,7 @@ class HerderSCPDriver : public SCPDriver
     void bootstrap();
     void stateChanged();
 
-    SCP&
-    getSCP()
+    SCP& getSCP()
     {
         return mSCP;
     }

--- a/src/herder/HerderUtils.cpp
+++ b/src/herder/HerderUtils.cpp
@@ -16,8 +16,7 @@
 namespace stellar
 {
 
-std::vector<Hash>
-getTxSetHashes(SCPEnvelope const& envelope)
+std::vector<Hash> getTxSetHashes(SCPEnvelope const& envelope)
 {
     auto values = getStellarValues(envelope.statement);
     auto result = std::vector<Hash>{};
@@ -29,8 +28,7 @@ getTxSetHashes(SCPEnvelope const& envelope)
     return result;
 }
 
-std::vector<StellarValue>
-getStellarValues(SCPStatement const& statement)
+std::vector<StellarValue> getStellarValues(SCPStatement const& statement)
 {
     auto values = Slot::getStatementValues(statement);
     auto result = std::vector<StellarValue>{};
@@ -49,8 +47,7 @@ getStellarValues(SCPStatement const& statement)
 // Render `id` as a short, human readable string. If `cfg` has a value, this
 // function uses `cfg` to render the string. Otherwise, it returns the first 5
 // hex values `id`.
-std::string
-toShortString(std::optional<Config> const& cfg, NodeID const& id)
+std::string toShortString(std::optional<Config> const& cfg, NodeID const& id)
 {
     if (cfg)
     {

--- a/src/herder/LedgerCloseData.cpp
+++ b/src/herder/LedgerCloseData.cpp
@@ -41,8 +41,7 @@ LedgerCloseData::LedgerCloseData(
 }
 #endif // BUILD_TESTS
 
-std::string
-stellarValueToString(Config const& c, StellarValue const& sv)
+std::string stellarValueToString(Config const& c, StellarValue const& sv)
 {
     std::stringstream res;
 

--- a/src/herder/LedgerCloseData.h
+++ b/src/herder/LedgerCloseData.h
@@ -35,36 +35,30 @@ class LedgerCloseData
                     std::optional<TransactionResultSet> const& expectedResults);
 #endif // BUILD_TESTS
 
-    uint32_t
-    getLedgerSeq() const
+    uint32_t getLedgerSeq() const
     {
         return mLedgerSeq;
     }
-    TxSetXDRFrameConstPtr
-    getTxSet() const
+    TxSetXDRFrameConstPtr getTxSet() const
     {
         return mTxSet;
     }
-    StellarValue const&
-    getValue() const
+    StellarValue const& getValue() const
     {
         return mValue;
     }
-    std::optional<Hash> const&
-    getExpectedHash() const
+    std::optional<Hash> const& getExpectedHash() const
     {
         return mExpectedLedgerHash;
     }
 #ifdef BUILD_TESTS
-    std::optional<TransactionResultSet> const&
-    getExpectedResults() const
+    std::optional<TransactionResultSet> const& getExpectedResults() const
     {
         return mExpectedResults;
     }
 #endif // BUILD_TESTS
 
-    StoredDebugTransactionSet
-    toXDR() const
+    StoredDebugTransactionSet toXDR() const
     {
         StoredDebugTransactionSet sts;
         mTxSet->storeXDR(sts.txSet);

--- a/src/herder/ParallelTxSetBuilder.cpp
+++ b/src/herder/ParallelTxSetBuilder.cpp
@@ -26,8 +26,7 @@ struct ParallelPartitionConfig
     {
     }
 
-    uint64_t
-    instructionsPerStage() const
+    uint64_t instructionsPerStage() const
     {
         return mInstructionsPerCluster * mClustersPerStage;
     }
@@ -74,8 +73,7 @@ struct Cluster
         mTxIds.set(tx.mId);
     }
 
-    void
-    merge(Cluster const& other)
+    void merge(Cluster const& other)
     {
         mInstructions += other.mInstructions;
         mConflictTxs.inplaceUnion(other.mConflictTxs);
@@ -100,8 +98,7 @@ class Stage
 
     // Tries to add a transaction to the stage and returns true if the
     // transaction has been added.
-    bool
-    tryAdd(BuilderTx const& tx)
+    bool tryAdd(BuilderTx const& tx)
     {
         ZoneScoped;
         // A fast-fail condition to ensure that adding the transaction won't
@@ -187,8 +184,7 @@ class Stage
     // Visit every transaction in the stage.
     // The visitor arguments are the index of the bin the transaction is packed
     // into and the index of the transaction itself.
-    void
-    visitAllTransactions(std::function<void(size_t, size_t)> visitor) const
+    void visitAllTransactions(std::function<void(size_t, size_t)> visitor) const
     {
         for (auto const& cluster : mClusters)
         {
@@ -216,8 +212,7 @@ class Stage
         return conflictingClusters;
     }
 
-    bool
-    inPlaceBinPacking(
+    bool inPlaceBinPacking(
         Cluster const& newCluster,
         std::unordered_set<Cluster const*> const& clustersToRemove)
     {
@@ -383,8 +378,7 @@ struct ParallelPhaseBuildResult
     int64_t mTotalInclusionFee = 0;
 };
 
-ParallelPhaseBuildResult
-buildSurgePricedParallelSorobanPhaseWithStageCount(
+ParallelPhaseBuildResult buildSurgePricedParallelSorobanPhaseWithStageCount(
     SurgePricingPriorityQueue queue,
     std::unordered_map<TransactionFrameBaseConstPtr, BuilderTx const*> const&
         builderTxForTx,
@@ -482,8 +476,7 @@ buildSurgePricedParallelSorobanPhaseWithStageCount(
 
 } // namespace
 
-TxStageFrameList
-buildSurgePricedParallelSorobanPhase(
+TxStageFrameList buildSurgePricedParallelSorobanPhase(
     TxFrameList const& txFrames, Config const& cfg,
     SorobanNetworkConfig const& sorobanCfg,
     std::shared_ptr<SurgePricingLaneConfig> laneConfig,

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -54,9 +54,8 @@ PendingEnvelopes::~PendingEnvelopes()
 {
 }
 
-void
-PendingEnvelopes::peerDoesntHave(MessageType type, Hash const& itemID,
-                                 Peer::pointer peer)
+void PendingEnvelopes::peerDoesntHave(MessageType type, Hash const& itemID,
+                                      Peer::pointer peer)
 {
     switch (type)
     {
@@ -76,8 +75,7 @@ PendingEnvelopes::peerDoesntHave(MessageType type, Hash const& itemID,
     }
 }
 
-SCPQuorumSetPtr
-PendingEnvelopes::getKnownQSet(Hash const& hash, bool touch)
+SCPQuorumSetPtr PendingEnvelopes::getKnownQSet(Hash const& hash, bool touch)
 {
     SCPQuorumSetPtr res;
     auto it = mKnownQSets.find(hash);
@@ -94,8 +92,8 @@ PendingEnvelopes::getKnownQSet(Hash const& hash, bool touch)
     return res;
 }
 
-SCPQuorumSetPtr
-PendingEnvelopes::putQSet(Hash const& qSetHash, SCPQuorumSet const& qSet)
+SCPQuorumSetPtr PendingEnvelopes::putQSet(Hash const& qSetHash,
+                                          SCPQuorumSet const& qSet)
 {
     CLOG_TRACE(Herder, "Add SCPQSet {}", hexAbbrev(qSetHash));
     SCPQuorumSetPtr res;
@@ -111,16 +109,14 @@ PendingEnvelopes::putQSet(Hash const& qSetHash, SCPQuorumSet const& qSet)
     return res;
 }
 
-void
-PendingEnvelopes::addSCPQuorumSet(Hash const& hash, SCPQuorumSet const& q)
+void PendingEnvelopes::addSCPQuorumSet(Hash const& hash, SCPQuorumSet const& q)
 {
     ZoneScoped;
     putQSet(hash, q);
     mQuorumSetFetcher.recv(hash, mFetchQsetTimer);
 }
 
-bool
-PendingEnvelopes::recvSCPQuorumSet(Hash const& hash, SCPQuorumSet const& q)
+bool PendingEnvelopes::recvSCPQuorumSet(Hash const& hash, SCPQuorumSet const& q)
 {
     ZoneScoped;
     CLOG_TRACE(Herder, "Got SCPQSet {}", hexAbbrev(hash));
@@ -144,8 +140,7 @@ PendingEnvelopes::recvSCPQuorumSet(Hash const& hash, SCPQuorumSet const& q)
     return res;
 }
 
-void
-PendingEnvelopes::discardSCPEnvelopesWithQSet(Hash const& hash)
+void PendingEnvelopes::discardSCPEnvelopesWithQSet(Hash const& hash)
 {
     ZoneScoped;
     CLOG_TRACE(Herder, "Discarding SCP Envelopes with SCPQSet {}",
@@ -156,8 +151,7 @@ PendingEnvelopes::discardSCPEnvelopesWithQSet(Hash const& hash)
         discardSCPEnvelope(envelope);
 }
 
-void
-PendingEnvelopes::updateMetrics()
+void PendingEnvelopes::updateMetrics()
 {
     int64 processed = 0;
     int64 discarded = 0;
@@ -180,9 +174,8 @@ PendingEnvelopes::updateMetrics()
     mReadyCount.set_count(ready);
 }
 
-TxSetXDRFrameConstPtr
-PendingEnvelopes::putTxSet(Hash const& hash, uint64 slot,
-                           TxSetXDRFrameConstPtr txset)
+TxSetXDRFrameConstPtr PendingEnvelopes::putTxSet(Hash const& hash, uint64 slot,
+                                                 TxSetXDRFrameConstPtr txset)
 {
     auto res = getKnownTxSet(hash, slot, true);
     if (!res)
@@ -197,8 +190,8 @@ PendingEnvelopes::putTxSet(Hash const& hash, uint64 slot,
 // tries to find a txset in memory, setting touch also touches the LRU,
 // extending the lifetime of the result *and* updating the slot number
 // to a greater value if needed
-TxSetXDRFrameConstPtr
-PendingEnvelopes::getKnownTxSet(Hash const& hash, uint64 slot, bool touch)
+TxSetXDRFrameConstPtr PendingEnvelopes::getKnownTxSet(Hash const& hash,
+                                                      uint64 slot, bool touch)
 {
     // slot is only used when `touch` is set
     releaseAssert(touch || (slot == 0));
@@ -226,9 +219,8 @@ PendingEnvelopes::getKnownTxSet(Hash const& hash, uint64 slot, bool touch)
     return res;
 }
 
-void
-PendingEnvelopes::addTxSet(Hash const& hash, uint64 lastSeenSlotIndex,
-                           TxSetXDRFrameConstPtr txset)
+void PendingEnvelopes::addTxSet(Hash const& hash, uint64 lastSeenSlotIndex,
+                                TxSetXDRFrameConstPtr txset)
 {
     ZoneScoped;
     CLOG_TRACE(Herder, "Add TxSet {}", hexAbbrev(hash));
@@ -237,8 +229,7 @@ PendingEnvelopes::addTxSet(Hash const& hash, uint64 lastSeenSlotIndex,
     mTxSetFetcher.recv(hash, mFetchTxSetTimer);
 }
 
-bool
-PendingEnvelopes::recvTxSet(Hash const& hash, TxSetXDRFrameConstPtr txset)
+bool PendingEnvelopes::recvTxSet(Hash const& hash, TxSetXDRFrameConstPtr txset)
 {
     ZoneScoped;
     CLOG_TRACE(Herder, "Got TxSet {}", hexAbbrev(hash));
@@ -253,8 +244,7 @@ PendingEnvelopes::recvTxSet(Hash const& hash, TxSetXDRFrameConstPtr txset)
     return true;
 }
 
-bool
-PendingEnvelopes::isNodeDefinitelyInQuorum(NodeID const& node)
+bool PendingEnvelopes::isNodeDefinitelyInQuorum(NodeID const& node)
 {
     if (mRebuildQuorum)
     {
@@ -264,8 +254,7 @@ PendingEnvelopes::isNodeDefinitelyInQuorum(NodeID const& node)
     return mQuorumTracker.isNodeDefinitelyInQuorum(node);
 }
 
-static std::string
-txSetsToStr(SCPEnvelope const& envelope)
+static std::string txSetsToStr(SCPEnvelope const& envelope)
 {
     auto hashes = getTxSetHashes(envelope);
     UnorderedSet<Hash> hashesSet(hashes.begin(), hashes.end());
@@ -380,8 +369,7 @@ PendingEnvelopes::recvSCPEnvelope(SCPEnvelope const& envelope)
     }
 }
 
-void
-PendingEnvelopes::discardSCPEnvelope(SCPEnvelope const& envelope)
+void PendingEnvelopes::discardSCPEnvelope(SCPEnvelope const& envelope)
 {
     try
     {
@@ -408,8 +396,7 @@ PendingEnvelopes::discardSCPEnvelope(SCPEnvelope const& envelope)
     updateMetrics();
 }
 
-bool
-PendingEnvelopes::isDiscarded(SCPEnvelope const& envelope) const
+bool PendingEnvelopes::isDiscarded(SCPEnvelope const& envelope) const
 {
     auto envelopes = mEnvelopes.find(envelope.statement.slotIndex);
     if (envelopes == mEnvelopes.end())
@@ -422,8 +409,7 @@ PendingEnvelopes::isDiscarded(SCPEnvelope const& envelope) const
     return discarded != discardedSet.end();
 }
 
-void
-PendingEnvelopes::cleanKnownData()
+void PendingEnvelopes::cleanKnownData()
 {
     auto it = mKnownQSets.begin();
     while (it != mKnownQSets.end())
@@ -452,16 +438,14 @@ PendingEnvelopes::cleanKnownData()
 }
 
 #ifdef BUILD_TESTS
-void
-PendingEnvelopes::clearQSetCache()
+void PendingEnvelopes::clearQSetCache()
 {
     mQsetCache.clear();
     mKnownQSets.clear();
 }
 #endif
 
-void
-PendingEnvelopes::recordReceivedCost(SCPEnvelope const& env)
+void PendingEnvelopes::recordReceivedCost(SCPEnvelope const& env)
 {
     ZoneScoped;
 
@@ -525,8 +509,7 @@ PendingEnvelopes::recordReceivedCost(SCPEnvelope const& env)
     }
 }
 
-void
-PendingEnvelopes::envelopeReady(SCPEnvelope const& envelope)
+void PendingEnvelopes::envelopeReady(SCPEnvelope const& envelope)
 {
     ZoneScoped;
     auto slot = envelope.statement.slotIndex;
@@ -548,8 +531,7 @@ PendingEnvelopes::envelopeReady(SCPEnvelope const& envelope)
     mEnvelopes[slot].mReadyEnvelopes.push_back(envW);
 }
 
-bool
-PendingEnvelopes::isFullyFetched(SCPEnvelope const& envelope)
+bool PendingEnvelopes::isFullyFetched(SCPEnvelope const& envelope)
 {
     if (!getKnownQSet(
             Slot::getCompanionQuorumSetHashFromStatement(envelope.statement),
@@ -565,8 +547,7 @@ PendingEnvelopes::isFullyFetched(SCPEnvelope const& envelope)
                        });
 }
 
-void
-PendingEnvelopes::startFetch(SCPEnvelope const& envelope)
+void PendingEnvelopes::startFetch(SCPEnvelope const& envelope)
 {
     ZoneScoped;
     Hash h = Slot::getCompanionQuorumSetHashFromStatement(envelope.statement);
@@ -595,8 +576,7 @@ PendingEnvelopes::startFetch(SCPEnvelope const& envelope)
     }
 }
 
-void
-PendingEnvelopes::stopFetch(SCPEnvelope const& envelope)
+void PendingEnvelopes::stopFetch(SCPEnvelope const& envelope)
 {
     ZoneScoped;
     Hash h = Slot::getCompanionQuorumSetHashFromStatement(envelope.statement);
@@ -612,8 +592,7 @@ PendingEnvelopes::stopFetch(SCPEnvelope const& envelope)
                envelope.statement.pledges.type());
 }
 
-void
-PendingEnvelopes::touchFetchCache(SCPEnvelope const& envelope)
+void PendingEnvelopes::touchFetchCache(SCPEnvelope const& envelope)
 {
     auto qsetHash =
         Slot::getCompanionQuorumSetHashFromStatement(envelope.statement);
@@ -625,8 +604,7 @@ PendingEnvelopes::touchFetchCache(SCPEnvelope const& envelope)
     }
 }
 
-SCPEnvelopeWrapperPtr
-PendingEnvelopes::pop(uint64 slotIndex)
+SCPEnvelopeWrapperPtr PendingEnvelopes::pop(uint64 slotIndex)
 {
     auto it = mEnvelopes.begin();
     while (it != mEnvelopes.end() && slotIndex >= it->first)
@@ -645,8 +623,7 @@ PendingEnvelopes::pop(uint64 slotIndex)
     return nullptr;
 }
 
-vector<uint64>
-PendingEnvelopes::readySlots()
+vector<uint64> PendingEnvelopes::readySlots()
 {
     vector<uint64> result;
     for (auto const& entry : mEnvelopes)
@@ -657,8 +634,7 @@ PendingEnvelopes::readySlots()
     return result;
 }
 
-void
-PendingEnvelopes::eraseBelow(uint64 slotIndex, uint64 slotToKeep)
+void PendingEnvelopes::eraseBelow(uint64 slotIndex, uint64 slotToKeep)
 {
     stopAllBelow(slotIndex, slotToKeep);
 
@@ -692,8 +668,7 @@ PendingEnvelopes::eraseBelow(uint64 slotIndex, uint64 slotToKeep)
     updateMetrics();
 }
 
-void
-PendingEnvelopes::stopAllBelow(uint64 slotIndex, uint64 slotToKeep)
+void PendingEnvelopes::stopAllBelow(uint64 slotIndex, uint64 slotToKeep)
 {
     // Before we purge a slot, check if any envelopes are still in
     // "fetching" mode and attempt to record cost
@@ -715,21 +690,18 @@ PendingEnvelopes::stopAllBelow(uint64 slotIndex, uint64 slotToKeep)
     mQuorumSetFetcher.stopFetchingBelow(slotIndex, slotToKeep);
 }
 
-void
-PendingEnvelopes::forceRebuildQuorum()
+void PendingEnvelopes::forceRebuildQuorum()
 {
     // force recomputing the transitive quorum
     mRebuildQuorum = true;
 }
 
-TxSetXDRFrameConstPtr
-PendingEnvelopes::getTxSet(Hash const& hash)
+TxSetXDRFrameConstPtr PendingEnvelopes::getTxSet(Hash const& hash)
 {
     return getKnownTxSet(hash, 0, false);
 }
 
-SCPQuorumSetPtr
-PendingEnvelopes::getQSet(Hash const& hash)
+SCPQuorumSetPtr PendingEnvelopes::getQSet(Hash const& hash)
 {
     auto qset = getKnownQSet(hash, false);
     if (qset)
@@ -754,8 +726,7 @@ PendingEnvelopes::getQSet(Hash const& hash)
     return qset;
 }
 
-Json::Value
-PendingEnvelopes::getJsonInfo(size_t limit)
+Json::Value PendingEnvelopes::getJsonInfo(size_t limit)
 {
     Json::Value ret;
 
@@ -789,8 +760,7 @@ PendingEnvelopes::getJsonInfo(size_t limit)
     return ret;
 }
 
-void
-PendingEnvelopes::rebuildQuorumTrackerState()
+void PendingEnvelopes::rebuildQuorumTrackerState()
 {
     // rebuild quorum information using data sources starting with the
     // freshest source
@@ -831,8 +801,7 @@ PendingEnvelopes::getCurrentlyTrackedQuorum() const
     return mQuorumTracker.getQuorum();
 }
 
-void
-PendingEnvelopes::envelopeProcessed(SCPEnvelope const& env)
+void PendingEnvelopes::envelopeProcessed(SCPEnvelope const& env)
 {
     auto const& st = env.statement;
     auto const& id = st.nodeID;
@@ -858,9 +827,8 @@ PendingEnvelopes::getCostPerValidator(uint64 slotIndex) const
     return {};
 }
 
-static bool
-shouldReportCostOutlier(double possibleOutlierCost, double expectedCost,
-                        double ratioLimit)
+static bool shouldReportCostOutlier(double possibleOutlierCost,
+                                    double expectedCost, double ratioLimit)
 {
     if (possibleOutlierCost <= 0 || expectedCost <= 0)
     {
@@ -876,9 +844,8 @@ shouldReportCostOutlier(double possibleOutlierCost, double expectedCost,
     return false;
 }
 
-void
-PendingEnvelopes::reportCostOutliersForSlot(int64_t slotIndex,
-                                            bool updateMetrics) const
+void PendingEnvelopes::reportCostOutliersForSlot(int64_t slotIndex,
+                                                 bool updateMetrics) const
 {
     ZoneScoped;
 
@@ -950,9 +917,8 @@ PendingEnvelopes::reportCostOutliersForSlot(int64_t slotIndex,
     }
 }
 
-Json::Value
-PendingEnvelopes::getJsonValidatorCost(bool summary, bool fullKeys,
-                                       uint64 index) const
+Json::Value PendingEnvelopes::getJsonValidatorCost(bool summary, bool fullKeys,
+                                                   uint64 index) const
 {
     Json::Value res;
 

--- a/src/herder/QuorumIntersectionChecker.h
+++ b/src/herder/QuorumIntersectionChecker.h
@@ -43,14 +43,12 @@ struct QuorumMapIntersectionState
     std::pair<std::vector<PublicKey>, std::vector<PublicKey>> mPotentialSplit{};
     std::set<std::set<PublicKey>> mIntersectionCriticalNodes{};
 
-    bool
-    hasAnyResults() const
+    bool hasAnyResults() const
     {
         return mLastGoodLedger != 0;
     }
 
-    bool
-    enjoysQuorunIntersection() const
+    bool enjoysQuorunIntersection() const
     {
         return mLastCheckLedger == mLastGoodLedger;
     }

--- a/src/herder/QuorumIntersectionCheckerImpl.cpp
+++ b/src/herder/QuorumIntersectionCheckerImpl.cpp
@@ -31,8 +31,7 @@ QBitSet::QBitSet(uint32_t threshold, BitSet const& nodes,
 {
 }
 
-void
-QBitSet::log(size_t indent) const
+void QBitSet::log(size_t indent) const
 {
     std::string s(indent, ' ');
     CLOG_DEBUG(SCP, "{}QBitSet: thresh={}/{} validators={}", s, mThreshold,
@@ -43,8 +42,7 @@ QBitSet::log(size_t indent) const
     }
 }
 
-BitSet
-QBitSet::getSuccessors(BitSet const& nodes, QGraph const& inner)
+BitSet QBitSet::getSuccessors(BitSet const& nodes, QGraph const& inner)
 {
     BitSet out(nodes);
     for (auto const& i : inner)
@@ -59,8 +57,7 @@ QBitSet::getSuccessors(BitSet const& nodes, QGraph const& inner)
 ////////////////////////////////////////////////////////////////////////////////
 
 // Slightly tweaked variant of Lachowski's next-node function.
-size_t
-MinQuorumEnumerator::pickSplitNode(
+size_t MinQuorumEnumerator::pickSplitNode(
     stellar::stellar_default_random_engine& randEngine) const
 {
     std::vector<size_t>& inDegrees = mQic.mInDegrees;
@@ -71,7 +68,6 @@ MinQuorumEnumerator::pickSplitNode(
     size_t maxDegree = 0;
     for (size_t i = 0; mRemaining.nextSet(i); ++i)
     {
-
         // Heuristic opportunity: biasing towards cross-org edges and
         // away from intra-org edges seems to help; work out some way
         // to make this a robust bias.
@@ -106,8 +102,7 @@ MinQuorumEnumerator::pickSplitNode(
     return maxNode;
 }
 
-size_t
-MinQuorumEnumerator::maxCommit() const
+size_t MinQuorumEnumerator::maxCommit() const
 {
     return mScanSCC.count() / 2;
 }
@@ -123,8 +118,7 @@ MinQuorumEnumerator::MinQuorumEnumerator(
 {
 }
 
-bool
-MinQuorumEnumerator::anyMinQuorumHasDisjointQuorum()
+bool MinQuorumEnumerator::anyMinQuorumHasDisjointQuorum()
 {
     if (mQic.mInterruptFlag)
     {
@@ -292,14 +286,12 @@ QuorumIntersectionCheckerImpl::getPotentialSplit() const
     return mPotentialSplit;
 }
 
-size_t
-QuorumIntersectionCheckerImpl::getMaxQuorumsFound() const
+size_t QuorumIntersectionCheckerImpl::getMaxQuorumsFound() const
 {
     return mStats.mMaxQuorumsSeen;
 }
 
-void
-QuorumIntersectionCheckerImpl::Stats::log() const
+void QuorumIntersectionCheckerImpl::Stats::log() const
 {
     CLOG_DEBUG(SCP, "Quorum intersection checker stats:");
     size_t exits = (mEarlyExit1s + mEarlyExit21s + mEarlyExit22s +
@@ -316,9 +308,8 @@ QuorumIntersectionCheckerImpl::Stats::log() const
 
 // This function is the innermost call in the checker and must be as fast
 // as possible. We spend almost all of our time in here.
-bool
-QuorumIntersectionCheckerImpl::containsQuorumSlice(BitSet const& bs,
-                                                   QBitSet const& qbs) const
+bool QuorumIntersectionCheckerImpl::containsQuorumSlice(
+    BitSet const& bs, QBitSet const& qbs) const
 {
     // First we do a very quick check: do we have enough bits in 'bs'
     // intersected with the top-level set of nodes to meet the threshold for
@@ -381,9 +372,8 @@ QuorumIntersectionCheckerImpl::containsQuorumSlice(BitSet const& bs,
     return false;
 }
 
-bool
-QuorumIntersectionCheckerImpl::containsQuorumSliceForNode(BitSet const& bs,
-                                                          size_t node) const
+bool QuorumIntersectionCheckerImpl::containsQuorumSliceForNode(
+    BitSet const& bs, size_t node) const
 {
     if (!bs.get(node))
     {
@@ -392,8 +382,7 @@ QuorumIntersectionCheckerImpl::containsQuorumSliceForNode(BitSet const& bs,
     return containsQuorumSlice(bs, mGraph.at(node));
 }
 
-bool
-QuorumIntersectionCheckerImpl::isAQuorum(BitSet const& nodes) const
+bool QuorumIntersectionCheckerImpl::isAQuorum(BitSet const& nodes) const
 {
     bool* pRes = mCachedQuorums.maybeGet(nodes);
     if (pRes == nullptr)
@@ -454,8 +443,7 @@ QuorumIntersectionCheckerImpl::contractToMaximalQuorum(BitSet nodes) const
     }
 }
 
-bool
-QuorumIntersectionCheckerImpl::isMinimalQuorum(BitSet const& nodes) const
+bool QuorumIntersectionCheckerImpl::isMinimalQuorum(BitSet const& nodes) const
 {
 #ifndef NDEBUG
     // We should only be called with a quorum, such that contracting to its
@@ -486,8 +474,7 @@ QuorumIntersectionCheckerImpl::isMinimalQuorum(BitSet const& nodes) const
     return true;
 }
 
-void
-QuorumIntersectionCheckerImpl::noteFoundDisjointQuorums(
+void QuorumIntersectionCheckerImpl::noteFoundDisjointQuorums(
     BitSet const& nodes, BitSet const& disj) const
 {
     mPotentialSplit.first.clear();
@@ -514,8 +501,7 @@ QuorumIntersectionCheckerImpl::noteFoundDisjointQuorums(
     }
 }
 
-bool
-MinQuorumEnumerator::hasDisjointQuorum(BitSet const& nodes) const
+bool MinQuorumEnumerator::hasDisjointQuorum(BitSet const& nodes) const
 {
     BitSet disj = mQic.contractToMaximalQuorum(mScanSCC - nodes);
     if (!disj.empty())
@@ -584,8 +570,7 @@ QuorumIntersectionCheckerImpl::convertSCPQuorumSet(SCPQuorumSet const& sqs)
     return QBitSet(threshold, nodeBits, inner);
 }
 
-void
-QuorumIntersectionCheckerImpl::buildGraph(
+void QuorumIntersectionCheckerImpl::buildGraph(
     QuorumIntersectionChecker::QuorumSetMap const& qmap)
 {
     mPubKeyBitNums.clear();
@@ -623,8 +608,7 @@ QuorumIntersectionCheckerImpl::buildGraph(
     mStats.mTotalNodes = mPubKeyBitNums.size();
 }
 
-void
-QuorumIntersectionCheckerImpl::buildSCCs()
+void QuorumIntersectionCheckerImpl::buildSCCs()
 {
     mTSC.calculateSCCs(mGraph.size(), [this](size_t i) -> BitSet const& {
         // NB: this closure must be written with the explicit const&
@@ -635,14 +619,12 @@ QuorumIntersectionCheckerImpl::buildSCCs()
     mStats.mNumSCCs = mTSC.mSCCs.size();
 }
 
-std::string
-QuorumIntersectionCheckerImpl::nodeName(size_t node) const
+std::string QuorumIntersectionCheckerImpl::nodeName(size_t node) const
 {
     return toShortString(mCfg, mBitNumPubKeys.at(node));
 }
 
-bool
-QuorumIntersectionCheckerImpl::networkEnjoysQuorumIntersection() const
+bool QuorumIntersectionCheckerImpl::networkEnjoysQuorumIntersection() const
 {
     if (!mQuiet)
     {
@@ -719,8 +701,7 @@ QuorumIntersectionCheckerImpl::networkEnjoysQuorumIntersection() const
     return !foundDisjoint;
 }
 
-bool
-pointsToCandidate(SCPQuorumSet const& p, NodeID const& candidate)
+bool pointsToCandidate(SCPQuorumSet const& p, NodeID const& candidate)
 {
     for (auto const& k : p.validators)
     {
@@ -739,9 +720,9 @@ pointsToCandidate(SCPQuorumSet const& p, NodeID const& candidate)
     return false;
 }
 
-void
-findCriticalityCandidates(SCPQuorumSet const& p,
-                          std::set<std::set<NodeID>>& candidates, bool root)
+void findCriticalityCandidates(SCPQuorumSet const& p,
+                               std::set<std::set<NodeID>>& candidates,
+                               bool root)
 {
     // Make a singleton-set for every validator, always.
     for (auto const& k : p.validators)
@@ -769,8 +750,8 @@ findCriticalityCandidates(SCPQuorumSet const& p,
     }
 }
 
-std::string
-groupString(std::optional<Config> const& cfg, std::set<NodeID> const& group)
+std::string groupString(std::optional<Config> const& cfg,
+                        std::set<NodeID> const& group)
 {
     std::ostringstream out;
     bool first = true;
@@ -792,8 +773,7 @@ groupString(std::optional<Config> const& cfg, std::set<NodeID> const& group)
 namespace stellar
 {
 
-void
-QuorumMapIntersectionState::reset(Application& app)
+void QuorumMapIntersectionState::reset(Application& app)
 {
     // NB: this deletes any existing tmp dir before creating a new one.
     mTmpDir =
@@ -809,8 +789,7 @@ QuorumMapIntersectionState::QuorumMapIntersectionState(Application& app)
     reset(app);
 }
 
-std::shared_ptr<QuorumIntersectionChecker>
-QuorumIntersectionChecker::create(
+std::shared_ptr<QuorumIntersectionChecker> QuorumIntersectionChecker::create(
     QuorumTracker::QuorumMap const& qmap, std::optional<Config> const& cfg,
     std::atomic<bool>& interruptFlag,
     stellar_default_random_engine::result_type seed, bool quiet)
@@ -819,8 +798,7 @@ QuorumIntersectionChecker::create(
                   quiet);
 }
 
-std::shared_ptr<QuorumIntersectionChecker>
-QuorumIntersectionChecker::create(
+std::shared_ptr<QuorumIntersectionChecker> QuorumIntersectionChecker::create(
     QuorumSetMap const& qmap, std::optional<Config> const& cfg,
     std::atomic<bool>& interruptFlag,
     stellar_default_random_engine::result_type seed, bool quiet)

--- a/src/herder/QuorumIntersectionCheckerImpl.h
+++ b/src/herder/QuorumIntersectionCheckerImpl.h
@@ -383,8 +383,7 @@ struct QBitSet
 
     QBitSet(uint32_t threshold, BitSet const& nodes, QGraph const& innerSets);
 
-    bool
-    empty() const
+    bool empty() const
     {
         return mThreshold == 0 && mAllSuccessors.empty();
     }
@@ -401,7 +400,6 @@ struct QBitSet
 // recursive cases.
 class MinQuorumEnumerator
 {
-
     // Set of nodes "committed to" in this branch of the recurrence. In other
     // words: set of nodes that this enumerator and its children will definitely
     // include in every subset S of the powerset that they examine. This set
@@ -449,7 +447,6 @@ class MinQuorumEnumerator
 // MinQuorumEnumerator to recursively scan the powerset.
 class QuorumIntersectionCheckerImpl : public stellar::QuorumIntersectionChecker
 {
-
     std::optional<stellar::Config> const mCfg;
 
     struct Stats
@@ -509,8 +506,8 @@ class QuorumIntersectionCheckerImpl : public stellar::QuorumIntersectionChecker
     std::atomic<bool>& mInterruptFlag;
 
     QBitSet convertSCPQuorumSet(stellar::SCPQuorumSet const& sqs);
-    void
-    buildGraph(stellar::QuorumIntersectionChecker::QuorumSetMap const& qmap);
+    void buildGraph(
+        stellar::QuorumIntersectionChecker::QuorumSetMap const& qmap);
     void buildSCCs();
 
     bool containsQuorumSlice(BitSet const& bs, QBitSet const& qbs) const;

--- a/src/herder/QuorumTracker.cpp
+++ b/src/herder/QuorumTracker.cpp
@@ -15,8 +15,7 @@ QuorumTracker::QuorumTracker(NodeID const& localNodeID)
 {
 }
 
-bool
-QuorumTracker::isNodeDefinitelyInQuorum(NodeID const& id)
+bool QuorumTracker::isNodeDefinitelyInQuorum(NodeID const& id)
 {
     auto it = mQuorum.find(id);
     return it != mQuorum.end();
@@ -31,8 +30,7 @@ QuorumTracker::isNodeDefinitelyInQuorum(NodeID const& id)
 // cleaned out the structure and only be rebuilding a consistent state;
 // returning `false` in that context should be impossible and will be treated as
 // a logic error, throwing an exception.
-bool
-QuorumTracker::expand(NodeID const& id, SCPQuorumSetPtr qSet)
+bool QuorumTracker::expand(NodeID const& id, SCPQuorumSetPtr qSet)
 {
     ZoneScoped;
 
@@ -132,8 +130,8 @@ QuorumTracker::expand(NodeID const& id, SCPQuorumSetPtr qSet)
     });
 }
 
-void
-QuorumTracker::rebuild(std::function<SCPQuorumSetPtr(NodeID const&)> lookup)
+void QuorumTracker::rebuild(
+    std::function<SCPQuorumSetPtr(NodeID const&)> lookup)
 {
     ZoneScoped;
 
@@ -186,8 +184,7 @@ QuorumTracker::rebuild(std::function<SCPQuorumSetPtr(NodeID const&)> lookup)
     }
 }
 
-QuorumTracker::QuorumMap const&
-QuorumTracker::getQuorum() const
+QuorumTracker::QuorumMap const& QuorumTracker::getQuorum() const
 {
     return mQuorum;
 }

--- a/src/herder/RustQuorumCheckerAdaptor.cpp
+++ b/src/herder/RustQuorumCheckerAdaptor.cpp
@@ -20,8 +20,7 @@ namespace
 {
 // local helper functions to convert various types to and from json. their
 // conventions need to be consistent (e.g. nodes are represented as full strkey)
-Json::Value
-toQuorumMapJson(QuorumTracker::QuorumMap const& qmap)
+Json::Value toQuorumMapJson(QuorumTracker::QuorumMap const& qmap)
 {
     Json::Value ret;
     ret["nodes"] = Json::Value(Json::arrayValue);
@@ -45,8 +44,7 @@ toQuorumMapJson(QuorumTracker::QuorumMap const& qmap)
     return ret;
 }
 
-Json::Value
-toQuorumSplitJson(QuorumSplit const& split)
+Json::Value toQuorumSplitJson(QuorumSplit const& split)
 {
     Json::Value splitValue(Json::arrayValue);
     Json::Value left(Json::arrayValue);
@@ -65,9 +63,8 @@ toQuorumSplitJson(QuorumSplit const& split)
     return splitValue;
 }
 
-void
-fromQuorumSplitJson(QuorumIntersectionChecker::PotentialSplit& split,
-                    Json::Value const& value)
+void fromQuorumSplitJson(QuorumIntersectionChecker::PotentialSplit& split,
+                         Json::Value const& value)
 {
     if (!value.isArray() || value.size() != 2 || !value[0].isArray() ||
         !value[1].isArray())
@@ -120,9 +117,8 @@ toCriticalGroupsJson(std::set<std::set<NodeID>> const& criticalGroups)
     return criticalValue;
 }
 
-void
-fromCriticalGroupsJson(std::set<std::set<NodeID>>& criticalGroups,
-                       Json::Value const& value)
+void fromCriticalGroupsJson(std::set<std::set<NodeID>>& criticalGroups,
+                            Json::Value const& value)
 {
     if (!value.isArray())
     {
@@ -151,8 +147,7 @@ fromCriticalGroupsJson(std::set<std::set<NodeID>>& criticalGroups,
     }
 }
 
-QuorumCheckerStatus
-fromQuorumCheckerStatusJson(Json::Value const& value)
+QuorumCheckerStatus fromQuorumCheckerStatusJson(Json::Value const& value)
 {
     if (!value.isUInt())
     {
@@ -169,12 +164,11 @@ fromQuorumCheckerStatusJson(Json::Value const& value)
     return static_cast<QuorumCheckerStatus>(statusInt);
 }
 
-void
-writeResults(std::string const& outPath, QuorumCheckerStatus status,
-             QuorumSplit const& split,
-             std::set<std::set<NodeID>> const& criticalGroups,
-             quorum_checker::QuorumCheckerMetrics metrics,
-             std::string const& errorMsg)
+void writeResults(std::string const& outPath, QuorumCheckerStatus status,
+                  QuorumSplit const& split,
+                  std::set<std::set<NodeID>> const& criticalGroups,
+                  quorum_checker::QuorumCheckerMetrics metrics,
+                  std::string const& errorMsg)
 {
     Json::Value results;
     results["status"] = static_cast<Json::UInt>(status);
@@ -199,8 +193,7 @@ writeResults(std::string const& outPath, QuorumCheckerStatus status,
     out.close();
 }
 
-Json::Value
-parseResultsJson(std::string const& resultsJson)
+Json::Value parseResultsJson(std::string const& resultsJson)
 {
     std::ifstream in(resultsJson);
     if (!in)
@@ -315,8 +308,7 @@ QuorumCheckerMetrics::QuorumCheckerMetrics(Json::Value const& value)
     mCumulativeMemByte = value["cumulative_mem_byte"].asUInt64();
 }
 
-Json::Value
-QuorumCheckerMetrics::toJson()
+Json::Value QuorumCheckerMetrics::toJson()
 {
     Json::Value ret;
     ret["successful_run_count"] = Json::UInt64(mSuccessfulRun);
@@ -329,8 +321,7 @@ QuorumCheckerMetrics::toJson()
     return ret;
 }
 
-void
-QuorumCheckerMetrics::flush(medida::MetricsRegistry& metrics)
+void QuorumCheckerMetrics::flush(medida::MetricsRegistry& metrics)
 {
     metrics.NewCounter({"scp", "qic", "successful-run"}).inc(mSuccessfulRun);
     metrics.NewCounter({"scp", "qic", "failed-run"}).inc(mFailedRun);
@@ -351,8 +342,7 @@ QuorumCheckerMetrics::flush(medida::MetricsRegistry& metrics)
     mCumulativeMemByte = 0;
 }
 
-QuorumCheckerStatus
-checkQuorumIntersectionInner(
+QuorumCheckerStatus checkQuorumIntersectionInner(
     QuorumIntersectionChecker::QuorumSetMap const& qmap, QuorumSplit& split,
     QuorumCheckerResource& limits, QuorumCheckerMetrics& metrics)
 {
@@ -468,8 +458,7 @@ networkEnjoysQuorumIntersection(std::string const& inJsonPath,
     return status;
 }
 
-void
-runQuorumIntersectionCheckAsync(
+void runQuorumIntersectionCheckAsync(
     Application& app, Hash const curr, uint32 ledger,
     std::string const& tmpDirName, QuorumTracker::QuorumMap const& qmap,
     std::weak_ptr<QuorumMapIntersectionState> hState, ProcessManager& pm,

--- a/src/herder/SurgePricingUtils.cpp
+++ b/src/herder/SurgePricingUtils.cpp
@@ -16,8 +16,8 @@ namespace
 {
 
 // Use _inclusion_ fee to order transactions
-int
-feeRate3WayCompare(TransactionFrameBase const& l, TransactionFrameBase const& r)
+int feeRate3WayCompare(TransactionFrameBase const& l,
+                       TransactionFrameBase const& r)
 {
     return stellar::feeRate3WayCompare(
         l.getInclusionFee(), l.getNumOperations(), r.getInclusionFee(),
@@ -26,9 +26,8 @@ feeRate3WayCompare(TransactionFrameBase const& l, TransactionFrameBase const& r)
 
 } // namespace
 
-int
-feeRate3WayCompare(int64_t lFeeBid, uint32_t lNbOps, int64_t rFeeBid,
-                   uint32_t rNbOps)
+int feeRate3WayCompare(int64_t lFeeBid, uint32_t lNbOps, int64_t rFeeBid,
+                       uint32_t rNbOps)
 {
     // Let f1, f2 be the two fee bids, and let n1, n2 be the two
     // operation counts. We want to calculate the boolean comparison
@@ -53,9 +52,8 @@ feeRate3WayCompare(int64_t lFeeBid, uint32_t lNbOps, int64_t rFeeBid,
     return 0;
 }
 
-int64_t
-computeBetterFee(TransactionFrameBase const& tx, int64_t refFeeBid,
-                 uint32_t refNbOps)
+int64_t computeBetterFee(TransactionFrameBase const& tx, int64_t refFeeBid,
+                         uint32_t refNbOps)
 {
     constexpr auto m = std::numeric_limits<int64_t>::max();
 
@@ -79,40 +77,33 @@ SurgePricingPriorityQueue::TxComparator::TxComparator(bool isGreater,
 {
 }
 
-bool
-SurgePricingPriorityQueue::TxComparator::operator()(
+bool SurgePricingPriorityQueue::TxComparator::operator()(
     TransactionFrameBasePtr const& tx1,
     TransactionFrameBasePtr const& tx2) const
 {
     return txLessThan(tx1, tx2) ^ mIsGreater;
 }
 
-bool
-SurgePricingPriorityQueue::TxComparator::compareFeeOnly(
+bool SurgePricingPriorityQueue::TxComparator::compareFeeOnly(
     TransactionFrameBase const& tx1, TransactionFrameBase const& tx2) const
 {
     return compareFeeOnly(tx1.getInclusionFee(), tx1.getNumOperations(),
                           tx2.getInclusionFee(), tx2.getNumOperations());
 }
 
-bool
-SurgePricingPriorityQueue::TxComparator::compareFeeOnly(int64_t tx1Bid,
-                                                        uint32_t tx1Ops,
-                                                        int64_t tx2Bid,
-                                                        uint32_t tx2Ops) const
+bool SurgePricingPriorityQueue::TxComparator::compareFeeOnly(
+    int64_t tx1Bid, uint32_t tx1Ops, int64_t tx2Bid, uint32_t tx2Ops) const
 {
     bool isLess = feeRate3WayCompare(tx1Bid, tx1Ops, tx2Bid, tx2Ops) < 0;
     return isLess ^ mIsGreater;
 }
 
-bool
-SurgePricingPriorityQueue::TxComparator::isGreater() const
+bool SurgePricingPriorityQueue::TxComparator::isGreater() const
 {
     return mIsGreater;
 }
 
-bool
-SurgePricingPriorityQueue::TxComparator::txLessThan(
+bool SurgePricingPriorityQueue::TxComparator::txLessThan(
     TransactionFrameBasePtr const& tx1,
     TransactionFrameBasePtr const& tx2) const
 {
@@ -210,8 +201,7 @@ SurgePricingPriorityQueue::getMostTopTxsWithinLimits(
     return outTxs;
 }
 
-void
-SurgePricingPriorityQueue::visitTopTxs(
+void SurgePricingPriorityQueue::visitTopTxs(
     std::function<VisitTxResult(TransactionFrameBasePtr const&)> const& visitor,
     std::vector<Resource>& laneLeftUntilLimit, uint32_t ledgerVersion,
     std::optional<std::vector<Resource>> const& customLimits)
@@ -222,9 +212,8 @@ SurgePricingPriorityQueue::visitTopTxs(
               hadTxNotFittingLane, ledgerVersion, customLimits);
 }
 
-void
-SurgePricingPriorityQueue::add(TransactionFrameBasePtr tx,
-                               uint32_t ledgerVersion)
+void SurgePricingPriorityQueue::add(TransactionFrameBasePtr tx,
+                                    uint32_t ledgerVersion)
 {
     releaseAssert(tx != nullptr);
     auto lane = mLaneConfig->getLane(*tx);
@@ -236,8 +225,7 @@ SurgePricingPriorityQueue::add(TransactionFrameBasePtr tx,
     }
 }
 
-std::vector<Resource>
-SurgePricingPriorityQueue::countTxsResources(
+std::vector<Resource> SurgePricingPriorityQueue::countTxsResources(
     std::vector<TransactionFrameBasePtr> const& txs,
     uint32_t ledgerVersion) const
 {
@@ -255,9 +243,8 @@ SurgePricingPriorityQueue::countTxsResources(
     return laneResources;
 }
 
-void
-SurgePricingPriorityQueue::erase(TransactionFrameBasePtr tx,
-                                 uint32_t ledgerVersion)
+void SurgePricingPriorityQueue::erase(TransactionFrameBasePtr tx,
+                                      uint32_t ledgerVersion)
 {
     releaseAssert(tx != nullptr);
     auto lane = mLaneConfig->getLane(*tx);
@@ -268,15 +255,14 @@ SurgePricingPriorityQueue::erase(TransactionFrameBasePtr tx,
     }
 }
 
-void
-SurgePricingPriorityQueue::erase(Iterator const& it, uint32_t ledgerVersion)
+void SurgePricingPriorityQueue::erase(Iterator const& it,
+                                      uint32_t ledgerVersion)
 {
     auto innerIt = it.getInnerIter();
     erase(innerIt.first, innerIt.second, ledgerVersion);
 }
 
-void
-SurgePricingPriorityQueue::erase(
+void SurgePricingPriorityQueue::erase(
     size_t lane, SurgePricingPriorityQueue::TxSortedSet::iterator iter,
     uint32_t ledgerVersion)
 {
@@ -286,8 +272,7 @@ SurgePricingPriorityQueue::erase(
     mTxSortedSets[lane].erase(iter);
 }
 
-void
-SurgePricingPriorityQueue::popTopTxs(
+void SurgePricingPriorityQueue::popTopTxs(
     bool allowGaps,
     std::function<VisitTxResult(TransactionFrameBasePtr const&)> const& visitor,
     std::vector<Resource>& laneLeftUntilLimit,
@@ -396,8 +381,7 @@ SurgePricingPriorityQueue::popTopTxs(
     }
 }
 
-std::pair<bool, int64_t>
-SurgePricingPriorityQueue::canFitWithEviction(
+std::pair<bool, int64_t> SurgePricingPriorityQueue::canFitWithEviction(
     TransactionFrameBase const& tx, std::optional<Resource> txDiscount,
     std::vector<std::pair<TransactionFrameBasePtr, bool>>& txsToEvict,
     uint32_t ledgerVersion) const
@@ -541,8 +525,7 @@ SurgePricingPriorityQueue::canFitWithEviction(
     releaseAssert(false);
 }
 
-SurgePricingPriorityQueue::Iterator
-SurgePricingPriorityQueue::getTop() const
+SurgePricingPriorityQueue::Iterator SurgePricingPriorityQueue::getTop() const
 {
     std::vector<LaneIter> iters;
     for (size_t lane = 0; lane < mTxSortedSets.size(); ++lane)
@@ -557,8 +540,7 @@ SurgePricingPriorityQueue::getTop() const
     return SurgePricingPriorityQueue::Iterator(*this, iters);
 }
 
-Resource
-SurgePricingPriorityQueue::totalResources() const
+Resource SurgePricingPriorityQueue::totalResources() const
 {
     releaseAssert(!mLaneCurrentCount.empty());
     auto resourceCount = mLaneCurrentCount.begin()->size();
@@ -567,8 +549,7 @@ SurgePricingPriorityQueue::totalResources() const
                            res);
 }
 
-Resource
-SurgePricingPriorityQueue::laneResources(size_t lane) const
+Resource SurgePricingPriorityQueue::laneResources(size_t lane) const
 {
     releaseAssert(lane < mLaneCurrentCount.size());
     return mLaneCurrentCount[lane];
@@ -597,8 +578,7 @@ SurgePricingPriorityQueue::Iterator::getMutableInnerIter() const
     return best;
 }
 
-TransactionFrameBasePtr
-SurgePricingPriorityQueue::Iterator::operator*() const
+TransactionFrameBasePtr SurgePricingPriorityQueue::Iterator::operator*() const
 {
     return *getMutableInnerIter()->second;
 }
@@ -609,14 +589,12 @@ SurgePricingPriorityQueue::Iterator::getInnerIter() const
     return *getMutableInnerIter();
 }
 
-bool
-SurgePricingPriorityQueue::Iterator::isEnd() const
+bool SurgePricingPriorityQueue::Iterator::isEnd() const
 {
     return mIters.empty();
 }
 
-void
-SurgePricingPriorityQueue::Iterator::advance()
+void SurgePricingPriorityQueue::Iterator::advance()
 {
     auto it = getMutableInnerIter();
     ++it->second;
@@ -626,8 +604,7 @@ SurgePricingPriorityQueue::Iterator::advance()
     }
 }
 
-void
-SurgePricingPriorityQueue::Iterator::dropLane()
+void SurgePricingPriorityQueue::Iterator::dropLane()
 {
     mIters.erase(getMutableInnerIter());
 }
@@ -643,28 +620,24 @@ DexLimitingLaneConfig::DexLimitingLaneConfig(Resource Limit,
     }
 }
 
-std::vector<Resource> const&
-DexLimitingLaneConfig::getLaneLimits() const
+std::vector<Resource> const& DexLimitingLaneConfig::getLaneLimits() const
 {
     return mLaneLimits;
 }
 
-void
-DexLimitingLaneConfig::updateGenericLaneLimit(Resource const& limit)
+void DexLimitingLaneConfig::updateGenericLaneLimit(Resource const& limit)
 {
     mLaneLimits[0] = limit;
 }
 
-Resource
-DexLimitingLaneConfig::getTxResources(TransactionFrameBase const& tx,
-                                      uint32_t ledgerVersion)
+Resource DexLimitingLaneConfig::getTxResources(TransactionFrameBase const& tx,
+                                               uint32_t ledgerVersion)
 {
     releaseAssert(!tx.isSoroban());
     return tx.getResources(mUseByteLimit, ledgerVersion);
 }
 
-size_t
-DexLimitingLaneConfig::getLane(TransactionFrameBase const& tx) const
+size_t DexLimitingLaneConfig::getLane(TransactionFrameBase const& tx) const
 {
     if (mLaneLimits.size() > DexLimitingLaneConfig::DEX_LANE &&
         tx.hasDexOperations())
@@ -682,8 +655,7 @@ SorobanGenericLaneConfig::SorobanGenericLaneConfig(Resource limit)
     mLaneLimits.push_back(limit);
 }
 
-size_t
-SorobanGenericLaneConfig::getLane(TransactionFrameBase const& tx) const
+size_t SorobanGenericLaneConfig::getLane(TransactionFrameBase const& tx) const
 {
     if (!tx.isSoroban())
     {
@@ -693,14 +665,12 @@ SorobanGenericLaneConfig::getLane(TransactionFrameBase const& tx) const
     return SurgePricingPriorityQueue::GENERIC_LANE;
 }
 
-std::vector<Resource> const&
-SorobanGenericLaneConfig::getLaneLimits() const
+std::vector<Resource> const& SorobanGenericLaneConfig::getLaneLimits() const
 {
     return mLaneLimits;
 }
 
-void
-SorobanGenericLaneConfig::updateGenericLaneLimit(Resource const& limit)
+void SorobanGenericLaneConfig::updateGenericLaneLimit(Resource const& limit)
 {
     mLaneLimits[0] = limit;
 }

--- a/src/herder/SurgePricingUtils.h
+++ b/src/herder/SurgePricingUtils.h
@@ -128,14 +128,12 @@ class SurgePricingPriorityQueue
     // Returns total amount of resources in the provided lane of the queue.
     Resource laneResources(size_t lane) const;
 
-    Resource
-    laneLimits(size_t lane) const
+    Resource laneLimits(size_t lane) const
     {
         return mLaneConfig->getLaneLimits().at(lane);
     }
 
-    size_t
-    getNumLanes() const
+    size_t getNumLanes() const
     {
         return mLaneConfig->getLaneLimits().size();
     }

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -147,8 +147,8 @@ ClassicTransactionQueue::ClassicTransactionQueue(Application& app,
                                  Resource::makeEmpty(NUM_CLASSIC_TX_RESOURCES));
 }
 
-bool
-ClassicTransactionQueue::allowTxBroadcast(TransactionFrameBasePtr const& tx)
+bool ClassicTransactionQueue::allowTxBroadcast(
+    TransactionFrameBasePtr const& tx)
 {
     bool allowTx{true};
 
@@ -226,9 +226,8 @@ TransactionQueue::~TransactionQueue()
 // `minFee` is set when returning false, and is the smallest _full_ fee
 // that would allow replace by fee to succeed in this situation
 // Note that replace-by-fee logic is done on _inclusion_ fee
-static bool
-canReplaceByFee(TransactionFrameBasePtr tx, TransactionFrameBasePtr oldTx,
-                int64_t& minFee)
+static bool canReplaceByFee(TransactionFrameBasePtr tx,
+                            TransactionFrameBasePtr oldTx, int64_t& minFee)
 {
     int64_t newFee = tx->getInclusionFee();
     uint32_t newNumOps = std::max<uint32_t>(1, tx->getNumOperations());
@@ -262,8 +261,8 @@ canReplaceByFee(TransactionFrameBasePtr tx, TransactionFrameBasePtr oldTx,
     return res;
 }
 
-static bool
-isDuplicateTx(TransactionFrameBasePtr oldTx, TransactionFrameBasePtr newTx)
+static bool isDuplicateTx(TransactionFrameBasePtr oldTx,
+                          TransactionFrameBasePtr newTx)
 {
     auto const& oldEnv = oldTx->getEnvelope();
     auto const& newEnv = newTx->getEnvelope();
@@ -293,14 +292,12 @@ isDuplicateTx(TransactionFrameBasePtr oldTx, TransactionFrameBasePtr newTx)
     return false;
 }
 
-bool
-TransactionQueue::sourceAccountPending(AccountID const& accountID) const
+bool TransactionQueue::sourceAccountPending(AccountID const& accountID) const
 {
     return mAccountStates.find(accountID) != mAccountStates.end();
 }
 
-TransactionQueue::AddResult
-TransactionQueue::canAdd(
+TransactionQueue::AddResult TransactionQueue::canAdd(
     TransactionFrameBasePtr tx, AccountStates::iterator& stateIter,
     std::vector<std::pair<TransactionFrameBasePtr, bool>>& txsToEvict
 #ifdef BUILD_TESTS
@@ -508,8 +505,8 @@ TransactionQueue::canAdd(
                      tx->createValidationSuccessResult());
 }
 
-void
-TransactionQueue::releaseFeeMaybeEraseAccountState(TransactionFrameBasePtr tx)
+void TransactionQueue::releaseFeeMaybeEraseAccountState(
+    TransactionFrameBasePtr tx)
 {
     auto iter = mAccountStates.find(tx->getFeeSourceID());
     releaseAssert(iter != mAccountStates.end() &&
@@ -522,8 +519,7 @@ TransactionQueue::releaseFeeMaybeEraseAccountState(TransactionFrameBasePtr tx)
     }
 }
 
-void
-TransactionQueue::prepareDropTransaction(AccountState& as)
+void TransactionQueue::prepareDropTransaction(AccountState& as)
 {
     releaseAssert(as.mTransaction);
     mTxQueueLimiter->removeTransaction(as.mTransaction->mTx);
@@ -644,11 +640,11 @@ TransactionQueue::findAllAssetPairsInvolvedInPaymentLoops(
     return ret;
 }
 
-TransactionQueue::AddResult
-TransactionQueue::tryAdd(TransactionFrameBasePtr tx, bool submittedFromSelf
+TransactionQueue::AddResult TransactionQueue::tryAdd(TransactionFrameBasePtr tx,
+                                                     bool submittedFromSelf
 #ifdef BUILD_TESTS
-                         ,
-                         bool isLoadgenTx
+                                                     ,
+                                                     bool isLoadgenTx
 #endif
 )
 {
@@ -720,8 +716,7 @@ TransactionQueue::tryAdd(TransactionFrameBasePtr tx, bool submittedFromSelf
     return res;
 }
 
-void
-TransactionQueue::dropTransaction(AccountStates::iterator stateIter)
+void TransactionQueue::dropTransaction(AccountStates::iterator stateIter)
 {
     ZoneScoped;
     // Remove fees and update queue size for each transaction to be dropped.
@@ -748,8 +743,7 @@ TransactionQueue::dropTransaction(AccountStates::iterator stateIter)
     }
 }
 
-void
-TransactionQueue::removeApplied(Transactions const& appliedTxs)
+void TransactionQueue::removeApplied(Transactions const& appliedTxs)
 {
     ZoneScoped;
 
@@ -815,8 +809,7 @@ TransactionQueue::removeApplied(Transactions const& appliedTxs)
     }
 }
 
-void
-TransactionQueue::ban(Transactions const& banTxs)
+void TransactionQueue::ban(Transactions const& banTxs)
 {
     ZoneScoped;
     auto& bannedFront = mBannedTransactions.front();
@@ -860,8 +853,7 @@ TransactionQueue::ban(Transactions const& banTxs)
 }
 
 #ifdef BUILD_TESTS
-TransactionQueue::AccountState
-TransactionQueue::getAccountTransactionQueueInfo(
+TransactionQueue::AccountState TransactionQueue::getAccountTransactionQueueInfo(
     AccountID const& accountID) const
 {
     auto i = mAccountStates.find(accountID);
@@ -872,15 +864,13 @@ TransactionQueue::getAccountTransactionQueueInfo(
     return i->second;
 }
 
-size_t
-TransactionQueue::countBanned(int index) const
+size_t TransactionQueue::countBanned(int index) const
 {
     return mBannedTransactions[index].size();
 }
 #endif
 
-void
-TransactionQueue::shift()
+void TransactionQueue::shift()
 {
     ZoneScoped;
     mBannedTransactions.pop_back();
@@ -955,8 +945,7 @@ TransactionQueue::shift()
                                      mBroadcastSeed);
 }
 
-bool
-TransactionQueue::isBanned(Hash const& hash) const
+bool TransactionQueue::isBanned(Hash const& hash) const
 {
     return std::any_of(
         std::begin(mBannedTransactions), std::end(mBannedTransactions),
@@ -965,8 +954,7 @@ TransactionQueue::isBanned(Hash const& hash) const
         });
 }
 
-TxFrameList
-TransactionQueue::getTransactions(LedgerHeader const& lcl) const
+TxFrameList TransactionQueue::getTransactions(LedgerHeader const& lcl) const
 {
     ZoneScoped;
     TxFrameList txs;
@@ -985,8 +973,7 @@ TransactionQueue::getTransactions(LedgerHeader const& lcl) const
     return txs;
 }
 
-TransactionFrameBaseConstPtr
-TransactionQueue::getTx(Hash const& hash) const
+TransactionFrameBaseConstPtr TransactionQueue::getTx(Hash const& hash) const
 {
     ZoneScoped;
     auto it = mKnownTxHashes.find(hash);
@@ -1125,8 +1112,7 @@ SorobanTransactionQueue::getMaxResourcesToFloodThisPeriod() const
     return std::make_pair(resToFlood, std::nullopt);
 }
 
-bool
-SorobanTransactionQueue::broadcastSome()
+bool SorobanTransactionQueue::broadcastSome()
 {
     ZoneScoped;
     // broadcast transactions in surge pricing order:
@@ -1174,8 +1160,7 @@ SorobanTransactionQueue::broadcastSome()
     return !totalResToFlood.isZero();
 }
 
-size_t
-SorobanTransactionQueue::getMaxQueueSizeOps() const
+size_t SorobanTransactionQueue::getMaxQueueSizeOps() const
 {
     if (protocolVersionStartsFrom(mApp.getLedgerManager()
                                       .getLastClosedLedgerHeader()
@@ -1192,8 +1177,7 @@ SorobanTransactionQueue::getMaxQueueSizeOps() const
     }
 }
 
-void
-SorobanTransactionQueue::resetAndRebuild(
+void SorobanTransactionQueue::resetAndRebuild(
     UnorderedSet<LedgerKey> const& keysToFilter)
 {
     ZoneScoped;
@@ -1234,8 +1218,7 @@ SorobanTransactionQueue::resetAndRebuild(
     }
 }
 
-bool
-ClassicTransactionQueue::broadcastSome()
+bool ClassicTransactionQueue::broadcastSome()
 {
     ZoneScoped;
     // broadcast transactions in surge pricing order:
@@ -1298,8 +1281,7 @@ ClassicTransactionQueue::broadcastSome()
     return !totalToFlood.isZero();
 }
 
-void
-TransactionQueue::broadcast(bool fromCallback)
+void TransactionQueue::broadcast(bool fromCallback)
 {
     if (mShutdown || (!fromCallback && mWaiting))
     {
@@ -1328,8 +1310,7 @@ TransactionQueue::broadcast(bool fromCallback)
     }
 }
 
-void
-TransactionQueue::rebroadcast()
+void TransactionQueue::rebroadcast()
 {
     // force to rebroadcast everything
     for (auto& m : mAccountStates)
@@ -1346,8 +1327,7 @@ TransactionQueue::rebroadcast()
     broadcast(false);
 }
 
-void
-TransactionQueue::shutdown()
+void TransactionQueue::shutdown()
 {
     mShutdown = true;
     mBroadcastTimer.cancel();
@@ -1362,8 +1342,7 @@ containsFilteredOperation(std::vector<Operation> const& ops,
     });
 }
 
-bool
-TransactionQueue::isFiltered(TransactionFrameBasePtr tx) const
+bool TransactionQueue::isFiltered(TransactionFrameBasePtr tx) const
 {
     // Avoid cost of checking if filtering is not in use
     if (mFilteredTypes.empty())
@@ -1393,8 +1372,7 @@ TransactionQueue::isFiltered(TransactionFrameBasePtr tx) const
 }
 
 #ifdef BUILD_TESTS
-size_t
-TransactionQueue::getQueueSizeOps() const
+size_t TransactionQueue::getQueueSizeOps() const
 {
     return mTxQueueLimiter->size();
 }
@@ -1415,8 +1393,7 @@ TransactionQueue::getInQueueSeqNum(AccountID const& account) const
 }
 #endif
 
-size_t
-ClassicTransactionQueue::getMaxQueueSizeOps() const
+size_t ClassicTransactionQueue::getMaxQueueSizeOps() const
 {
     auto res = mTxQueueLimiter->maxScaledLedgerResources(false);
     releaseAssert(res.size() == NUM_CLASSIC_TX_RESOURCES);

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -310,8 +310,7 @@ class SorobanTransactionQueue : public TransactionQueue
     SorobanTransactionQueue(Application& app, uint32 pendingDepth,
                             uint32 banDepth, uint32 poolLedgerMultiplier,
                             UnorderedSet<LedgerKey> const& keysToFilter);
-    int
-    getFloodPeriod() const override
+    int getFloodPeriod() const override
     {
         return mApp.getConfig().FLOOD_SOROBAN_TX_PERIOD_MS;
     }
@@ -328,8 +327,7 @@ class SorobanTransactionQueue : public TransactionQueue
     void resetAndRebuild(UnorderedSet<LedgerKey> const& keysToFilter);
 
 #ifdef BUILD_TESTS
-    void
-    clearBroadcastCarryover()
+    void clearBroadcastCarryover()
     {
         mBroadcastOpCarryover.clear();
         mBroadcastOpCarryover.resize(1, Resource::makeEmptySoroban());
@@ -342,8 +340,7 @@ class SorobanTransactionQueue : public TransactionQueue
     virtual bool broadcastSome() override;
     std::vector<Resource> mBroadcastOpCarryover;
     // No special flooding rules for Soroban
-    virtual bool
-    allowTxBroadcast(TransactionFrameBasePtr const& tx) override
+    virtual bool allowTxBroadcast(TransactionFrameBasePtr const& tx) override
     {
         return true;
     }
@@ -355,8 +352,7 @@ class ClassicTransactionQueue : public TransactionQueue
     ClassicTransactionQueue(Application& app, uint32 pendingDepth,
                             uint32 banDepth, uint32 poolLedgerMultiplier);
 
-    int
-    getFloodPeriod() const override
+    int getFloodPeriod() const override
     {
         return mApp.getConfig().FLOOD_TX_PERIOD_MS;
     }

--- a/src/herder/TxQueueLimiter.cpp
+++ b/src/herder/TxQueueLimiter.cpp
@@ -14,9 +14,8 @@ namespace stellar
 namespace
 {
 
-int64_t
-computeBetterFee(std::pair<int64, uint32_t> const& evictedBid,
-                 TransactionFrameBase const& tx)
+int64_t computeBetterFee(std::pair<int64, uint32_t> const& evictedBid,
+                         TransactionFrameBase const& tx)
 {
     if (evictedBid.second != 0 &&
         feeRate3WayCompare(evictedBid.first, evictedBid.second,
@@ -50,22 +49,19 @@ TxQueueLimiter::~TxQueueLimiter()
 }
 
 #ifdef BUILD_TESTS
-size_t
-TxQueueLimiter::size() const
+size_t TxQueueLimiter::size() const
 {
     return mTxs->totalResources().getVal(Resource::Type::OPERATIONS);
 }
 #endif
 
-Resource
-TxQueueLimiter::maxScaledLedgerResources(bool isSoroban) const
+Resource TxQueueLimiter::maxScaledLedgerResources(bool isSoroban) const
 {
     return saturatedMultiplyByDouble(
         mLedgerManager.maxLedgerResources(isSoroban), mPoolLedgerMultiplier);
 }
 
-void
-TxQueueLimiter::addTransaction(TransactionFrameBasePtr const& tx)
+void TxQueueLimiter::addTransaction(TransactionFrameBasePtr const& tx)
 {
     releaseAssert(tx->isSoroban() == mIsSoroban);
     auto ledgerVersion = mApp.getLedgerManager()
@@ -75,8 +71,7 @@ TxQueueLimiter::addTransaction(TransactionFrameBasePtr const& tx)
     mTxsToFlood->add(tx, ledgerVersion);
 }
 
-void
-TxQueueLimiter::removeTransaction(TransactionFrameBasePtr const& tx)
+void TxQueueLimiter::removeTransaction(TransactionFrameBasePtr const& tx)
 {
     auto ledgerVersion = mApp.getLedgerManager()
                              .getLastClosedLedgerHeader()
@@ -86,8 +81,7 @@ TxQueueLimiter::removeTransaction(TransactionFrameBasePtr const& tx)
 }
 
 #ifdef BUILD_TESTS
-std::pair<bool, int64>
-TxQueueLimiter::canAddTx(
+std::pair<bool, int64> TxQueueLimiter::canAddTx(
     TransactionFrameBasePtr const& newTx, TransactionFrameBasePtr const& oldTx,
     std::vector<std::pair<TransactionFrameBasePtr, bool>>& txsToEvict)
 {
@@ -100,8 +94,7 @@ TxQueueLimiter::canAddTx(
 }
 #endif
 
-void
-TxQueueLimiter::resetBestFeeTxs(uint32_t ledgerVersion, size_t seed)
+void TxQueueLimiter::resetBestFeeTxs(uint32_t ledgerVersion, size_t seed)
 {
     if (mIsSoroban)
     {
@@ -121,8 +114,7 @@ TxQueueLimiter::resetBestFeeTxs(uint32_t ledgerVersion, size_t seed)
         /* isHighestPriority */ true, mTxsToFloodLaneConfig, seed);
 }
 
-std::pair<bool, int64>
-TxQueueLimiter::canAddTx(
+std::pair<bool, int64> TxQueueLimiter::canAddTx(
     TransactionFrameBasePtr const& newTx, TransactionFrameBasePtr const& oldTx,
     std::vector<std::pair<TransactionFrameBasePtr, bool>>& txsToEvict,
     uint32_t ledgerVersion, size_t broadcastSeed)
@@ -185,8 +177,7 @@ TxQueueLimiter::canAddTx(
                                     ledgerVersion);
 }
 
-void
-TxQueueLimiter::evictTransactions(
+void TxQueueLimiter::evictTransactions(
     std::vector<std::pair<TransactionFrameBasePtr, bool>> const& txsToEvict,
     TransactionFrameBase const& txToFit,
     std::function<void(TransactionFrameBasePtr const&)> evict)
@@ -240,8 +231,7 @@ TxQueueLimiter::evictTransactions(
     releaseAssert(mTxs->totalResources() + resourcesToFit <= maxLimits);
 }
 
-void
-TxQueueLimiter::reset(uint32_t ledgerVersion)
+void TxQueueLimiter::reset(uint32_t ledgerVersion)
 {
     if (mIsSoroban)
     {
@@ -276,8 +266,7 @@ TxQueueLimiter::reset(uint32_t ledgerVersion)
     resetEvictionState();
 }
 
-void
-TxQueueLimiter::resetEvictionState()
+void TxQueueLimiter::resetEvictionState()
 {
     if (mSurgePricingLaneConfig != nullptr)
     {
@@ -290,8 +279,7 @@ TxQueueLimiter::resetEvictionState()
     }
 }
 
-void
-TxQueueLimiter::visitTopTxs(
+void TxQueueLimiter::visitTopTxs(
     std::function<SurgePricingPriorityQueue::VisitTxResult(
         TransactionFrameBasePtr const&)> const& visitor,
     std::vector<Resource>& laneResourcesLeftUntilLimit, uint32_t ledgerVersion,
@@ -306,9 +294,8 @@ TxQueueLimiter::visitTopTxs(
     }
 }
 
-void
-TxQueueLimiter::markTxForFlood(TransactionFrameBasePtr const& tx,
-                               uint32_t ledgerVersion)
+void TxQueueLimiter::markTxForFlood(TransactionFrameBasePtr const& tx,
+                                    uint32_t ledgerVersion)
 {
     mTxsToFlood->add(tx, ledgerVersion);
 }

--- a/src/herder/TxQueueLimiter.h
+++ b/src/herder/TxQueueLimiter.h
@@ -95,8 +95,7 @@ class TxQueueLimiter
                      std::optional<std::vector<Resource>> const& customLimits =
                          std::nullopt);
 
-    Resource
-    getTotalResourcesToFlood() const
+    Resource getTotalResourcesToFlood() const
     {
         return mTxsToFlood->totalResources();
     }

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -35,8 +35,7 @@ namespace stellar
 
 namespace
 {
-std::string
-getTxSetPhaseName(TxSetPhase phase)
+std::string getTxSetPhaseName(TxSetPhase phase)
 {
     switch (phase)
     {
@@ -49,8 +48,7 @@ getTxSetPhaseName(TxSetPhase phase)
     }
 }
 
-bool
-validateSequentialPhaseXDRStructure(TransactionPhase const& phase)
+bool validateSequentialPhaseXDRStructure(TransactionPhase const& phase)
 {
     bool componentsNormalized =
         std::is_sorted(phase.v0Components().begin(), phase.v0Components().end(),
@@ -99,8 +97,7 @@ validateSequentialPhaseXDRStructure(TransactionPhase const& phase)
     return true;
 }
 
-bool
-validateParallelComponent(ParallelTxsComponent const& component)
+bool validateParallelComponent(ParallelTxsComponent const& component)
 {
     for (auto const& stage : component.executionStages)
     {
@@ -121,8 +118,7 @@ validateParallelComponent(ParallelTxsComponent const& component)
     return true;
 }
 
-bool
-validateTxSetXDRStructure(GeneralizedTransactionSet const& txSet)
+bool validateTxSetXDRStructure(GeneralizedTransactionSet const& txSet)
 {
     int const MAX_PHASE = 1;
 
@@ -185,9 +181,8 @@ struct ApplyTxSorter
     {
     }
 
-    bool
-    operator()(TransactionFrameBasePtr const& tx1,
-               TransactionFrameBasePtr const& tx2) const
+    bool operator()(TransactionFrameBasePtr const& tx1,
+                    TransactionFrameBasePtr const& tx2) const
     {
         // need to use the hash of whole tx here since multiple txs could
         // have the same Contents
@@ -195,8 +190,7 @@ struct ApplyTxSorter
     }
 };
 
-Hash
-computeNonGeneralizedTxSetContentsHash(TransactionSet const& xdrTxSet)
+Hash computeNonGeneralizedTxSetContentsHash(TransactionSet const& xdrTxSet)
 {
     ZoneScoped;
     SHA256 hasher;
@@ -210,8 +204,7 @@ computeNonGeneralizedTxSetContentsHash(TransactionSet const& xdrTxSet)
 
 // Note: Soroban txs also use this functionality for simplicity, as it's a
 // no-op (all Soroban txs have 1 op max)
-int64_t
-computePerOpFee(TransactionFrameBase const& tx, uint32_t ledgerVersion)
+int64_t computePerOpFee(TransactionFrameBase const& tx, uint32_t ledgerVersion)
 {
     auto rounding =
         protocolVersionStartsFrom(ledgerVersion, SOROBAN_PROTOCOL_VERSION)
@@ -222,10 +215,9 @@ computePerOpFee(TransactionFrameBase const& tx, uint32_t ledgerVersion)
                             static_cast<int64_t>(txOps), rounding);
 }
 
-void
-transactionsToTransactionSetXDR(TxFrameList const& txs,
-                                Hash const& previousLedgerHash,
-                                TransactionSet& txSet)
+void transactionsToTransactionSetXDR(TxFrameList const& txs,
+                                     Hash const& previousLedgerHash,
+                                     TransactionSet& txSet)
 {
     ZoneScoped;
     txSet.txs.resize(xdr::size32(txs.size()));
@@ -237,10 +229,9 @@ transactionsToTransactionSetXDR(TxFrameList const& txs,
     txSet.previousLedgerHash = previousLedgerHash;
 }
 
-void
-sequentialPhaseToXdr(TxFrameList const& txs,
-                     InclusionFeeMap const& inclusionFeeMap,
-                     TransactionPhase& xdrPhase)
+void sequentialPhaseToXdr(TxFrameList const& txs,
+                          InclusionFeeMap const& inclusionFeeMap,
+                          TransactionPhase& xdrPhase)
 {
     xdrPhase.v(0);
 
@@ -276,10 +267,9 @@ sequentialPhaseToXdr(TxFrameList const& txs,
     }
 }
 
-void
-parallelPhaseToXdr(TxStageFrameList const& txs,
-                   InclusionFeeMap const& inclusionFeeMap,
-                   TransactionPhase& xdrPhase)
+void parallelPhaseToXdr(TxStageFrameList const& txs,
+                        InclusionFeeMap const& inclusionFeeMap,
+                        TransactionPhase& xdrPhase)
 {
     xdrPhase.v(1);
 
@@ -317,8 +307,7 @@ parallelPhaseToXdr(TxStageFrameList const& txs,
     }
 }
 
-void
-transactionsToGeneralizedTransactionSetXDR(
+void transactionsToGeneralizedTransactionSetXDR(
     std::vector<TxSetPhaseFrame> const& phases, Hash const& previousLedgerHash,
     GeneralizedTransactionSet& generalizedTxSet)
 {
@@ -334,8 +323,8 @@ transactionsToGeneralizedTransactionSetXDR(
     }
 }
 
-TxFrameList
-sortedForApplySequential(TxFrameList const& txs, Hash const& txSetHash)
+TxFrameList sortedForApplySequential(TxFrameList const& txs,
+                                     Hash const& txSetHash)
 {
     TxFrameList retList;
     retList.reserve(txs.size());
@@ -384,8 +373,8 @@ sortedForApplySequential(TxFrameList const& txs, Hash const& txSetHash)
     return retList;
 }
 
-TxStageFrameList
-sortedForApplyParallel(TxStageFrameList const& stages, Hash const& txSetHash)
+TxStageFrameList sortedForApplyParallel(TxStageFrameList const& stages,
+                                        Hash const& txSetHash)
 {
     ZoneScoped;
     TxStageFrameList sortedStages = stages;
@@ -409,10 +398,9 @@ sortedForApplyParallel(TxStageFrameList const& stages, Hash const& txSetHash)
     return sortedStages;
 }
 
-bool
-addWireTxsToList(Hash const& networkID,
-                 xdr::xvector<TransactionEnvelope> const& xdrTxs,
-                 TxFrameList& txList)
+bool addWireTxsToList(Hash const& networkID,
+                      xdr::xvector<TransactionEnvelope> const& xdrTxs,
+                      TxFrameList& txList)
 {
     auto prevSize = txList.size();
     txList.reserve(prevSize + xdrTxs.size());
@@ -534,8 +522,7 @@ createSurgePricingLangeConfig(TxSetPhase phase, Application& app)
     return surgePricingLaneConfig;
 }
 
-TxFrameList
-buildSurgePricedSequentialPhase(
+TxFrameList buildSurgePricedSequentialPhase(
     TxFrameList const& txs,
     std::shared_ptr<SurgePricingLaneConfig> surgePricingLaneConfig,
     std::vector<bool>& hadTxNotFittingLane, uint32_t ledgerVersion)
@@ -680,8 +667,7 @@ applySurgePricing(TxSetPhase phase, TxFrameList const& txs, Application& app
     return std::make_pair(includedTxs, inclusionFeeMapPtr);
 }
 
-size_t
-countOps(TxFrameList const& txs)
+size_t countOps(TxFrameList const& txs)
 {
     return std::accumulate(txs.begin(), txs.end(), size_t(0),
                            [&](size_t a, TransactionFrameBasePtr const& tx) {
@@ -689,9 +675,8 @@ countOps(TxFrameList const& txs)
                            });
 }
 
-int64_t
-computeBaseFeeForLegacyTxSet(LedgerHeader const& lclHeader,
-                             TxFrameList const& txs)
+int64_t computeBaseFeeForLegacyTxSet(LedgerHeader const& lclHeader,
+                                     TxFrameList const& txs)
 {
     ZoneScoped;
     auto ledgerVersion = lclHeader.ledgerVersion;
@@ -718,8 +703,7 @@ computeBaseFeeForLegacyTxSet(LedgerHeader const& lclHeader,
     return baseFee;
 }
 
-bool
-checkFeeMap(InclusionFeeMap const& feeMap, LedgerHeader const& lclHeader)
+bool checkFeeMap(InclusionFeeMap const& feeMap, LedgerHeader const& lclHeader)
 {
     for (auto const& [tx, fee] : feeMap)
     {
@@ -729,7 +713,6 @@ checkFeeMap(InclusionFeeMap const& feeMap, LedgerHeader const& lclHeader)
         }
         if (*fee < lclHeader.baseFee)
         {
-
             CLOG_DEBUG(Herder,
                        "Got bad txSet: {} has too low component "
                        "base fee {}",
@@ -1061,8 +1044,7 @@ makeTxSetFromTransactions(
     return res;
 }
 
-StellarMessage
-TxSetXDRFrame::toStellarMessage() const
+StellarMessage TxSetXDRFrame::toStellarMessage() const
 {
     StellarMessage newMsg;
     if (isGeneralizedTxSet())
@@ -1131,20 +1113,17 @@ TxSetXDRFrame::prepareForApply(Application& app,
         app, isGeneralizedTxSet(), previousLedgerHash(), phaseFrames, mHash));
 }
 
-bool
-TxSetXDRFrame::isGeneralizedTxSet() const
+bool TxSetXDRFrame::isGeneralizedTxSet() const
 {
     return std::holds_alternative<GeneralizedTransactionSet>(mXDRTxSet);
 }
 
-Hash const&
-TxSetXDRFrame::getContentsHash() const
+Hash const& TxSetXDRFrame::getContentsHash() const
 {
     return mHash;
 }
 
-Hash const&
-TxSetXDRFrame::previousLedgerHash() const
+Hash const& TxSetXDRFrame::previousLedgerHash() const
 {
     if (isGeneralizedTxSet())
     {
@@ -1155,8 +1134,7 @@ TxSetXDRFrame::previousLedgerHash() const
     return std::get<TransactionSet>(mXDRTxSet).previousLedgerHash;
 }
 
-size_t
-TxSetXDRFrame::sizeTxTotal() const
+size_t TxSetXDRFrame::sizeTxTotal() const
 {
     if (isGeneralizedTxSet())
     {
@@ -1195,8 +1173,7 @@ TxSetXDRFrame::sizeTxTotal() const
     }
 }
 
-size_t
-TxSetXDRFrame::sizeOpTotalForLogging() const
+size_t TxSetXDRFrame::sizeOpTotalForLogging() const
 {
     auto accumulateTxsFn = [](size_t sz, TransactionEnvelope const& tx) {
         size_t txOps = 0;
@@ -1316,28 +1293,24 @@ TxSetXDRFrame::createTransactionFrames(Hash const& networkID) const
     return phaseTxs;
 }
 
-size_t
-TxSetXDRFrame::encodedSize() const
+size_t TxSetXDRFrame::encodedSize() const
 {
     return mEncodedSize;
 }
 
-void
-TxSetXDRFrame::toXDR(TransactionSet& txSet) const
+void TxSetXDRFrame::toXDR(TransactionSet& txSet) const
 {
     releaseAssert(!isGeneralizedTxSet());
     txSet = std::get<TransactionSet>(mXDRTxSet);
 }
 
-void
-TxSetXDRFrame::toXDR(GeneralizedTransactionSet& txSet) const
+void TxSetXDRFrame::toXDR(GeneralizedTransactionSet& txSet) const
 {
     releaseAssert(isGeneralizedTxSet());
     txSet = std::get<GeneralizedTransactionSet>(mXDRTxSet);
 }
 
-void
-TxSetXDRFrame::storeXDR(StoredTransactionSet& txSet) const
+void TxSetXDRFrame::storeXDR(StoredTransactionSet& txSet) const
 {
     if (isGeneralizedTxSet())
     {
@@ -1358,10 +1331,8 @@ TxSetPhaseFrame::Iterator::Iterator(TxStageFrameList const& txs,
 {
 }
 
-TransactionFrameBasePtr
-TxSetPhaseFrame::Iterator::operator*() const
+TransactionFrameBasePtr TxSetPhaseFrame::Iterator::operator*() const
 {
-
     if (mStageIndex >= mStages.size() ||
         mClusterIndex >= mStages[mStageIndex].size() ||
         mTxIndex >= mStages[mStageIndex][mClusterIndex].size())
@@ -1371,8 +1342,7 @@ TxSetPhaseFrame::Iterator::operator*() const
     return mStages[mStageIndex][mClusterIndex][mTxIndex];
 }
 
-TxSetPhaseFrame::Iterator&
-TxSetPhaseFrame::Iterator::operator++()
+TxSetPhaseFrame::Iterator& TxSetPhaseFrame::Iterator::operator++()
 {
     if (mStageIndex >= mStages.size() ||
         mClusterIndex >= mStages[mStageIndex].size())
@@ -1393,16 +1363,14 @@ TxSetPhaseFrame::Iterator::operator++()
     return *this;
 }
 
-TxSetPhaseFrame::Iterator
-TxSetPhaseFrame::Iterator::operator++(int)
+TxSetPhaseFrame::Iterator TxSetPhaseFrame::Iterator::operator++(int)
 {
     auto it = *this;
     ++(*this);
     return it;
 }
 
-bool
-TxSetPhaseFrame::Iterator::operator==(Iterator const& other) const
+bool TxSetPhaseFrame::Iterator::operator==(Iterator const& other) const
 {
     return mStageIndex == other.mStageIndex &&
            mClusterIndex == other.mClusterIndex && mTxIndex == other.mTxIndex &&
@@ -1411,8 +1379,7 @@ TxSetPhaseFrame::Iterator::operator==(Iterator const& other) const
            &mStages == &other.mStages;
 }
 
-bool
-TxSetPhaseFrame::Iterator::operator!=(Iterator const& other) const
+bool TxSetPhaseFrame::Iterator::operator!=(Iterator const& other) const
 {
     return !(*this == other);
 }
@@ -1536,8 +1503,7 @@ TxSetPhaseFrame::makeFromWire(TxSetPhase phase, Hash const& networkID,
     return phaseFrame;
 }
 
-std::optional<TxSetPhaseFrame>
-TxSetPhaseFrame::makeFromWireLegacy(
+std::optional<TxSetPhaseFrame> TxSetPhaseFrame::makeFromWireLegacy(
     LedgerHeader const& lclHeader, Hash const& networkID,
     xdr::xvector<TransactionEnvelope> const& xdrTxs)
 {
@@ -1561,8 +1527,7 @@ TxSetPhaseFrame::makeFromWireLegacy(
                            inclusionFeeMapPtr);
 }
 
-TxSetPhaseFrame
-TxSetPhaseFrame::makeEmpty(TxSetPhase phase, bool isParallel)
+TxSetPhaseFrame TxSetPhaseFrame::makeEmpty(TxSetPhase phase, bool isParallel)
 {
     if (isParallel)
     {
@@ -1594,27 +1559,23 @@ TxSetPhaseFrame::TxSetPhaseFrame(
 {
 }
 
-TxSetPhaseFrame::Iterator
-TxSetPhaseFrame::begin() const
+TxSetPhaseFrame::Iterator TxSetPhaseFrame::begin() const
 {
     return TxSetPhaseFrame::Iterator(mStages, 0);
 }
 
-TxSetPhaseFrame::Iterator
-TxSetPhaseFrame::end() const
+TxSetPhaseFrame::Iterator TxSetPhaseFrame::end() const
 {
     return TxSetPhaseFrame::Iterator(mStages, mStages.size());
 }
 
-size_t
-TxSetPhaseFrame::sizeTx() const
+size_t TxSetPhaseFrame::sizeTx() const
 {
     ZoneScoped;
     return std::distance(this->begin(), this->end());
 }
 
-size_t
-TxSetPhaseFrame::sizeOp() const
+size_t TxSetPhaseFrame::sizeOp() const
 {
     ZoneScoped;
     return std::accumulate(this->begin(), this->end(), size_t(0),
@@ -1623,8 +1584,7 @@ TxSetPhaseFrame::sizeOp() const
                            });
 }
 
-size_t
-TxSetPhaseFrame::size(LedgerHeader const& lclHeader) const
+size_t TxSetPhaseFrame::size(LedgerHeader const& lclHeader) const
 {
     switch (mPhase)
     {
@@ -1640,27 +1600,23 @@ TxSetPhaseFrame::size(LedgerHeader const& lclHeader) const
     }
 }
 
-bool
-TxSetPhaseFrame::empty() const
+bool TxSetPhaseFrame::empty() const
 {
     return sizeTx() == 0;
 }
 
-bool
-TxSetPhaseFrame::isParallel() const
+bool TxSetPhaseFrame::isParallel() const
 {
     return mIsParallel;
 }
 
-TxStageFrameList const&
-TxSetPhaseFrame::getParallelStages() const
+TxStageFrameList const& TxSetPhaseFrame::getParallelStages() const
 {
     releaseAssert(isParallel());
     return mStages;
 }
 
-TxFrameList const&
-TxSetPhaseFrame::getSequentialTxs() const
+TxFrameList const& TxSetPhaseFrame::getSequentialTxs() const
 {
     releaseAssert(!isParallel());
     static TxFrameList empty;
@@ -1671,10 +1627,8 @@ TxSetPhaseFrame::getSequentialTxs() const
     return mStages.at(0).at(0);
 }
 
-void
-TxSetPhaseFrame::toXDR(TransactionPhase& xdrPhase) const
+void TxSetPhaseFrame::toXDR(TransactionPhase& xdrPhase) const
 {
-
     if (isParallel())
     {
         parallelPhaseToXdr(mStages, *mInclusionFeeMap, xdrPhase);
@@ -1685,14 +1639,12 @@ TxSetPhaseFrame::toXDR(TransactionPhase& xdrPhase) const
     }
 }
 
-InclusionFeeMap const&
-TxSetPhaseFrame::getInclusionFeeMap() const
+InclusionFeeMap const& TxSetPhaseFrame::getInclusionFeeMap() const
 {
     return *mInclusionFeeMap;
 }
 
-TxSetPhaseFrame
-TxSetPhaseFrame::sortedForApply(Hash const& txSetHash) const
+TxSetPhaseFrame TxSetPhaseFrame::sortedForApply(Hash const& txSetHash) const
 {
     if (isParallel())
     {
@@ -1708,11 +1660,10 @@ TxSetPhaseFrame::sortedForApply(Hash const& txSetHash) const
     }
 }
 
-bool
-TxSetPhaseFrame::checkValid(Application& app,
-                            uint64_t lowerBoundCloseTimeOffset,
-                            uint64_t upperBoundCloseTimeOffset,
-                            bool txsAreValidated) const
+bool TxSetPhaseFrame::checkValid(Application& app,
+                                 uint64_t lowerBoundCloseTimeOffset,
+                                 uint64_t upperBoundCloseTimeOffset,
+                                 bool txsAreValidated) const
 {
     auto const& lcl = app.getLedgerManager().getLastClosedLedgerHeader();
     // Verify the fee map for the phase. This check is independent of the phase
@@ -1760,8 +1711,7 @@ TxSetPhaseFrame::checkValid(Application& app,
                        upperBoundCloseTimeOffset);
 }
 
-bool
-TxSetPhaseFrame::checkValidClassic(LedgerHeader const& lclHeader) const
+bool TxSetPhaseFrame::checkValidClassic(LedgerHeader const& lclHeader) const
 {
     if (isParallel())
     {
@@ -1777,8 +1727,7 @@ TxSetPhaseFrame::checkValidClassic(LedgerHeader const& lclHeader) const
     return true;
 }
 
-bool
-TxSetPhaseFrame::checkValidSoroban(
+bool TxSetPhaseFrame::checkValidSoroban(
     LedgerHeader const& lclHeader,
     SorobanNetworkConfig const& sorobanConfig) const
 {
@@ -1945,10 +1894,9 @@ TxSetPhaseFrame::checkValidSoroban(
 // This assumes that the overall phase structure validation has already been
 // done, specifically that there are no transactions that belong to the same
 // source account.
-bool
-TxSetPhaseFrame::txsAreValid(Application& app,
-                             uint64_t lowerBoundCloseTimeOffset,
-                             uint64_t upperBoundCloseTimeOffset) const
+bool TxSetPhaseFrame::txsAreValid(Application& app,
+                                  uint64_t lowerBoundCloseTimeOffset,
+                                  uint64_t upperBoundCloseTimeOffset) const
 {
     ZoneScoped;
     // This is done so minSeqLedgerGap is validated against the next
@@ -1967,7 +1915,6 @@ TxSetPhaseFrame::txsAreValid(Application& app,
                                        upperBoundCloseTimeOffset, diagnostics);
         if (!txResult->isSuccess())
         {
-
             CLOG_DEBUG(
                 Herder, "Got bad txSet: tx invalid tx: {} result: {}",
                 xdrToCerealString(tx->getEnvelope(), "TransactionEnvelope"),
@@ -2029,22 +1976,19 @@ ApplicableTxSetFrame::ApplicableTxSetFrame(
 {
 }
 
-Hash const&
-ApplicableTxSetFrame::getContentsHash() const
+Hash const& ApplicableTxSetFrame::getContentsHash() const
 {
     releaseAssert(mContentsHash);
     return *mContentsHash;
 }
 
-TxSetPhaseFrame const&
-ApplicableTxSetFrame::getPhase(TxSetPhase phaseTxs) const
+TxSetPhaseFrame const& ApplicableTxSetFrame::getPhase(TxSetPhase phaseTxs) const
 {
     releaseAssert(static_cast<size_t>(phaseTxs) < mPhases.size());
     return mPhases.at(static_cast<size_t>(phaseTxs));
 }
 
-std::vector<TxSetPhaseFrame> const&
-ApplicableTxSetFrame::getPhases() const
+std::vector<TxSetPhaseFrame> const& ApplicableTxSetFrame::getPhases() const
 {
     return mPhases;
 }
@@ -2065,10 +2009,9 @@ ApplicableTxSetFrame::getPhasesInApplyOrder() const
     return mApplyOrderPhases;
 }
 
-bool
-ApplicableTxSetFrame::checkValid(Application& app,
-                                 uint64_t lowerBoundCloseTimeOffset,
-                                 uint64_t upperBoundCloseTimeOffset) const
+bool ApplicableTxSetFrame::checkValid(Application& app,
+                                      uint64_t lowerBoundCloseTimeOffset,
+                                      uint64_t upperBoundCloseTimeOffset) const
 {
     // For public-facing methods, always do full validation
     return checkValidInternal(app, lowerBoundCloseTimeOffset,
@@ -2079,11 +2022,9 @@ ApplicableTxSetFrame::checkValid(Application& app,
 // need to make sure every account that is submitting a tx has enough to pay
 // the fees of all the tx it has submitted in this set
 // check seq num
-bool
-ApplicableTxSetFrame::checkValidInternal(Application& app,
-                                         uint64_t lowerBoundCloseTimeOffset,
-                                         uint64_t upperBoundCloseTimeOffset,
-                                         bool txsAreValidated) const
+bool ApplicableTxSetFrame::checkValidInternal(
+    Application& app, uint64_t lowerBoundCloseTimeOffset,
+    uint64_t upperBoundCloseTimeOffset, bool txsAreValidated) const
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -2153,9 +2094,8 @@ ApplicableTxSetFrame::checkValidInternal(Application& app,
     return true;
 }
 
-size_t
-ApplicableTxSetFrame::size(LedgerHeader const& lh,
-                           std::optional<TxSetPhase> phaseType) const
+size_t ApplicableTxSetFrame::size(LedgerHeader const& lh,
+                                  std::optional<TxSetPhase> phaseType) const
 {
     ZoneScoped;
     if (phaseType)
@@ -2171,14 +2111,12 @@ ApplicableTxSetFrame::size(LedgerHeader const& lh,
     return sz;
 }
 
-size_t
-ApplicableTxSetFrame::sizeOp(TxSetPhase phase) const
+size_t ApplicableTxSetFrame::sizeOp(TxSetPhase phase) const
 {
     return mPhases.at(static_cast<size_t>(phase)).sizeOp();
 }
 
-size_t
-ApplicableTxSetFrame::sizeOpTotal() const
+size_t ApplicableTxSetFrame::sizeOpTotal() const
 {
     ZoneScoped;
     size_t total = 0;
@@ -2189,14 +2127,12 @@ ApplicableTxSetFrame::sizeOpTotal() const
     return total;
 }
 
-size_t
-ApplicableTxSetFrame::sizeTx(TxSetPhase phase) const
+size_t ApplicableTxSetFrame::sizeTx(TxSetPhase phase) const
 {
     return mPhases.at(static_cast<size_t>(phase)).sizeTx();
 }
 
-size_t
-ApplicableTxSetFrame::sizeTxTotal() const
+size_t ApplicableTxSetFrame::sizeTxTotal() const
 {
     ZoneScoped;
     size_t total = 0;
@@ -2221,8 +2157,7 @@ ApplicableTxSetFrame::getTxBaseFee(TransactionFrameBaseConstPtr const& tx) const
     throw std::runtime_error("Transaction not found in tx set");
 }
 
-int64_t
-ApplicableTxSetFrame::getTotalFees(LedgerHeader const& lh) const
+int64_t ApplicableTxSetFrame::getTotalFees(LedgerHeader const& lh) const
 {
     ZoneScoped;
     int64_t total{0};
@@ -2236,8 +2171,7 @@ ApplicableTxSetFrame::getTotalFees(LedgerHeader const& lh) const
     return total;
 }
 
-int64_t
-ApplicableTxSetFrame::getTotalInclusionFees() const
+int64_t ApplicableTxSetFrame::getTotalInclusionFees() const
 {
     ZoneScoped;
     int64_t total{0};
@@ -2251,8 +2185,7 @@ ApplicableTxSetFrame::getTotalInclusionFees() const
     return total;
 }
 
-std::string
-ApplicableTxSetFrame::summary() const
+std::string ApplicableTxSetFrame::summary() const
 {
     if (empty())
     {
@@ -2319,8 +2252,7 @@ ApplicableTxSetFrame::summary() const
     return status;
 }
 
-void
-ApplicableTxSetFrame::toXDR(TransactionSet& txSet) const
+void ApplicableTxSetFrame::toXDR(TransactionSet& txSet) const
 {
     ZoneScoped;
     releaseAssert(!isGeneralizedTxSet());
@@ -2329,8 +2261,8 @@ ApplicableTxSetFrame::toXDR(TransactionSet& txSet) const
                                     mPreviousLedgerHash, txSet);
 }
 
-void
-ApplicableTxSetFrame::toXDR(GeneralizedTransactionSet& generalizedTxSet) const
+void ApplicableTxSetFrame::toXDR(
+    GeneralizedTransactionSet& generalizedTxSet) const
 {
     ZoneScoped;
     releaseAssert(isGeneralizedTxSet());
@@ -2340,8 +2272,7 @@ ApplicableTxSetFrame::toXDR(GeneralizedTransactionSet& generalizedTxSet) const
                                                generalizedTxSet);
 }
 
-TxSetXDRFrameConstPtr
-ApplicableTxSetFrame::toWireTxSetFrame() const
+TxSetXDRFrameConstPtr ApplicableTxSetFrame::toWireTxSetFrame() const
 {
     TxSetXDRFrameConstPtr outputTxSet;
     if (mIsGeneralized)
@@ -2359,8 +2290,7 @@ ApplicableTxSetFrame::toWireTxSetFrame() const
     return outputTxSet;
 }
 
-bool
-ApplicableTxSetFrame::isGeneralizedTxSet() const
+bool ApplicableTxSetFrame::isGeneralizedTxSet() const
 {
     return mIsGeneralized;
 }

--- a/src/herder/TxSetFrame.h
+++ b/src/herder/TxSetFrame.h
@@ -429,15 +429,13 @@ class ApplicableTxSetFrame
     size_t sizeOpTotal() const;
 
     // Returns whether this transaction set is empty.
-    bool
-    empty() const
+    bool empty() const
     {
         return sizeTxTotal() == 0;
     }
 
     // Returns the number of phases in this tx set.
-    size_t
-    numPhases() const
+    size_t numPhases() const
     {
         return mPhases.size();
     }

--- a/src/herder/TxSetUtils.cpp
+++ b/src/herder/TxSetUtils.cpp
@@ -35,8 +35,7 @@ namespace
 {
 // Target use case is to remove a subset of invalid transactions from a TxSet.
 // I.e. txSet.size() >= txsToRemove.size()
-TxFrameList
-removeTxs(TxFrameList const& txs, TxFrameList const& txsToRemove)
+TxFrameList removeTxs(TxFrameList const& txs, TxFrameList const& txsToRemove)
 {
     UnorderedSet<Hash> txsToRemoveSet;
     txsToRemoveSet.reserve(txsToRemove.size());
@@ -75,38 +74,33 @@ AccountTransactionQueue::AccountTransactionQueue(
     }
 }
 
-TransactionFrameBasePtr
-AccountTransactionQueue::getTopTx() const
+TransactionFrameBasePtr AccountTransactionQueue::getTopTx() const
 {
     releaseAssert(!mTxs.empty());
     return mTxs.front();
 }
 
-bool
-AccountTransactionQueue::empty() const
+bool AccountTransactionQueue::empty() const
 {
     return mTxs.empty();
 }
 
-void
-AccountTransactionQueue::popTopTx()
+void AccountTransactionQueue::popTopTx()
 {
     releaseAssert(!mTxs.empty());
     mNumOperations -= mTxs.front()->getNumOperations();
     mTxs.pop_front();
 }
 
-bool
-TxSetUtils::hashTxSorter(TransactionFrameBasePtr const& tx1,
-                         TransactionFrameBasePtr const& tx2)
+bool TxSetUtils::hashTxSorter(TransactionFrameBasePtr const& tx1,
+                              TransactionFrameBasePtr const& tx2)
 {
     // need to use the hash of whole tx here since multiple txs could have
     // the same Contents
     return tx1->getFullHash() < tx2->getFullHash();
 }
 
-TxFrameList
-TxSetUtils::sortTxsInHashOrder(TxFrameList const& transactions)
+TxFrameList TxSetUtils::sortTxsInHashOrder(TxFrameList const& transactions)
 {
     ZoneScoped;
     TxFrameList sortedTxs(transactions);
@@ -161,10 +155,10 @@ TxSetUtils::buildAccountTxQueues(TxFrameList const& txs)
     return queues;
 }
 
-TxFrameList
-TxSetUtils::getInvalidTxList(TxFrameList const& txs, Application& app,
-                             uint64_t lowerBoundCloseTimeOffset,
-                             uint64_t upperBoundCloseTimeOffset)
+TxFrameList TxSetUtils::getInvalidTxList(TxFrameList const& txs,
+                                         Application& app,
+                                         uint64_t lowerBoundCloseTimeOffset,
+                                         uint64_t upperBoundCloseTimeOffset)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -190,11 +184,10 @@ TxSetUtils::getInvalidTxList(TxFrameList const& txs, Application& app,
     return invalidTxs;
 }
 
-TxFrameList
-TxSetUtils::trimInvalid(TxFrameList const& txs, Application& app,
-                        uint64_t lowerBoundCloseTimeOffset,
-                        uint64_t upperBoundCloseTimeOffset,
-                        TxFrameList& invalidTxs)
+TxFrameList TxSetUtils::trimInvalid(TxFrameList const& txs, Application& app,
+                                    uint64_t lowerBoundCloseTimeOffset,
+                                    uint64_t upperBoundCloseTimeOffset,
+                                    TxFrameList& invalidTxs)
 {
     invalidTxs = getInvalidTxList(txs, app, lowerBoundCloseTimeOffset,
                                   upperBoundCloseTimeOffset);

--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -41,8 +41,7 @@
 namespace cereal
 {
 template <class Archive>
-void
-save(Archive& ar, stellar::Upgrades::UpgradeParameters const& p)
+void save(Archive& ar, stellar::Upgrades::UpgradeParameters const& p)
 {
     // NB: See 'rewriteOptionalFieldKeys' below before adding any new fields to
     // this type, and in particular avoid using field names "has" or "val",
@@ -65,8 +64,7 @@ save(Archive& ar, stellar::Upgrades::UpgradeParameters const& p)
 }
 
 template <class Archive>
-void
-load(Archive& ar, stellar::Upgrades::UpgradeParameters& o)
+void load(Archive& ar, stellar::Upgrades::UpgradeParameters& o)
 {
     time_t t;
     ar(make_nvp("time", t));
@@ -115,8 +113,7 @@ namespace stellar
 {
 namespace
 {
-uint32_t
-readMaxSorobanTxSetSize(LedgerSnapshot const& ls)
+uint32_t readMaxSorobanTxSetSize(LedgerSnapshot const& ls)
 {
     LedgerKey key(LedgerEntryType::CONFIG_SETTING);
     key.configSetting().configSettingID =
@@ -128,8 +125,7 @@ readMaxSorobanTxSetSize(LedgerSnapshot const& ls)
         .ledgerMaxTxCount;
 }
 
-void
-upgradeMaxSorobanTxSetSize(AbstractLedgerTxn& ltx, uint32_t maxTxSetSize)
+void upgradeMaxSorobanTxSetSize(AbstractLedgerTxn& ltx, uint32_t maxTxSetSize)
 {
     LedgerKey key(LedgerEntryType::CONFIG_SETTING);
     key.configSetting().configSettingID =
@@ -141,8 +137,7 @@ upgradeMaxSorobanTxSetSize(AbstractLedgerTxn& ltx, uint32_t maxTxSetSize)
 } // namespace
 std::chrono::hours const Upgrades::UPDGRADE_EXPIRATION_HOURS(12);
 
-std::string
-Upgrades::UpgradeParameters::toJson() const
+std::string Upgrades::UpgradeParameters::toJson() const
 {
     std::ostringstream out;
     {
@@ -183,8 +178,7 @@ Upgrades::UpgradeParameters::toDebugJson(LedgerSnapshot const& ls) const
     return writer.write(upgradesJson);
 }
 
-static std::string
-rewriteOptionalFieldKeys(std::string s)
+static std::string rewriteOptionalFieldKeys(std::string s)
 {
     // When transitioning from C++14 to C++17, we migrated from a custom
     // implementation of 'optional' types, to using std::optional.
@@ -222,8 +216,7 @@ rewriteOptionalFieldKeys(std::string s)
     return s;
 }
 
-void
-Upgrades::UpgradeParameters::fromJson(std::string const& s)
+void Upgrades::UpgradeParameters::fromJson(std::string const& s)
 {
     std::string s1 = rewriteOptionalFieldKeys(s);
     std::istringstream in(s1);
@@ -237,8 +230,7 @@ Upgrades::Upgrades(UpgradeParameters const& params) : mParams(params)
 {
 }
 
-void
-Upgrades::setParameters(UpgradeParameters const& params, Config const& cfg)
+void Upgrades::setParameters(UpgradeParameters const& params, Config const& cfg)
 {
     if (params.mProtocolVersion &&
         *params.mProtocolVersion > cfg.LEDGER_PROTOCOL_VERSION)
@@ -251,8 +243,7 @@ Upgrades::setParameters(UpgradeParameters const& params, Config const& cfg)
     mParams = params;
 }
 
-Upgrades::UpgradeParameters const&
-Upgrades::getParameters() const
+Upgrades::UpgradeParameters const& Upgrades::getParameters() const
 {
     return mParams;
 }
@@ -324,9 +315,8 @@ Upgrades::createUpgradesFor(LedgerHeader const& lclHeader,
     return result;
 }
 
-void
-Upgrades::applyTo(LedgerUpgrade const& upgrade, Application& app,
-                  AbstractLedgerTxn& ltx)
+void Upgrades::applyTo(LedgerUpgrade const& upgrade, Application& app,
+                       AbstractLedgerTxn& ltx)
 {
     switch (upgrade.type())
     {
@@ -375,8 +365,7 @@ Upgrades::applyTo(LedgerUpgrade const& upgrade, Application& app,
     }
 }
 
-std::string
-Upgrades::toString(LedgerUpgrade const& upgrade)
+std::string Upgrades::toString(LedgerUpgrade const& upgrade)
 {
     switch (upgrade.type())
     {
@@ -405,8 +394,7 @@ Upgrades::toString(LedgerUpgrade const& upgrade)
     }
 }
 
-std::string
-Upgrades::toString() const
+std::string Upgrades::toString() const
 {
     std::stringstream r;
     bool first = true;
@@ -615,9 +603,8 @@ Upgrades::isValidForApply(UpgradeType const& opaqueUpgrade,
     return res ? UpgradeValidity::VALID : UpgradeValidity::INVALID;
 }
 
-bool
-Upgrades::isValidForNomination(LedgerUpgrade const& upgrade,
-                               LedgerSnapshot const& ls) const
+bool Upgrades::isValidForNomination(LedgerUpgrade const& upgrade,
+                                    LedgerSnapshot const& ls) const
 {
     if (!timeForUpgrade(ls.getLedgerHeader().current().scpValue.closeTime))
     {
@@ -661,9 +648,9 @@ Upgrades::isValidForNomination(LedgerUpgrade const& upgrade,
     }
 }
 
-bool
-Upgrades::isValid(UpgradeType const& upgrade, LedgerUpgradeType& upgradeType,
-                  bool nomination, Application& app) const
+bool Upgrades::isValid(UpgradeType const& upgrade,
+                       LedgerUpgradeType& upgradeType, bool nomination,
+                       Application& app) const
 {
     LedgerUpgrade lupgrade;
     auto ls = LedgerSnapshot(app);
@@ -682,14 +669,12 @@ Upgrades::isValid(UpgradeType const& upgrade, LedgerUpgradeType& upgradeType,
     return res;
 }
 
-bool
-Upgrades::timeForUpgrade(uint64_t time) const
+bool Upgrades::timeForUpgrade(uint64_t time) const
 {
     return mParams.mUpgradeTime <= VirtualClock::from_time_t(time);
 }
 
-void
-Upgrades::dropAll(Database& db)
+void Upgrades::dropAll(Database& db)
 {
     db.getRawSession() << "DROP TABLE IF EXISTS upgradehistory";
     db.getRawSession() << "CREATE TABLE upgradehistory ("
@@ -703,8 +688,7 @@ Upgrades::dropAll(Database& db)
         << "CREATE INDEX upgradehistbyseq ON upgradehistory (ledgerseq);";
 }
 
-void
-Upgrades::dropSupportUpgradeHistory(Database& db)
+void Upgrades::dropSupportUpgradeHistory(Database& db)
 {
     db.getRawSession() << "DROP TABLE IF EXISTS upgradehistory";
 }
@@ -729,11 +713,9 @@ addLiabilities(std::map<Asset, std::unique_ptr<int64_t>>& liabilities,
     }
 }
 
-static int64_t
-getAvailableBalanceExcludingLiabilities(AccountID const& accountID,
-                                        Asset const& asset,
-                                        int64_t balanceAboveReserve,
-                                        AbstractLedgerTxn& ltx)
+static int64_t getAvailableBalanceExcludingLiabilities(
+    AccountID const& accountID, Asset const& asset, int64_t balanceAboveReserve,
+    AbstractLedgerTxn& ltx)
 {
     if (asset.type() == ASSET_TYPE_NATIVE)
     {
@@ -758,10 +740,10 @@ getAvailableBalanceExcludingLiabilities(AccountID const& accountID,
     }
 }
 
-static int64_t
-getAvailableLimitExcludingLiabilities(AccountID const& accountID,
-                                      Asset const& asset, int64_t balance,
-                                      AbstractLedgerTxn& ltx)
+static int64_t getAvailableLimitExcludingLiabilities(AccountID const& accountID,
+                                                     Asset const& asset,
+                                                     int64_t balance,
+                                                     AbstractLedgerTxn& ltx)
 {
     if (asset.type() == ASSET_TYPE_NATIVE)
     {
@@ -814,8 +796,7 @@ enum class UpdateOfferResult
     Erase
 };
 
-static UpdateOfferResult
-updateOffer(
+static UpdateOfferResult updateOffer(
     LedgerTxnEntry& offerEntry, int64_t balance, int64_t balanceAboveReserve,
     std::map<Asset, Liabilities>& liabilities,
     std::map<Asset, std::unique_ptr<int64_t>> const& initialBuyingLiabilities,
@@ -891,8 +872,7 @@ updateOffer(
     return res;
 }
 
-static UnorderedMap<AccountID, int64_t>
-getOfferAccountMinBalances(
+static UnorderedMap<AccountID, int64_t> getOfferAccountMinBalances(
     AbstractLedgerTxn& ltx, LedgerTxnHeader const& header,
     std::map<AccountID, std::vector<LedgerTxnEntry>> const& offersByAccount)
 {
@@ -914,12 +894,10 @@ getOfferAccountMinBalances(
     return minBalanceMap;
 }
 
-static void
-eraseOfferWithPossibleSponsorship(AbstractLedgerTxn& ltx,
-                                  LedgerTxnHeader const& header,
-                                  LedgerTxnEntry& offerEntry,
-                                  LedgerTxnEntry& accountEntry,
-                                  UnorderedSet<AccountID>& changedAccounts)
+static void eraseOfferWithPossibleSponsorship(
+    AbstractLedgerTxn& ltx, LedgerTxnHeader const& header,
+    LedgerTxnEntry& offerEntry, LedgerTxnEntry& accountEntry,
+    UnorderedSet<AccountID>& changedAccounts)
 {
     LedgerEntry::_ext_t extension = offerEntry.current().ext;
     bool isSponsored = extension.v() == 1 && extension.v1().sponsoringID;
@@ -956,8 +934,8 @@ eraseOfferWithPossibleSponsorship(AbstractLedgerTxn& ltx,
 // It is essential to note that the excess liabilities are determined only
 // using the initial result of step (1), so it does not matter what order the
 // offers are processed.
-static void
-prepareLiabilities(AbstractLedgerTxn& ltx, LedgerTxnHeader const& header)
+static void prepareLiabilities(AbstractLedgerTxn& ltx,
+                               LedgerTxnHeader const& header)
 {
     CLOG_INFO(Ledger, "Starting prepareLiabilities");
 
@@ -1126,8 +1104,7 @@ prepareLiabilities(AbstractLedgerTxn& ltx, LedgerTxnHeader const& header)
               nUpdatedOffers[UpdateOfferResult::Erase]);
 }
 
-static void
-upgradeFromProtocol15To16(AbstractLedgerTxn& ltx)
+static void upgradeFromProtocol15To16(AbstractLedgerTxn& ltx)
 {
     if (gIsProductionNetwork)
     {
@@ -1171,17 +1148,15 @@ upgradeFromProtocol15To16(AbstractLedgerTxn& ltx)
     }
 }
 
-static bool
-needUpgradeToVersion(ProtocolVersion targetVersion, uint32_t prevVersion,
-                     uint32_t newVersion)
+static bool needUpgradeToVersion(ProtocolVersion targetVersion,
+                                 uint32_t prevVersion, uint32_t newVersion)
 {
     return protocolVersionIsBefore(prevVersion, targetVersion) &&
            protocolVersionStartsFrom(newVersion, targetVersion);
 }
 
-void
-Upgrades::applyVersionUpgrade(Application& app, AbstractLedgerTxn& ltx,
-                              uint32_t newVersion)
+void Upgrades::applyVersionUpgrade(Application& app, AbstractLedgerTxn& ltx,
+                                   uint32_t newVersion)
 {
     uint32_t prevVersion = ltx.loadHeader().current().ledgerVersion;
 
@@ -1251,8 +1226,7 @@ Upgrades::applyVersionUpgrade(Application& app, AbstractLedgerTxn& ltx,
     }
 }
 
-void
-Upgrades::applyReserveUpgrade(AbstractLedgerTxn& ltx, uint32_t newReserve)
+void Upgrades::applyReserveUpgrade(AbstractLedgerTxn& ltx, uint32_t newReserve)
 {
     auto header = ltx.loadHeader();
     bool didReserveIncrease = newReserve > header.current().baseReserve;
@@ -1316,9 +1290,8 @@ ConfigUpgradeSetFrame::ConfigUpgradeSetFrame(
 {
 }
 
-bool
-ConfigUpgradeSetFrame::isValidXDR(ConfigUpgradeSet const& upgradeSetXDR,
-                                  ConfigUpgradeSetKey const& key) const
+bool ConfigUpgradeSetFrame::isValidXDR(ConfigUpgradeSet const& upgradeSetXDR,
+                                       ConfigUpgradeSetKey const& key) const
 {
     if (key.contentHash != sha256(xdr::xdr_to_opaque(upgradeSetXDR)))
     {
@@ -1361,14 +1334,12 @@ ConfigUpgradeSetFrame::isValidXDR(ConfigUpgradeSet const& upgradeSetXDR,
     return true;
 }
 
-ConfigUpgradeSet const&
-ConfigUpgradeSetFrame::toXDR() const
+ConfigUpgradeSet const& ConfigUpgradeSetFrame::toXDR() const
 {
     return mConfigUpgradeSet;
 }
 
-ConfigUpgradeSetKey const&
-ConfigUpgradeSetFrame::getKey() const
+ConfigUpgradeSetKey const& ConfigUpgradeSetFrame::getKey() const
 {
     return mKey;
 }
@@ -1390,8 +1361,7 @@ ConfigUpgradeSetFrame::getLedgerKey(ConfigUpgradeSetKey const& upgradeKey)
     return lk;
 }
 
-bool
-ConfigUpgradeSetFrame::upgradeNeeded(LedgerSnapshot const& ls) const
+bool ConfigUpgradeSetFrame::upgradeNeeded(LedgerSnapshot const& ls) const
 {
     if (protocolVersionIsBefore(ls.getLedgerHeader().current().ledgerVersion,
                                 SOROBAN_PROTOCOL_VERSION))
@@ -1412,8 +1382,8 @@ ConfigUpgradeSetFrame::upgradeNeeded(LedgerSnapshot const& ls) const
     return false;
 }
 
-void
-ConfigUpgradeSetFrame::applyTo(AbstractLedgerTxn& ltx, Application& app) const
+void ConfigUpgradeSetFrame::applyTo(AbstractLedgerTxn& ltx,
+                                    Application& app) const
 {
     bool writeLiveSorobanStateSizeWindow = false;
     bool hasMemorySettingsUpgrade = false;
@@ -1453,8 +1423,7 @@ ConfigUpgradeSetFrame::applyTo(AbstractLedgerTxn& ltx, Application& app) const
     }
 }
 
-bool
-ConfigUpgradeSetFrame::isConsistentWith(
+bool ConfigUpgradeSetFrame::isConsistentWith(
     ConfigUpgradeSetFrameConstPtr const& scheduledUpgrade) const
 {
     if (scheduledUpgrade == nullptr)
@@ -1465,8 +1434,7 @@ ConfigUpgradeSetFrame::isConsistentWith(
     return mKey == scheduledUpgrade->getKey();
 }
 
-Upgrades::UpgradeValidity
-ConfigUpgradeSetFrame::isValidForApply() const
+Upgrades::UpgradeValidity ConfigUpgradeSetFrame::isValidForApply() const
 {
     if (!mValidXDR)
     {
@@ -1484,14 +1452,12 @@ ConfigUpgradeSetFrame::isValidForApply() const
     return Upgrades::UpgradeValidity::VALID;
 }
 
-std::string
-ConfigUpgradeSetFrame::encodeAsString() const
+std::string ConfigUpgradeSetFrame::encodeAsString() const
 {
     return decoder::encode_b64(xdr::xdr_to_opaque(mConfigUpgradeSet));
 }
 
-std::string
-ConfigUpgradeSetFrame::toJson() const
+std::string ConfigUpgradeSetFrame::toJson() const
 {
     std::ostringstream out;
     cereal::JSONOutputArchive ar(out);

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -223,8 +223,8 @@ makeMultiPayment(stellar::TestAccount& destAccount, stellar::TestAccount& src,
     return tx;
 }
 
-static TransactionTestFramePtr
-makeSelfPayment(stellar::TestAccount& account, int nbOps, uint32_t fee)
+static TransactionTestFramePtr makeSelfPayment(stellar::TestAccount& account,
+                                               int nbOps, uint32_t fee)
 {
     std::vector<stellar::Operation> ops;
     for (int i = 0; i < nbOps; i++)
@@ -238,8 +238,7 @@ makeSelfPayment(stellar::TestAccount& account, int nbOps, uint32_t fee)
     return tx;
 }
 
-static void
-testTxSet(uint32 protocolVersion)
+static void testTxSet(uint32 protocolVersion)
 {
     Config cfg(getTestConfig());
     cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE = 15;
@@ -346,17 +345,17 @@ testTxSet(uint32 protocolVersion)
     }
 }
 
-static TransactionTestFramePtr
-transaction(Application& app, TestAccount& account, int64_t sequenceDelta,
-            int64_t amount, uint32_t fee)
+static TransactionTestFramePtr transaction(Application& app,
+                                           TestAccount& account,
+                                           int64_t sequenceDelta,
+                                           int64_t amount, uint32_t fee)
 {
     return transactionFromOperations(
         app, account, account.getLastSequenceNumber() + sequenceDelta,
         {payment(account.getPublicKey(), amount)}, fee);
 }
 
-static void
-testTxSetWithFeeBumps(uint32 protocolVersion)
+static void testTxSetWithFeeBumps(uint32 protocolVersion)
 {
     Config cfg(getTestConfig());
     cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE = 14;
@@ -1890,8 +1889,8 @@ TEST_CASE("generalized tx set applied to ledger", "[herder][txset][soroban]")
     }
 }
 
-static void
-testSCPDriver(uint32 protocolVersion, uint32_t maxTxSetSize, size_t expectedOps)
+static void testSCPDriver(uint32 protocolVersion, uint32_t maxTxSetSize,
+                          size_t expectedOps)
 {
     using SVUpgrades = decltype(StellarValue::upgrades);
 
@@ -3148,7 +3147,6 @@ TEST_CASE("soroban txs each parameter surge priced", "[soroban][herder]")
                                 .txsMaybeDiscountedFee()
                                 .baseFee)
                         {
-
                             baseFee = *phase.v0Components()
                                            .at(0)
                                            .txsMaybeDiscountedFee()
@@ -3679,15 +3677,13 @@ TEST_CASE("soroban txs accepted by the network",
     }
 }
 
-static void
-checkSynced(Application& app)
+static void checkSynced(Application& app)
 {
     REQUIRE(app.getLedgerManager().isSynced());
     REQUIRE(!app.getLedgerApplyManager().maybeGetNextBufferedLedgerToApply());
 }
 
-void
-checkInvariants(Application& app, HerderImpl& herder)
+void checkInvariants(Application& app, HerderImpl& herder)
 {
     auto lcl = app.getLedgerManager().getLastClosedLedgerNum();
     // Either tracking or last tracking must be set
@@ -3695,9 +3691,8 @@ checkInvariants(Application& app, HerderImpl& herder)
     REQUIRE(herder.trackingConsensusLedgerIndex() >= lcl);
 }
 
-static void
-checkHerder(Application& app, HerderImpl& herder, Herder::State expectedState,
-            uint32_t ledger)
+static void checkHerder(Application& app, HerderImpl& herder,
+                        Herder::State expectedState, uint32_t ledger)
 {
     checkInvariants(app, herder);
     REQUIRE(herder.getState() == expectedState);
@@ -4636,9 +4631,10 @@ TEST_CASE("In quorum filtering", "[quorum][herder][acceptance]")
     REQUIRE(!found[0]);
 }
 
-static void
-externalize(SecretKey const& sk, LedgerManager& lm, HerderImpl& herder,
-            std::vector<TransactionFrameBasePtr> const& txs, Application& app)
+static void externalize(SecretKey const& sk, LedgerManager& lm,
+                        HerderImpl& herder,
+                        std::vector<TransactionFrameBasePtr> const& txs,
+                        Application& app)
 {
     auto const& lcl = lm.getLastClosedLedgerHeader();
     auto ledgerSeq = lcl.header.ledgerSeq + 1;
@@ -5163,7 +5159,6 @@ TEST_CASE("do not flood too many transactions with DEX separation",
             auto& source = accs[accountIndex];
             if (isDex)
             {
-
                 Asset asset1(ASSET_TYPE_CREDIT_ALPHANUM4);
                 strToAssetCode(asset1.alphaNum4().assetCode, "USD");
                 Asset asset2(ASSET_TYPE_NATIVE);
@@ -5815,8 +5810,7 @@ TEST_CASE("SCP message capture from previous ledger", "[herder]")
 using Topology = std::pair<std::vector<SecretKey>, std::vector<ValidatorEntry>>;
 
 // Generate a Topology with a single org containing 3 validators of HIGH quality
-static Topology
-simpleThreeNode()
+static Topology simpleThreeNode()
 {
     // Generate validators
     std::vector<SecretKey> sks;
@@ -5838,8 +5832,7 @@ simpleThreeNode()
 
 // Generate a topology with 3 orgs of HIGH quality. Two orgs have 3 validators
 // and one org has 5 validators.
-static Topology
-unbalancedOrgs()
+static Topology unbalancedOrgs()
 {
     // Generate validators
     std::vector<SecretKey> sks;
@@ -5872,8 +5865,7 @@ unbalancedOrgs()
 
 // Generate a tier1-like topology. This topology has 7 HIGH quality orgs, 6 of
 // which have 3 validators and 1 has 5 validators.
-static Topology
-teir1Like()
+static Topology teir1Like()
 {
     std::vector<SecretKey> sks;
     std::vector<ValidatorEntry> validators;
@@ -5900,8 +5892,7 @@ teir1Like()
 }
 
 // Returns a random quality up to `maxQuality`
-static ValidatorQuality
-randomQuality(ValidatorQuality maxQuality)
+static ValidatorQuality randomQuality(ValidatorQuality maxQuality)
 {
     return static_cast<ValidatorQuality>(rand_uniform<int>(
         static_cast<int>(ValidatorQuality::VALIDATOR_LOW_QUALITY),
@@ -5924,8 +5915,7 @@ static int constexpr minOrgSize(ValidatorQuality q)
 
 // Generate a random topology with up to `maxValidators` validators. Ensures at
 // least one org is HIGH quality.
-static Topology
-randomTopology(int maxValidators)
+static Topology randomTopology(int maxValidators)
 {
     int const numValidators = rand_uniform<int>(3, maxValidators);
     int constexpr minCritOrgSize =
@@ -5970,8 +5960,7 @@ randomTopology(int maxValidators)
 // quality of `maxQuality` and or quality counts of `orgQualityCounts`. This
 // function normalizes the weight so that the highest quality has a weight of
 // `1`.
-static double
-expectedOrgNormalizedWeight(
+static double expectedOrgNormalizedWeight(
     std::unordered_map<ValidatorQuality, uint64> const& orgQualityCounts,
     ValidatorQuality maxQuality, ValidatorQuality orgQuality)
 {
@@ -5997,8 +5986,7 @@ expectedOrgNormalizedWeight(
 // `orgQuality`.  `maxQuality` is the maximum quality present in the
 // configuration. This function normalizes the weight so that the highest
 // organization-level quality has a weight of `1`.
-static double
-expectedNormalizedWeight(
+static double expectedNormalizedWeight(
     std::unordered_map<ValidatorQuality, uint64> const& orgQualityCounts,
     ValidatorQuality maxQuality, ValidatorQuality orgQuality, int orgSize)
 {
@@ -6046,8 +6034,7 @@ collectOrgInfo(ValidatorQuality& maxQuality,
 
 // Given a list of validators, test that the weights of the validators herder
 // reports are correct
-static void
-testWeights(std::vector<ValidatorEntry> const& validators)
+static void testWeights(std::vector<ValidatorEntry> const& validators)
 {
     Config cfg = getTestConfig(0);
 
@@ -6124,8 +6111,7 @@ TEST_CASE("getNodeWeight", "[herder]")
     }
 }
 
-static Value
-getRandomValue()
+static Value getRandomValue()
 {
     auto h = sha256(fmt::format("value {}", getGlobalRandomEngine()()));
     return xdr::xdr_to_opaque(h);
@@ -6139,8 +6125,7 @@ class TestNominationProtocol : public NominationProtocol
     {
     }
 
-    std::set<NodeID> const&
-    updateRoundLeadersForTesting(
+    std::set<NodeID> const& updateRoundLeadersForTesting(
         std::optional<Value> const& previousValue = std::nullopt)
     {
         mPreviousValue = previousValue.value_or(getRandomValue());
@@ -6149,8 +6134,7 @@ class TestNominationProtocol : public NominationProtocol
     }
 
     // Detect fast timeouts by examining the final round number
-    bool
-    fastTimedOut() const
+    bool fastTimedOut() const
     {
         return mRoundNumber > 0;
     }
@@ -6159,10 +6143,9 @@ class TestNominationProtocol : public NominationProtocol
 // Test nomination over `numLedgers` slots. After running, check that the win
 // percentages of each node and org are within 5% of the expected win
 // percentages.
-static void
-testWinProbabilities(std::vector<SecretKey> const& sks,
-                     std::vector<ValidatorEntry> const& validators,
-                     int const numLedgers)
+static void testWinProbabilities(std::vector<SecretKey> const& sks,
+                                 std::vector<ValidatorEntry> const& validators,
+                                 int const numLedgers)
 {
     REQUIRE(sks.size() == validators.size());
 
@@ -6305,8 +6288,7 @@ TEST_CASE("Fair nomination win rates", "[herder]")
 // Returns a new `Topology` with the last org in `t` replaced with a new org
 // with 3 validators. Requires that the last org in `t` have 3 validators and be
 // contiguous at the back of the validators vecto.
-static Topology
-replaceOneOrg(Topology const& t)
+static Topology replaceOneOrg(Topology const& t)
 {
     Topology t2(t); // Copy the topology
     auto& [sks, validators] = t2;
@@ -6345,8 +6327,7 @@ replaceOneOrg(Topology const& t)
 
 // Add `orgsToAdd` new orgs to the topology `t`. Each org will have 3
 // validators.
-static Topology
-addOrgs(int orgsToAdd, Topology const& t)
+static Topology addOrgs(int orgsToAdd, Topology const& t)
 {
     Topology t2(t); // Copy the topology
     auto& [sks, validators] = t2;
@@ -6374,9 +6355,8 @@ addOrgs(int orgsToAdd, Topology const& t)
 
 // Returns `true` if the set intersection of `leaders1` and `leaders2` is not
 // empty.
-bool
-leadersIntersect(std::set<NodeID> const& leaders1,
-                 std::set<NodeID> const& leaders2)
+bool leadersIntersect(std::set<NodeID> const& leaders1,
+                      std::set<NodeID> const& leaders2)
 {
     std::vector<NodeID> intersection;
     std::set_intersection(leaders1.begin(), leaders1.end(), leaders2.begin(),
@@ -6387,8 +6367,7 @@ leadersIntersect(std::set<NodeID> const& leaders1,
 // Given two quorum sets consisting of validators in `validators1` and
 // `validators2`, this function returns the probability that the two quorum sets
 // will agree on a leader in the first round of nomination.
-double
-computeExpectedFirstRoundAgreementProbability(
+double computeExpectedFirstRoundAgreementProbability(
     std::vector<ValidatorEntry> const& validators1,
     std::vector<ValidatorEntry> const& validators2)
 {
@@ -6426,9 +6405,8 @@ computeExpectedFirstRoundAgreementProbability(
 // test aims to analyze the worst case scenario where the two sides are fairly
 // balanced and real-world networking conditions are in place (some nodes
 // lagging, etc), such that disagreement always results in a timeout.
-void
-testAsymmetricTimeouts(Topology const& qs1, Topology const& qs2,
-                       int const numLedgers)
+void testAsymmetricTimeouts(Topology const& qs1, Topology const& qs2,
+                            int const numLedgers)
 {
     auto const& [sks1, validators1] = qs1;
     auto const& [sks2, validators2] = qs2;
@@ -6577,9 +6555,8 @@ TEST_CASE("Asymmetric quorum timeouts", "[herder]")
 // Test that the nomination algorithm behaves as expected when a random
 // `numUnresponsive` set of nodes in `qs` are unresponsive.  Runs simulation for
 // `numLedgers` slots.
-void
-testUnresponsiveTimeouts(Topology const& qs, int numUnresponsive,
-                         int const numLedgers)
+void testUnresponsiveTimeouts(Topology const& qs, int numUnresponsive,
+                              int const numLedgers)
 {
     auto const& [sks, validators] = qs;
     REQUIRE(sks.size() == validators.size());
@@ -6835,7 +6812,6 @@ TEST_CASE("trigger next ledger side effects", "[herder][parallel]")
 
 TEST_CASE("detect dead nodes in quorum set", "[herder]")
 {
-
     Hash networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
     Simulation::pointer simulation = Topologies::core(
         3, 0.5, Simulation::OVER_LOOPBACK, networkID,

--- a/src/herder/test/QuorumIntersectionTests.cpp
+++ b/src/herder/test/QuorumIntersectionTests.cpp
@@ -28,8 +28,7 @@ using VQ = xdr::xvector<QS>;
 using VK = xdr::xvector<PublicKey>;
 using std::make_shared;
 
-void
-quorumIntersectionCheckerV2Wrapper(
+void quorumIntersectionCheckerV2Wrapper(
     Application& app, std::shared_ptr<QuorumMapIntersectionState> const& state,
     QuorumTracker::QuorumMap const& qmap, ProcessManager& pm,
     VirtualClock& clock, bool analyzeCriticalGroups, uint32_t timeLimit,
@@ -95,9 +94,8 @@ quorumIntersectionCheckerV2Wrapper(
     }
 }
 
-bool
-networkEnjoysQuorumIntersectionV2Wrapper(QuorumTracker::QuorumMap const& qmap,
-                                         Config const& cfg)
+bool networkEnjoysQuorumIntersectionV2Wrapper(
+    QuorumTracker::QuorumMap const& qmap, Config const& cfg)
 {
     VirtualClock clock;
     Application::pointer app = createTestApplication(clock, cfg);
@@ -483,8 +481,7 @@ TEST_CASE("quorum plausible non intersection", "[herder][quorumintersection]")
     REQUIRE(!networkEnjoysQuorumIntersectionV2Wrapper(qm, cfg));
 }
 
-uint32
-roundUpPct(size_t n, size_t pct)
+uint32 roundUpPct(size_t n, size_t pct)
 {
     return static_cast<uint32>(size_t(1) +
                                (((n * pct) - size_t(1)) / size_t(100)));
@@ -1150,8 +1147,7 @@ TEST_CASE("quorum criticality check interruption v2",
                       QuorumIntersectionChecker::InterruptedException);
 }
 
-static void
-debugQmap(Config const& cfg, QuorumTracker::QuorumMap const& qm)
+static void debugQmap(Config const& cfg, QuorumTracker::QuorumMap const& qm)
 {
     for (auto const& pair : qm)
     {

--- a/src/herder/test/QuorumTrackerTests.cpp
+++ b/src/herder/test/QuorumTrackerTests.cpp
@@ -14,8 +14,7 @@
 
 using namespace stellar;
 
-void
-testQuorumTracker()
+void testQuorumTracker()
 {
     Config cfg(getTestConfig(0, Config::TESTDB_BUCKET_DB_PERSISTENT));
     cfg.MANUAL_CLOSE = false;

--- a/src/herder/test/TestTxSetUtils.cpp
+++ b/src/herder/test/TestTxSetUtils.cpp
@@ -16,9 +16,8 @@ namespace testtxset
 {
 namespace
 {
-TransactionSet
-makeTxSetXDR(std::vector<TransactionFrameBasePtr> const& txs,
-             Hash const& previousLedgerHash)
+TransactionSet makeTxSetXDR(std::vector<TransactionFrameBasePtr> const& txs,
+                            Hash const& previousLedgerHash)
 {
     TransactionSet txSet;
     txSet.previousLedgerHash = previousLedgerHash;
@@ -155,8 +154,7 @@ makeNonValidatedTxSetBasedOnLedgerVersion(
     }
 }
 
-void
-normalizeParallelPhaseXDR(TransactionPhase& phase)
+void normalizeParallelPhaseXDR(TransactionPhase& phase)
 {
     auto compareTxHash = [](TransactionEnvelope const& tx1,
                             TransactionEnvelope const& tx2) -> bool {

--- a/src/herder/test/TransactionQueueTests.cpp
+++ b/src/herder/test/TransactionQueueTests.cpp
@@ -39,9 +39,10 @@ using namespace stellar::txtest;
 
 namespace
 {
-TransactionTestFramePtr
-transaction(Application& app, TestAccount& account, int64_t sequenceDelta,
-            int64_t amount, uint32_t fee, int nbOps = 1, bool isSoroban = false)
+TransactionTestFramePtr transaction(Application& app, TestAccount& account,
+                                    int64_t sequenceDelta, int64_t amount,
+                                    uint32_t fee, int nbOps = 1,
+                                    bool isSoroban = false)
 {
     if (!isSoroban)
     {
@@ -101,24 +102,21 @@ class TransactionQueueTest
     {
     }
 
-    TransactionQueue::AddResult
-    add(TransactionFrameBasePtr const& tx,
-        TransactionQueue::AddResultCode expected)
+    TransactionQueue::AddResult add(TransactionFrameBasePtr const& tx,
+                                    TransactionQueue::AddResultCode expected)
     {
         auto res = mTransactionQueue.tryAdd(tx, false);
         REQUIRE(res.code == expected);
         return res;
     }
 
-    TransactionQueue&
-    getTransactionQueue()
+    TransactionQueue& getTransactionQueue()
     {
         return mTransactionQueue;
     }
 
-    void
-    removeApplied(std::vector<TransactionFrameBasePtr> const& toRemove,
-                  bool noChangeExpected = false)
+    void removeApplied(std::vector<TransactionFrameBasePtr> const& toRemove,
+                       bool noChangeExpected = false)
     {
         auto size = mTransactionQueue.getTransactions({}).size();
         mTransactionQueue.removeApplied(toRemove);
@@ -142,8 +140,7 @@ class TransactionQueueTest
         }
     }
 
-    void
-    ban(std::vector<TransactionFrameBasePtr> const& toRemove)
+    void ban(std::vector<TransactionFrameBasePtr> const& toRemove)
     {
         auto txsBefore = mTransactionQueue.getTransactions({});
         // count the number of transactions from `toRemove` already included
@@ -162,14 +159,12 @@ class TransactionQueueTest
         REQUIRE(txsBefore.size() - inPoolCount >= txsAfter.size());
     }
 
-    void
-    shift()
+    void shift()
     {
         mTransactionQueue.shift();
     }
 
-    void
-    check(const TransactionQueueState& state)
+    void check(const TransactionQueueState& state)
     {
         std::map<AccountID, int64_t> expectedFees;
         for (auto const& accountState : state.mAccountStates)
@@ -522,8 +517,7 @@ TEST_CASE("TransactionQueue complex scenarios", "[herder][transactionqueue]")
     }
 }
 
-void
-testTransactionQueueBasicScenarios()
+void testTransactionQueueBasicScenarios()
 {
     VirtualClock clock;
     auto cfg = getTestConfig();
@@ -1084,8 +1078,7 @@ class SorobanLimitingLaneConfigForTesting : public SurgePricingLaneConfig
         }
     }
 
-    size_t
-    getLane(TransactionFrameBase const& tx) const override
+    size_t getLane(TransactionFrameBase const& tx) const override
     {
         bool limitedLane = tx.getEnvelope().v1().tx.memo.type() == MEMO_TEXT &&
                            tx.getEnvelope().v1().tx.memo.text() == "limit";
@@ -1100,19 +1093,16 @@ class SorobanLimitingLaneConfigForTesting : public SurgePricingLaneConfig
             return SurgePricingPriorityQueue::GENERIC_LANE;
         }
     }
-    std::vector<Resource> const&
-    getLaneLimits() const override
+    std::vector<Resource> const& getLaneLimits() const override
     {
         return mLaneOpsLimits;
     }
-    virtual void
-    updateGenericLaneLimit(Resource const& limit) override
+    virtual void updateGenericLaneLimit(Resource const& limit) override
     {
         mLaneOpsLimits[0] = limit;
     }
-    virtual Resource
-    getTxResources(TransactionFrameBase const& tx,
-                   uint32_t ledgerVersion) override
+    virtual Resource getTxResources(TransactionFrameBase const& tx,
+                                    uint32_t ledgerVersion) override
     {
         releaseAssert(tx.isSoroban());
         return tx.getResources(false, ledgerVersion);

--- a/src/herder/test/TxSetTests.cpp
+++ b/src/herder/test/TxSetTests.cpp
@@ -473,8 +473,7 @@ TEST_CASE("generalized tx set XDR validation", "[txset]")
     }
 }
 
-void
-testGeneralizedTxSetXDRConversion(ProtocolVersion protocolVersion)
+void testGeneralizedTxSetXDRConversion(ProtocolVersion protocolVersion)
 {
     VirtualClock clock;
     auto cfg = getTestConfig();
@@ -1277,7 +1276,6 @@ TEST_CASE("applicable txset validation - Soroban resources", "[txset][soroban]")
             }
             else
             {
-
                 for (int i = 0; i < 8; ++i)
                 {
                     resources.footprint.readOnly.push_back(
@@ -1490,7 +1488,6 @@ TEST_CASE("applicable txset validation - Soroban resources", "[txset][soroban]")
         {
             SECTION("data dependency validation")
             {
-
                 auto buildAndValidate = [&](TxStageFrameList txsPerStage) {
                     auto ledgerHash = app->getLedgerManager()
                                           .getLastClosedLedgerHeader()
@@ -2068,7 +2065,6 @@ TEST_CASE("txset nomination", "[txset]")
                 std::vector<Operation> ops;
                 if (i < dexOpsCount)
                 {
-
                     for (uint32_t j = 1; j <= numOps; ++j)
                     {
                         ops.emplace_back(manageBuyOffer(
@@ -2313,8 +2309,7 @@ TEST_CASE("txset nomination", "[txset]")
 #endif
 }
 
-void
-runParallelTxSetBuildingTest(bool variableStageCount)
+void runParallelTxSetBuildingTest(bool variableStageCount)
 {
     int const STAGE_COUNT = 4;
     int const CLUSTER_COUNT = 8;

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -75,10 +75,9 @@ struct LedgerUpgradeCheck
 
 namespace
 {
-void
-simulateUpgrade(std::vector<LedgerUpgradeNode> const& nodes,
-                std::vector<LedgerUpgradeCheck> const& checks,
-                bool checkUpgradeStatus = false)
+void simulateUpgrade(std::vector<LedgerUpgradeNode> const& nodes,
+                     std::vector<LedgerUpgradeCheck> const& checks,
+                     bool checkUpgradeStatus = false)
 {
     auto networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
     historytestutils::TmpDirHistoryConfigurator configurator{};
@@ -197,48 +196,42 @@ simulateUpgrade(std::vector<LedgerUpgradeNode> const& nodes,
     }
 }
 
-LedgerUpgrade
-makeProtocolVersionUpgrade(int version)
+LedgerUpgrade makeProtocolVersionUpgrade(int version)
 {
     auto result = LedgerUpgrade{LEDGER_UPGRADE_VERSION};
     result.newLedgerVersion() = version;
     return result;
 }
 
-LedgerUpgrade
-makeBaseFeeUpgrade(int baseFee)
+LedgerUpgrade makeBaseFeeUpgrade(int baseFee)
 {
     auto result = LedgerUpgrade{LEDGER_UPGRADE_BASE_FEE};
     result.newBaseFee() = baseFee;
     return result;
 }
 
-LedgerUpgrade
-makeTxCountUpgrade(int txCount)
+LedgerUpgrade makeTxCountUpgrade(int txCount)
 {
     auto result = LedgerUpgrade{LEDGER_UPGRADE_MAX_TX_SET_SIZE};
     result.newMaxTxSetSize() = txCount;
     return result;
 }
 
-LedgerUpgrade
-makeMaxSorobanTxSizeUpgrade(int txSize)
+LedgerUpgrade makeMaxSorobanTxSizeUpgrade(int txSize)
 {
     auto result = LedgerUpgrade{LEDGER_UPGRADE_MAX_SOROBAN_TX_SET_SIZE};
     result.newMaxSorobanTxSetSize() = txSize;
     return result;
 }
 
-LedgerUpgrade
-makeFlagsUpgrade(int flags)
+LedgerUpgrade makeFlagsUpgrade(int flags)
 {
     auto result = LedgerUpgrade{LEDGER_UPGRADE_FLAGS};
     result.newFlags() = flags;
     return result;
 }
 
-ConfigUpgradeSetFrameConstPtr
-makeMaxContractSizeBytesTestUpgrade(
+ConfigUpgradeSetFrameConstPtr makeMaxContractSizeBytesTestUpgrade(
     AbstractLedgerTxn& ltx, uint32_t maxContractSizeBytes,
     bool expiredEntry = false,
     ContractDataDurability type = ContractDataDurability::TEMPORARY)
@@ -270,8 +263,7 @@ makeLiveSorobanStateSizeWindowSampleSizeTestUpgrade(Application& app,
     return makeConfigUpgradeSet(ltx, configUpgradeSet);
 }
 
-LedgerKey
-getMaxContractSizeKey()
+LedgerKey getMaxContractSizeKey()
 {
     LedgerKey maxContractSizeKey(CONFIG_SETTING);
     maxContractSizeKey.configSetting().configSettingID =
@@ -279,8 +271,7 @@ getMaxContractSizeKey()
     return maxContractSizeKey;
 }
 
-LedgerKey
-getliveSorobanStateSizeWindowKey()
+LedgerKey getliveSorobanStateSizeWindowKey()
 {
     LedgerKey windowKey(CONFIG_SETTING);
     windowKey.configSetting().configSettingID =
@@ -288,8 +279,7 @@ getliveSorobanStateSizeWindowKey()
     return windowKey;
 }
 
-LedgerKey
-getParallelComputeSettingsLedgerKey()
+LedgerKey getParallelComputeSettingsLedgerKey()
 {
     LedgerKey maxContractSizeKey(CONFIG_SETTING);
     maxContractSizeKey.configSetting().configSettingID =
@@ -309,9 +299,8 @@ makeParallelComputeUpdgrade(AbstractLedgerTxn& ltx,
     return makeConfigUpgradeSet(ltx, configUpgradeSet);
 }
 
-void
-testListUpgrades(VirtualClock::system_time_point preferredUpgradeDatetime,
-                 bool shouldListAny)
+void testListUpgrades(VirtualClock::system_time_point preferredUpgradeDatetime,
+                      bool shouldListAny)
 {
     auto cfg = getTestConfig();
     cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION = 10;
@@ -396,9 +385,8 @@ testListUpgrades(VirtualClock::system_time_point preferredUpgradeDatetime,
     }
 }
 
-void
-testValidateUpgrades(VirtualClock::system_time_point preferredUpgradeDatetime,
-                     bool canBeValid)
+void testValidateUpgrades(
+    VirtualClock::system_time_point preferredUpgradeDatetime, bool canBeValid)
 {
     auto cfg = getTestConfig(0, Config::TESTDB_IN_MEMORY);
     cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION = 10;
@@ -924,7 +912,6 @@ TEST_CASE("SCP timing config affects consensus behavior", "[upgrades][herder]")
 
     SECTION("ledger close time changes after config upgrade")
     {
-
         // Verify initial ledger close time
         auto initialCloseTime = simulation->getExpectedLedgerCloseTime();
         REQUIRE(initialCloseTime ==

--- a/src/history/CheckpointBuilder.cpp
+++ b/src/history/CheckpointBuilder.cpp
@@ -7,8 +7,7 @@
 
 namespace stellar
 {
-bool
-CheckpointBuilder::ensureOpen(uint32_t ledgerSeq)
+bool CheckpointBuilder::ensureOpen(uint32_t ledgerSeq)
 {
     ZoneScoped;
     releaseAssert(mApp.getHistoryArchiveManager().publishEnabled());
@@ -53,8 +52,7 @@ CheckpointBuilder::ensureOpen(uint32_t ledgerSeq)
     return true;
 }
 
-void
-CheckpointBuilder::checkpointComplete(uint32_t checkpoint)
+void CheckpointBuilder::checkpointComplete(uint32_t checkpoint)
 {
     ZoneScoped;
     releaseAssert(mApp.getHistoryArchiveManager().publishEnabled());
@@ -100,11 +98,9 @@ CheckpointBuilder::CheckpointBuilder(Application& app) : mApp(app)
 {
 }
 
-void
-CheckpointBuilder::appendTransactionSet(uint32_t ledgerSeq,
-                                        TxSetXDRFrameConstPtr const& txSet,
-                                        TransactionResultSet const& resultSet,
-                                        bool skipStartupCheck)
+void CheckpointBuilder::appendTransactionSet(
+    uint32_t ledgerSeq, TxSetXDRFrameConstPtr const& txSet,
+    TransactionResultSet const& resultSet, bool skipStartupCheck)
 {
     ZoneScoped;
     TransactionHistoryEntry txs;
@@ -122,11 +118,9 @@ CheckpointBuilder::appendTransactionSet(uint32_t ledgerSeq,
     appendTransactionSet(ledgerSeq, txs, resultSet);
 }
 
-void
-CheckpointBuilder::appendTransactionSet(uint32_t ledgerSeq,
-                                        TransactionHistoryEntry const& txSet,
-                                        TransactionResultSet const& resultSet,
-                                        bool skipStartupCheck)
+void CheckpointBuilder::appendTransactionSet(
+    uint32_t ledgerSeq, TransactionHistoryEntry const& txSet,
+    TransactionResultSet const& resultSet, bool skipStartupCheck)
 {
     ZoneScoped;
     if (!mStartupValidationComplete &&
@@ -150,9 +144,8 @@ CheckpointBuilder::appendTransactionSet(uint32_t ledgerSeq,
     }
 }
 
-void
-CheckpointBuilder::appendLedgerHeader(LedgerHeader const& header,
-                                      bool skipStartupCheck)
+void CheckpointBuilder::appendLedgerHeader(LedgerHeader const& header,
+                                           bool skipStartupCheck)
 {
     ZoneScoped;
     if (!mStartupValidationComplete &&
@@ -174,26 +167,22 @@ CheckpointBuilder::appendLedgerHeader(LedgerHeader const& header,
     mLedgerHeaders->flush();
 }
 
-uint32_t
-getLedgerSeq(TransactionHistoryEntry const& entry)
+uint32_t getLedgerSeq(TransactionHistoryEntry const& entry)
 {
     return entry.ledgerSeq;
 }
 
-uint32_t
-getLedgerSeq(TransactionHistoryResultEntry const& entry)
+uint32_t getLedgerSeq(TransactionHistoryResultEntry const& entry)
 {
     return entry.ledgerSeq;
 }
 
-uint32_t
-getLedgerSeq(LedgerHeaderHistoryEntry const& entry)
+uint32_t getLedgerSeq(LedgerHeaderHistoryEntry const& entry)
 {
     return entry.header.ledgerSeq;
 }
 
-void
-CheckpointBuilder::cleanup(uint32_t lcl)
+void CheckpointBuilder::cleanup(uint32_t lcl)
 {
     if (mStartupValidationComplete)
     {

--- a/src/history/FileTransferInfo.cpp
+++ b/src/history/FileTransferInfo.cpp
@@ -9,8 +9,7 @@
 namespace stellar
 {
 
-void
-createPath(std::filesystem::path path)
+void createPath(std::filesystem::path path)
 {
     if (fs::exists(path.string()))
     {
@@ -30,8 +29,7 @@ createPath(std::filesystem::path path)
     }
 }
 
-std::string
-FileTransferInfo::getLocalDir(TmpDir const& localRoot) const
+std::string FileTransferInfo::getLocalDir(TmpDir const& localRoot) const
 {
     ZoneScoped;
     auto localDir = localRoot.getName();
@@ -40,8 +38,7 @@ FileTransferInfo::getLocalDir(TmpDir const& localRoot) const
     return localDir;
 }
 
-std::string
-typeString(FileType type)
+std::string typeString(FileType type)
 {
     switch (type)
     {
@@ -58,8 +55,7 @@ typeString(FileType type)
     }
 }
 
-std::filesystem::path
-createPublishDir(FileType type, Config const& cfg)
+std::filesystem::path createPublishDir(FileType type, Config const& cfg)
 {
     std::filesystem::path root = cfg.BUCKET_DIR_PATH;
     auto path = getPublishHistoryDir(type, cfg);
@@ -67,8 +63,7 @@ createPublishDir(FileType type, Config const& cfg)
     return path;
 }
 
-std::filesystem::path
-getPublishHistoryDir(FileType type, Config const& cfg)
+std::filesystem::path getPublishHistoryDir(FileType type, Config const& cfg)
 {
     std::filesystem::path root = cfg.BUCKET_DIR_PATH;
     return root / HISTORY_LOCAL_DIR_NAME / typeString(type);

--- a/src/history/FileTransferInfo.h
+++ b/src/history/FileTransferInfo.h
@@ -71,64 +71,53 @@ class FileTransferInfo
     {
     }
 
-    FileType
-    getType() const
+    FileType getType() const
     {
         return mType;
     }
 
-    std::string
-    getTypeString() const
+    std::string getTypeString() const
     {
         return typeString(mType);
     }
 
-    std::string
-    localPath_nogz() const
+    std::string localPath_nogz() const
     {
         return mLocalPath;
     }
 
-    std::string
-    localPath_nogz_dirty() const
+    std::string localPath_nogz_dirty() const
     {
         return mLocalPath + ".dirty";
     }
 
-    std::string
-    localPath_gz() const
+    std::string localPath_gz() const
     {
         return mLocalPath + ".gz";
     }
-    std::string
-    localPath_gz_tmp() const
+    std::string localPath_gz_tmp() const
     {
         return mLocalPath + ".gz.tmp";
     }
 
-    std::string
-    baseName_nogz() const
+    std::string baseName_nogz() const
     {
         return fs::baseName(getTypeString(), mHexDigits, "xdr");
     }
-    std::string
-    baseName_gz() const
+    std::string baseName_gz() const
     {
         return baseName_nogz() + ".gz";
     }
-    std::string
-    baseName_gz_tmp() const
+    std::string baseName_gz_tmp() const
     {
         return baseName_nogz() + ".gz.tmp";
     }
 
-    std::string
-    remoteDir() const
+    std::string remoteDir() const
     {
         return fs::remoteDir(getTypeString(), mHexDigits);
     }
-    std::string
-    remoteName() const
+    std::string remoteName() const
     {
         return fs::remoteName(getTypeString(), mHexDigits, "xdr.gz");
     }

--- a/src/history/HistoryArchive.cpp
+++ b/src/history/HistoryArchive.cpp
@@ -37,8 +37,8 @@ namespace stellar
 {
 
 template <typename... Tokens>
-std::string
-formatString(std::string const& templateString, Tokens const&... tokens)
+std::string formatString(std::string const& templateString,
+                         Tokens const&... tokens)
 {
     try
     {
@@ -53,8 +53,7 @@ formatString(std::string const& templateString, Tokens const&... tokens)
     }
 }
 
-bool
-HistoryArchiveState::futuresAllResolved() const
+bool HistoryArchiveState::futuresAllResolved() const
 {
     ZoneScoped;
     for (auto const& level : currentBuckets)
@@ -75,8 +74,7 @@ HistoryArchiveState::futuresAllResolved() const
     return true;
 }
 
-bool
-HistoryArchiveState::futuresAllClear() const
+bool HistoryArchiveState::futuresAllClear() const
 {
     return std::all_of(currentBuckets.begin(), currentBuckets.end(),
                        [](auto const& bl) { return bl.next.isClear(); }) &&
@@ -84,8 +82,7 @@ HistoryArchiveState::futuresAllClear() const
                        [](auto const& bl) { return bl.next.isClear(); });
 }
 
-void
-HistoryArchiveState::resolveAllFutures()
+void HistoryArchiveState::resolveAllFutures()
 {
     ZoneScoped;
     for (auto& level : currentBuckets)
@@ -105,8 +102,7 @@ HistoryArchiveState::resolveAllFutures()
     }
 }
 
-void
-HistoryArchiveState::resolveAnyReadyFutures()
+void HistoryArchiveState::resolveAnyReadyFutures()
 {
     ZoneScoped;
     auto resolveMerged = [](auto& buckets) {
@@ -123,8 +119,7 @@ HistoryArchiveState::resolveAnyReadyFutures()
     resolveMerged(hotArchiveBuckets);
 }
 
-void
-HistoryArchiveState::save(std::string const& outFile) const
+void HistoryArchiveState::save(std::string const& outFile) const
 {
     ZoneScoped;
     std::ofstream out;
@@ -134,8 +129,7 @@ HistoryArchiveState::save(std::string const& outFile) const
     serialize(ar);
 }
 
-std::string
-HistoryArchiveState::toString() const
+std::string HistoryArchiveState::toString() const
 {
     ZoneScoped;
     // We serialize-to-a-string any HAS, regardless of resolvedness, as we are
@@ -149,8 +143,7 @@ HistoryArchiveState::toString() const
     return out.str();
 }
 
-void
-HistoryArchiveState::load(std::string const& inFile)
+void HistoryArchiveState::load(std::string const& inFile)
 {
     ZoneScoped;
     std::ifstream in(inFile);
@@ -171,8 +164,7 @@ HistoryArchiveState::load(std::string const& inFile)
     }
 }
 
-void
-HistoryArchiveState::fromString(std::string const& str)
+void HistoryArchiveState::fromString(std::string const& str)
 {
     ZoneScoped;
     std::istringstream in(str);
@@ -180,47 +172,40 @@ HistoryArchiveState::fromString(std::string const& str)
     serialize(ar);
 }
 
-std::string
-HistoryArchiveState::baseName()
+std::string HistoryArchiveState::baseName()
 {
     return std::string("stellar-history.json");
 }
 
-std::string
-HistoryArchiveState::wellKnownRemoteDir()
+std::string HistoryArchiveState::wellKnownRemoteDir()
 {
     // The RFC 5785 dir
     return std::string(".well-known");
 }
 
-std::string
-HistoryArchiveState::wellKnownRemoteName()
+std::string HistoryArchiveState::wellKnownRemoteName()
 {
     return wellKnownRemoteDir() + "/" + baseName();
 }
 
-std::string
-HistoryArchiveState::remoteDir(uint32_t snapshotNumber)
+std::string HistoryArchiveState::remoteDir(uint32_t snapshotNumber)
 {
     return fs::remoteDir("history", fs::hexStr(snapshotNumber));
 }
 
-std::string
-HistoryArchiveState::remoteName(uint32_t snapshotNumber)
+std::string HistoryArchiveState::remoteName(uint32_t snapshotNumber)
 {
     return fs::remoteName("history", fs::hexStr(snapshotNumber), "json");
 }
 
-std::string
-HistoryArchiveState::localName(Application& app,
-                               std::string const& uniquePrefix)
+std::string HistoryArchiveState::localName(Application& app,
+                                           std::string const& uniquePrefix)
 {
     return app.getHistoryManager().localFilename(uniquePrefix + "-" +
                                                  baseName());
 }
 
-Hash
-HistoryArchiveState::getBucketListHash() const
+Hash HistoryArchiveState::getBucketListHash() const
 {
     ZoneScoped;
     // NB: This hash algorithm has to match "what the BucketList does" to
@@ -308,8 +293,7 @@ HistoryArchiveState::differingBuckets(HistoryArchiveState const& other) const
     return BucketHashReturnT(std::move(liveHashes), std::move(hotHashes));
 }
 
-std::vector<std::string>
-HistoryArchiveState::allBuckets() const
+std::vector<std::string> HistoryArchiveState::allBuckets() const
 {
     ZoneScoped;
     std::set<std::string> buckets;
@@ -335,10 +319,9 @@ namespace
 // checking that the bucket list has the correct number of levels, versioning
 // consistency, and future bucket state.
 template <typename HistoryStateBucketT>
-bool
-validateBucketListHelper(Application& app,
-                         std::vector<HistoryStateBucketT> const& buckets,
-                         uint32_t expectedLevels)
+bool validateBucketListHelper(Application& app,
+                              std::vector<HistoryStateBucketT> const& buckets,
+                              uint32_t expectedLevels)
 {
     // Get Bucket version and set nonEmptySeen
     bool nonEmptySeen = false;
@@ -444,8 +427,7 @@ validateBucketListHelper(Application& app,
 }
 }
 
-bool
-HistoryArchiveState::containsValidBuckets(Application& app) const
+bool HistoryArchiveState::containsValidBuckets(Application& app) const
 {
     ZoneScoped;
     if (!validateBucketListHelper(app, currentBuckets,
@@ -464,8 +446,7 @@ HistoryArchiveState::containsValidBuckets(Application& app) const
     return true;
 }
 
-void
-HistoryArchiveState::prepareForPublish(Application& app)
+void HistoryArchiveState::prepareForPublish(Application& app)
 {
     ZoneScoped;
     auto prepareBucketList = [&](auto& buckets, size_t numLevels) {
@@ -591,50 +572,43 @@ HistoryArchive::~HistoryArchive()
 {
 }
 
-bool
-HistoryArchive::hasGetCmd() const
+bool HistoryArchive::hasGetCmd() const
 {
     return !mConfig.mGetCmd.empty();
 }
 
-bool
-HistoryArchive::hasPutCmd() const
+bool HistoryArchive::hasPutCmd() const
 {
     return !mConfig.mPutCmd.empty();
 }
 
-bool
-HistoryArchive::hasMkdirCmd() const
+bool HistoryArchive::hasMkdirCmd() const
 {
     return !mConfig.mMkdirCmd.empty();
 }
 
-std::string const&
-HistoryArchive::getName() const
+std::string const& HistoryArchive::getName() const
 {
     return mConfig.mName;
 }
 
-std::string
-HistoryArchive::getFileCmd(std::string const& remote,
-                           std::string const& local) const
+std::string HistoryArchive::getFileCmd(std::string const& remote,
+                                       std::string const& local) const
 {
     if (mConfig.mGetCmd.empty())
         return "";
     return formatString(mConfig.mGetCmd, remote, local);
 }
 
-std::string
-HistoryArchive::putFileCmd(std::string const& local,
-                           std::string const& remote) const
+std::string HistoryArchive::putFileCmd(std::string const& local,
+                                       std::string const& remote) const
 {
     if (mConfig.mPutCmd.empty())
         return "";
     return formatString(mConfig.mPutCmd, local, remote);
 }
 
-std::string
-HistoryArchive::mkdirCmd(std::string const& remoteDir) const
+std::string HistoryArchive::mkdirCmd(std::string const& remoteDir) const
 {
     if (mConfig.mMkdirCmd.empty())
         return "";

--- a/src/history/HistoryArchive.h
+++ b/src/history/HistoryArchive.h
@@ -43,16 +43,12 @@ template <class BucketT> struct HistoryStateBucket
     FutureBucket<BucketT> next;
     std::string snap;
 
-    template <class Archive>
-    void
-    serialize(Archive& ar) const
+    template <class Archive> void serialize(Archive& ar) const
     {
         ar(CEREAL_NVP(curr), CEREAL_NVP(next), CEREAL_NVP(snap));
     }
 
-    template <class Archive>
-    void
-    serialize(Archive& ar)
+    template <class Archive> void serialize(Archive& ar)
     {
         ar(CEREAL_NVP(curr), CEREAL_NVP(next), CEREAL_NVP(snap));
     }
@@ -133,9 +129,7 @@ struct HistoryArchiveState
     // Return vector of all buckets referenced by this state.
     std::vector<std::string> allBuckets() const;
 
-    template <class Archive>
-    void
-    serialize(Archive& ar)
+    template <class Archive> void serialize(Archive& ar)
     {
         ar(CEREAL_NVP(version), CEREAL_NVP(server), CEREAL_NVP(currentLedger));
         try
@@ -160,9 +154,7 @@ struct HistoryArchiveState
         }
     }
 
-    template <class Archive>
-    void
-    serialize(Archive& ar) const
+    template <class Archive> void serialize(Archive& ar) const
     {
         ar(CEREAL_NVP(version), CEREAL_NVP(server), CEREAL_NVP(currentLedger));
         if (!networkPassphrase.empty())
@@ -207,8 +199,7 @@ struct HistoryArchiveState
     void prepareForPublish(Application& app);
     bool containsValidBuckets(Application& app) const;
 
-    bool
-    hasHotArchiveBuckets() const
+    bool hasHotArchiveBuckets() const
     {
         return version >= HISTORY_ARCHIVE_STATE_VERSION_WITH_HOT_ARCHIVE;
     }

--- a/src/history/HistoryArchiveManager.cpp
+++ b/src/history/HistoryArchiveManager.cpp
@@ -28,8 +28,7 @@ HistoryArchiveManager::HistoryArchiveManager(Application& app) : mApp{app}
             std::make_shared<HistoryArchive>(archiveConfiguration.second));
 }
 
-bool
-HistoryArchiveManager::checkSensibleConfig() const
+bool HistoryArchiveManager::checkSensibleConfig() const
 {
     // Check reasonable-ness of history archive definitions
     std::vector<std::string> readOnlyArchives;
@@ -181,8 +180,7 @@ HistoryArchiveManager::getHistoryArchiveReportWork() const
     return std::make_shared<HistoryArchiveReportWork>(mApp, hasWorks);
 };
 
-std::shared_ptr<BasicWork>
-HistoryArchiveManager::getCheckLedgerHeaderWork(
+std::shared_ptr<BasicWork> HistoryArchiveManager::getCheckLedgerHeaderWork(
     LedgerHeaderHistoryEntry const& lhhe) const
 {
     std::vector<std::shared_ptr<BasicWork>> checkWorks;
@@ -196,8 +194,8 @@ HistoryArchiveManager::getCheckLedgerHeaderWork(
                                           /*stopOnFirstFailure=*/false);
 }
 
-bool
-HistoryArchiveManager::initializeHistoryArchive(std::string const& arch) const
+bool HistoryArchiveManager::initializeHistoryArchive(
+    std::string const& arch) const
 {
     auto archive = getHistoryArchive(arch);
     if (!archive)
@@ -238,8 +236,7 @@ HistoryArchiveManager::initializeHistoryArchive(std::string const& arch) const
     }
 }
 
-bool
-HistoryArchiveManager::publishEnabled() const
+bool HistoryArchiveManager::publishEnabled() const
 {
     return std::any_of(std::begin(mArchives), std::end(mArchives),
                        [](std::shared_ptr<HistoryArchive> const& x) {

--- a/src/history/HistoryArchiveReportWork.cpp
+++ b/src/history/HistoryArchiveReportWork.cpp
@@ -25,8 +25,7 @@ HistoryArchiveReportWork::HistoryArchiveReportWork(
 {
 }
 
-void
-HistoryArchiveReportWork::onSuccess()
+void HistoryArchiveReportWork::onSuccess()
 {
     for (auto const& work : mGetHistoryArchiveStateWorks)
     {
@@ -40,8 +39,7 @@ HistoryArchiveReportWork::onSuccess()
     }
 }
 
-void
-HistoryArchiveReportWork::onFailureRaise()
+void HistoryArchiveReportWork::onFailureRaise()
 {
     for (auto const& work : mGetHistoryArchiveStateWorks)
     {

--- a/src/history/HistoryManager.h
+++ b/src/history/HistoryManager.h
@@ -220,8 +220,8 @@ class HistoryManager
     // Return checkpoint that contains given ledger. Checkpoint is identified
     // by last ledger in range. This does not consult the network nor take
     // account of manual checkpoints.
-    static uint32_t
-    checkpointContainingLedger(uint32_t ledger, Config const& cfg)
+    static uint32_t checkpointContainingLedger(uint32_t ledger,
+                                               Config const& cfg)
     {
         uint32_t freq = getCheckpointFrequency(cfg);
         // Round-up to next multiple of freq, then subtract 1 since checkpoints
@@ -233,27 +233,25 @@ class HistoryManager
     // Return true iff closing `ledger` should cause publishing a checkpoint.
     // Equivalent to `ledger == checkpointContainingLedger(ledger)` but a little
     // more obviously named.
-    static bool
-    publishCheckpointOnLedgerClose(uint32_t ledger, Config const& cfg)
+    static bool publishCheckpointOnLedgerClose(uint32_t ledger,
+                                               Config const& cfg)
     {
         return checkpointContainingLedger(ledger, cfg) == ledger;
     }
 
-    static bool
-    isFirstLedgerInCheckpoint(uint32_t ledger, Config const& cfg)
+    static bool isFirstLedgerInCheckpoint(uint32_t ledger, Config const& cfg)
     {
         return firstLedgerInCheckpointContaining(ledger, cfg) == ledger;
     }
 
-    static bool
-    isLastLedgerInCheckpoint(uint32_t ledger, Config const& cfg)
+    static bool isLastLedgerInCheckpoint(uint32_t ledger, Config const& cfg)
     {
         return checkpointContainingLedger(ledger, cfg) == ledger;
     }
 
     // Return the number of ledgers in the checkpoint containing a given ledger.
-    static uint32_t
-    sizeOfCheckpointContaining(uint32_t ledger, Config const& cfg)
+    static uint32_t sizeOfCheckpointContaining(uint32_t ledger,
+                                               Config const& cfg)
     {
         uint32_t freq = getCheckpointFrequency(cfg);
         if (ledger < freq)
@@ -264,8 +262,8 @@ class HistoryManager
     }
 
     // Return the first ledger in the checkpoint containing a given ledger.
-    static uint32_t
-    firstLedgerInCheckpointContaining(uint32_t ledger, Config const& cfg)
+    static uint32_t firstLedgerInCheckpointContaining(uint32_t ledger,
+                                                      Config const& cfg)
     {
         uint32_t last =
             checkpointContainingLedger(ledger, cfg); // == 63, 127, 191
@@ -275,8 +273,8 @@ class HistoryManager
     }
 
     // Return the first ledger after the checkpoint containing a given ledger.
-    static uint32_t
-    firstLedgerAfterCheckpointContaining(uint32_t ledger, Config const& cfg)
+    static uint32_t firstLedgerAfterCheckpointContaining(uint32_t ledger,
+                                                         Config const& cfg)
     {
         uint32_t first =
             firstLedgerInCheckpointContaining(ledger, cfg); // == 1, 64, 128
@@ -287,8 +285,8 @@ class HistoryManager
 
     // Return the last ledger before the checkpoint containing a given ledger,
     // or zero if `ledger` is contained inside the first checkpoint.
-    static uint32_t
-    lastLedgerBeforeCheckpointContaining(uint32_t ledger, Config const& cfg)
+    static uint32_t lastLedgerBeforeCheckpointContaining(uint32_t ledger,
+                                                         Config const& cfg)
     {
         uint32_t last =
             checkpointContainingLedger(ledger, cfg); // == 63, 127, 191

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -55,42 +55,36 @@ static std::string kSQLCreateStatement =
     "state    TEXT"
     "); ";
 
-void
-HistoryManager::dropAll(Database& db)
+void HistoryManager::dropAll(Database& db)
 {
     db.getRawSession() << "DROP TABLE IF EXISTS publishqueue;";
     soci::statement st = db.getRawSession().prepare << kSQLCreateStatement;
     st.execute(true);
 }
 
-std::filesystem::path
-HistoryManager::publishQueuePath(Config const& cfg)
+std::filesystem::path HistoryManager::publishQueuePath(Config const& cfg)
 {
     std::filesystem::path b = cfg.BUCKET_DIR_PATH;
     return b / "publishqueue";
 }
 
-void
-HistoryManager::createPublishQueueDir(Config const& cfg)
+void HistoryManager::createPublishQueueDir(Config const& cfg)
 {
     fs::mkpath(HistoryManager::publishQueuePath(cfg).string());
 }
 
-std::filesystem::path
-publishQueueFileName(uint32_t seq)
+std::filesystem::path publishQueueFileName(uint32_t seq)
 {
     return fs::hexStr(seq) + ".checkpoint";
 }
 
-std::filesystem::path
-publishQueueTmpFileName(uint32_t seq)
+std::filesystem::path publishQueueTmpFileName(uint32_t seq)
 {
     return fs::hexStr(seq) + ".checkpoint.dirty";
 }
 
-void
-writeCheckpointFile(Application& app, HistoryArchiveState const& has,
-                    bool finalize)
+void writeCheckpointFile(Application& app, HistoryArchiveState const& has,
+                         bool finalize)
 {
     releaseAssert(HistoryManager::isLastLedgerInCheckpoint(has.currentLedger,
                                                            app.getConfig()));
@@ -134,8 +128,7 @@ writeCheckpointFile(Application& app, HistoryArchiveState const& has,
     }
 }
 
-void
-HistoryManagerImpl::dropSQLBasedPublish()
+void HistoryManagerImpl::dropSQLBasedPublish()
 {
     if (!mApp.getHistoryArchiveManager().publishEnabled())
     {
@@ -216,8 +209,7 @@ HistoryManagerImpl::dropSQLBasedPublish()
     dropSupportTxSetHistory(db);
 }
 
-std::unique_ptr<HistoryManager>
-HistoryManager::create(Application& app)
+std::unique_ptr<HistoryManager> HistoryManager::create(Application& app)
 {
     return std::make_unique<HistoryManagerImpl>(app);
 }
@@ -240,8 +232,7 @@ HistoryManagerImpl::~HistoryManagerImpl()
 {
 }
 
-uint32_t
-HistoryManager::getCheckpointFrequency(Config const& cfg)
+uint32_t HistoryManager::getCheckpointFrequency(Config const& cfg)
 {
     if (cfg.ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING)
     {
@@ -253,8 +244,7 @@ HistoryManager::getCheckpointFrequency(Config const& cfg)
     }
 }
 
-void
-HistoryManagerImpl::logAndUpdatePublishStatus()
+void HistoryManagerImpl::logAndUpdatePublishStatus()
 {
     std::stringstream stateStr;
     if (mPublishWork)
@@ -282,31 +272,27 @@ HistoryManagerImpl::logAndUpdatePublishStatus()
     }
 }
 
-bool
-isPublishFile(std::string const& name)
+bool isPublishFile(std::string const& name)
 {
     std::regex re("^[a-z0-9]{8}\\.checkpoint$");
     auto a = regex_match(name, re);
     return a;
 }
 
-bool
-isPublishTmpFile(std::string const& name)
+bool isPublishTmpFile(std::string const& name)
 {
     std::regex re("^[a-z0-9]{8}\\.checkpoint.dirty$");
     auto a = regex_match(name, re);
     return a;
 }
 
-std::vector<std::string>
-findPublishFiles(std::string const& dir)
+std::vector<std::string> findPublishFiles(std::string const& dir)
 {
     return fs::findfiles(dir, isPublishFile);
 }
 
-void
-iterateOverCheckpoints(std::vector<std::string> const& files,
-                       std::function<void(uint32_t, std::string const&)> f)
+void iterateOverCheckpoints(std::vector<std::string> const& files,
+                            std::function<void(uint32_t, std::string const&)> f)
 {
     for (auto const& file : files)
     {
@@ -315,29 +301,25 @@ iterateOverCheckpoints(std::vector<std::string> const& files,
     }
 }
 
-void
-forEveryQueuedCheckpoint(std::string const& dir,
-                         std::function<void(uint32_t, std::string const&)> f)
+void forEveryQueuedCheckpoint(
+    std::string const& dir, std::function<void(uint32_t, std::string const&)> f)
 {
     iterateOverCheckpoints(findPublishFiles(dir), f);
 }
 
-void
-forEveryTmpCheckpoint(std::string const& dir,
-                      std::function<void(uint32_t, std::string const&)> f)
+void forEveryTmpCheckpoint(std::string const& dir,
+                           std::function<void(uint32_t, std::string const&)> f)
 {
     iterateOverCheckpoints(fs::findfiles(dir, isPublishTmpFile), f);
 }
 
-size_t
-HistoryManager::publishQueueLength(Config const& cfg)
+size_t HistoryManager::publishQueueLength(Config const& cfg)
 {
     ZoneScoped;
     return findPublishFiles(publishQueuePath(cfg).string()).size();
 }
 
-string const&
-HistoryManagerImpl::getTmpDir()
+string const& HistoryManagerImpl::getTmpDir()
 {
     ZoneScoped;
     if (!mWorkDir)
@@ -348,14 +330,12 @@ HistoryManagerImpl::getTmpDir()
     return mWorkDir->getName();
 }
 
-std::string
-HistoryManagerImpl::localFilename(std::string const& basename)
+std::string HistoryManagerImpl::localFilename(std::string const& basename)
 {
     return this->getTmpDir() + "/" + basename;
 }
 
-uint32_t
-HistoryManager::getMinLedgerQueuedToPublish(Config const& cfg)
+uint32_t HistoryManager::getMinLedgerQueuedToPublish(Config const& cfg)
 {
     ZoneScoped;
     auto min = std::numeric_limits<uint32_t>::max();
@@ -365,8 +345,7 @@ HistoryManager::getMinLedgerQueuedToPublish(Config const& cfg)
     return min == std::numeric_limits<uint32_t>::max() ? 0 : min;
 }
 
-uint32_t
-HistoryManager::getMaxLedgerQueuedToPublish(Config const& cfg)
+uint32_t HistoryManager::getMaxLedgerQueuedToPublish(Config const& cfg)
 {
     ZoneScoped;
     uint32_t max = 0;
@@ -376,9 +355,8 @@ HistoryManager::getMaxLedgerQueuedToPublish(Config const& cfg)
     return max;
 }
 
-bool
-HistoryManagerImpl::maybeQueueHistoryCheckpoint(uint32_t lcl,
-                                                uint32_t ledgerVers)
+bool HistoryManagerImpl::maybeQueueHistoryCheckpoint(uint32_t lcl,
+                                                     uint32_t ledgerVers)
 {
     if (!publishCheckpointOnLedgerClose(lcl, mApp.getConfig()))
     {
@@ -396,8 +374,8 @@ HistoryManagerImpl::maybeQueueHistoryCheckpoint(uint32_t lcl,
     return true;
 }
 
-void
-HistoryManagerImpl::queueCurrentHistory(uint32_t ledger, uint32_t ledgerVers)
+void HistoryManagerImpl::queueCurrentHistory(uint32_t ledger,
+                                             uint32_t ledgerVers)
 {
     ZoneScoped;
 
@@ -437,8 +415,7 @@ HistoryManagerImpl::queueCurrentHistory(uint32_t ledger, uint32_t ledgerVers)
     mPublishQueued++;
 }
 
-void
-HistoryManagerImpl::takeSnapshotAndPublish(HistoryArchiveState const& has)
+void HistoryManagerImpl::takeSnapshotAndPublish(HistoryArchiveState const& has)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -491,8 +468,7 @@ HistoryManagerImpl::takeSnapshotAndPublish(HistoryArchiveState const& has)
         "delay-publishing-to-archive", delayTimeout, publishWork);
 }
 
-HistoryArchiveState
-loadCheckpointHAS(std::string const& filename)
+HistoryArchiveState loadCheckpointHAS(std::string const& filename)
 {
     HistoryArchiveState has;
     std::ifstream in(filename, std::ios::binary);
@@ -507,8 +483,7 @@ loadCheckpointHAS(std::string const& filename)
     return has;
 }
 
-size_t
-HistoryManagerImpl::publishQueuedHistory()
+size_t HistoryManagerImpl::publishQueuedHistory()
 {
     if (mApp.isStopping())
     {
@@ -536,8 +511,7 @@ HistoryManagerImpl::publishQueuedHistory()
     return 1;
 }
 
-void
-HistoryManagerImpl::maybeCheckpointComplete(uint32_t lcl)
+void HistoryManagerImpl::maybeCheckpointComplete(uint32_t lcl)
 {
     if (!publishCheckpointOnLedgerClose(lcl, mApp.getConfig()) ||
         !mApp.getHistoryArchiveManager().publishEnabled())
@@ -613,8 +587,7 @@ HistoryManagerImpl::getMissingBucketsReferencedByPublishQueue()
     return std::vector<std::string>(buckets.begin(), buckets.end());
 }
 
-void
-HistoryManager::deletePublishedFiles(uint32_t ledgerSeq, Config const& cfg)
+void HistoryManager::deletePublishedFiles(uint32_t ledgerSeq, Config const& cfg)
 {
     releaseAssert(HistoryManager::isLastLedgerInCheckpoint(ledgerSeq, cfg));
 
@@ -673,8 +646,7 @@ HistoryManager::deletePublishedFiles(uint32_t ledgerSeq, Config const& cfg)
     }
 }
 
-void
-HistoryManagerImpl::historyPublished(
+void HistoryManagerImpl::historyPublished(
     uint32_t ledgerSeq, std::vector<std::string> const& originalBuckets,
     bool success)
 {
@@ -705,10 +677,9 @@ HistoryManagerImpl::historyPublished(
                           "HistoryManagerImpl: publishQueuedHistory");
 }
 
-void
-HistoryManagerImpl::appendTransactionSet(uint32_t ledgerSeq,
-                                         TxSetXDRFrameConstPtr const& txSet,
-                                         TransactionResultSet const& resultSet)
+void HistoryManagerImpl::appendTransactionSet(
+    uint32_t ledgerSeq, TxSetXDRFrameConstPtr const& txSet,
+    TransactionResultSet const& resultSet)
 {
     if (mApp.getHistoryArchiveManager().publishEnabled())
     {
@@ -716,8 +687,7 @@ HistoryManagerImpl::appendTransactionSet(uint32_t ledgerSeq,
     }
 }
 
-void
-HistoryManagerImpl::appendLedgerHeader(LedgerHeader const& header)
+void HistoryManagerImpl::appendLedgerHeader(LedgerHeader const& header)
 {
     if (mApp.getHistoryArchiveManager().publishEnabled())
     {
@@ -731,8 +701,7 @@ HistoryManagerImpl::appendLedgerHeader(LedgerHeader const& header)
     }
 }
 
-void
-HistoryManagerImpl::restoreCheckpoint(uint32_t lcl)
+void HistoryManagerImpl::restoreCheckpoint(uint32_t lcl)
 {
     if (mApp.getHistoryArchiveManager().publishEnabled())
     {
@@ -778,27 +747,23 @@ HistoryManagerImpl::restoreCheckpoint(uint32_t lcl)
     }
 }
 
-uint64_t
-HistoryManagerImpl::getPublishQueueCount() const
+uint64_t HistoryManagerImpl::getPublishQueueCount() const
 {
     return mPublishQueued;
 }
 
-uint64_t
-HistoryManagerImpl::getPublishSuccessCount() const
+uint64_t HistoryManagerImpl::getPublishSuccessCount() const
 {
     return mPublishSuccess.count();
 }
 
-uint64_t
-HistoryManagerImpl::getPublishFailureCount() const
+uint64_t HistoryManagerImpl::getPublishFailureCount() const
 {
     return mPublishFailure.count();
 }
 
 #ifdef BUILD_TESTS
-void
-HistoryManagerImpl::setPublicationEnabled(bool enabled)
+void HistoryManagerImpl::setPublicationEnabled(bool enabled)
 {
     CLOG_INFO(History, "{} history publication",
               (enabled ? "Enabling" : "Disabling"));
@@ -806,8 +771,7 @@ HistoryManagerImpl::setPublicationEnabled(bool enabled)
 }
 #endif
 
-void
-HistoryManagerImpl::waitForCheckpointPublish()
+void HistoryManagerImpl::waitForCheckpointPublish()
 {
     // This may only be used for the load testing (apply-load specifically, but
     // we don't have a separate flag for that).
@@ -821,8 +785,7 @@ HistoryManagerImpl::waitForCheckpointPublish()
     }
 }
 
-Config const&
-HistoryManagerImpl::getConfig() const
+Config const& HistoryManagerImpl::getConfig() const
 {
     return mApp.getConfig();
 }

--- a/src/history/HistoryManagerImpl.h
+++ b/src/history/HistoryManagerImpl.h
@@ -85,8 +85,7 @@ class HistoryManagerImpl : public HistoryManager
     void setPublicationEnabled(bool enabled) override;
     // Throw after inseting ledger `n` into a checkpoint
     uint32_t mThrowOnAppend{0};
-    CheckpointBuilder&
-    getCheckpointBuilder()
+    CheckpointBuilder& getCheckpointBuilder()
     {
         return mCheckpointBuilder;
     }

--- a/src/history/HistoryUtils.cpp
+++ b/src/history/HistoryUtils.cpp
@@ -12,10 +12,9 @@ namespace stellar
 {
 
 template <typename T>
-bool
-getHistoryEntryForLedger(XDRInputFileStream& stream, T& currentEntry,
-                         uint32_t targetLedger,
-                         std::function<void(uint32_t ledgerSeq)> validateFn)
+bool getHistoryEntryForLedger(
+    XDRInputFileStream& stream, T& currentEntry, uint32_t targetLedger,
+    std::function<void(uint32_t ledgerSeq)> validateFn)
 {
     ZoneScoped;
 

--- a/src/history/StateSnapshot.cpp
+++ b/src/history/StateSnapshot.cpp
@@ -50,8 +50,7 @@ StateSnapshot::StateSnapshot(Application& app, HistoryArchiveState const& state)
     }
 }
 
-bool
-StateSnapshot::writeSCPMessages() const
+bool StateSnapshot::writeSCPMessages() const
 {
     ZoneScoped;
     std::unique_ptr<soci::session> snapSess(

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -617,8 +617,8 @@ TEST_CASE("History publish", "[history][publish]")
     catchupSimulation.ensureOfflineCatchupPossible(checkpointLedger);
 }
 
-void
-validateCheckpointFiles(Application& app, uint32_t ledger, bool isFinalized)
+void validateCheckpointFiles(Application& app, uint32_t ledger,
+                             bool isFinalized)
 {
     auto const& cfg = app.getConfig();
     auto validateHdr = [](std::string path, uint32_t ledger) {
@@ -874,8 +874,7 @@ TEST_CASE("Publish works correctly post shadow removal", "[history]")
     }
 }
 
-static std::string
-resumeModeName(uint32_t count)
+static std::string resumeModeName(uint32_t count)
 {
     switch (count)
     {
@@ -888,8 +887,7 @@ resumeModeName(uint32_t count)
     }
 }
 
-static std::string
-dbModeName(Config::TestDbMode mode)
+static std::string dbModeName(Config::TestDbMode mode)
 {
     switch (mode)
     {

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -39,8 +39,7 @@ namespace historytestutils
 
 namespace
 {
-void
-setConfigForArchival(Config& cfg)
+void setConfigForArchival(Config& cfg)
 {
     // Evict very aggressively, but only 1 entry at a time so that Hot
     // Archive Buckets churn
@@ -52,8 +51,7 @@ setConfigForArchival(Config& cfg)
 }
 }
 
-std::string
-HistoryConfigurator::getArchiveDirName() const
+std::string HistoryConfigurator::getArchiveDirName() const
 {
     return "";
 }
@@ -63,14 +61,12 @@ TmpDirHistoryConfigurator::TmpDirHistoryConfigurator()
 {
 }
 
-std::string
-TmpDirHistoryConfigurator::getArchiveDirName() const
+std::string TmpDirHistoryConfigurator::getArchiveDirName() const
 {
     return mName;
 }
 
-Config&
-TmpDirHistoryConfigurator::configure(Config& cfg, bool writable) const
+Config& TmpDirHistoryConfigurator::configure(Config& cfg, bool writable) const
 {
     std::string d = getArchiveDirName();
     std::string getCmd = "cp " + d + "/{0} {1}";
@@ -99,8 +95,8 @@ MultiArchiveHistoryConfigurator::MultiArchiveHistoryConfigurator(
     }
 }
 
-Config&
-MultiArchiveHistoryConfigurator::configure(Config& cfg, bool writable) const
+Config& MultiArchiveHistoryConfigurator::configure(Config& cfg,
+                                                   bool writable) const
 {
     for (auto const& conf : mConfigurators)
     {
@@ -110,8 +106,7 @@ MultiArchiveHistoryConfigurator::configure(Config& cfg, bool writable) const
     return cfg;
 }
 
-Config&
-S3HistoryConfigurator::configure(Config& mCfg, bool writable) const
+Config& S3HistoryConfigurator::configure(Config& mCfg, bool writable) const
 {
     char const* s3bucket = getenv("S3BUCKET");
     if (!s3bucket)
@@ -135,9 +130,8 @@ S3HistoryConfigurator::configure(Config& mCfg, bool writable) const
     return mCfg;
 }
 
-Config&
-RealGenesisTmpDirHistoryConfigurator::configure(Config& mCfg,
-                                                bool writable) const
+Config& RealGenesisTmpDirHistoryConfigurator::configure(Config& mCfg,
+                                                        bool writable) const
 {
     TmpDirHistoryConfigurator::configure(mCfg, writable);
     mCfg.USE_CONFIG_FOR_GENESIS = false;
@@ -200,8 +194,7 @@ TestBucketGenerator::TestBucketGenerator(
 }
 
 template <typename BucketT>
-std::string
-TestBucketGenerator::generateBucket(TestBucketState state)
+std::string TestBucketGenerator::generateBucket(TestBucketState state)
 {
     BUCKET_TYPE_ASSERT(BucketT);
 
@@ -267,8 +260,7 @@ TestLedgerChainGenerator::TestLedgerChainGenerator(
 {
 }
 
-void
-TestLedgerChainGenerator::createHistoryFiles(
+void TestLedgerChainGenerator::createHistoryFiles(
     std::vector<LedgerHeaderHistoryEntry> const& lhv,
     LedgerHeaderHistoryEntry& first, LedgerHeaderHistoryEntry& last,
     uint32_t checkpoint)
@@ -370,8 +362,7 @@ CatchupPerformedWork::CatchupPerformedWork(
 {
 }
 
-bool
-operator==(CatchupPerformedWork const& x, CatchupPerformedWork const& y)
+bool operator==(CatchupPerformedWork const& x, CatchupPerformedWork const& y)
 {
     if (x.mHistoryArchiveStatesDownloaded != y.mHistoryArchiveStatesDownloaded)
     {
@@ -408,8 +399,7 @@ operator==(CatchupPerformedWork const& x, CatchupPerformedWork const& y)
     return true;
 }
 
-bool
-operator!=(CatchupPerformedWork const& x, CatchupPerformedWork const& y)
+bool operator!=(CatchupPerformedWork const& x, CatchupPerformedWork const& y)
 {
     return !(x == y);
 }
@@ -452,8 +442,7 @@ CatchupSimulation::getLastCheckpointLedger(uint32_t checkpointIndex) const
            1;
 }
 
-void
-CatchupSimulation::generateRandomLedger(uint32_t version)
+void CatchupSimulation::generateRandomLedger(uint32_t version)
 {
     uint32_t const setupLedgers = 4;
     auto& lm = getApp().getLedgerManager();
@@ -642,18 +631,16 @@ CatchupSimulation::generateRandomLedger(uint32_t version)
     stroopySeqs.push_back(stroopy.loadSequenceNumber());
 }
 
-void
-CatchupSimulation::setUpgradeLedger(uint32_t ledger,
-                                    ProtocolVersion upgradeProtocolVersion)
+void CatchupSimulation::setUpgradeLedger(uint32_t ledger,
+                                         ProtocolVersion upgradeProtocolVersion)
 {
     REQUIRE(getApp().getLedgerManager().getLastClosedLedgerNum() < ledger);
     mUpgradeLedgerSeq = ledger;
     mUpgradeProtocolVersion = upgradeProtocolVersion;
 }
 
-void
-CatchupSimulation::ensureLedgerAvailable(uint32_t targetLedger,
-                                         std::optional<uint32_t> restartLedger)
+void CatchupSimulation::ensureLedgerAvailable(
+    uint32_t targetLedger, std::optional<uint32_t> restartLedger)
 {
     while (getApp().getLedgerManager().getLastClosedLedgerNum() < targetLedger)
     {
@@ -701,8 +688,7 @@ CatchupSimulation::ensureLedgerAvailable(uint32_t targetLedger,
     }
 }
 
-void
-CatchupSimulation::ensurePublishesComplete()
+void CatchupSimulation::ensurePublishesComplete()
 {
     auto& hm = getApp().getHistoryManager();
     auto const& cfg = getApp().getConfig();
@@ -741,8 +727,7 @@ CatchupSimulation::ensurePublishesComplete()
     }
 }
 
-void
-CatchupSimulation::ensureOfflineCatchupPossible(
+void CatchupSimulation::ensureOfflineCatchupPossible(
     uint32_t targetLedger, std::optional<uint32_t> restartLedger)
 {
     // One additional ledger is needed for publish.
@@ -753,9 +738,8 @@ CatchupSimulation::ensureOfflineCatchupPossible(
     ensurePublishesComplete();
 }
 
-void
-CatchupSimulation::ensureOnlineCatchupPossible(uint32_t targetLedger,
-                                               uint32_t bufferLedgers)
+void CatchupSimulation::ensureOnlineCatchupPossible(uint32_t targetLedger,
+                                                    uint32_t bufferLedgers)
 {
     // One additional ledger is needed for publish, one as a trigger ledger for
     // catchup, one as closing ledger.
@@ -787,8 +771,7 @@ CatchupSimulation::getAllPublishedCheckpoints() const
     return res;
 }
 
-LedgerNumHashPair
-CatchupSimulation::getLastPublishedCheckpoint() const
+LedgerNumHashPair CatchupSimulation::getLastPublishedCheckpoint() const
 {
     LedgerNumHashPair pair;
     assert(mLedgerHashes.size() == mLedgerSeqs.size());
@@ -808,8 +791,7 @@ CatchupSimulation::getLastPublishedCheckpoint() const
     return pair;
 }
 
-Application::pointer
-CatchupSimulation::createCatchupApplication(
+Application::pointer CatchupSimulation::createCatchupApplication(
     uint32_t count, Config::TestDbMode dbMode, std::string const& appName,
     bool publish, std::optional<uint32_t> ledgerVersion, bool skipKnownResults)
 {
@@ -837,9 +819,8 @@ CatchupSimulation::createCatchupApplication(
     return newApp;
 }
 
-bool
-CatchupSimulation::catchupOffline(Application::pointer app, uint32_t toLedger,
-                                  bool extraValidation)
+bool CatchupSimulation::catchupOffline(Application::pointer app,
+                                       uint32_t toLedger, bool extraValidation)
 {
     CLOG_INFO(History, "starting offline catchup with toLedger={}", toLedger);
 
@@ -887,11 +868,10 @@ CatchupSimulation::catchupOffline(Application::pointer app, uint32_t toLedger,
     return success;
 }
 
-bool
-CatchupSimulation::catchupOnline(Application::pointer app, uint32_t initLedger,
-                                 uint32_t bufferLedgers, uint32_t gapLedger,
-                                 int32_t numGapLedgers,
-                                 std::vector<uint32_t> const& ledgersToInject)
+bool CatchupSimulation::catchupOnline(
+    Application::pointer app, uint32_t initLedger, uint32_t bufferLedgers,
+    uint32_t gapLedger, int32_t numGapLedgers,
+    std::vector<uint32_t> const& ledgersToInject)
 {
     auto& lm = app->getLedgerManager();
     auto startCatchupMetrics = app->getLedgerApplyManager().getCatchupMetrics();
@@ -1003,8 +983,7 @@ CatchupSimulation::catchupOnline(Application::pointer app, uint32_t initLedger,
     return result;
 }
 
-void
-CatchupSimulation::externalizeLedger(HerderImpl& herder, uint32_t ledger)
+void CatchupSimulation::externalizeLedger(HerderImpl& herder, uint32_t ledger)
 {
     // Remember the vectors count from 2, not 0.
     if (ledger - 2 >= mLedgerCloseDatas.size())
@@ -1024,8 +1003,7 @@ CatchupSimulation::externalizeLedger(HerderImpl& herder, uint32_t ledger)
         lcd.getLedgerSeq(), xdr::xdr_to_opaque(lcd.getValue()));
 }
 
-void
-CatchupSimulation::validateCatchup(Application::pointer app)
+void CatchupSimulation::validateCatchup(Application::pointer app)
 {
     auto& lm = app->getLedgerManager();
     auto nextLedger = lm.getLastClosedLedgerNum() + 1;
@@ -1139,8 +1117,7 @@ CatchupSimulation::validateCatchup(Application::pointer app)
     CHECK(haveStrpSeq == wantStrpSeq);
 }
 
-CatchupPerformedWork
-CatchupSimulation::computeCatchupPerformedWork(
+CatchupPerformedWork CatchupSimulation::computeCatchupPerformedWork(
     uint32_t lastClosedLedger, CatchupConfiguration const& catchupConfiguration,
     Application& app)
 {
@@ -1187,8 +1164,7 @@ CatchupSimulation::computeCatchupPerformedWork(
             txSetsApplied};
 }
 
-void
-CatchupSimulation::restartApp()
+void CatchupSimulation::restartApp()
 {
     mAppPtr.reset();
     mClock = std::make_unique<VirtualClock>(mClock->getMode());

--- a/src/history/test/HistoryTestsUtils.h
+++ b/src/history/test/HistoryTestsUtils.h
@@ -225,20 +225,17 @@ class CatchupSimulation
         Config::TestDbMode dbMode = Config::TESTDB_IN_MEMORY);
     ~CatchupSimulation();
 
-    Application&
-    getApp() const
+    Application& getApp() const
     {
         return *mAppPtr;
     }
 
-    VirtualClock&
-    getClock()
+    VirtualClock& getClock()
     {
         return *mClock;
     }
 
-    HistoryConfigurator&
-    getHistoryConfigurator() const
+    HistoryConfigurator& getHistoryConfigurator() const
     {
         return *mHistoryConfigurator.get();
     }
@@ -254,9 +251,9 @@ class CatchupSimulation
     void generateRandomLedger(uint32_t version = 0);
 
     void ensurePublishesComplete();
-    void
-    ensureLedgerAvailable(uint32_t targetLedger,
-                          std::optional<uint32_t> restartLedger = std::nullopt);
+    void ensureLedgerAvailable(
+        uint32_t targetLedger,
+        std::optional<uint32_t> restartLedger = std::nullopt);
     void ensureOfflineCatchupPossible(
         uint32_t targetLedger,
         std::optional<uint32_t> restartLedger = std::nullopt);

--- a/src/historywork/BatchDownloadWork.cpp
+++ b/src/historywork/BatchDownloadWork.cpp
@@ -29,8 +29,7 @@ BatchDownloadWork::BatchDownloadWork(Application& app, CheckpointRange range,
 {
 }
 
-std::string
-BatchDownloadWork::getStatus() const
+std::string BatchDownloadWork::getStatus() const
 {
     if (!isDone() && !isAborting())
     {
@@ -41,8 +40,7 @@ BatchDownloadWork::getStatus() const
     return BatchWork::getStatus();
 }
 
-std::shared_ptr<BasicWork>
-BatchDownloadWork::yieldMoreWork()
+std::shared_ptr<BasicWork> BatchDownloadWork::yieldMoreWork()
 {
     ZoneScoped;
     if (!hasNext())
@@ -62,14 +60,12 @@ BatchDownloadWork::yieldMoreWork()
     return getAndUnzip;
 }
 
-bool
-BatchDownloadWork::hasNext() const
+bool BatchDownloadWork::hasNext() const
 {
     return mNext < mRange.limit();
 }
 
-void
-BatchDownloadWork::resetIter()
+void BatchDownloadWork::resetIter()
 {
     mNext = mRange.mFirst;
 }

--- a/src/historywork/CheckSingleLedgerHeaderWork.cpp
+++ b/src/historywork/CheckSingleLedgerHeaderWork.cpp
@@ -37,22 +37,19 @@ CheckSingleLedgerHeaderWork::~CheckSingleLedgerHeaderWork()
 {
 }
 
-void
-CheckSingleLedgerHeaderWork::onSuccess()
+void CheckSingleLedgerHeaderWork::onSuccess()
 {
     mCheckSuccess.Mark();
     Work::onSuccess();
 }
 
-void
-CheckSingleLedgerHeaderWork::onFailureRaise()
+void CheckSingleLedgerHeaderWork::onFailureRaise()
 {
     mCheckFailed.Mark();
     Work::onFailureRaise();
 }
 
-void
-CheckSingleLedgerHeaderWork::doReset()
+void CheckSingleLedgerHeaderWork::doReset()
 {
     mGetLedgerFileWork.reset();
     mDownloadDir =
@@ -63,8 +60,7 @@ CheckSingleLedgerHeaderWork::doReset()
         *mDownloadDir, FileType::HISTORY_FILE_TYPE_LEDGER, checkpoint);
 }
 
-BasicWork::State
-CheckSingleLedgerHeaderWork::doWork()
+BasicWork::State CheckSingleLedgerHeaderWork::doWork()
 {
     if (mExpected.header.ledgerSeq == 0)
     {

--- a/src/historywork/DownloadBucketsWork.cpp
+++ b/src/historywork/DownloadBucketsWork.cpp
@@ -32,8 +32,7 @@ DownloadBucketsWork::DownloadBucketsWork(
 {
 }
 
-std::string
-DownloadBucketsWork::getStatus() const
+std::string DownloadBucketsWork::getStatus() const
 {
     if (!BatchWork::isDone() && !BatchWork::isAborting())
     {
@@ -57,25 +56,23 @@ DownloadBucketsWork::getStatus() const
     return BatchWork::getStatus();
 }
 
-bool
-DownloadBucketsWork::hasNext() const
+bool DownloadBucketsWork::hasNext() const
 {
     return mLiveBucketsState.nextIter != mLiveBucketsState.hashes.end() ||
            mHotBucketsState.nextIter != mHotBucketsState.hashes.end();
 }
 
-void
-DownloadBucketsWork::resetIter()
+void DownloadBucketsWork::resetIter()
 {
     mLiveBucketsState.nextIter = mLiveBucketsState.hashes.begin();
     mHotBucketsState.nextIter = mHotBucketsState.hashes.begin();
 }
 
 template <typename BucketT>
-void
-DownloadBucketsWork::onSuccessCb(Application& app, FileTransferInfo const& ft,
-                                 std::string const& hash, int currId,
-                                 BucketState<BucketT>& state)
+void DownloadBucketsWork::onSuccessCb(Application& app,
+                                      FileTransferInfo const& ft,
+                                      std::string const& hash, int currId,
+                                      BucketState<BucketT>& state)
 {
     // To avoid dangling references, maintain a map of index pointers
     // and do a lookup inside the callback instead of capturing anything
@@ -148,8 +145,7 @@ DownloadBucketsWork::prepareWorkForBucketType(
     return {verifyWork, adoptBucketCb};
 }
 
-std::shared_ptr<BasicWork>
-DownloadBucketsWork::yieldMoreWork()
+std::shared_ptr<BasicWork> DownloadBucketsWork::yieldMoreWork()
 {
     ZoneScoped;
     if (!hasNext())

--- a/src/historywork/DownloadVerifyTxResultsWork.cpp
+++ b/src/historywork/DownloadVerifyTxResultsWork.cpp
@@ -27,8 +27,7 @@ DownloadVerifyTxResultsWork::DownloadVerifyTxResultsWork(
 {
 }
 
-std::string
-DownloadVerifyTxResultsWork::getStatus() const
+std::string DownloadVerifyTxResultsWork::getStatus() const
 {
     if (!isDone() && !isAborting())
     {
@@ -41,20 +40,17 @@ DownloadVerifyTxResultsWork::getStatus() const
     return BatchWork::getStatus();
 }
 
-bool
-DownloadVerifyTxResultsWork::hasNext() const
+bool DownloadVerifyTxResultsWork::hasNext() const
 {
     return mCurrCheckpoint < mRange.limit();
 }
 
-void
-DownloadVerifyTxResultsWork::resetIter()
+void DownloadVerifyTxResultsWork::resetIter()
 {
     mCurrCheckpoint = mRange.mFirst;
 }
 
-std::shared_ptr<BasicWork>
-DownloadVerifyTxResultsWork::yieldMoreWork()
+std::shared_ptr<BasicWork> DownloadVerifyTxResultsWork::yieldMoreWork()
 {
     ZoneScoped;
     if (!hasNext())

--- a/src/historywork/FetchRecentQsetsWork.cpp
+++ b/src/historywork/FetchRecentQsetsWork.cpp
@@ -22,8 +22,7 @@ FetchRecentQsetsWork::FetchRecentQsetsWork(Application& app, uint32_t ledgerNum)
 {
 }
 
-void
-FetchRecentQsetsWork::doReset()
+void FetchRecentQsetsWork::doReset()
 {
     mGetHistoryArchiveStateWork.reset();
     mDownloadSCPMessagesWork.reset();
@@ -31,8 +30,7 @@ FetchRecentQsetsWork::doReset()
         std::make_unique<TmpDir>(mApp.getTmpDirManager().tmpDir(getName()));
 }
 
-BasicWork::State
-FetchRecentQsetsWork::doWork()
+BasicWork::State FetchRecentQsetsWork::doWork()
 {
     ZoneScoped;
     // Phase 1: fetch remote history archive state

--- a/src/historywork/GetAndUnzipRemoteFileWork.cpp
+++ b/src/historywork/GetAndUnzipRemoteFileWork.cpp
@@ -28,8 +28,7 @@ GetAndUnzipRemoteFileWork::GetAndUnzipRemoteFileWork(
 {
 }
 
-std::string
-GetAndUnzipRemoteFileWork::getStatus() const
+std::string GetAndUnzipRemoteFileWork::getStatus() const
 {
     if (mGunzipFileWork)
     {
@@ -42,8 +41,7 @@ GetAndUnzipRemoteFileWork::getStatus() const
     return BasicWork::getStatus();
 }
 
-void
-GetAndUnzipRemoteFileWork::doReset()
+void GetAndUnzipRemoteFileWork::doReset()
 {
     fs::removeWithLog(mFt.localPath_nogz());
     fs::removeWithLog(mFt.localPath_gz());
@@ -52,8 +50,7 @@ GetAndUnzipRemoteFileWork::doReset()
     mGunzipFileWork.reset();
 }
 
-void
-GetAndUnzipRemoteFileWork::onFailureRaise()
+void GetAndUnzipRemoteFileWork::onFailureRaise()
 {
     // Blame archive if file was downloaded but failed validation
     std::shared_ptr<HistoryArchive> ar = getArchive();
@@ -73,15 +70,13 @@ GetAndUnzipRemoteFileWork::onFailureRaise()
     Work::onFailureRaise();
 }
 
-void
-GetAndUnzipRemoteFileWork::onSuccess()
+void GetAndUnzipRemoteFileWork::onSuccess()
 {
     mApp.getLedgerApplyManager().fileDownloaded(mFt.getType());
     Work::onSuccess();
 }
 
-BasicWork::State
-GetAndUnzipRemoteFileWork::doWork()
+BasicWork::State GetAndUnzipRemoteFileWork::doWork()
 {
     ZoneScoped;
     if (mGunzipFileWork)
@@ -134,8 +129,7 @@ GetAndUnzipRemoteFileWork::doWork()
     }
 }
 
-bool
-GetAndUnzipRemoteFileWork::validateFile()
+bool GetAndUnzipRemoteFileWork::validateFile()
 {
     ZoneScoped;
     if (!fs::exists(mFt.localPath_gz_tmp()))
@@ -215,8 +209,7 @@ GetAndUnzipRemoteFileWork::validateFile()
     return true;
 }
 
-std::shared_ptr<HistoryArchive>
-GetAndUnzipRemoteFileWork::getArchive() const
+std::shared_ptr<HistoryArchive> GetAndUnzipRemoteFileWork::getArchive() const
 {
     if (mGetRemoteFileWork &&
         mGetRemoteFileWork->getState() == BasicWork::State::WORK_SUCCESS)

--- a/src/historywork/GetHistoryArchiveStateWork.cpp
+++ b/src/historywork/GetHistoryArchiveStateWork.cpp
@@ -29,14 +29,12 @@ GetHistoryArchiveStateWork::GetHistoryArchiveStateWork(
 {
 }
 
-static bool
-isWellKnown(uint32_t seq)
+static bool isWellKnown(uint32_t seq)
 {
     return seq == 0;
 }
 
-BasicWork::State
-GetHistoryArchiveStateWork::doWork()
+BasicWork::State GetHistoryArchiveStateWork::doWork()
 {
     ZoneScoped;
     if (mGetRemoteFile)
@@ -91,16 +89,14 @@ GetHistoryArchiveStateWork::doWork()
     }
 }
 
-void
-GetHistoryArchiveStateWork::doReset()
+void GetHistoryArchiveStateWork::doReset()
 {
     mGetRemoteFile.reset();
     fs::removeWithLog(mLocalFilename);
     mState = {};
 }
 
-void
-GetHistoryArchiveStateWork::onSuccess()
+void GetHistoryArchiveStateWork::onSuccess()
 {
     if (mReportMetric)
     {
@@ -109,15 +105,13 @@ GetHistoryArchiveStateWork::onSuccess()
     Work::onSuccess();
 }
 
-std::string
-GetHistoryArchiveStateWork::getRemoteName() const
+std::string GetHistoryArchiveStateWork::getRemoteName() const
 {
     return isWellKnown(mSeq) ? HistoryArchiveState::wellKnownRemoteName()
                              : HistoryArchiveState::remoteName(mSeq);
 }
 
-std::string
-GetHistoryArchiveStateWork::getStatus() const
+std::string GetHistoryArchiveStateWork::getStatus() const
 {
     std::string ledgerString = mSeq == 0 ? "current" : std::to_string(mSeq);
     return fmt::format(FMT_STRING("Downloading state file {} for ledger {}"),

--- a/src/historywork/GetHistoryArchiveStateWork.h
+++ b/src/historywork/GetHistoryArchiveStateWork.h
@@ -32,8 +32,7 @@ class GetHistoryArchiveStateWork : public Work
         size_t maxRetries = BasicWork::RETRY_A_FEW);
     ~GetHistoryArchiveStateWork() = default;
 
-    HistoryArchiveState const&
-    getHistoryArchiveState() const
+    HistoryArchiveState const& getHistoryArchiveState() const
     {
         if (getState() != State::WORK_SUCCESS)
         {
@@ -43,8 +42,7 @@ class GetHistoryArchiveStateWork : public Work
         return mState;
     }
 
-    std::shared_ptr<HistoryArchive>
-    getArchive() const
+    std::shared_ptr<HistoryArchive> getArchive() const
     {
         return mArchive;
     }

--- a/src/historywork/GetRemoteFileWork.cpp
+++ b/src/historywork/GetRemoteFileWork.cpp
@@ -30,8 +30,7 @@ GetRemoteFileWork::GetRemoteFileWork(Application& app,
 {
 }
 
-CommandInfo
-GetRemoteFileWork::getCommand()
+CommandInfo GetRemoteFileWork::getCommand()
 {
     mCurrentArchive = mArchive;
     if (!mCurrentArchive)
@@ -50,23 +49,20 @@ GetRemoteFileWork::getCommand()
     return CommandInfo{cmdLine, std::string()};
 }
 
-void
-GetRemoteFileWork::onReset()
+void GetRemoteFileWork::onReset()
 {
     fs::removeWithLog(mLocal);
     RunCommandWork::onReset();
 }
 
-void
-GetRemoteFileWork::onSuccess()
+void GetRemoteFileWork::onSuccess()
 {
     releaseAssert(mCurrentArchive);
     mBytesPerSecond.Mark(fs::size(mLocal));
     RunCommandWork::onSuccess();
 }
 
-void
-GetRemoteFileWork::onFailureRaise()
+void GetRemoteFileWork::onFailureRaise()
 {
     releaseAssert(mCurrentArchive);
     mFailuresPerSecond.Mark(1);
@@ -76,8 +72,7 @@ GetRemoteFileWork::onFailureRaise()
     RunCommandWork::onFailureRaise();
 }
 
-std::shared_ptr<HistoryArchive>
-GetRemoteFileWork::getCurrentArchive() const
+std::shared_ptr<HistoryArchive> GetRemoteFileWork::getCurrentArchive() const
 {
     return mCurrentArchive;
 }

--- a/src/historywork/GunzipFileWork.cpp
+++ b/src/historywork/GunzipFileWork.cpp
@@ -17,8 +17,7 @@ GunzipFileWork::GunzipFileWork(Application& app, std::string const& filenameGz,
     fs::checkGzipSuffix(mFilenameGz);
 }
 
-CommandInfo
-GunzipFileWork::getCommand()
+CommandInfo GunzipFileWork::getCommand()
 {
     std::string cmdLine, outFile;
     cmdLine = "gzip -d ";
@@ -31,8 +30,7 @@ GunzipFileWork::getCommand()
     return CommandInfo{cmdLine, outFile};
 }
 
-void
-GunzipFileWork::onReset()
+void GunzipFileWork::onReset()
 {
     std::string filenameNoGz = mFilenameGz.substr(0, mFilenameGz.size() - 3);
     fs::removeWithLog(filenameNoGz);

--- a/src/historywork/GzipFileWork.cpp
+++ b/src/historywork/GzipFileWork.cpp
@@ -18,15 +18,13 @@ GzipFileWork::GzipFileWork(Application& app, std::string const& filenameNoGz,
     fs::checkNoGzipSuffix(mFilenameNoGz);
 }
 
-void
-GzipFileWork::onReset()
+void GzipFileWork::onReset()
 {
     std::string filenameGz = mFilenameNoGz + ".gz";
     fs::removeWithLog(filenameGz);
 }
 
-CommandInfo
-GzipFileWork::getCommand()
+CommandInfo GzipFileWork::getCommand()
 {
     std::string cmdLine = "gzip ";
     std::string outFile;

--- a/src/historywork/MakeRemoteDirWork.cpp
+++ b/src/historywork/MakeRemoteDirWork.cpp
@@ -20,8 +20,7 @@ MakeRemoteDirWork::MakeRemoteDirWork(Application& app, std::string const& dir,
     releaseAssert(mArchive);
 }
 
-CommandInfo
-MakeRemoteDirWork::getCommand()
+CommandInfo MakeRemoteDirWork::getCommand()
 {
     std::string cmdLine;
     if (mArchive->hasMkdirCmd())

--- a/src/historywork/Progress.cpp
+++ b/src/historywork/Progress.cpp
@@ -12,9 +12,8 @@
 namespace stellar
 {
 
-std::string
-fmtProgress(Application& app, std::string const& task, LedgerRange const& range,
-            uint32_t curr)
+std::string fmtProgress(Application& app, std::string const& task,
+                        LedgerRange const& range, uint32_t curr)
 {
     auto step = HistoryManager::getCheckpointFrequency(app.getConfig());
     // Step is only ever 8 or 64.

--- a/src/historywork/PublishWork.cpp
+++ b/src/historywork/PublishWork.cpp
@@ -27,8 +27,7 @@ PublishWork::PublishWork(Application& app,
 {
 }
 
-void
-PublishWork::onFailureRaise()
+void PublishWork::onFailureRaise()
 {
     ZoneScoped;
     // use mOriginalBuckets as mSnapshot->mLocalState.allBuckets() could change
@@ -37,8 +36,7 @@ PublishWork::onFailureRaise()
         mSnapshot->mLocalState.currentLedger, mOriginalBuckets, false);
 }
 
-void
-PublishWork::onSuccess()
+void PublishWork::onSuccess()
 {
     ZoneScoped;
     // use mOriginalBuckets as mSnapshot->mLocalState.allBuckets() could change

--- a/src/historywork/PutFilesWork.cpp
+++ b/src/historywork/PutFilesWork.cpp
@@ -26,8 +26,7 @@ PutFilesWork::PutFilesWork(Application& app,
 {
 }
 
-BasicWork::State
-PutFilesWork::doWork()
+BasicWork::State PutFilesWork::doWork()
 {
     ZoneScoped;
     if (!mChildrenSpawned)
@@ -54,8 +53,7 @@ PutFilesWork::doWork()
     }
 }
 
-void
-PutFilesWork::doReset()
+void PutFilesWork::doReset()
 {
     mChildrenSpawned = false;
 }

--- a/src/historywork/PutHistoryArchiveStateWork.cpp
+++ b/src/historywork/PutHistoryArchiveStateWork.cpp
@@ -33,15 +33,13 @@ PutHistoryArchiveStateWork::PutHistoryArchiveStateWork(
     }
 }
 
-void
-PutHistoryArchiveStateWork::doReset()
+void PutHistoryArchiveStateWork::doReset()
 {
     mPutRemoteFileWork.reset();
     fs::removeWithLog(mLocalFilename);
 }
 
-BasicWork::State
-PutHistoryArchiveStateWork::doWork()
+BasicWork::State PutHistoryArchiveStateWork::doWork()
 {
     ZoneScoped;
     if (!mPutRemoteFileWork)
@@ -65,8 +63,7 @@ PutHistoryArchiveStateWork::doWork()
     }
 }
 
-void
-PutHistoryArchiveStateWork::spawnPublishWork()
+void PutHistoryArchiveStateWork::spawnPublishWork()
 {
     ZoneScoped;
     // Put the file in the history/ww/xx/yy/history-wwxxyyzz.json file

--- a/src/historywork/PutRemoteFileWork.cpp
+++ b/src/historywork/PutRemoteFileWork.cpp
@@ -22,8 +22,7 @@ PutRemoteFileWork::PutRemoteFileWork(Application& app, std::string const& local,
     releaseAssert(mArchive->hasPutCmd());
 }
 
-CommandInfo
-PutRemoteFileWork::getCommand()
+CommandInfo PutRemoteFileWork::getCommand()
 {
     auto cmdLine = mArchive->putFileCmd(mLocal, mRemote);
     return CommandInfo{cmdLine, std::string()};

--- a/src/historywork/PutSnapshotFilesWork.cpp
+++ b/src/historywork/PutSnapshotFilesWork.cpp
@@ -19,8 +19,7 @@
 namespace stellar
 {
 
-void
-PutSnapshotFilesWork::cleanup()
+void PutSnapshotFilesWork::cleanup()
 {
     // Delete `gz` files produced by this work
     for (auto const& f : mFilesToUpload)
@@ -40,8 +39,7 @@ PutSnapshotFilesWork::PutSnapshotFilesWork(
 {
 }
 
-BasicWork::State
-PutSnapshotFilesWork::doWork()
+BasicWork::State PutSnapshotFilesWork::doWork()
 {
     ZoneScoped;
     if (!mUploadSeqs.empty())
@@ -104,8 +102,7 @@ PutSnapshotFilesWork::doWork()
     return State::WORK_RUNNING;
 }
 
-void
-PutSnapshotFilesWork::doReset()
+void PutSnapshotFilesWork::doReset()
 {
     cleanup();
 
@@ -115,8 +112,7 @@ PutSnapshotFilesWork::doReset()
     mFilesToUpload.clear();
 }
 
-void
-PutSnapshotFilesWork::createGzipWorks()
+void PutSnapshotFilesWork::createGzipWorks()
 {
     // Sanity check: there are states for all archives
     if (mGetStateWorks.size() !=
@@ -139,8 +135,7 @@ PutSnapshotFilesWork::createGzipWorks()
     }
 }
 
-std::string
-PutSnapshotFilesWork::getStatus() const
+std::string PutSnapshotFilesWork::getStatus() const
 {
     if (!mUploadSeqs.empty())
     {
@@ -160,8 +155,7 @@ PutSnapshotFilesWork::getStatus() const
     return BasicWork::getStatus();
 }
 
-void
-PutSnapshotFilesWork::onSuccess()
+void PutSnapshotFilesWork::onSuccess()
 {
     cleanup();
 }

--- a/src/historywork/ResolveSnapshotWork.cpp
+++ b/src/historywork/ResolveSnapshotWork.cpp
@@ -23,8 +23,7 @@ ResolveSnapshotWork::ResolveSnapshotWork(
     }
 }
 
-BasicWork::State
-ResolveSnapshotWork::onRun()
+BasicWork::State ResolveSnapshotWork::onRun()
 {
     ZoneScoped;
     mSnapshot->mLocalState.prepareForPublish(mApp);

--- a/src/historywork/ResolveSnapshotWork.h
+++ b/src/historywork/ResolveSnapshotWork.h
@@ -22,8 +22,7 @@ class ResolveSnapshotWork : public BasicWork
 
   protected:
     State onRun() override;
-    bool
-    onAbort() override
+    bool onAbort() override
     {
         return true;
     };

--- a/src/historywork/RunCommandWork.cpp
+++ b/src/historywork/RunCommandWork.cpp
@@ -16,8 +16,7 @@ RunCommandWork::RunCommandWork(Application& app, std::string const& name,
 {
 }
 
-BasicWork::State
-RunCommandWork::onRun()
+BasicWork::State RunCommandWork::onRun()
 {
     ZoneScoped;
     if (mDone)
@@ -58,16 +57,14 @@ RunCommandWork::onRun()
     }
 }
 
-void
-RunCommandWork::onReset()
+void RunCommandWork::onReset()
 {
     mDone = false;
     mEc = asio::error_code();
     mExitEvent.reset();
 }
 
-bool
-RunCommandWork::onAbort()
+bool RunCommandWork::onAbort()
 {
     ZoneScoped;
     auto process = mExitEvent.lock();

--- a/src/historywork/VerifyBucketWork.cpp
+++ b/src/historywork/VerifyBucketWork.cpp
@@ -35,9 +35,7 @@ VerifyBucketWork<BucketT>::VerifyBucketWork(
 {
 }
 
-template <typename BucketT>
-BasicWork::State
-VerifyBucketWork<BucketT>::onRun()
+template <typename BucketT> BasicWork::State VerifyBucketWork<BucketT>::onRun()
 {
     ZoneScoped;
     if (mDone)
@@ -53,9 +51,7 @@ VerifyBucketWork<BucketT>::onRun()
     return State::WORK_WAITING;
 }
 
-template <typename BucketT>
-void
-VerifyBucketWork<BucketT>::spawnVerifier()
+template <typename BucketT> void VerifyBucketWork<BucketT>::spawnVerifier()
 {
     std::string filename = mBucketFile;
     if (auto size = fs::size(filename);
@@ -152,9 +148,7 @@ VerifyBucketWork<BucketT>::spawnVerifier()
         "VerifyBucket: start in background");
 }
 
-template <typename BucketT>
-void
-VerifyBucketWork<BucketT>::onFailureRaise()
+template <typename BucketT> void VerifyBucketWork<BucketT>::onFailureRaise()
 {
     if (mOnFailure)
     {

--- a/src/historywork/VerifyBucketWork.h
+++ b/src/historywork/VerifyBucketWork.h
@@ -42,8 +42,7 @@ template <typename BucketT> class VerifyBucketWork : public BasicWork
 
   protected:
     BasicWork::State onRun() override;
-    bool
-    onAbort() override
+    bool onAbort() override
     {
         return true;
     };

--- a/src/historywork/VerifyTxResultsWork.cpp
+++ b/src/historywork/VerifyTxResultsWork.cpp
@@ -26,8 +26,7 @@ VerifyTxResultsWork::VerifyTxResultsWork(Application& app,
 {
 }
 
-void
-VerifyTxResultsWork::onReset()
+void VerifyTxResultsWork::onReset()
 {
     mHdrIn.close();
     mResIn.close();
@@ -37,8 +36,7 @@ VerifyTxResultsWork::onReset()
     mLastSeenLedger = 0;
 }
 
-BasicWork::State
-VerifyTxResultsWork::onRun()
+BasicWork::State VerifyTxResultsWork::onRun()
 {
     if (mDone)
     {
@@ -84,8 +82,7 @@ VerifyTxResultsWork::onRun()
     return State::WORK_WAITING;
 }
 
-bool
-VerifyTxResultsWork::verifyTxResultsOfCheckpoint()
+bool VerifyTxResultsWork::verifyTxResultsOfCheckpoint()
 {
     ZoneScoped;
     try

--- a/src/historywork/VerifyTxResultsWork.h
+++ b/src/historywork/VerifyTxResultsWork.h
@@ -37,8 +37,7 @@ class VerifyTxResultsWork : public BasicWork
     BasicWork::State onRun() override;
     void onReset() override;
 
-    bool
-    onAbort() override
+    bool onAbort() override
     {
         return true;
     };

--- a/src/historywork/WriteSnapshotWork.cpp
+++ b/src/historywork/WriteSnapshotWork.cpp
@@ -23,8 +23,7 @@ WriteSnapshotWork::WriteSnapshotWork(Application& app,
 {
 }
 
-BasicWork::State
-WriteSnapshotWork::onRun()
+BasicWork::State WriteSnapshotWork::onRun()
 {
     if (mDone)
     {

--- a/src/historywork/WriteSnapshotWork.h
+++ b/src/historywork/WriteSnapshotWork.h
@@ -24,8 +24,7 @@ class WriteSnapshotWork : public BasicWork
 
   protected:
     State onRun() override;
-    bool
-    onAbort() override
+    bool onAbort() override
     {
         return true;
     };

--- a/src/historywork/WriteVerifiedCheckpointHashesWork.cpp
+++ b/src/historywork/WriteVerifiedCheckpointHashesWork.cpp
@@ -58,8 +58,7 @@ WriteVerifiedCheckpointHashesWork::loadLatestHashPairFromJsonOutput(
     return {jpair[0].asUInt(), hexToBin256(jpair[1].asString())};
 }
 
-Hash
-WriteVerifiedCheckpointHashesWork::loadHashFromJsonOutput(
+Hash WriteVerifiedCheckpointHashesWork::loadHashFromJsonOutput(
     uint32_t seq, std::filesystem::path const& path)
 {
     std::ifstream in(path);
@@ -128,8 +127,7 @@ WriteVerifiedCheckpointHashesWork::~WriteVerifiedCheckpointHashesWork()
     endOutputFile();
 }
 
-bool
-WriteVerifiedCheckpointHashesWork::hasNext() const
+bool WriteVerifiedCheckpointHashesWork::hasNext() const
 {
     if (mFromLedger)
     {
@@ -142,8 +140,7 @@ WriteVerifiedCheckpointHashesWork::hasNext() const
     return mCurrCheckpoint != LedgerManager::GENESIS_LEDGER_SEQ;
 }
 
-std::shared_ptr<BasicWork>
-WriteVerifiedCheckpointHashesWork::yieldMoreWork()
+std::shared_ptr<BasicWork> WriteVerifiedCheckpointHashesWork::yieldMoreWork()
 {
     ZoneScoped;
     if (!hasNext())
@@ -249,8 +246,7 @@ WriteVerifiedCheckpointHashesWork::yieldMoreWork()
     return workSeq;
 }
 
-void
-WriteVerifiedCheckpointHashesWork::startOutputFile()
+void WriteVerifiedCheckpointHashesWork::startOutputFile()
 {
     releaseAssert(!mOutputFile);
     auto mode = std::ios::out | std::ios::trunc;
@@ -263,8 +259,7 @@ WriteVerifiedCheckpointHashesWork::startOutputFile()
     (*mOutputFile) << "[";
 }
 
-void
-WriteVerifiedCheckpointHashesWork::endOutputFile()
+void WriteVerifiedCheckpointHashesWork::endOutputFile()
 {
     if (mOutputFile && mOutputFile->is_open())
     {
@@ -310,8 +305,7 @@ WriteVerifiedCheckpointHashesWork::endOutputFile()
     }
 }
 
-void
-WriteVerifiedCheckpointHashesWork::resetIter()
+void WriteVerifiedCheckpointHashesWork::resetIter()
 {
     mCurrCheckpoint = mRangeEnd.first;
     mTmpDirs.clear();
@@ -319,8 +313,7 @@ WriteVerifiedCheckpointHashesWork::resetIter()
     startOutputFile();
 }
 
-void
-WriteVerifiedCheckpointHashesWork::onSuccess()
+void WriteVerifiedCheckpointHashesWork::onSuccess()
 {
     endOutputFile();
 }

--- a/src/invariant/AccountSubEntriesCountIsValid.cpp
+++ b/src/invariant/AccountSubEntriesCountIsValid.cpp
@@ -14,15 +14,14 @@
 namespace stellar
 {
 
-static bool
-isPoolShareTrustline(LedgerEntry const& le)
+static bool isPoolShareTrustline(LedgerEntry const& le)
 {
     return le.data.type() == TRUSTLINE &&
            le.data.trustLine().asset.type() == ASSET_TYPE_POOL_SHARE;
 }
 
-static int32_t
-calculateDelta(LedgerEntry const* current, LedgerEntry const* previous)
+static int32_t calculateDelta(LedgerEntry const* current,
+                              LedgerEntry const* previous)
 {
     int32_t delta = 0;
     if (current)
@@ -50,8 +49,7 @@ calculateDelta(LedgerEntry const* current, LedgerEntry const* previous)
     return delta;
 }
 
-static void
-updateChangedSubEntriesCount(
+static void updateChangedSubEntriesCount(
     UnorderedMap<AccountID, SubEntriesChange>& subEntriesChange,
     LedgerEntry const* current, LedgerEntry const* previous)
 {
@@ -108,8 +106,7 @@ updateChangedSubEntriesCount(
     }
 }
 
-static void
-updateChangedSubEntriesCount(
+static void updateChangedSubEntriesCount(
     UnorderedMap<AccountID, SubEntriesChange>& subEntriesChange,
     std::shared_ptr<InternalLedgerEntry const> const& genCurrent,
     std::shared_ptr<InternalLedgerEntry const> const& genPrevious)
@@ -136,14 +133,12 @@ AccountSubEntriesCountIsValid::registerInvariant(Application& app)
         .registerInvariant<AccountSubEntriesCountIsValid>();
 }
 
-std::string
-AccountSubEntriesCountIsValid::getName() const
+std::string AccountSubEntriesCountIsValid::getName() const
 {
     return "AccountSubEntriesCountIsValid";
 }
 
-std::string
-AccountSubEntriesCountIsValid::checkOnOperationApply(
+std::string AccountSubEntriesCountIsValid::checkOnOperationApply(
     Operation const& operation, OperationResult const& result,
     LedgerTxnDelta const& ltxDelta, std::vector<ContractEvent> const& events,
     AppConnector&)

--- a/src/invariant/ArchivedStateConsistency.cpp
+++ b/src/invariant/ArchivedStateConsistency.cpp
@@ -27,8 +27,7 @@ ArchivedStateConsistency::ArchivedStateConsistency() : Invariant(true)
 
 // This test iterates through both the live and archived bucket lists and checks
 // that no entry is live in both BucketLists simultaneously.
-std::string
-ArchivedStateConsistency::checkSnapshot(
+std::string ArchivedStateConsistency::checkSnapshot(
     CompleteConstLedgerStatePtr ledgerState,
     InMemorySorobanState const& inMemorySnapshot)
 {
@@ -104,14 +103,12 @@ ArchivedStateConsistency::registerInvariant(Application& app)
         .registerInvariant<ArchivedStateConsistency>();
 }
 
-std::string
-ArchivedStateConsistency::getName() const
+std::string ArchivedStateConsistency::getName() const
 {
     return "ArchivedStateConsistency";
 }
 
-std::string
-ArchivedStateConsistency::checkOnLedgerCommit(
+std::string ArchivedStateConsistency::checkOnLedgerCommit(
     SearchableSnapshotConstPtr lclLiveState,
     SearchableHotArchiveSnapshotConstPtr lclHotArchiveState,
     std::vector<LedgerEntry> const& persitentEvictedFromLive,
@@ -208,8 +205,7 @@ ArchivedStateConsistency::checkOnLedgerCommit(
     }
 }
 
-std::string
-ArchivedStateConsistency::checkEvictionInvariants(
+std::string ArchivedStateConsistency::checkEvictionInvariants(
     UnorderedMap<LedgerKey, LedgerEntry> const& preloadedLiveEntries,
     UnorderedMap<LedgerKey, HotArchiveBucketEntry> const&
         preloadedArchivedEntries,
@@ -358,8 +354,7 @@ ArchivedStateConsistency::checkEvictionInvariants(
     return std::string{};
 }
 
-std::string
-ArchivedStateConsistency::checkRestoreInvariants(
+std::string ArchivedStateConsistency::checkRestoreInvariants(
     UnorderedMap<LedgerKey, LedgerEntry> const& preloadedLiveEntries,
     UnorderedMap<LedgerKey, HotArchiveBucketEntry> const&
         preloadedArchivedEntries,

--- a/src/invariant/BucketListIsConsistentWithDatabase.cpp
+++ b/src/invariant/BucketListIsConsistentWithDatabase.cpp
@@ -28,8 +28,8 @@ namespace stellar
 
 namespace
 {
-std::string
-checkAgainstDatabase(AbstractLedgerTxn& ltx, LedgerEntry const& entry)
+std::string checkAgainstDatabase(AbstractLedgerTxn& ltx,
+                                 LedgerEntry const& entry)
 {
     auto fromDb = ltx.loadWithoutRecord(LedgerEntryKey(entry));
     if (!fromDb)
@@ -53,8 +53,7 @@ checkAgainstDatabase(AbstractLedgerTxn& ltx, LedgerEntry const& entry)
     }
 }
 
-std::string
-checkAgainstDatabase(AbstractLedgerTxn& ltx, LedgerKey const& key)
+std::string checkAgainstDatabase(AbstractLedgerTxn& ltx, LedgerKey const& key)
 {
     auto fromDb = ltx.loadWithoutRecord(key);
     if (!fromDb)
@@ -67,9 +66,8 @@ checkAgainstDatabase(AbstractLedgerTxn& ltx, LedgerKey const& key)
     return s;
 }
 
-std::string
-checkDbEntryCounts(Application& app, LedgerRange const& range,
-                   uint64_t expectedOfferCount)
+std::string checkDbEntryCounts(Application& app, LedgerRange const& range,
+                               uint64_t expectedOfferCount)
 {
     std::string msg;
     auto& ltxRoot = app.getLedgerTxnRoot();
@@ -99,14 +97,12 @@ BucketListIsConsistentWithDatabase::BucketListIsConsistentWithDatabase(
 {
 }
 
-std::string
-BucketListIsConsistentWithDatabase::getName() const
+std::string BucketListIsConsistentWithDatabase::getName() const
 {
     return "BucketListIsConsistentWithDatabase";
 }
 
-void
-BucketListIsConsistentWithDatabase::checkEntireBucketlist()
+void BucketListIsConsistentWithDatabase::checkEntireBucketlist()
 {
     auto& lm = mApp.getLedgerManager();
     auto& bm = mApp.getBucketManager();
@@ -239,8 +235,7 @@ BucketListIsConsistentWithDatabase::checkAfterAssumeState(uint32_t newestLedger)
     return checkDbEntryCounts(mApp, range, offerCount);
 }
 
-std::string
-BucketListIsConsistentWithDatabase::checkOnBucketApply(
+std::string BucketListIsConsistentWithDatabase::checkOnBucketApply(
     std::shared_ptr<LiveBucket const> bucket, uint32_t oldestLedger,
     uint32_t newestLedger, std::unordered_set<LedgerKey> const& shadowedKeys)
 {

--- a/src/invariant/ConservationOfLumens.cpp
+++ b/src/invariant/ConservationOfLumens.cpp
@@ -14,9 +14,9 @@
 namespace stellar
 {
 
-static int64_t
-calculateDeltaBalance(LumenContractInfo const& lumenContractInfo,
-                      LedgerEntry const* current, LedgerEntry const* previous)
+static int64_t calculateDeltaBalance(LumenContractInfo const& lumenContractInfo,
+                                     LedgerEntry const* current,
+                                     LedgerEntry const* previous)
 {
     releaseAssert(current || previous);
     auto let = current ? current->data.type() : previous->data.type();
@@ -134,8 +134,7 @@ calculateDeltaBalance(LumenContractInfo const& lumenContractInfo,
     return 0;
 }
 
-static int64_t
-calculateDeltaBalance(
+static int64_t calculateDeltaBalance(
     LumenContractInfo const& lumenContractInfo,
     std::shared_ptr<InternalLedgerEntry const> const& genCurrent,
     std::shared_ptr<InternalLedgerEntry const> const& genPrevious)
@@ -170,14 +169,12 @@ ConservationOfLumens::registerInvariant(Application& app)
         lumenInfo);
 }
 
-std::string
-ConservationOfLumens::getName() const
+std::string ConservationOfLumens::getName() const
 {
     return "ConservationOfLumens";
 }
 
-std::string
-ConservationOfLumens::checkOnOperationApply(
+std::string ConservationOfLumens::checkOnOperationApply(
     Operation const& operation, OperationResult const& result,
     LedgerTxnDelta const& ltxDelta, std::vector<ContractEvent> const& events,
     AppConnector&)

--- a/src/invariant/ConstantProductInvariant.cpp
+++ b/src/invariant/ConstantProductInvariant.cpp
@@ -20,22 +20,20 @@ ConstantProductInvariant::registerInvariant(Application& app)
         .registerInvariant<ConstantProductInvariant>();
 }
 
-std::string
-ConstantProductInvariant::getName() const
+std::string ConstantProductInvariant::getName() const
 {
     return "ConstantProductInvariant";
 }
 
-bool
-validateConstantProduct(uint64_t currentReserveA, uint64_t currentReserveB,
-                        uint64_t previousReserveA, uint64_t previousReserveB)
+bool validateConstantProduct(uint64_t currentReserveA, uint64_t currentReserveB,
+                             uint64_t previousReserveA,
+                             uint64_t previousReserveB)
 {
     return (uint128_t)currentReserveA * (uint128_t)currentReserveB >=
            (uint128_t)previousReserveA * (uint128_t)previousReserveB;
 }
 
-std::string
-ConstantProductInvariant::checkOnOperationApply(
+std::string ConstantProductInvariant::checkOnOperationApply(
     Operation const& operation, OperationResult const& result,
     LedgerTxnDelta const& ltxDelta, std::vector<ContractEvent> const& events,
     AppConnector&)

--- a/src/invariant/EventsAreConsistentWithEntryDiffs.cpp
+++ b/src/invariant/EventsAreConsistentWithEntryDiffs.cpp
@@ -37,9 +37,9 @@ struct AggregatedEvents
     CxxI128 consumeAmount(SCAddress const& addr, Asset const& asset);
 };
 
-bool
-AggregatedEvents::addAssetBalance(SCAddress const& addr, Asset const& asset,
-                                  CxxI128 const& amount)
+bool AggregatedEvents::addAssetBalance(SCAddress const& addr,
+                                       Asset const& asset,
+                                       CxxI128 const& amount)
 {
     auto current = mEventAmounts[addr][asset];
 
@@ -52,10 +52,9 @@ AggregatedEvents::addAssetBalance(SCAddress const& addr, Asset const& asset,
     return true;
 }
 
-bool
-AggregatedEvents::subtractAssetBalance(SCAddress const& addr,
-                                       Asset const& asset,
-                                       CxxI128 const& amount)
+bool AggregatedEvents::subtractAssetBalance(SCAddress const& addr,
+                                            Asset const& asset,
+                                            CxxI128 const& amount)
 {
     auto current = mEventAmounts[addr][asset];
 
@@ -68,8 +67,8 @@ AggregatedEvents::subtractAssetBalance(SCAddress const& addr,
     return true;
 }
 
-CxxI128
-AggregatedEvents::consumeAmount(SCAddress const& addr, Asset const& asset)
+CxxI128 AggregatedEvents::consumeAmount(SCAddress const& addr,
+                                        Asset const& asset)
 {
     auto lkAssetMapIt = mEventAmounts.find(addr);
     if (lkAssetMapIt == mEventAmounts.end())
@@ -95,8 +94,7 @@ AggregatedEvents::consumeAmount(SCAddress const& addr, Asset const& asset)
     return res;
 }
 
-CxxI128
-getAmountFromData(SCVal const& data)
+CxxI128 getAmountFromData(SCVal const& data)
 {
     if (data.type() == SCV_I128)
     {
@@ -119,8 +117,7 @@ getAmountFromData(SCVal const& data)
     return I128ZERO;
 }
 
-std::optional<SCAddress>
-getAddressFromBalanceKey(LedgerKey const& lk)
+std::optional<SCAddress> getAddressFromBalanceKey(LedgerKey const& lk)
 {
     if (lk.contractData().key.type() != SCV_VEC)
     {
@@ -144,10 +141,9 @@ getAddressFromBalanceKey(LedgerKey const& lk)
 }
 
 // Should only be called with trustlines as input
-bool
-checkAuthorization(AggregatedEvents& agg, SCAddress const& trustlineOwner,
-                   Asset const& asset, LedgerEntry const* current,
-                   LedgerEntry const* previous)
+bool checkAuthorization(AggregatedEvents& agg, SCAddress const& trustlineOwner,
+                        Asset const& asset, LedgerEntry const* current,
+                        LedgerEntry const* previous)
 {
     if (!current || !previous)
     {
@@ -573,16 +569,14 @@ EventsAreConsistentWithEntryDiffs::registerInvariant(Application& app)
             app.getNetworkID());
 }
 
-std::string
-EventsAreConsistentWithEntryDiffs::getName() const
+std::string EventsAreConsistentWithEntryDiffs::getName() const
 {
     return "EventsAreConsistentWithEntryDiffs";
 }
 
 // Note that this invariant only verifies balance changes in the context of an
 // operation. The fee events should not be accounted for here.
-std::string
-EventsAreConsistentWithEntryDiffs::checkOnOperationApply(
+std::string EventsAreConsistentWithEntryDiffs::checkOnOperationApply(
     Operation const& operation, OperationResult const& result,
     LedgerTxnDelta const& ltxDelta, std::vector<ContractEvent> const& events,
     AppConnector& app)

--- a/src/invariant/Invariant.h
+++ b/src/invariant/Invariant.h
@@ -42,8 +42,7 @@ class Invariant
 
     virtual std::string getName() const = 0;
 
-    bool
-    isStrict() const
+    bool isStrict() const
     {
         return mStrict;
     }
@@ -56,24 +55,20 @@ class Invariant
         return std::string{};
     }
 
-    virtual std::string
-    checkAfterAssumeState(uint32_t newestLedger)
+    virtual std::string checkAfterAssumeState(uint32_t newestLedger)
     {
         return std::string{};
     }
 
-    virtual std::string
-    checkOnOperationApply(Operation const& operation,
-                          OperationResult const& result,
-                          LedgerTxnDelta const& ltxDelta,
-                          std::vector<ContractEvent> const& events,
-                          AppConnector& app)
+    virtual std::string checkOnOperationApply(
+        Operation const& operation, OperationResult const& result,
+        LedgerTxnDelta const& ltxDelta,
+        std::vector<ContractEvent> const& events, AppConnector& app)
     {
         return std::string{};
     }
 
-    virtual std::string
-    checkOnLedgerCommit(
+    virtual std::string checkOnLedgerCommit(
         SearchableSnapshotConstPtr lclLiveState,
         SearchableHotArchiveSnapshotConstPtr lclHotArchiveState,
         std::vector<LedgerEntry> const& persitentEvictedFromLive,
@@ -92,13 +87,11 @@ class Invariant
     }
 
 #ifdef BUILD_TESTS
-    virtual void
-    snapshotForFuzzer()
+    virtual void snapshotForFuzzer()
     {
     }
 
-    virtual void
-    resetForFuzzer()
+    virtual void resetForFuzzer()
     {
     }
 #endif // BUILD_TESTS

--- a/src/invariant/InvariantManager.h
+++ b/src/invariant/InvariantManager.h
@@ -84,8 +84,7 @@ class InvariantManager
 #endif // BUILD_TESTS
 
     template <typename T, typename... Args>
-    std::shared_ptr<T>
-    registerInvariant(Args&&... args)
+    std::shared_ptr<T> registerInvariant(Args&&... args)
     {
         auto invariant = std::make_shared<T>(std::forward<Args>(args)...);
         registerInvariant(invariant);

--- a/src/invariant/LedgerEntryIsValid.cpp
+++ b/src/invariant/LedgerEntryIsValid.cpp
@@ -16,8 +16,7 @@
 namespace stellar
 {
 
-static bool
-signerCompare(Signer const& s1, Signer const& s2)
+static bool signerCompare(Signer const& s1, Signer const& s2)
 {
     return s1.key < s2.key;
 }
@@ -36,14 +35,12 @@ LedgerEntryIsValid::registerInvariant(Application& app)
         lumenInfo);
 }
 
-std::string
-LedgerEntryIsValid::getName() const
+std::string LedgerEntryIsValid::getName() const
 {
     return "LedgerEntryIsValid";
 }
 
-std::string
-LedgerEntryIsValid::checkOnOperationApply(
+std::string LedgerEntryIsValid::checkOnOperationApply(
     Operation const& operation, OperationResult const& result,
     LedgerTxnDelta const& ltxDelta, std::vector<ContractEvent> const& events,
     AppConnector&)
@@ -73,8 +70,7 @@ LedgerEntryIsValid::checkOnOperationApply(
     return {};
 }
 
-std::string
-LedgerEntryIsValid::checkIsValid(
+std::string LedgerEntryIsValid::checkIsValid(
     InternalLedgerEntry const& le,
     std::shared_ptr<InternalLedgerEntry const> const& genPrevious,
     uint32_t ledgerSeq, uint32 version) const
@@ -88,10 +84,10 @@ LedgerEntryIsValid::checkIsValid(
     return "";
 }
 
-std::string
-LedgerEntryIsValid::checkIsValid(LedgerEntry const& le,
-                                 LedgerEntry const* previous,
-                                 uint32_t ledgerSeq, uint32 version) const
+std::string LedgerEntryIsValid::checkIsValid(LedgerEntry const& le,
+                                             LedgerEntry const* previous,
+                                             uint32_t ledgerSeq,
+                                             uint32 version) const
 {
     if (le.lastModifiedLedgerSeq != ledgerSeq)
     {
@@ -142,8 +138,8 @@ LedgerEntryIsValid::checkIsValid(LedgerEntry const& le,
     }
 }
 
-std::string
-LedgerEntryIsValid::checkIsValid(AccountEntry const& ae, uint32 version) const
+std::string LedgerEntryIsValid::checkIsValid(AccountEntry const& ae,
+                                             uint32 version) const
 {
     if (ae.balance < 0)
     {
@@ -210,10 +206,9 @@ LedgerEntryIsValid::checkIsValid(AccountEntry const& ae, uint32 version) const
     return {};
 }
 
-std::string
-LedgerEntryIsValid::checkIsValid(TrustLineEntry const& tl,
-                                 LedgerEntry const* previous,
-                                 uint32 version) const
+std::string LedgerEntryIsValid::checkIsValid(TrustLineEntry const& tl,
+                                             LedgerEntry const* previous,
+                                             uint32 version) const
 {
     if (tl.asset.type() == ASSET_TYPE_NATIVE)
     {
@@ -268,8 +263,8 @@ LedgerEntryIsValid::checkIsValid(TrustLineEntry const& tl,
     return {};
 }
 
-std::string
-LedgerEntryIsValid::checkIsValid(OfferEntry const& oe, uint32 version) const
+std::string LedgerEntryIsValid::checkIsValid(OfferEntry const& oe,
+                                             uint32 version) const
 {
     if (oe.offerID <= 0)
     {
@@ -300,8 +295,8 @@ LedgerEntryIsValid::checkIsValid(OfferEntry const& oe, uint32 version) const
     return {};
 }
 
-std::string
-LedgerEntryIsValid::checkIsValid(DataEntry const& de, uint32 version) const
+std::string LedgerEntryIsValid::checkIsValid(DataEntry const& de,
+                                             uint32 version) const
 {
     if (de.dataName.size() == 0)
     {
@@ -314,9 +309,8 @@ LedgerEntryIsValid::checkIsValid(DataEntry const& de, uint32 version) const
     return {};
 }
 
-bool
-LedgerEntryIsValid::validatePredicate(ClaimPredicate const& pred,
-                                      uint32_t depth) const
+bool LedgerEntryIsValid::validatePredicate(ClaimPredicate const& pred,
+                                           uint32_t depth) const
 {
     if (depth > 4)
     {
@@ -366,10 +360,9 @@ LedgerEntryIsValid::validatePredicate(ClaimPredicate const& pred,
     return true;
 }
 
-std::string
-LedgerEntryIsValid::checkIsValid(ClaimableBalanceEntry const& cbe,
-                                 LedgerEntry const* previous,
-                                 uint32 version) const
+std::string LedgerEntryIsValid::checkIsValid(ClaimableBalanceEntry const& cbe,
+                                             LedgerEntry const* previous,
+                                             uint32 version) const
 {
     if (protocolVersionIsBefore(version, ProtocolVersion::V_17) &&
         cbe.ext.v() == 1)
@@ -423,10 +416,9 @@ LedgerEntryIsValid::checkIsValid(ClaimableBalanceEntry const& cbe,
     return {};
 }
 
-std::string
-LedgerEntryIsValid::checkIsValid(LiquidityPoolEntry const& lp,
-                                 LedgerEntry const* previous,
-                                 uint32 version) const
+std::string LedgerEntryIsValid::checkIsValid(LiquidityPoolEntry const& lp,
+                                             LedgerEntry const* previous,
+                                             uint32 version) const
 {
     if (protocolVersionIsBefore(version, ProtocolVersion::V_18))
     {
@@ -496,10 +488,9 @@ LedgerEntryIsValid::checkIsValid(LiquidityPoolEntry const& lp,
     return {};
 }
 
-std::string
-LedgerEntryIsValid::checkIsValid(ContractDataEntry const& cde,
-                                 LedgerEntry const* previous,
-                                 uint32 version) const
+std::string LedgerEntryIsValid::checkIsValid(ContractDataEntry const& cde,
+                                             LedgerEntry const* previous,
+                                             uint32 version) const
 {
     // Lumen contract validation
     if (cde.contract.type() == SC_ADDRESS_TYPE_CONTRACT &&
@@ -542,10 +533,9 @@ LedgerEntryIsValid::checkIsValid(ContractDataEntry const& cde,
     return {};
 }
 
-std::string
-LedgerEntryIsValid::checkIsValid(ContractCodeEntry const& cce,
-                                 LedgerEntry const* previous,
-                                 uint32 version) const
+std::string LedgerEntryIsValid::checkIsValid(ContractCodeEntry const& cce,
+                                             LedgerEntry const* previous,
+                                             uint32 version) const
 {
     if (sha256(cce.code) != cce.hash)
     {
@@ -574,20 +564,18 @@ LedgerEntryIsValid::checkIsValid(ContractCodeEntry const& cce,
     return {};
 }
 
-std::string
-LedgerEntryIsValid::checkIsValid(ConfigSettingEntry const& cfg,
-                                 LedgerEntry const* previous,
-                                 uint32 version) const
+std::string LedgerEntryIsValid::checkIsValid(ConfigSettingEntry const& cfg,
+                                             LedgerEntry const* previous,
+                                             uint32 version) const
 {
     // ConfigSettingEntry is not affected on operation apply path, so invariants
     // will not be checked.
     return {};
 }
 
-std::string
-LedgerEntryIsValid::checkIsValid(TTLEntry const& te,
-                                 LedgerEntry const* previous,
-                                 uint32_t version) const
+std::string LedgerEntryIsValid::checkIsValid(TTLEntry const& te,
+                                             LedgerEntry const* previous,
+                                             uint32_t version) const
 {
     if (!previous)
     {

--- a/src/invariant/LiabilitiesMatchOffers.cpp
+++ b/src/invariant/LiabilitiesMatchOffers.cpp
@@ -20,8 +20,7 @@ namespace stellar
 typedef std::map<AccountID, std::map<TrustLineAsset, Liabilities>>
     LiabilitiesMap;
 
-static int64_t
-getOfferBuyingLiabilities(LedgerEntry const& le)
+static int64_t getOfferBuyingLiabilities(LedgerEntry const& le)
 {
     auto const& oe = le.data.offer();
     auto res = exchangeV10WithoutPriceErrorThresholds(
@@ -30,8 +29,7 @@ getOfferBuyingLiabilities(LedgerEntry const& le)
     return res.numSheepSend;
 }
 
-static int64_t
-getOfferSellingLiabilities(LedgerEntry const& le)
+static int64_t getOfferSellingLiabilities(LedgerEntry const& le)
 {
     auto const& oe = le.data.offer();
     auto res = exchangeV10WithoutPriceErrorThresholds(
@@ -40,8 +38,7 @@ getOfferSellingLiabilities(LedgerEntry const& le)
     return res.numWheatReceived;
 }
 
-static int64_t
-getBuyingLiabilities(LedgerEntry const& le)
+static int64_t getBuyingLiabilities(LedgerEntry const& le)
 {
     if (le.data.type() == ACCOUNT)
     {
@@ -56,8 +53,7 @@ getBuyingLiabilities(LedgerEntry const& le)
     throw std::runtime_error("Unknown LedgerEntry type");
 }
 
-int64_t
-getSellingLiabilities(LedgerEntry const& le)
+int64_t getSellingLiabilities(LedgerEntry const& le)
 {
     if (le.data.type() == ACCOUNT)
     {
@@ -72,8 +68,8 @@ getSellingLiabilities(LedgerEntry const& le)
     throw std::runtime_error("Unknown LedgerEntry type");
 }
 
-static std::string
-checkAuthorized(LedgerEntry const* current, LedgerEntry const* previous)
+static std::string checkAuthorized(LedgerEntry const* current,
+                                   LedgerEntry const* previous)
 {
     if (!current)
     {
@@ -138,9 +134,8 @@ checkAuthorized(std::shared_ptr<InternalLedgerEntry const> const& genCurrent,
     return "";
 }
 
-static void
-addOrSubtractLiabilities(LiabilitiesMap& deltaLiabilities,
-                         LedgerEntry const* entry, bool isAdd)
+static void addOrSubtractLiabilities(LiabilitiesMap& deltaLiabilities,
+                                     LedgerEntry const* entry, bool isAdd)
 {
     if (!entry)
     {
@@ -186,8 +181,7 @@ addOrSubtractLiabilities(LiabilitiesMap& deltaLiabilities,
     }
 }
 
-static void
-addOrSubtractLiabilities(
+static void addOrSubtractLiabilities(
     LiabilitiesMap& deltaLiabilities,
     std::shared_ptr<InternalLedgerEntry const> const& genEntry, bool isAdd)
 {
@@ -198,8 +192,7 @@ addOrSubtractLiabilities(
     }
 }
 
-static void
-accumulateLiabilities(
+static void accumulateLiabilities(
     LiabilitiesMap& deltaLiabilities,
     std::shared_ptr<InternalLedgerEntry const> const& current,
     std::shared_ptr<InternalLedgerEntry const> const& previous)
@@ -208,9 +201,9 @@ accumulateLiabilities(
     addOrSubtractLiabilities(deltaLiabilities, previous, false);
 }
 
-static bool
-shouldCheckAccount(LedgerEntry const* current, LedgerEntry const* previous,
-                   uint32_t ledgerVersion)
+static bool shouldCheckAccount(LedgerEntry const* current,
+                               LedgerEntry const* previous,
+                               uint32_t ledgerVersion)
 {
     if (!previous)
     {
@@ -237,9 +230,10 @@ shouldCheckAccount(LedgerEntry const* current, LedgerEntry const* previous,
     }
 }
 
-static std::string
-checkBalanceAndLimit(LedgerHeader const& header, LedgerEntry const* current,
-                     LedgerEntry const* previous, uint32_t ledgerVersion)
+static std::string checkBalanceAndLimit(LedgerHeader const& header,
+                                        LedgerEntry const* current,
+                                        LedgerEntry const* previous,
+                                        uint32_t ledgerVersion)
 {
     if (!current)
     {
@@ -288,8 +282,7 @@ checkBalanceAndLimit(LedgerHeader const& header, LedgerEntry const* current,
     return {};
 }
 
-static std::string
-checkBalanceAndLimit(
+static std::string checkBalanceAndLimit(
     LedgerHeader const& header,
     std::shared_ptr<InternalLedgerEntry const> const& genCurrent,
     std::shared_ptr<InternalLedgerEntry const> const& genPrevious,
@@ -317,14 +310,12 @@ LiabilitiesMatchOffers::LiabilitiesMatchOffers() : Invariant(false)
 {
 }
 
-std::string
-LiabilitiesMatchOffers::getName() const
+std::string LiabilitiesMatchOffers::getName() const
 {
     return "LiabilitiesMatchOffers";
 }
 
-std::string
-LiabilitiesMatchOffers::checkOnOperationApply(
+std::string LiabilitiesMatchOffers::checkOnOperationApply(
     Operation const& operation, OperationResult const& result,
     LedgerTxnDelta const& ltxDelta, std::vector<ContractEvent> const& events,
     AppConnector&)

--- a/src/invariant/OrderBookIsNotCrossed.cpp
+++ b/src/invariant/OrderBookIsNotCrossed.cpp
@@ -20,8 +20,7 @@ namespace stellar
 {
 namespace
 {
-double
-priceAsDouble(Price const& price)
+double priceAsDouble(Price const& price)
 {
     return static_cast<double>(price.n) / static_cast<double>(price.d);
 }
@@ -49,9 +48,8 @@ extractAssetPairs(LedgerTxnDelta const& ltxd)
     return assets;
 }
 
-std::string
-checkCrossed(Asset const& a, Asset const& b,
-             OrderBookIsNotCrossed::OrderBook const& orderBook)
+std::string checkCrossed(Asset const& a, Asset const& b,
+                         OrderBookIsNotCrossed::OrderBook const& orderBook)
 {
     // If either side of the order book for this asset pair is empty or does not
     // yet exist, then the order book cannot be crossed.
@@ -108,9 +106,8 @@ checkCrossed(Asset const& a, Asset const& b,
 }
 }
 
-bool
-OrderBookIsNotCrossed::OfferEntryCmp::operator()(OfferEntry const& a,
-                                                 OfferEntry const& b) const
+bool OrderBookIsNotCrossed::OfferEntryCmp::operator()(OfferEntry const& a,
+                                                      OfferEntry const& b) const
 {
     auto const priceA = priceAsDouble(a.price);
     auto const priceB = priceAsDouble(b.price);
@@ -133,8 +130,7 @@ OrderBookIsNotCrossed::OfferEntryCmp::operator()(OfferEntry const& a,
     return false;
 }
 
-void
-OrderBookIsNotCrossed::updateOrderBook(LedgerTxnDelta const& ltxd)
+void OrderBookIsNotCrossed::updateOrderBook(LedgerTxnDelta const& ltxd)
 {
     for (auto const& entry : ltxd.entry)
     {
@@ -166,8 +162,7 @@ OrderBookIsNotCrossed::updateOrderBook(LedgerTxnDelta const& ltxd)
     }
 }
 
-std::string
-OrderBookIsNotCrossed::check(AssetPairSet const& assetPairs)
+std::string OrderBookIsNotCrossed::check(AssetPairSet const& assetPairs)
 {
     releaseAssert(!mRestoreBeforeNextUpdate);
     for (auto const& assetPair : assetPairs)
@@ -192,14 +187,12 @@ OrderBookIsNotCrossed::registerAndEnableInvariant(Application& app)
     return invariant;
 }
 
-std::string
-OrderBookIsNotCrossed::getName() const
+std::string OrderBookIsNotCrossed::getName() const
 {
     return "OrderBookIsNotCrossed";
 }
 
-std::string
-OrderBookIsNotCrossed::checkOnOperationApply(
+std::string OrderBookIsNotCrossed::checkOnOperationApply(
     Operation const& operation, OperationResult const& result,
     LedgerTxnDelta const& ltxDelta, std::vector<ContractEvent> const& events,
     AppConnector&)
@@ -209,14 +202,12 @@ OrderBookIsNotCrossed::checkOnOperationApply(
     return assetPairs.size() > 0 ? check(assetPairs) : std::string{};
 }
 
-void
-OrderBookIsNotCrossed::snapshotForFuzzer()
+void OrderBookIsNotCrossed::snapshotForFuzzer()
 {
     mOrderBookSnapshot = mOrderBook;
 }
 
-void
-OrderBookIsNotCrossed::resetForFuzzer()
+void OrderBookIsNotCrossed::resetForFuzzer()
 {
     // This call indicates that the fuzzer has completed one test and its next
     // call to `checkOnOperationApply` will be in the context of the order book

--- a/src/invariant/OrderBookIsNotCrossed.h
+++ b/src/invariant/OrderBookIsNotCrossed.h
@@ -55,8 +55,7 @@ class OrderBookIsNotCrossed : public Invariant
         LedgerTxnDelta const& ltxDelta,
         std::vector<ContractEvent> const& events, AppConnector& app) override;
 
-    OrderBook const&
-    getOrderBook() const
+    OrderBook const& getOrderBook() const
     {
         return mOrderBook;
     }

--- a/src/invariant/SponsorshipCountIsValid.cpp
+++ b/src/invariant/SponsorshipCountIsValid.cpp
@@ -26,14 +26,12 @@ SponsorshipCountIsValid::registerInvariant(Application& app)
         .registerInvariant<SponsorshipCountIsValid>();
 }
 
-std::string
-SponsorshipCountIsValid::getName() const
+std::string SponsorshipCountIsValid::getName() const
 {
     return "SponsorshipCountIsValid";
 }
 
-static int64_t
-getMult(LedgerEntry const& le)
+static int64_t getMult(LedgerEntry const& le)
 {
     switch (le.data.type())
     {
@@ -58,8 +56,7 @@ getMult(LedgerEntry const& le)
     }
 }
 
-static AccountID const&
-getAccountID(LedgerEntry const& le)
+static AccountID const& getAccountID(LedgerEntry const& le)
 {
     switch (le.data.type())
     {
@@ -83,11 +80,10 @@ getAccountID(LedgerEntry const& le)
     }
 }
 
-static void
-updateCounters(LedgerEntry const& le,
-               UnorderedMap<AccountID, int64_t>& numSponsoring,
-               UnorderedMap<AccountID, int64_t>& numSponsored,
-               int64_t& claimableBalanceReserve, int64_t sign)
+static void updateCounters(LedgerEntry const& le,
+                           UnorderedMap<AccountID, int64_t>& numSponsoring,
+                           UnorderedMap<AccountID, int64_t>& numSponsored,
+                           int64_t& claimableBalanceReserve, int64_t sign)
 {
     if (le.ext.v() == 1 && le.ext.v1().sponsoringID)
     {
@@ -121,8 +117,7 @@ updateCounters(LedgerEntry const& le,
     }
 }
 
-static void
-updateChangedSponsorshipCounts(
+static void updateChangedSponsorshipCounts(
     std::shared_ptr<InternalLedgerEntry const> current,
     std::shared_ptr<InternalLedgerEntry const> previous,
     UnorderedMap<AccountID, int64_t>& numSponsoring,
@@ -160,8 +155,7 @@ getDeltaSponsoringAndSponsored(std::shared_ptr<InternalLedgerEntry const> le,
     }
 }
 
-std::string
-SponsorshipCountIsValid::checkOnOperationApply(
+std::string SponsorshipCountIsValid::checkOnOperationApply(
     Operation const& operation, OperationResult const& result,
     LedgerTxnDelta const& ltxDelta, std::vector<ContractEvent> const& events,
     AppConnector&)

--- a/src/invariant/test/AccountSubEntriesCountIsValidTests.cpp
+++ b/src/invariant/test/AccountSubEntriesCountIsValidTests.cpp
@@ -22,8 +22,7 @@
 using namespace stellar;
 using namespace stellar::InvariantTestUtils;
 
-static LedgerEntry
-generateRandomAccountWithNoSubEntries(uint32_t ledgerSeq)
+static LedgerEntry generateRandomAccountWithNoSubEntries(uint32_t ledgerSeq)
 {
     LedgerEntry le;
     le.lastModifiedLedgerSeq = ledgerSeq;
@@ -41,8 +40,7 @@ generateRandomAccountWithNoSubEntries(uint32_t ledgerSeq)
     return le;
 }
 
-static LedgerEntry
-generateRandomSubEntry(LedgerEntry const& acc)
+static LedgerEntry generateRandomSubEntry(LedgerEntry const& acc)
 {
     static auto validAccountIDGenerator =
         autocheck::map([](AccountID&& id, size_t s) { return std::move(id); },
@@ -103,8 +101,8 @@ generateRandomSubEntry(LedgerEntry const& acc)
     return le;
 }
 
-static LedgerEntry
-generateRandomModifiedSubEntry(LedgerEntry const& acc, LedgerEntry const& se)
+static LedgerEntry generateRandomModifiedSubEntry(LedgerEntry const& acc,
+                                                  LedgerEntry const& se)
 {
     LedgerEntry res;
     do
@@ -149,10 +147,10 @@ static auto validSignerGenerator = autocheck::map(
     },
     autocheck::generator<Signer>());
 
-static void
-updateAccountSubEntries(Application& app, LedgerEntry& leCurr,
-                        LedgerEntry lePrev, int32_t deltaNumSubEntries,
-                        UpdateList const& updatesBase)
+static void updateAccountSubEntries(Application& app, LedgerEntry& leCurr,
+                                    LedgerEntry lePrev,
+                                    int32_t deltaNumSubEntries,
+                                    UpdateList const& updatesBase)
 {
     if (deltaNumSubEntries != 0)
     {
@@ -173,9 +171,8 @@ updateAccountSubEntries(Application& app, LedgerEntry& leCurr,
     }
 }
 
-static void
-addRandomSubEntryToAccount(Application& app, LedgerEntry& le,
-                           std::vector<LedgerEntry>& subentries)
+static void addRandomSubEntryToAccount(Application& app, LedgerEntry& le,
+                                       std::vector<LedgerEntry>& subentries)
 {
     auto lePrev = le;
     auto& acc = le.data.account();

--- a/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
+++ b/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
@@ -53,8 +53,7 @@ struct BucketListGenerator
     }
 
     template <typename T = ApplyBucketsWork, typename... Args>
-    void
-    applyBuckets(Application::pointer app, Args&&... args)
+    void applyBuckets(Application::pointer app, Args&&... args)
     {
         std::map<std::string, std::shared_ptr<LiveBucket>> buckets;
         auto has = getHistoryArchiveState(app);
@@ -66,8 +65,7 @@ struct BucketListGenerator
     }
 
     template <typename T = ApplyBucketsWork, typename... Args>
-    void
-    applyBuckets(Args&&... args)
+    void applyBuckets(Args&&... args)
     {
         VirtualClock clock;
         Application::pointer app =
@@ -75,8 +73,7 @@ struct BucketListGenerator
         applyBuckets<T, Args...>(app, std::forward<Args>(args)...);
     }
 
-    void
-    generateLedger()
+    void generateLedger()
     {
         auto& app = mAppGenerate;
         LedgerTxn ltx(app->getLedgerTxnRoot(), false);
@@ -118,8 +115,7 @@ struct BucketListGenerator
         ltx.commit();
     }
 
-    void
-    generateLedgers(uint32_t n)
+    void generateLedgers(uint32_t n)
     {
         uint32_t stopLedger = mLedgerSeq + n - 1;
         while (mLedgerSeq <= stopLedger)
@@ -128,8 +124,7 @@ struct BucketListGenerator
         }
     }
 
-    virtual std::vector<LedgerEntry>
-    generateLiveEntries(AbstractLedgerTxn& ltx)
+    virtual std::vector<LedgerEntry> generateLiveEntries(AbstractLedgerTxn& ltx)
     {
         auto entries =
             LedgerTestUtils::generateValidUniqueLedgerEntriesWithTypes({OFFER},
@@ -141,8 +136,7 @@ struct BucketListGenerator
         return entries;
     }
 
-    virtual std::vector<LedgerKey>
-    generateDeadEntries(AbstractLedgerTxn& ltx)
+    virtual std::vector<LedgerKey> generateDeadEntries(AbstractLedgerTxn& ltx)
     {
         UnorderedSet<LedgerKey> liveDeletable = mLiveKeys;
         std::vector<LedgerKey> dead;
@@ -165,8 +159,7 @@ struct BucketListGenerator
         return dead;
     }
 
-    HistoryArchiveState
-    getHistoryArchiveState(Application::pointer app)
+    HistoryArchiveState getHistoryArchiveState(Application::pointer app)
     {
         auto& blGenerate = mAppGenerate->getBucketManager().getLiveBucketList();
         auto& bmApply = app->getBucketManager();
@@ -208,9 +201,8 @@ struct BucketListGenerator
     }
 };
 
-bool
-doesBucketContain(std::shared_ptr<LiveBucket const> bucket,
-                  const BucketEntry& be)
+bool doesBucketContain(std::shared_ptr<LiveBucket const> bucket,
+                       const BucketEntry& be)
 {
     for (LiveBucketInputIterator iter(bucket); iter; ++iter)
     {
@@ -222,8 +214,7 @@ doesBucketContain(std::shared_ptr<LiveBucket const> bucket,
     return false;
 }
 
-bool
-doesBucketListContain(LiveBucketList& bl, const BucketEntry& be)
+bool doesBucketListContain(LiveBucketList& bl, const BucketEntry& be)
 {
     for (uint32_t i = 0; i < LiveBucketList::kNumLevels; ++i)
     {
@@ -249,8 +240,7 @@ struct SelectBucketListGenerator : public BucketListGenerator
     {
     }
 
-    virtual std::vector<LedgerEntry>
-    generateLiveEntries(AbstractLedgerTxn& ltx)
+    virtual std::vector<LedgerEntry> generateLiveEntries(AbstractLedgerTxn& ltx)
     {
         if (mLedgerSeq == mSelectLedger)
         {
@@ -285,8 +275,7 @@ struct SelectBucketListGenerator : public BucketListGenerator
         return live;
     }
 
-    virtual std::vector<LedgerKey>
-    generateDeadEntries(AbstractLedgerTxn& ltx)
+    virtual std::vector<LedgerKey> generateDeadEntries(AbstractLedgerTxn& ltx)
     {
         auto dead = BucketListGenerator::generateDeadEntries(ltx);
         if (mSelected)
@@ -321,8 +310,7 @@ class ApplyBucketsWorkAddEntry : public ApplyBucketsWork
         REQUIRE(entry.lastModifiedLedgerSeq >= 2);
     }
 
-    BasicWork::State
-    doWork() override
+    BasicWork::State doWork() override
     {
         if (!mAdded)
         {
@@ -370,8 +358,7 @@ class ApplyBucketsWorkDeleteEntry : public ApplyBucketsWork
     {
     }
 
-    BasicWork::State
-    doWork() override
+    BasicWork::State doWork() override
     {
         if (!mDeleted)
         {
@@ -400,8 +387,7 @@ class ApplyBucketsWorkModifyEntry : public ApplyBucketsWork
     LedgerEntry const mEntry;
     bool mModified;
 
-    void
-    modifyOfferEntry(LedgerEntry& entry)
+    void modifyOfferEntry(LedgerEntry& entry)
     {
         OfferEntry const& offer = mEntry.data.offer();
         entry.lastModifiedLedgerSeq = mEntry.lastModifiedLedgerSeq;
@@ -423,8 +409,7 @@ class ApplyBucketsWorkModifyEntry : public ApplyBucketsWork
     {
     }
 
-    BasicWork::State
-    doWork() override
+    BasicWork::State doWork() override
     {
         if (!mModified)
         {

--- a/src/invariant/test/ConservationOfLumensTests.cpp
+++ b/src/invariant/test/ConservationOfLumensTests.cpp
@@ -21,8 +21,7 @@
 using namespace stellar;
 using namespace stellar::InvariantTestUtils;
 
-int64_t
-getTotalBalance(std::vector<LedgerEntry> const& entries)
+int64_t getTotalBalance(std::vector<LedgerEntry> const& entries)
 {
     return std::accumulate(entries.begin(), entries.end(),
                            static_cast<int64_t>(0),
@@ -31,8 +30,8 @@ getTotalBalance(std::vector<LedgerEntry> const& entries)
                            });
 }
 
-int64_t
-getCoinsAboveReserve(std::vector<LedgerEntry> const& entries, Application& app)
+int64_t getCoinsAboveReserve(std::vector<LedgerEntry> const& entries,
+                             Application& app)
 {
     return std::accumulate(
         entries.begin(), entries.end(), static_cast<int64_t>(0),
@@ -42,9 +41,9 @@ getCoinsAboveReserve(std::vector<LedgerEntry> const& entries, Application& app)
         });
 }
 
-std::vector<LedgerEntry>
-updateBalances(std::vector<LedgerEntry> entries, Application& app,
-               int64_t netChange, bool updateTotalCoins)
+std::vector<LedgerEntry> updateBalances(std::vector<LedgerEntry> entries,
+                                        Application& app, int64_t netChange,
+                                        bool updateTotalCoins)
 {
     int64_t initialCoins = getTotalBalance(entries);
     int64_t pool = netChange + getCoinsAboveReserve(entries, app);
@@ -95,8 +94,8 @@ updateBalances(std::vector<LedgerEntry> entries, Application& app,
     return entries;
 }
 
-std::vector<LedgerEntry>
-updateBalances(std::vector<LedgerEntry> const& entries, Application& app)
+std::vector<LedgerEntry> updateBalances(std::vector<LedgerEntry> const& entries,
+                                        Application& app)
 {
     int64_t coinsAboveReserve = getCoinsAboveReserve(entries, app);
 

--- a/src/invariant/test/InvariantTestUtils.cpp
+++ b/src/invariant/test/InvariantTestUtils.cpp
@@ -19,8 +19,7 @@ namespace stellar
 namespace InvariantTestUtils
 {
 
-LedgerEntry
-generateRandomAccount(uint32_t ledgerSeq)
+LedgerEntry generateRandomAccount(uint32_t ledgerSeq)
 {
     LedgerEntry le;
     le.lastModifiedLedgerSeq = ledgerSeq;
@@ -34,9 +33,8 @@ generateRandomAccount(uint32_t ledgerSeq)
     return le;
 }
 
-LedgerEntry
-generateOffer(Asset const& selling, Asset const& buying, int64_t amount,
-              Price price)
+LedgerEntry generateOffer(Asset const& selling, Asset const& buying,
+                          int64_t amount, Price price)
 {
     REQUIRE(!(selling == buying));
     REQUIRE(amount >= 1);
@@ -55,9 +53,8 @@ generateOffer(Asset const& selling, Asset const& buying, int64_t amount,
     return le;
 }
 
-bool
-store(Application& app, UpdateList const& apply, AbstractLedgerTxn* ltxPtr,
-      OperationResult const* resPtr)
+bool store(Application& app, UpdateList const& apply, AbstractLedgerTxn* ltxPtr,
+           OperationResult const* resPtr)
 {
     bool shouldCommit = !ltxPtr;
     std::unique_ptr<LedgerTxn> ltxStore;
@@ -127,8 +124,8 @@ store(Application& app, UpdateList const& apply, AbstractLedgerTxn* ltxPtr,
     return doInvariantsHold;
 }
 
-UpdateList
-makeUpdateList(std::vector<LedgerEntry> const& current, std::nullptr_t previous)
+UpdateList makeUpdateList(std::vector<LedgerEntry> const& current,
+                          std::nullptr_t previous)
 {
     UpdateList updates;
     std::transform(current.begin(), current.end(), std::back_inserter(updates),
@@ -139,9 +136,8 @@ makeUpdateList(std::vector<LedgerEntry> const& current, std::nullptr_t previous)
     return updates;
 }
 
-UpdateList
-makeUpdateList(std::vector<LedgerEntry> const& current,
-               std::vector<LedgerEntry> const& previous)
+UpdateList makeUpdateList(std::vector<LedgerEntry> const& current,
+                          std::vector<LedgerEntry> const& previous)
 {
     assert(current.size() == previous.size());
     UpdateList updates;
@@ -155,8 +151,8 @@ makeUpdateList(std::vector<LedgerEntry> const& current,
     return updates;
 }
 
-UpdateList
-makeUpdateList(std::nullptr_t current, std::vector<LedgerEntry> const& previous)
+UpdateList makeUpdateList(std::nullptr_t current,
+                          std::vector<LedgerEntry> const& previous)
 {
     UpdateList updates;
     std::transform(previous.begin(), previous.end(),
@@ -167,8 +163,7 @@ makeUpdateList(std::nullptr_t current, std::vector<LedgerEntry> const& previous)
     return updates;
 }
 
-void
-normalizeSigners(AccountEntry& acc)
+void normalizeSigners(AccountEntry& acc)
 {
     // Get indexes after sorting by acc.signer keys
     std::vector<std::size_t> indices(acc.signers.size());
@@ -202,8 +197,7 @@ normalizeSigners(AccountEntry& acc)
     }
 }
 
-int64_t
-getMinBalance(Application& app, AccountEntry const& acc)
+int64_t getMinBalance(Application& app, AccountEntry const& acc)
 {
     LedgerTxn ltx(app.getLedgerTxnRoot());
     return getMinBalance(ltx.loadHeader().current(), acc);

--- a/src/invariant/test/InvariantTests.cpp
+++ b/src/invariant/test/InvariantTests.cpp
@@ -44,8 +44,7 @@ class TestInvariant : public Invariant
     }
 
     // if id < 0, generate prefix that will match any invariant
-    static std::string
-    toString(int id, bool fail)
+    static std::string toString(int id, bool fail)
     {
         if (id < 0)
         {
@@ -58,14 +57,12 @@ class TestInvariant : public Invariant
         }
     }
 
-    virtual std::string
-    getName() const override
+    virtual std::string getName() const override
     {
         return toString(mInvariantID, mShouldFail);
     }
 
-    virtual std::string
-    checkOnBucketApply(
+    virtual std::string checkOnBucketApply(
         std::shared_ptr<LiveBucket const> bucket, uint32_t oldestLedger,
         uint32_t newestLedger,
         std::unordered_set<LedgerKey> const& shadowedKeys) override
@@ -73,18 +70,15 @@ class TestInvariant : public Invariant
         return mShouldFail ? "fail" : "";
     }
 
-    virtual std::string
-    checkAfterAssumeState(uint32_t newestLedger) override
+    virtual std::string checkAfterAssumeState(uint32_t newestLedger) override
     {
         return mShouldFail ? "fail" : "";
     }
 
-    virtual std::string
-    checkOnOperationApply(Operation const& operation,
-                          OperationResult const& result,
-                          LedgerTxnDelta const& ltxDelta,
-                          std::vector<ContractEvent> const& events,
-                          AppConnector& app) override
+    virtual std::string checkOnOperationApply(
+        Operation const& operation, OperationResult const& result,
+        LedgerTxnDelta const& ltxDelta,
+        std::vector<ContractEvent> const& events, AppConnector& app) override
     {
         return mShouldFail ? "fail" : "";
     }

--- a/src/invariant/test/LiabilitiesMatchOffersTests.cpp
+++ b/src/invariant/test/LiabilitiesMatchOffersTests.cpp
@@ -22,9 +22,9 @@
 using namespace stellar;
 using namespace stellar::InvariantTestUtils;
 
-LedgerEntry
-updateAccountWithRandomBalance(LedgerEntry le, Application& app,
-                               bool exceedsMinimum, int32_t direction)
+LedgerEntry updateAccountWithRandomBalance(LedgerEntry le, Application& app,
+                                           bool exceedsMinimum,
+                                           int32_t direction)
 {
     auto& account = le.data.account();
 
@@ -146,9 +146,9 @@ TEST_CASE("Account below minimum balance decreases",
     }
 }
 
-static LedgerEntry
-generateSellingLiabilities(Application& app, LedgerEntry offer, bool excess,
-                           uint32_t authorized)
+static LedgerEntry generateSellingLiabilities(Application& app,
+                                              LedgerEntry offer, bool excess,
+                                              uint32_t authorized)
 {
     auto const& oe = offer.data.offer();
 
@@ -190,9 +190,9 @@ generateSellingLiabilities(Application& app, LedgerEntry offer, bool excess,
     return le;
 }
 
-static LedgerEntry
-generateBuyingLiabilities(Application& app, LedgerEntry offer, bool excess,
-                          uint32_t authorized)
+static LedgerEntry generateBuyingLiabilities(Application& app,
+                                             LedgerEntry offer, bool excess,
+                                             uint32_t authorized)
 {
     auto const& oe = offer.data.offer();
 

--- a/src/invariant/test/OrderBookIsNotCrossedTests.cpp
+++ b/src/invariant/test/OrderBookIsNotCrossedTests.cpp
@@ -17,9 +17,8 @@ namespace stellar
 
 namespace
 {
-void
-applyCheck(Application& app, std::vector<LedgerEntry> const& current,
-           std::vector<LedgerEntry> const& previous, bool shouldPass)
+void applyCheck(Application& app, std::vector<LedgerEntry> const& current,
+                std::vector<LedgerEntry> const& previous, bool shouldPass)
 {
     stellar::InvariantTestUtils::UpdateList updates;
 
@@ -47,33 +46,29 @@ applyCheck(Application& app, std::vector<LedgerEntry> const& current,
             shouldPass);
 }
 
-LedgerEntry
-createOffer(Asset const& ask, Asset const& bid, int64 amount,
-            Price const& price, bool passive = false)
+LedgerEntry createOffer(Asset const& ask, Asset const& bid, int64 amount,
+                        Price const& price, bool passive = false)
 {
     auto offer = InvariantTestUtils::generateOffer(ask, bid, amount, price);
     offer.data.offer().flags = passive ? PASSIVE_FLAG : 0;
     return offer;
 }
 
-LedgerEntry
-modifyOffer(LedgerEntry offer, bool passive)
+LedgerEntry modifyOffer(LedgerEntry offer, bool passive)
 {
     offer.data.offer().flags = passive ? PASSIVE_FLAG : 0;
     return offer;
 }
 
-LedgerEntry
-modifyOffer(LedgerEntry offer, int64 amount, Price const& price)
+LedgerEntry modifyOffer(LedgerEntry offer, int64 amount, Price const& price)
 {
     offer.data.offer().amount = amount;
     offer.data.offer().price = price;
     return offer;
 }
 
-LedgerEntry
-modifyOffer(LedgerEntry offer, Asset const& ask, Asset const& bid, int64 amount,
-            Price const& price)
+LedgerEntry modifyOffer(LedgerEntry offer, Asset const& ask, Asset const& bid,
+                        int64 amount, Price const& price)
 {
     offer.data.offer().selling = ask;
     offer.data.offer().buying = bid;
@@ -186,7 +181,6 @@ TEST_CASE("OrderBookIsNotCrossed in-memory order book is consistent with "
 TEST_CASE("OrderBookIsNotCrossed properly throws if order book is crossed",
           "[invariant][OrderBookIsNotCrossed]")
 {
-
     VirtualClock clock;
     auto cfg = getTestConfig(0, Config::TESTDB_IN_MEMORY);
     // When testing the order book not crossed invariant, enable it and no other

--- a/src/ledger/CheckpointRange.cpp
+++ b/src/ledger/CheckpointRange.cpp
@@ -22,9 +22,8 @@ CheckpointRange::CheckpointRange(uint32_t first, uint32_t count,
 
 namespace
 {
-uint32_t
-checkpointCount(uint32_t firstCheckpoint, LedgerRange const& r,
-                HistoryManager const& hm)
+uint32_t checkpointCount(uint32_t firstCheckpoint, LedgerRange const& r,
+                         HistoryManager const& hm)
 {
     if (r.mCount == 0)
     {
@@ -56,14 +55,12 @@ CheckpointRange::CheckpointRange(LedgerRange const& ledgerRange,
     }
 }
 
-std::string
-CheckpointRange::toString() const
+std::string CheckpointRange::toString() const
 {
     return fmt::format(FMT_STRING("[{:d},{:d})"), mFirst, limit());
 }
 
-bool
-operator==(CheckpointRange const& x, CheckpointRange const& y)
+bool operator==(CheckpointRange const& x, CheckpointRange const& y)
 {
     if (x.mFirst != y.mFirst)
     {
@@ -80,8 +77,7 @@ operator==(CheckpointRange const& x, CheckpointRange const& y)
     return true;
 }
 
-bool
-operator!=(CheckpointRange const& x, CheckpointRange const& y)
+bool operator!=(CheckpointRange const& x, CheckpointRange const& y)
 {
     return !(x == y);
 }

--- a/src/ledger/CheckpointRange.h
+++ b/src/ledger/CheckpointRange.h
@@ -24,8 +24,8 @@ struct CheckpointRange final
     uint32_t const mFrequency;
 
     CheckpointRange(uint32_t first, uint32_t count, uint32_t frequency);
-    static CheckpointRange
-    inclusive(uint32_t first, uint32_t last, uint32_t frequency)
+    static CheckpointRange inclusive(uint32_t first, uint32_t last,
+                                     uint32_t frequency)
     {
         // CheckpointRange is half-open: in exchange for being able to represent
         // empty ranges, it can't represent ranges that include UINT32_MAX.
@@ -46,26 +46,22 @@ struct CheckpointRange final
     friend bool operator==(CheckpointRange const& x, CheckpointRange const& y);
     friend bool operator!=(CheckpointRange const& x, CheckpointRange const& y);
 
-    LedgerRange
-    getLedgerRange() const
+    LedgerRange getLedgerRange() const
     {
         return LedgerRange{mFirst, getLedgerCount()};
     }
 
-    uint32_t
-    getLedgerCount() const
+    uint32_t getLedgerCount() const
     {
         return mCount * mFrequency;
     }
 
-    uint32_t
-    limit() const
+    uint32_t limit() const
     {
         return mFirst + getLedgerCount();
     }
 
-    uint32_t
-    last() const
+    uint32_t last() const
     {
         if (mCount == 0)
         {

--- a/src/ledger/FlushAndRotateMetaDebugWork.cpp
+++ b/src/ledger/FlushAndRotateMetaDebugWork.cpp
@@ -28,8 +28,7 @@ FlushAndRotateMetaDebugWork::FlushAndRotateMetaDebugWork(
 {
 }
 
-BasicWork::State
-FlushAndRotateMetaDebugWork::doWork()
+BasicWork::State FlushAndRotateMetaDebugWork::doWork()
 {
     // Step 1: transfer ownership of mMetaDebugFile to background thread
     // and flush/fsync it. When that completes, it will post an action

--- a/src/ledger/InMemorySorobanState.cpp
+++ b/src/ledger/InMemorySorobanState.cpp
@@ -14,10 +14,9 @@ namespace stellar
 
 namespace
 {
-uint32_t
-contractCodeSizeForRent(LedgerEntry const& ledgerEntry,
-                        SorobanNetworkConfig const& sorobanConfig,
-                        uint32_t ledgerVersion)
+uint32_t contractCodeSizeForRent(LedgerEntry const& ledgerEntry,
+                                 SorobanNetworkConfig const& sorobanConfig,
+                                 uint32_t ledgerVersion)
 {
     releaseAssertOrThrow(ledgerEntry.data.type() == CONTRACT_CODE);
     // Subtle: in-memory state size accounting is only used starting from
@@ -32,8 +31,7 @@ contractCodeSizeForRent(LedgerEntry const& ledgerEntry,
 }
 } // namespace
 
-bool
-TTLData::isDefault() const
+bool TTLData::isDefault() const
 {
     if (liveUntilLedgerSeq == 0)
     {
@@ -47,8 +45,7 @@ TTLData::isDefault() const
     }
 }
 
-void
-InMemorySorobanState::updateContractDataTTL(
+void InMemorySorobanState::updateContractDataTTL(
     std::unordered_set<InternalContractDataMapEntry,
                        InternalContractDataEntryHash>::iterator dataIt,
     TTLData newTtlData)
@@ -60,8 +57,7 @@ InMemorySorobanState::updateContractDataTTL(
         InternalContractDataMapEntry(std::move(ledgerEntryPtr), newTtlData));
 }
 
-void
-InMemorySorobanState::updateTTL(LedgerEntry const& ttlEntry)
+void InMemorySorobanState::updateTTL(LedgerEntry const& ttlEntry)
 {
     releaseAssertOrThrow(ttlEntry.data.type() == TTL);
 
@@ -86,8 +82,7 @@ InMemorySorobanState::updateTTL(LedgerEntry const& ttlEntry)
     }
 }
 
-void
-InMemorySorobanState::updateContractData(LedgerEntry const& ledgerEntry)
+void InMemorySorobanState::updateContractData(LedgerEntry const& ledgerEntry)
 {
     releaseAssertOrThrow(ledgerEntry.data.type() == CONTRACT_DATA);
 
@@ -108,8 +103,8 @@ InMemorySorobanState::updateContractData(LedgerEntry const& ledgerEntry)
         InternalContractDataMapEntry(ledgerEntry, preservedTTL));
 }
 
-void
-InMemorySorobanState::createContractDataEntry(LedgerEntry const& ledgerEntry)
+void InMemorySorobanState::createContractDataEntry(
+    LedgerEntry const& ledgerEntry)
 {
     releaseAssertOrThrow(ledgerEntry.data.type() == CONTRACT_DATA);
 
@@ -139,15 +134,13 @@ InMemorySorobanState::createContractDataEntry(LedgerEntry const& ledgerEntry)
         InternalContractDataMapEntry(ledgerEntry, ttlData));
 }
 
-bool
-InMemorySorobanState::isInMemoryType(LedgerKey const& ledgerKey)
+bool InMemorySorobanState::isInMemoryType(LedgerKey const& ledgerKey)
 {
     return ledgerKey.type() == CONTRACT_DATA ||
            ledgerKey.type() == CONTRACT_CODE || ledgerKey.type() == TTL;
 }
 
-void
-InMemorySorobanState::createTTL(LedgerEntry const& ttlEntry)
+void InMemorySorobanState::createTTL(LedgerEntry const& ttlEntry)
 {
     releaseAssertOrThrow(ttlEntry.data.type() == TTL);
 
@@ -186,8 +179,7 @@ InMemorySorobanState::createTTL(LedgerEntry const& ttlEntry)
     }
 }
 
-void
-InMemorySorobanState::deleteContractData(LedgerKey const& ledgerKey)
+void InMemorySorobanState::deleteContractData(LedgerKey const& ledgerKey)
 {
     releaseAssertOrThrow(ledgerKey.type() == CONTRACT_DATA);
     auto it =
@@ -233,8 +225,7 @@ InMemorySorobanState::get(LedgerKey const& ledgerKey) const
     }
 }
 
-void
-InMemorySorobanState::createContractCodeEntry(
+void InMemorySorobanState::createContractCodeEntry(
     LedgerEntry const& ledgerEntry, SorobanNetworkConfig const& sorobanConfig,
     uint32_t ledgerVersion)
 {
@@ -272,8 +263,7 @@ InMemorySorobanState::createContractCodeEntry(
                               ttlData, entrySize));
 }
 
-void
-InMemorySorobanState::updateContractCode(
+void InMemorySorobanState::updateContractCode(
     LedgerEntry const& ledgerEntry, SorobanNetworkConfig const& sorobanConfig,
     uint32_t ledgerVersion)
 {
@@ -299,8 +289,7 @@ InMemorySorobanState::updateContractCode(
                               ttlData, newEntrySize);
 }
 
-void
-InMemorySorobanState::deleteContractCode(LedgerKey const& ledgerKey)
+void InMemorySorobanState::deleteContractCode(LedgerKey const& ledgerKey)
 {
     releaseAssertOrThrow(ledgerKey.type() == CONTRACT_CODE);
 
@@ -313,8 +302,7 @@ InMemorySorobanState::deleteContractCode(LedgerKey const& ledgerKey)
     mContractCodeEntries.erase(it);
 }
 
-bool
-InMemorySorobanState::hasTTL(LedgerKey const& ledgerKey) const
+bool InMemorySorobanState::hasTTL(LedgerKey const& ledgerKey) const
 {
     releaseAssertOrThrow(ledgerKey.type() == TTL);
 
@@ -348,21 +336,19 @@ InMemorySorobanState::hasTTL(LedgerKey const& ledgerKey) const
     return false;
 }
 
-bool
-InMemorySorobanState::isEmpty() const
+bool InMemorySorobanState::isEmpty() const
 {
     return mContractDataEntries.empty() && mContractCodeEntries.empty() &&
            mPendingTTLs.empty();
 }
 
-uint32_t
-InMemorySorobanState::getLedgerSeq() const
+uint32_t InMemorySorobanState::getLedgerSeq() const
 {
     return mLastClosedLedgerSeq;
 }
 
-void
-InMemorySorobanState::assertLastClosedLedger(uint32_t expectedLedgerSeq) const
+void InMemorySorobanState::assertLastClosedLedger(
+    uint32_t expectedLedgerSeq) const
 {
     releaseAssertOrThrow(mLastClosedLedgerSeq == expectedLedgerSeq);
 }
@@ -403,8 +389,7 @@ InMemorySorobanState::getTTL(LedgerKey const& ledgerKey) const
     return nullptr;
 }
 
-void
-InMemorySorobanState::initializeStateFromSnapshot(
+void InMemorySorobanState::initializeStateFromSnapshot(
     SearchableSnapshotConstPtr snap, uint32_t ledgerVersion)
 {
     releaseAssertOrThrow(mContractDataEntries.empty());
@@ -489,8 +474,7 @@ InMemorySorobanState::initializeStateFromSnapshot(
     checkUpdateInvariants();
 }
 
-void
-InMemorySorobanState::updateState(
+void InMemorySorobanState::updateState(
     std::vector<LedgerEntry> const& initEntries,
     std::vector<LedgerEntry> const& liveEntries,
     std::vector<LedgerKey> const& deadEntries, LedgerHeader const& lh,
@@ -558,8 +542,7 @@ InMemorySorobanState::updateState(
     reportMetrics(metrics);
 }
 
-void
-InMemorySorobanState::recomputeContractCodeSize(
+void InMemorySorobanState::recomputeContractCodeSize(
     SorobanNetworkConfig const& sorobanConfig, uint32_t ledgerVersion)
 {
     for (auto& [_, entry] : mContractCodeEntries)
@@ -572,8 +555,7 @@ InMemorySorobanState::recomputeContractCodeSize(
     }
 }
 
-uint64_t
-InMemorySorobanState::getSize() const
+uint64_t InMemorySorobanState::getSize() const
 {
     releaseAssertOrThrow(mContractCodeStateSize >= 0);
     releaseAssertOrThrow(mContractDataStateSize >= 0);
@@ -581,8 +563,7 @@ InMemorySorobanState::getSize() const
                                  mContractDataStateSize);
 }
 
-void
-InMemorySorobanState::reportMetrics(SorobanMetrics& metrics) const
+void InMemorySorobanState::reportMetrics(SorobanMetrics& metrics) const
 {
     metrics.mContractCodeStateSize.set_count(mContractCodeStateSize);
     metrics.mContractDataStateSize.set_count(mContractDataStateSize);
@@ -598,22 +579,19 @@ InMemorySorobanState::reportMetrics(SorobanMetrics& metrics) const
               static_cast<int64_t>(mContractDataEntries.size()));
 }
 
-void
-InMemorySorobanState::manuallyAdvanceLedgerHeader(LedgerHeader const& lh)
+void InMemorySorobanState::manuallyAdvanceLedgerHeader(LedgerHeader const& lh)
 {
     mLastClosedLedgerSeq = lh.ledgerSeq;
 }
 
-void
-InMemorySorobanState::checkUpdateInvariants() const
+void InMemorySorobanState::checkUpdateInvariants() const
 {
     // No TTLs should be orphaned after finishing an update
     releaseAssertOrThrow(mPendingTTLs.empty());
 }
-void
-InMemorySorobanState::updateStateSizeOnEntryUpdate(uint32_t oldEntrySize,
-                                                   uint32_t newEntrySize,
-                                                   bool isContractCode)
+void InMemorySorobanState::updateStateSizeOnEntryUpdate(uint32_t oldEntrySize,
+                                                        uint32_t newEntrySize,
+                                                        bool isContractCode)
 {
     int64_t sizeDelta =
         static_cast<int64_t>(newEntrySize) - static_cast<int64_t>(oldEntrySize);
@@ -639,8 +617,7 @@ InMemorySorobanState::updateStateSizeOnEntryUpdate(uint32_t oldEntrySize,
 }
 
 #ifdef BUILD_TESTS
-void
-InMemorySorobanState::clearForTesting()
+void InMemorySorobanState::clearForTesting()
 {
     mContractDataEntries.clear();
     mContractCodeEntries.clear();

--- a/src/ledger/InMemorySorobanState.h
+++ b/src/ledger/InMemorySorobanState.h
@@ -125,8 +125,7 @@ class InternalContractDataMapEntry
         virtual std::unique_ptr<AbstractEntry> clone() const = 0;
 
         // Equality comparison based on TTL keys
-        virtual bool
-        operator==(AbstractEntry const& other) const
+        virtual bool operator==(AbstractEntry const& other) const
         {
             return copyKey() == other.copyKey();
         }
@@ -146,27 +145,23 @@ class InternalContractDataMapEntry
         {
         }
 
-        uint256
-        copyKey() const override
+        uint256 copyKey() const override
         {
             auto ttlKey = getTTLKey(LedgerEntryKey(*entry.ledgerEntry));
             return ttlKey.ttl().keyHash;
         }
 
-        size_t
-        hash() const override
+        size_t hash() const override
         {
             return std::hash<uint256>{}(copyKey());
         }
 
-        ContractDataMapEntryT const&
-        get() const override
+        ContractDataMapEntryT const& get() const override
         {
             return entry;
         }
 
-        std::unique_ptr<AbstractEntry>
-        clone() const override
+        std::unique_ptr<AbstractEntry> clone() const override
         {
             return std::make_unique<ValueEntry>(
                 std::make_shared<LedgerEntry const>(*entry.ledgerEntry),
@@ -186,28 +181,24 @@ class InternalContractDataMapEntry
         {
         }
 
-        uint256
-        copyKey() const override
+        uint256 copyKey() const override
         {
             return ledgerKeyHash;
         }
 
-        size_t
-        hash() const override
+        size_t hash() const override
         {
             return std::hash<uint256>{}(ledgerKeyHash);
         }
 
         // Should never be called - QueryKey is only for lookups
-        ContractDataMapEntryT const&
-        get() const override
+        ContractDataMapEntryT const& get() const override
         {
             throw std::runtime_error(
                 "QueryKey::get() called - this is a logic error");
         }
 
-        std::unique_ptr<AbstractEntry>
-        clone() const override
+        std::unique_ptr<AbstractEntry> clone() const override
         {
             return std::make_unique<QueryKey>(ledgerKeyHash);
         }
@@ -258,20 +249,17 @@ class InternalContractDataMapEntry
         }
     }
 
-    size_t
-    hash() const
+    size_t hash() const
     {
         return impl->hash();
     }
 
-    bool
-    operator==(InternalContractDataMapEntry const& other) const
+    bool operator==(InternalContractDataMapEntry const& other) const
     {
         return impl->operator==(*other.impl);
     }
 
-    ContractDataMapEntryT const&
-    get() const
+    ContractDataMapEntryT const& get() const
     {
         return impl->get();
     }
@@ -279,8 +267,7 @@ class InternalContractDataMapEntry
 
 struct InternalContractDataEntryHash
 {
-    size_t
-    operator()(InternalContractDataMapEntry const& entry) const
+    size_t operator()(InternalContractDataMapEntry const& entry) const
     {
         return entry.hash();
     }
@@ -438,13 +425,12 @@ class InMemorySorobanState
 
     // Update the map with entries from a ledger close. ledgerSeq must be
     // exactly mLastClosedLedgerSeq + 1.
-    void
-    updateState(std::vector<LedgerEntry> const& initEntries,
-                std::vector<LedgerEntry> const& liveEntries,
-                std::vector<LedgerKey> const& deadEntries,
-                LedgerHeader const& lh,
-                std::optional<SorobanNetworkConfig const> const& sorobanConfig,
-                SorobanMetrics& metrics);
+    void updateState(
+        std::vector<LedgerEntry> const& initEntries,
+        std::vector<LedgerEntry> const& liveEntries,
+        std::vector<LedgerKey> const& deadEntries, LedgerHeader const& lh,
+        std::optional<SorobanNetworkConfig const> const& sorobanConfig,
+        SorobanMetrics& metrics);
 
     // Should only be called in manual ledger close paths.
     void manuallyAdvanceLedgerHeader(LedgerHeader const& lh);

--- a/src/ledger/InternalLedgerEntry.cpp
+++ b/src/ledger/InternalLedgerEntry.cpp
@@ -14,79 +14,71 @@
 namespace stellar
 {
 
-bool
-operator==(SponsorshipKey const& lhs, SponsorshipKey const& rhs)
+bool operator==(SponsorshipKey const& lhs, SponsorshipKey const& rhs)
 {
     return lhs.sponsoredID == rhs.sponsoredID;
 }
 
-bool
-operator!=(SponsorshipKey const& lhs, SponsorshipKey const& rhs)
+bool operator!=(SponsorshipKey const& lhs, SponsorshipKey const& rhs)
 {
     return !(lhs == rhs);
 }
 
-bool
-operator==(SponsorshipEntry const& lhs, SponsorshipEntry const& rhs)
+bool operator==(SponsorshipEntry const& lhs, SponsorshipEntry const& rhs)
 {
     return lhs.sponsoredID == rhs.sponsoredID &&
            lhs.sponsoringID == rhs.sponsoringID;
 }
 
-bool
-operator!=(SponsorshipEntry const& lhs, SponsorshipEntry const& rhs)
+bool operator!=(SponsorshipEntry const& lhs, SponsorshipEntry const& rhs)
 {
     return !(lhs == rhs);
 }
 
-bool
-operator==(SponsorshipCounterKey const& lhs, SponsorshipCounterKey const& rhs)
+bool operator==(SponsorshipCounterKey const& lhs,
+                SponsorshipCounterKey const& rhs)
 {
     return lhs.sponsoringID == rhs.sponsoringID;
 }
 
-bool
-operator!=(SponsorshipCounterKey const& lhs, SponsorshipCounterKey const& rhs)
+bool operator!=(SponsorshipCounterKey const& lhs,
+                SponsorshipCounterKey const& rhs)
 {
     return !(lhs == rhs);
 }
 
-bool
-operator==(SponsorshipCounterEntry const& lhs,
-           SponsorshipCounterEntry const& rhs)
+bool operator==(SponsorshipCounterEntry const& lhs,
+                SponsorshipCounterEntry const& rhs)
 {
     return lhs.sponsoringID == rhs.sponsoringID &&
            lhs.numSponsoring == rhs.numSponsoring;
 }
 
-bool
-operator!=(SponsorshipCounterEntry const& lhs,
-           SponsorshipCounterEntry const& rhs)
+bool operator!=(SponsorshipCounterEntry const& lhs,
+                SponsorshipCounterEntry const& rhs)
 {
     return !(lhs == rhs);
 }
 
-bool
-operator==(MaxSeqNumToApplyKey const& lhs, MaxSeqNumToApplyKey const& rhs)
+bool operator==(MaxSeqNumToApplyKey const& lhs, MaxSeqNumToApplyKey const& rhs)
 {
     return lhs.sourceAccount == rhs.sourceAccount;
 }
 
-bool
-operator!=(MaxSeqNumToApplyKey const& lhs, MaxSeqNumToApplyKey const& rhs)
+bool operator!=(MaxSeqNumToApplyKey const& lhs, MaxSeqNumToApplyKey const& rhs)
 {
     return !(lhs == rhs);
 }
 
-bool
-operator==(MaxSeqNumToApplyEntry const& lhs, MaxSeqNumToApplyEntry const& rhs)
+bool operator==(MaxSeqNumToApplyEntry const& lhs,
+                MaxSeqNumToApplyEntry const& rhs)
 {
     return lhs.sourceAccount == rhs.sourceAccount &&
            lhs.maxSeqNum == rhs.maxSeqNum;
 }
 
-bool
-operator!=(MaxSeqNumToApplyEntry const& lhs, MaxSeqNumToApplyEntry const& rhs)
+bool operator!=(MaxSeqNumToApplyEntry const& lhs,
+                MaxSeqNumToApplyEntry const& rhs)
 {
     return !(lhs == rhs);
 }
@@ -162,16 +154,14 @@ InternalLedgerKey::makeMaxSeqNumToApplyKey(AccountID const& sourceAccount)
     return res;
 }
 
-InternalLedgerKey&
-InternalLedgerKey::operator=(InternalLedgerKey const& glk)
+InternalLedgerKey& InternalLedgerKey::operator=(InternalLedgerKey const& glk)
 {
     type(glk.type());
     assign(glk);
     return *this;
 }
 
-InternalLedgerKey&
-InternalLedgerKey::operator=(InternalLedgerKey&& glk)
+InternalLedgerKey& InternalLedgerKey::operator=(InternalLedgerKey&& glk)
 {
     if (this == &glk)
     {
@@ -188,8 +178,7 @@ InternalLedgerKey::~InternalLedgerKey()
     destruct();
 }
 
-size_t
-InternalLedgerKey::hash() const
+size_t InternalLedgerKey::hash() const
 {
     if (mHash != 0)
     {
@@ -221,8 +210,7 @@ InternalLedgerKey::hash() const
     return res;
 }
 
-void
-InternalLedgerKey::assign(InternalLedgerKey const& glk)
+void InternalLedgerKey::assign(InternalLedgerKey const& glk)
 {
     releaseAssert(glk.type() == mType);
     mHash = glk.mHash;
@@ -245,8 +233,7 @@ InternalLedgerKey::assign(InternalLedgerKey const& glk)
     }
 }
 
-void
-InternalLedgerKey::assign(InternalLedgerKey&& glk)
+void InternalLedgerKey::assign(InternalLedgerKey&& glk)
 {
     releaseAssert(glk.type() == mType);
     mHash = glk.mHash;
@@ -269,8 +256,7 @@ InternalLedgerKey::assign(InternalLedgerKey&& glk)
     }
 }
 
-void
-InternalLedgerKey::construct()
+void InternalLedgerKey::construct()
 {
     switch (mType)
     {
@@ -292,8 +278,7 @@ InternalLedgerKey::construct()
     mHash = 0;
 }
 
-void
-InternalLedgerKey::destruct()
+void InternalLedgerKey::destruct()
 {
     switch (mType)
     {
@@ -315,8 +300,7 @@ InternalLedgerKey::destruct()
     mHash = 0;
 }
 
-void
-InternalLedgerKey::type(InternalLedgerEntryType t)
+void InternalLedgerKey::type(InternalLedgerEntryType t)
 {
     if (t != mType)
     {
@@ -326,14 +310,13 @@ InternalLedgerKey::type(InternalLedgerEntryType t)
     }
 }
 
-InternalLedgerEntryType
-InternalLedgerKey::type() const
+InternalLedgerEntryType InternalLedgerKey::type() const
 {
     return mType;
 }
 
-void
-InternalLedgerKey::checkDiscriminant(InternalLedgerEntryType expected) const
+void InternalLedgerKey::checkDiscriminant(
+    InternalLedgerEntryType expected) const
 {
     if (mType != expected)
     {
@@ -341,68 +324,59 @@ InternalLedgerKey::checkDiscriminant(InternalLedgerEntryType expected) const
     }
 }
 
-LedgerKey&
-InternalLedgerKey::ledgerKeyRef()
+LedgerKey& InternalLedgerKey::ledgerKeyRef()
 {
     checkDiscriminant(InternalLedgerEntryType::LEDGER_ENTRY);
     mHash = 0;
     return mLedgerKey;
 }
 
-LedgerKey const&
-InternalLedgerKey::ledgerKey() const
+LedgerKey const& InternalLedgerKey::ledgerKey() const
 {
     checkDiscriminant(InternalLedgerEntryType::LEDGER_ENTRY);
     return mLedgerKey;
 }
 
-SponsorshipKey&
-InternalLedgerKey::sponsorshipKeyRef()
+SponsorshipKey& InternalLedgerKey::sponsorshipKeyRef()
 {
     checkDiscriminant(InternalLedgerEntryType::SPONSORSHIP);
     mHash = 0;
     return mSponsorshipKey;
 }
 
-SponsorshipKey const&
-InternalLedgerKey::sponsorshipKey() const
+SponsorshipKey const& InternalLedgerKey::sponsorshipKey() const
 {
     checkDiscriminant(InternalLedgerEntryType::SPONSORSHIP);
     return mSponsorshipKey;
 }
 
-SponsorshipCounterKey&
-InternalLedgerKey::sponsorshipCounterKeyRef()
+SponsorshipCounterKey& InternalLedgerKey::sponsorshipCounterKeyRef()
 {
     checkDiscriminant(InternalLedgerEntryType::SPONSORSHIP_COUNTER);
     mHash = 0;
     return mSponsorshipCounterKey;
 }
 
-SponsorshipCounterKey const&
-InternalLedgerKey::sponsorshipCounterKey() const
+SponsorshipCounterKey const& InternalLedgerKey::sponsorshipCounterKey() const
 {
     checkDiscriminant(InternalLedgerEntryType::SPONSORSHIP_COUNTER);
     return mSponsorshipCounterKey;
 }
 
-MaxSeqNumToApplyKey&
-InternalLedgerKey::maxSeqNumToApplyKeyRef()
+MaxSeqNumToApplyKey& InternalLedgerKey::maxSeqNumToApplyKeyRef()
 {
     checkDiscriminant(InternalLedgerEntryType::MAX_SEQ_NUM_TO_APPLY);
     mHash = 0;
     return mMaxSeqNumToApplyKey;
 }
 
-MaxSeqNumToApplyKey const&
-InternalLedgerKey::maxSeqNumToApplyKey() const
+MaxSeqNumToApplyKey const& InternalLedgerKey::maxSeqNumToApplyKey() const
 {
     checkDiscriminant(InternalLedgerEntryType::MAX_SEQ_NUM_TO_APPLY);
     return mMaxSeqNumToApplyKey;
 }
 
-std::string
-InternalLedgerKey::toString() const
+std::string InternalLedgerKey::toString() const
 {
     switch (mType)
     {
@@ -428,8 +402,7 @@ InternalLedgerKey::toString() const
     }
 }
 
-bool
-operator==(InternalLedgerKey const& lhs, InternalLedgerKey const& rhs)
+bool operator==(InternalLedgerKey const& lhs, InternalLedgerKey const& rhs)
 {
     if (lhs.hash() != rhs.hash() || lhs.type() != rhs.type())
     {
@@ -451,8 +424,7 @@ operator==(InternalLedgerKey const& lhs, InternalLedgerKey const& rhs)
     }
 }
 
-bool
-operator!=(InternalLedgerKey const& lhs, InternalLedgerKey const& rhs)
+bool operator!=(InternalLedgerKey const& lhs, InternalLedgerKey const& rhs)
 {
     return !(lhs == rhs);
 }
@@ -517,8 +489,7 @@ InternalLedgerEntry::operator=(InternalLedgerEntry const& gle)
     return *this;
 }
 
-InternalLedgerEntry&
-InternalLedgerEntry::operator=(InternalLedgerEntry&& gle)
+InternalLedgerEntry& InternalLedgerEntry::operator=(InternalLedgerEntry&& gle)
 {
     if (this == &gle)
     {
@@ -535,8 +506,7 @@ InternalLedgerEntry::~InternalLedgerEntry()
     destruct();
 }
 
-void
-InternalLedgerEntry::assign(InternalLedgerEntry const& gle)
+void InternalLedgerEntry::assign(InternalLedgerEntry const& gle)
 {
     releaseAssert(gle.type() == mType);
     switch (mType)
@@ -558,8 +528,7 @@ InternalLedgerEntry::assign(InternalLedgerEntry const& gle)
     }
 }
 
-void
-InternalLedgerEntry::assign(InternalLedgerEntry&& gle)
+void InternalLedgerEntry::assign(InternalLedgerEntry&& gle)
 {
     releaseAssert(gle.type() == mType);
     switch (mType)
@@ -581,8 +550,7 @@ InternalLedgerEntry::assign(InternalLedgerEntry&& gle)
     }
 }
 
-void
-InternalLedgerEntry::construct()
+void InternalLedgerEntry::construct()
 {
     switch (mType)
     {
@@ -603,8 +571,7 @@ InternalLedgerEntry::construct()
     }
 }
 
-void
-InternalLedgerEntry::destruct()
+void InternalLedgerEntry::destruct()
 {
     switch (mType)
     {
@@ -625,8 +592,7 @@ InternalLedgerEntry::destruct()
     }
 }
 
-void
-InternalLedgerEntry::type(InternalLedgerEntryType t)
+void InternalLedgerEntry::type(InternalLedgerEntryType t)
 {
     if (t != mType)
     {
@@ -636,14 +602,13 @@ InternalLedgerEntry::type(InternalLedgerEntryType t)
     }
 }
 
-InternalLedgerEntryType
-InternalLedgerEntry::type() const
+InternalLedgerEntryType InternalLedgerEntry::type() const
 {
     return mType;
 }
 
-void
-InternalLedgerEntry::checkDiscriminant(InternalLedgerEntryType expected) const
+void InternalLedgerEntry::checkDiscriminant(
+    InternalLedgerEntryType expected) const
 {
     if (mType != expected)
     {
@@ -651,36 +616,31 @@ InternalLedgerEntry::checkDiscriminant(InternalLedgerEntryType expected) const
     }
 }
 
-LedgerEntry&
-InternalLedgerEntry::ledgerEntry()
+LedgerEntry& InternalLedgerEntry::ledgerEntry()
 {
     checkDiscriminant(InternalLedgerEntryType::LEDGER_ENTRY);
     return mLedgerEntry;
 }
 
-LedgerEntry const&
-InternalLedgerEntry::ledgerEntry() const
+LedgerEntry const& InternalLedgerEntry::ledgerEntry() const
 {
     checkDiscriminant(InternalLedgerEntryType::LEDGER_ENTRY);
     return mLedgerEntry;
 }
 
-SponsorshipEntry&
-InternalLedgerEntry::sponsorshipEntry()
+SponsorshipEntry& InternalLedgerEntry::sponsorshipEntry()
 {
     checkDiscriminant(InternalLedgerEntryType::SPONSORSHIP);
     return mSponsorshipEntry;
 }
 
-SponsorshipEntry const&
-InternalLedgerEntry::sponsorshipEntry() const
+SponsorshipEntry const& InternalLedgerEntry::sponsorshipEntry() const
 {
     checkDiscriminant(InternalLedgerEntryType::SPONSORSHIP);
     return mSponsorshipEntry;
 }
 
-SponsorshipCounterEntry&
-InternalLedgerEntry::sponsorshipCounterEntry()
+SponsorshipCounterEntry& InternalLedgerEntry::sponsorshipCounterEntry()
 {
     checkDiscriminant(InternalLedgerEntryType::SPONSORSHIP_COUNTER);
     return mSponsorshipCounterEntry;
@@ -693,22 +653,19 @@ InternalLedgerEntry::sponsorshipCounterEntry() const
     return mSponsorshipCounterEntry;
 }
 
-MaxSeqNumToApplyEntry&
-InternalLedgerEntry::maxSeqNumToApplyEntry()
+MaxSeqNumToApplyEntry& InternalLedgerEntry::maxSeqNumToApplyEntry()
 {
     checkDiscriminant(InternalLedgerEntryType::MAX_SEQ_NUM_TO_APPLY);
     return mMaxSeqNumToApplyEntry;
 }
 
-MaxSeqNumToApplyEntry const&
-InternalLedgerEntry::maxSeqNumToApplyEntry() const
+MaxSeqNumToApplyEntry const& InternalLedgerEntry::maxSeqNumToApplyEntry() const
 {
     checkDiscriminant(InternalLedgerEntryType::MAX_SEQ_NUM_TO_APPLY);
     return mMaxSeqNumToApplyEntry;
 }
 
-InternalLedgerKey
-InternalLedgerEntry::toKey() const
+InternalLedgerKey InternalLedgerEntry::toKey() const
 {
     switch (mType)
     {
@@ -728,8 +685,7 @@ InternalLedgerEntry::toKey() const
     }
 }
 
-std::string
-InternalLedgerEntry::toString() const
+std::string InternalLedgerEntry::toString() const
 {
     switch (mType)
     {
@@ -757,8 +713,7 @@ InternalLedgerEntry::toString() const
     }
 }
 
-bool
-operator==(InternalLedgerEntry const& lhs, InternalLedgerEntry const& rhs)
+bool operator==(InternalLedgerEntry const& lhs, InternalLedgerEntry const& rhs)
 {
     if (lhs.type() != rhs.type())
     {
@@ -780,8 +735,7 @@ operator==(InternalLedgerEntry const& lhs, InternalLedgerEntry const& rhs)
     }
 }
 
-bool
-operator!=(InternalLedgerEntry const& lhs, InternalLedgerEntry const& rhs)
+bool operator!=(InternalLedgerEntry const& lhs, InternalLedgerEntry const& rhs)
 {
     return !(lhs == rhs);
 }

--- a/src/ledger/LedgerCloseMetaFrame.cpp
+++ b/src/ledger/LedgerCloseMetaFrame.cpp
@@ -32,8 +32,7 @@ LedgerCloseMetaFrame::LedgerCloseMetaFrame(uint32_t protocolVersion)
     mLedgerCloseMeta.v(mVersion);
 }
 
-LedgerHeaderHistoryEntry&
-LedgerCloseMetaFrame::ledgerHeader()
+LedgerHeaderHistoryEntry& LedgerCloseMetaFrame::ledgerHeader()
 {
     switch (mVersion)
     {
@@ -48,8 +47,7 @@ LedgerCloseMetaFrame::ledgerHeader()
     }
 }
 
-void
-LedgerCloseMetaFrame::reserveTxProcessing(size_t n)
+void LedgerCloseMetaFrame::reserveTxProcessing(size_t n)
 {
     switch (mVersion)
     {
@@ -67,8 +65,7 @@ LedgerCloseMetaFrame::reserveTxProcessing(size_t n)
     }
 }
 
-void
-LedgerCloseMetaFrame::pushTxFeeProcessing(
+void LedgerCloseMetaFrame::pushTxFeeProcessing(
     LedgerEntryChanges const& feeProcessing)
 {
     switch (mVersion)
@@ -90,8 +87,7 @@ LedgerCloseMetaFrame::pushTxFeeProcessing(
     }
 }
 
-void
-LedgerCloseMetaFrame::setTxProcessingMetaAndResultPair(
+void LedgerCloseMetaFrame::setTxProcessingMetaAndResultPair(
     TransactionMeta&& tm, TransactionResultPair&& rp, int index)
 {
     switch (mVersion)
@@ -122,17 +118,15 @@ LedgerCloseMetaFrame::setTxProcessingMetaAndResultPair(
     }
 }
 
-void
-LedgerCloseMetaFrame::setPostTxApplyFeeProcessing(LedgerEntryChanges&& changes,
-                                                  int index)
+void LedgerCloseMetaFrame::setPostTxApplyFeeProcessing(
+    LedgerEntryChanges&& changes, int index)
 {
     releaseAssert(mVersion == 2);
     mLedgerCloseMeta.v2().txProcessing.at(index).postTxApplyFeeProcessing =
         std::move(changes);
 }
 
-xdr::xvector<UpgradeEntryMeta>&
-LedgerCloseMetaFrame::upgradesProcessing()
+xdr::xvector<UpgradeEntryMeta>& LedgerCloseMetaFrame::upgradesProcessing()
 {
     switch (mVersion)
     {
@@ -147,8 +141,7 @@ LedgerCloseMetaFrame::upgradesProcessing()
     }
 }
 
-void
-LedgerCloseMetaFrame::populateTxSet(TxSetXDRFrame const& txSet)
+void LedgerCloseMetaFrame::populateTxSet(TxSetXDRFrame const& txSet)
 {
     switch (mVersion)
     {
@@ -166,8 +159,7 @@ LedgerCloseMetaFrame::populateTxSet(TxSetXDRFrame const& txSet)
     }
 }
 
-void
-LedgerCloseMetaFrame::populateEvictedEntries(
+void LedgerCloseMetaFrame::populateEvictedEntries(
     EvictedStateVectors const& evictedState)
 {
     releaseAssert(mVersion == 1 || mVersion == 2);
@@ -186,8 +178,7 @@ LedgerCloseMetaFrame::populateEvictedEntries(
     }
 }
 
-void
-LedgerCloseMetaFrame::setNetworkConfiguration(
+void LedgerCloseMetaFrame::setNetworkConfiguration(
     SorobanNetworkConfig const& networkConfig, bool emitExtV1)
 {
     releaseAssert(mVersion == 1 || mVersion == 2);
@@ -207,8 +198,7 @@ LedgerCloseMetaFrame::setNetworkConfiguration(
     }
 }
 
-LedgerCloseMeta const&
-LedgerCloseMetaFrame::getXDR() const
+LedgerCloseMeta const& LedgerCloseMetaFrame::getXDR() const
 {
     return mLedgerCloseMeta;
 }
@@ -227,8 +217,7 @@ LedgerCloseMetaFrame::LedgerCloseMetaFrame(LedgerCloseMeta const& lm)
     }
 }
 
-LedgerHeader const&
-LedgerCloseMetaFrame::getLedgerHeader() const
+LedgerHeader const& LedgerCloseMetaFrame::getLedgerHeader() const
 {
     switch (mVersion)
     {
@@ -243,8 +232,7 @@ LedgerCloseMetaFrame::getLedgerHeader() const
     }
 }
 
-xdr::xvector<LedgerKey> const&
-LedgerCloseMetaFrame::getEvictedKeys() const
+xdr::xvector<LedgerKey> const& LedgerCloseMetaFrame::getEvictedKeys() const
 {
     switch (mVersion)
     {
@@ -257,8 +245,7 @@ LedgerCloseMetaFrame::getEvictedKeys() const
     }
 }
 
-size_t
-LedgerCloseMetaFrame::getTransactionResultMetaCount() const
+size_t LedgerCloseMetaFrame::getTransactionResultMetaCount() const
 {
     switch (mVersion)
     {
@@ -314,8 +301,7 @@ LedgerCloseMetaFrame::getPostTxApplyFeeProcessing(size_t index) const
         .postTxApplyFeeProcessing;
 }
 
-void
-LedgerCloseMetaFrame::sortTxMetaByHash()
+void LedgerCloseMetaFrame::sortTxMetaByHash()
 {
     auto sortTxMeta = [](auto& txProcessing) {
         std::sort(txProcessing.begin(), txProcessing.end(),

--- a/src/ledger/LedgerHashUtils.h
+++ b/src/ledger/LedgerHashUtils.h
@@ -14,20 +14,17 @@
 namespace stellar
 {
 
-static PoolID const&
-getLiquidityPoolID(Asset const& asset)
+static PoolID const& getLiquidityPoolID(Asset const& asset)
 {
     throw std::runtime_error("cannot get PoolID from Asset");
 }
 
-static PoolID const&
-getLiquidityPoolID(TrustLineAsset const& tlAsset)
+static PoolID const& getLiquidityPoolID(TrustLineAsset const& tlAsset)
 {
     return tlAsset.liquidityPoolID();
 }
 
-static inline void
-hashMix(size_t& h, size_t v)
+static inline void hashMix(size_t& h, size_t v)
 {
     // from https://github.com/ztanml/fast-hash (MIT license)
     v ^= v >> 23;
@@ -37,9 +34,7 @@ hashMix(size_t& h, size_t v)
     h *= 0x880355f21e6d1965ULL;
 }
 
-template <typename T>
-static size_t
-getAssetHash(T const& asset)
+template <typename T> static size_t getAssetHash(T const& asset)
 {
     size_t res = asset.type();
 
@@ -82,8 +77,7 @@ namespace std
 template <> class hash<stellar::Asset>
 {
   public:
-    size_t
-    operator()(stellar::Asset const& asset) const
+    size_t operator()(stellar::Asset const& asset) const
     {
         return stellar::getAssetHash<stellar::Asset>(asset);
     }
@@ -92,8 +86,7 @@ template <> class hash<stellar::Asset>
 template <> class hash<stellar::TrustLineAsset>
 {
   public:
-    size_t
-    operator()(stellar::TrustLineAsset const& asset) const
+    size_t operator()(stellar::TrustLineAsset const& asset) const
     {
         return stellar::getAssetHash<stellar::TrustLineAsset>(asset);
     }
@@ -102,8 +95,7 @@ template <> class hash<stellar::TrustLineAsset>
 template <> class hash<stellar::SCAddress>
 {
   public:
-    size_t
-    operator()(stellar::SCAddress const& addr) const
+    size_t operator()(stellar::SCAddress const& addr) const
     {
         size_t res = addr.type();
         switch (addr.type())
@@ -136,8 +128,7 @@ template <> class hash<stellar::SCAddress>
 template <> class hash<stellar::LedgerKey>
 {
   public:
-    size_t
-    operator()(stellar::LedgerKey const& lk) const
+    size_t operator()(stellar::LedgerKey const& lk) const
     {
         size_t res = lk.type();
         switch (lk.type())
@@ -205,8 +196,7 @@ template <> class hash<stellar::LedgerKey>
 template <> class hash<stellar::InternalLedgerKey>
 {
   public:
-    size_t
-    operator()(stellar::InternalLedgerKey const& glk) const
+    size_t operator()(stellar::InternalLedgerKey const& glk) const
     {
         return glk.hash();
     }

--- a/src/ledger/LedgerHeaderUtils.cpp
+++ b/src/ledger/LedgerHeaderUtils.cpp
@@ -25,14 +25,12 @@ namespace stellar
 namespace LedgerHeaderUtils
 {
 
-uint32_t
-getFlags(LedgerHeader const& lh)
+uint32_t getFlags(LedgerHeader const& lh)
 {
     return lh.ext.v() == 1 ? lh.ext.v1().flags : 0;
 }
 
-bool
-isValid(LedgerHeader const& lh)
+bool isValid(LedgerHeader const& lh)
 {
     bool res = (lh.ledgerSeq <= INT32_MAX);
 
@@ -42,8 +40,8 @@ isValid(LedgerHeader const& lh)
     return res;
 }
 
-void
-storeInDatabase(Database& db, LedgerHeader const& header, SessionWrapper& sess)
+void storeInDatabase(Database& db, LedgerHeader const& header,
+                     SessionWrapper& sess)
 {
     ZoneScoped;
     if (!isValid(header))
@@ -84,8 +82,7 @@ storeInDatabase(Database& db, LedgerHeader const& header, SessionWrapper& sess)
     }
 }
 
-LedgerHeader
-decodeFromData(std::string const& data)
+LedgerHeader decodeFromData(std::string const& data)
 {
     ZoneScoped;
     LedgerHeader lh;
@@ -103,8 +100,7 @@ decodeFromData(std::string const& data)
     return lh;
 }
 
-std::shared_ptr<LedgerHeader>
-loadByHash(Database& db, Hash const& hash)
+std::shared_ptr<LedgerHeader> loadByHash(Database& db, Hash const& hash)
 {
     ZoneScoped;
     std::shared_ptr<LedgerHeader> lhPtr;
@@ -140,8 +136,7 @@ loadByHash(Database& db, Hash const& hash)
     return lhPtr;
 }
 
-uint32_t
-loadMaxLedgerSeq(Database& db)
+uint32_t loadMaxLedgerSeq(Database& db)
 {
     ZoneScoped;
     uint32_t seq = 0;
@@ -159,8 +154,8 @@ loadMaxLedgerSeq(Database& db)
     return 0;
 }
 
-std::shared_ptr<LedgerHeader>
-loadBySequence(Database& db, soci::session& sess, uint32_t seq)
+std::shared_ptr<LedgerHeader> loadBySequence(Database& db, soci::session& sess,
+                                             uint32_t seq)
 {
     ZoneScoped;
     std::shared_ptr<LedgerHeader> lhPtr;
@@ -189,17 +184,15 @@ loadBySequence(Database& db, soci::session& sess, uint32_t seq)
     return lhPtr;
 }
 
-void
-deleteOldEntries(soci::session& sess, uint32_t ledgerSeq, uint32_t count)
+void deleteOldEntries(soci::session& sess, uint32_t ledgerSeq, uint32_t count)
 {
     ZoneScoped;
     DatabaseUtils::deleteOldEntriesHelper(sess, ledgerSeq, count,
                                           "ledgerheaders", "ledgerseq");
 }
 
-size_t
-copyToStream(soci::session& sess, uint32_t ledgerSeq, uint32_t ledgerCount,
-             CheckpointBuilder& checkpointBuilder)
+size_t copyToStream(soci::session& sess, uint32_t ledgerSeq,
+                    uint32_t ledgerCount, CheckpointBuilder& checkpointBuilder)
 {
     ZoneNamedN(selectLedgerHeadersZone, "select ledgerheaders history", true);
     uint32_t begin = ledgerSeq, end = ledgerSeq + ledgerCount;
@@ -229,8 +222,7 @@ copyToStream(soci::session& sess, uint32_t ledgerSeq, uint32_t ledgerCount,
     return n;
 }
 
-void
-dropAll(Database& db)
+void dropAll(Database& db)
 {
     std::string coll = db.getSimpleCollationClause();
 

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -158,7 +158,6 @@ class InMemorySorobanState;
 // thread.
 class LedgerManager
 {
-
   protected:
     friend void ApplicationImpl::initialize(bool createNewDB,
                                             bool forceRebuild);
@@ -199,8 +198,7 @@ class LedgerManager
     virtual State getState() const = 0;
     virtual std::string getStateHuman() const = 0;
 
-    bool
-    isSynced() const
+    bool isSynced() const
     {
         return getState() == LM_SYNCED_STATE;
     }
@@ -340,8 +338,7 @@ class LedgerManager
 
     virtual void assertSetupPhase() const = 0;
 #ifdef BUILD_TESTS
-    void
-    applyLedger(LedgerCloseData const& ledgerData)
+    void applyLedger(LedgerCloseData const& ledgerData)
     {
         applyLedger(ledgerData, /* externalize */ false);
     }

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -115,8 +115,7 @@ const int64_t LedgerManager::GENESIS_LEDGER_TOTAL_COINS = 1000000000000000000;
 namespace
 {
 
-std::vector<uint32_t>
-getModuleCacheProtocols()
+std::vector<uint32_t> getModuleCacheProtocols()
 {
     std::vector<uint32_t> ledgerVersions;
     for (uint32_t i = (uint32_t)REUSABLE_SOROBAN_MODULE_CACHE_PROTOCOL_VERSION;
@@ -136,16 +135,14 @@ getModuleCacheProtocols()
     return ledgerVersions;
 }
 
-void
-setLedgerTxnHeader(LedgerHeader const& lh, Application& app)
+void setLedgerTxnHeader(LedgerHeader const& lh, Application& app)
 {
     LedgerTxn ltx(app.getLedgerTxnRoot());
     ltx.loadHeader().current() = lh;
     ltx.commit();
 }
 
-bool
-mergeOpInTx(std::vector<Operation> const& ops)
+bool mergeOpInTx(std::vector<Operation> const& ops)
 {
     for (auto const& op : ops)
     {
@@ -158,34 +155,30 @@ mergeOpInTx(std::vector<Operation> const& ops)
 }
 }
 
-std::unique_ptr<LedgerManager>
-LedgerManager::create(Application& app)
+std::unique_ptr<LedgerManager> LedgerManager::create(Application& app)
 {
     return std::make_unique<LedgerManagerImpl>(app);
 }
 
-std::string
-LedgerManager::ledgerAbbrev(LedgerHeader const& header)
+std::string LedgerManager::ledgerAbbrev(LedgerHeader const& header)
 {
     return ledgerAbbrev(header, xdrSha256(header));
 }
 
-std::string
-LedgerManager::ledgerAbbrev(uint32_t seq, uint256 const& hash)
+std::string LedgerManager::ledgerAbbrev(uint32_t seq, uint256 const& hash)
 {
     std::ostringstream oss;
     oss << "[seq=" << seq << ", hash=" << hexAbbrev(hash) << "]";
     return oss.str();
 }
 
-std::string
-LedgerManager::ledgerAbbrev(LedgerHeader const& header, uint256 const& hash)
+std::string LedgerManager::ledgerAbbrev(LedgerHeader const& header,
+                                        uint256 const& hash)
 {
     return ledgerAbbrev(header.ledgerSeq, hash);
 }
 
-std::string
-LedgerManager::ledgerAbbrev(LedgerHeaderHistoryEntry const& he)
+std::string LedgerManager::ledgerAbbrev(LedgerHeaderHistoryEntry const& he)
 {
     return ledgerAbbrev(he.header, he.hash);
 }
@@ -266,8 +259,7 @@ LedgerManagerImpl::ApplyState::getSorobanInMemoryStateSizeForTesting() const
 }
 #endif
 
-void
-LedgerManagerImpl::ApplyState::threadInvariant() const
+void LedgerManagerImpl::ApplyState::threadInvariant() const
 {
     if (mAppConnector.getConfig().parallelLedgerClose())
     {
@@ -287,20 +279,17 @@ LedgerManagerImpl::ApplyState::getModuleCache() const
     return mModuleCache;
 }
 
-void
-LedgerManagerImpl::markApplyStateReset()
+void LedgerManagerImpl::markApplyStateReset()
 {
     mApplyState.resetToSetupPhase();
 }
 
-bool
-LedgerManagerImpl::ApplyState::isCompilationRunning() const
+bool LedgerManagerImpl::ApplyState::isCompilationRunning() const
 {
     return static_cast<bool>(mCompiler);
 }
 
-void
-LedgerManagerImpl::ApplyState::updateInMemorySorobanState(
+void LedgerManagerImpl::ApplyState::updateInMemorySorobanState(
     std::vector<LedgerEntry> const& initEntries,
     std::vector<LedgerEntry> const& liveEntries,
     std::vector<LedgerKey> const& deadEntries, LedgerHeader const& lh,
@@ -312,8 +301,7 @@ LedgerManagerImpl::ApplyState::updateInMemorySorobanState(
                                       getMetrics().mSorobanMetrics);
 }
 
-uint64_t
-LedgerManagerImpl::ApplyState::getSorobanInMemoryStateSize() const
+uint64_t LedgerManagerImpl::ApplyState::getSorobanInMemoryStateSize() const
 {
     // This assert is not strictly necessary, but we don't really want to
     // access the state size outside of the snapshotting process during the
@@ -322,8 +310,7 @@ LedgerManagerImpl::ApplyState::getSorobanInMemoryStateSize() const
     return mInMemorySorobanState.getSize();
 }
 
-void
-LedgerManagerImpl::ApplyState::manuallyAdvanceLedgerHeader(
+void LedgerManagerImpl::ApplyState::manuallyAdvanceLedgerHeader(
     LedgerHeader const& lh)
 {
     assertCommittingPhase();
@@ -343,14 +330,12 @@ LedgerManagerImpl::LedgerManagerImpl(Application& app)
     setupLedgerCloseMetaStream();
 }
 
-void
-LedgerManagerImpl::moveToSynced()
+void LedgerManagerImpl::moveToSynced()
 {
     setState(LM_SYNCED_STATE);
 }
 
-void
-LedgerManagerImpl::beginApply()
+void LedgerManagerImpl::beginApply()
 {
     releaseAssert(threadIsMain());
 
@@ -358,8 +343,7 @@ LedgerManagerImpl::beginApply()
     mCurrentlyApplyingLedger = true;
 }
 
-void
-LedgerManagerImpl::setState(State s)
+void LedgerManagerImpl::setState(State s)
 {
     releaseAssert(threadIsMain());
     if (s != getState())
@@ -375,22 +359,19 @@ LedgerManagerImpl::setState(State s)
     }
 }
 
-LedgerManager::State
-LedgerManagerImpl::getState() const
+LedgerManager::State LedgerManagerImpl::getState() const
 {
     return mState;
 }
 
-std::string
-LedgerManagerImpl::getStateHuman() const
+std::string LedgerManagerImpl::getStateHuman() const
 {
     static std::array<const char*, LM_NUM_STATE> stateStrings = std::array{
         "LM_BOOTING_STATE", "LM_SYNCED_STATE", "LM_CATCHING_UP_STATE"};
     return std::string(stateStrings[getState()]);
 }
 
-LedgerHeader
-LedgerManager::genesisLedger()
+LedgerHeader LedgerManager::genesisLedger()
 {
     LedgerHeader result;
     // all fields are initialized by default to 0
@@ -404,8 +385,7 @@ LedgerManager::genesisLedger()
     return result;
 }
 
-void
-LedgerManagerImpl::startNewLedger(LedgerHeader const& genesisLedger)
+void LedgerManagerImpl::startNewLedger(LedgerHeader const& genesisLedger)
 {
     mApplyState.assertSetupPhase();
     auto ledgerTime = mApplyState.getMetrics().mLedgerClose.TimeScope();
@@ -485,8 +465,7 @@ LedgerManagerImpl::startNewLedger(LedgerHeader const& genesisLedger)
     // LedgerManager after creating the genesis ledger.
 }
 
-void
-LedgerManagerImpl::startNewLedger()
+void LedgerManagerImpl::startNewLedger()
 {
     auto ledger = genesisLedger();
     auto const& cfg = mApp.getConfig();
@@ -501,8 +480,7 @@ LedgerManagerImpl::startNewLedger()
     startNewLedger(ledger);
 }
 
-void
-LedgerManagerImpl::loadLastKnownLedgerInternal(bool skipBuildingFullState)
+void LedgerManagerImpl::loadLastKnownLedgerInternal(bool skipBuildingFullState)
 {
     ZoneScoped;
     mApplyState.assertSetupPhase();
@@ -606,26 +584,22 @@ LedgerManagerImpl::loadLastKnownLedgerInternal(bool skipBuildingFullState)
     mApplyState.markEndOfSetupPhase();
 }
 
-void
-LedgerManagerImpl::loadLastKnownLedger()
+void LedgerManagerImpl::loadLastKnownLedger()
 {
     loadLastKnownLedgerInternal(/* skipBuildingFullState */ false);
 }
 
-void
-LedgerManagerImpl::partiallyLoadLastKnownLedgerForUtils()
+void LedgerManagerImpl::partiallyLoadLastKnownLedgerForUtils()
 {
     loadLastKnownLedgerInternal(/* skipBuildingFullState */ true);
 }
 
-Database&
-LedgerManagerImpl::getDatabase()
+Database& LedgerManagerImpl::getDatabase()
 {
     return mApp.getDatabase();
 }
 
-uint32_t
-LedgerManagerImpl::getLastMaxTxSetSize() const
+uint32_t LedgerManagerImpl::getLastMaxTxSetSize() const
 {
     releaseAssert(threadIsMain());
     releaseAssert(mLastClosedLedgerState);
@@ -633,8 +607,7 @@ LedgerManagerImpl::getLastMaxTxSetSize() const
         .header.maxTxSetSize;
 }
 
-uint32_t
-LedgerManagerImpl::getLastMaxTxSetSizeOps() const
+uint32_t LedgerManagerImpl::getLastMaxTxSetSizeOps() const
 {
     releaseAssert(threadIsMain());
     releaseAssert(mLastClosedLedgerState);
@@ -648,8 +621,7 @@ LedgerManagerImpl::getLastMaxTxSetSizeOps() const
                : (n * MAX_OPS_PER_TX);
 }
 
-Resource
-LedgerManagerImpl::maxLedgerResources(bool isSoroban)
+Resource LedgerManagerImpl::maxLedgerResources(bool isSoroban)
 {
     ZoneScoped;
 
@@ -664,8 +636,7 @@ LedgerManagerImpl::maxLedgerResources(bool isSoroban)
     }
 }
 
-Resource
-LedgerManagerImpl::maxSorobanTransactionResources()
+Resource LedgerManagerImpl::maxSorobanTransactionResources()
 {
     ZoneScoped;
 
@@ -682,8 +653,7 @@ LedgerManagerImpl::maxSorobanTransactionResources()
     return Resource(limits);
 }
 
-int64_t
-LedgerManagerImpl::getLastMinBalance(uint32_t ownerCount) const
+int64_t LedgerManagerImpl::getLastMinBalance(uint32_t ownerCount) const
 {
     releaseAssert(threadIsMain());
     releaseAssert(mLastClosedLedgerState);
@@ -694,8 +664,7 @@ LedgerManagerImpl::getLastMinBalance(uint32_t ownerCount) const
         return (2LL + ownerCount) * int64_t(lh.baseReserve);
 }
 
-uint32_t
-LedgerManagerImpl::getLastReserve() const
+uint32_t LedgerManagerImpl::getLastReserve() const
 {
     releaseAssert(threadIsMain());
     releaseAssert(mLastClosedLedgerState);
@@ -703,8 +672,7 @@ LedgerManagerImpl::getLastReserve() const
         .header.baseReserve;
 }
 
-uint32_t
-LedgerManagerImpl::getLastTxFee() const
+uint32_t LedgerManagerImpl::getLastTxFee() const
 {
     releaseAssert(threadIsMain());
     releaseAssert(mLastClosedLedgerState);
@@ -719,16 +687,14 @@ LedgerManagerImpl::getLastClosedLedgerHeader() const
     return mLastClosedLedgerState->getLastClosedLedgerHeader();
 }
 
-HistoryArchiveState
-LedgerManagerImpl::getLastClosedLedgerHAS() const
+HistoryArchiveState LedgerManagerImpl::getLastClosedLedgerHAS() const
 {
     releaseAssert(threadIsMain());
     releaseAssert(mLastClosedLedgerState);
     return mLastClosedLedgerState->getLastClosedHistoryArchiveState();
 }
 
-uint32_t
-LedgerManagerImpl::getLastClosedLedgerNum() const
+uint32_t LedgerManagerImpl::getLastClosedLedgerNum() const
 {
     releaseAssert(threadIsMain());
     releaseAssert(mLastClosedLedgerState);
@@ -750,8 +716,7 @@ LedgerManagerImpl::maybeCopySorobanStateForInvariant() const
     return inMemorySnapshotForInvariant;
 }
 
-void
-LedgerManagerImpl::maybeRunSnapshotInvariantFromLedgerState(
+void LedgerManagerImpl::maybeRunSnapshotInvariantFromLedgerState(
     CompleteConstLedgerStatePtr const& ledgerState,
     std::shared_ptr<InMemorySorobanState const> inMemorySnapshotForInvariant,
     bool runInParallel) const
@@ -798,16 +763,14 @@ LedgerManagerImpl::getLastClosedSorobanNetworkConfig() const
     return mLastClosedLedgerState->getSorobanConfig();
 }
 
-bool
-LedgerManagerImpl::hasLastClosedSorobanNetworkConfig() const
+bool LedgerManagerImpl::hasLastClosedSorobanNetworkConfig() const
 {
     releaseAssert(threadIsMain());
     releaseAssert(mLastClosedLedgerState);
     return mLastClosedLedgerState->hasSorobanConfig();
 }
 
-std::chrono::milliseconds
-LedgerManagerImpl::getExpectedLedgerCloseTime() const
+std::chrono::milliseconds LedgerManagerImpl::getExpectedLedgerCloseTime() const
 {
     releaseAssert(threadIsMain());
 
@@ -843,8 +806,7 @@ LedgerManagerImpl::getLastClosedLedgerCloseMeta()
     return mLastLedgerCloseMeta;
 }
 
-void
-LedgerManagerImpl::storeCurrentLedgerForTest(LedgerHeader const& header)
+void LedgerManagerImpl::storeCurrentLedgerForTest(LedgerHeader const& header)
 {
     storePersistentStateAndLedgerHeaderInDB(header, true);
 }
@@ -855,8 +817,8 @@ LedgerManagerImpl::getInMemorySorobanStateForTesting()
     return mApplyState.getInMemorySorobanStateForTesting();
 }
 
-void
-LedgerManagerImpl::rebuildInMemorySorobanStateForTesting(uint32_t ledgerVersion)
+void LedgerManagerImpl::rebuildInMemorySorobanStateForTesting(
+    uint32_t ledgerVersion)
 {
     mApplyState.resetToSetupPhase();
     mApplyState.getInMemorySorobanStateForTesting().clearForTesting();
@@ -872,15 +834,13 @@ LedgerManagerImpl::getModuleCacheForTesting()
     return mApplyState.getModuleCacheForTesting()->shallow_clone();
 }
 
-uint64_t
-LedgerManagerImpl::getSorobanInMemoryStateSizeForTesting()
+uint64_t LedgerManagerImpl::getSorobanInMemoryStateSizeForTesting()
 {
     return mApplyState.getSorobanInMemoryStateSizeForTesting();
 }
 #endif
 
-SorobanMetrics&
-LedgerManagerImpl::getSorobanMetrics()
+SorobanMetrics& LedgerManagerImpl::getSorobanMetrics()
 {
     return mApplyState.getMetrics().mSorobanMetrics;
 }
@@ -904,8 +864,7 @@ LedgerManagerImpl::createLedgerTxnRoot(Application& app, size_t entryCacheSize,
     );
 }
 
-::rust::Box<rust_bridge::SorobanModuleCache>
-LedgerManagerImpl::getModuleCache()
+::rust::Box<rust_bridge::SorobanModuleCache> LedgerManagerImpl::getModuleCache()
 {
     // There should not be any compilation running when
     // anyone calls this function. It is accessed from
@@ -914,16 +873,15 @@ LedgerManagerImpl::getModuleCache()
     return mApplyState.getModuleCache()->shallow_clone();
 }
 
-void
-LedgerManagerImpl::handleUpgradeAffectingSorobanInMemoryStateSize(
+void LedgerManagerImpl::handleUpgradeAffectingSorobanInMemoryStateSize(
     AbstractLedgerTxn& upgradeLtx)
 {
     mApplyState.handleUpgradeAffectingSorobanInMemoryStateSize(upgradeLtx);
 }
 
-void
-LedgerManagerImpl::ApplyState::handleUpgradeAffectingSorobanInMemoryStateSize(
-    AbstractLedgerTxn& upgradeLtx)
+void LedgerManagerImpl::ApplyState::
+    handleUpgradeAffectingSorobanInMemoryStateSize(
+        AbstractLedgerTxn& upgradeLtx)
 {
     assertCommittingPhase();
 
@@ -945,8 +903,7 @@ LedgerManagerImpl::ApplyState::handleUpgradeAffectingSorobanInMemoryStateSize(
     }
 }
 
-void
-LedgerManagerImpl::ApplyState::finishPendingCompilation()
+void LedgerManagerImpl::ApplyState::finishPendingCompilation()
 {
     assertWritablePhase();
     releaseAssert(mCompiler);
@@ -961,8 +918,7 @@ LedgerManagerImpl::ApplyState::finishPendingCompilation()
     mCompiler.reset();
 }
 
-void
-LedgerManagerImpl::ApplyState::compileAllContractsInLedger(
+void LedgerManagerImpl::ApplyState::compileAllContractsInLedger(
     SearchableSnapshotConstPtr snap, uint32_t minLedgerVersion)
 {
     assertSetupPhase();
@@ -970,69 +926,60 @@ LedgerManagerImpl::ApplyState::compileAllContractsInLedger(
     finishPendingCompilation();
 }
 
-void
-LedgerManagerImpl::ApplyState::populateInMemorySorobanState(
+void LedgerManagerImpl::ApplyState::populateInMemorySorobanState(
     SearchableSnapshotConstPtr snap, uint32_t ledgerVersion)
 {
     assertSetupPhase();
     mInMemorySorobanState.initializeStateFromSnapshot(snap, ledgerVersion);
 }
 
-void
-LedgerManagerImpl::ApplyState::assertCommittingPhase() const
+void LedgerManagerImpl::ApplyState::assertCommittingPhase() const
 {
     threadInvariant();
     releaseAssert(mPhase == Phase::COMMITTING);
 }
 
-void
-LedgerManagerImpl::ApplyState::markStartOfApplying()
+void LedgerManagerImpl::ApplyState::markStartOfApplying()
 {
     threadInvariant();
     releaseAssert(mPhase == Phase::READY_TO_APPLY);
     mPhase = Phase::APPLYING;
 }
 
-void
-LedgerManagerImpl::ApplyState::markStartOfCommitting()
+void LedgerManagerImpl::ApplyState::markStartOfCommitting()
 {
     threadInvariant();
     releaseAssert(mPhase == Phase::APPLYING);
     mPhase = Phase::COMMITTING;
 }
 
-void
-LedgerManagerImpl::ApplyState::markEndOfCommitting()
+void LedgerManagerImpl::ApplyState::markEndOfCommitting()
 {
     assertCommittingPhase();
     mPhase = Phase::READY_TO_APPLY;
 }
 
-void
-LedgerManagerImpl::ApplyState::markEndOfSetupPhase()
+void LedgerManagerImpl::ApplyState::markEndOfSetupPhase()
 {
     threadInvariant();
     releaseAssert(mPhase == Phase::SETTING_UP_STATE);
     mPhase = Phase::READY_TO_APPLY;
 }
 
-void
-LedgerManagerImpl::ApplyState::resetToSetupPhase()
+void LedgerManagerImpl::ApplyState::resetToSetupPhase()
 {
     threadInvariant();
     releaseAssert(mPhase == Phase::READY_TO_APPLY);
     mPhase = Phase::SETTING_UP_STATE;
 }
 
-void
-LedgerManagerImpl::ApplyState::assertSetupPhase() const
+void LedgerManagerImpl::ApplyState::assertSetupPhase() const
 {
     threadInvariant();
     releaseAssert(mPhase == Phase::SETTING_UP_STATE);
 }
 
-void
-LedgerManagerImpl::ApplyState::startCompilingAllContracts(
+void LedgerManagerImpl::ApplyState::startCompilingAllContracts(
     SearchableSnapshotConstPtr snap, uint32_t minLedgerVersion)
 {
     threadInvariant();
@@ -1052,16 +999,14 @@ LedgerManagerImpl::ApplyState::startCompilingAllContracts(
     mCompiler->start();
 }
 
-void
-LedgerManagerImpl::ApplyState::assertWritablePhase() const
+void LedgerManagerImpl::ApplyState::assertWritablePhase() const
 {
     threadInvariant();
     releaseAssert(mPhase == Phase::SETTING_UP_STATE ||
                   mPhase == Phase::COMMITTING);
 }
 
-void
-LedgerManagerImpl::ApplyState::maybeRebuildModuleCache(
+void LedgerManagerImpl::ApplyState::maybeRebuildModuleCache(
     SearchableSnapshotConstPtr snap, uint32_t minLedgerVersion)
 {
     assertCommittingPhase();
@@ -1127,8 +1072,7 @@ LedgerManagerImpl::ApplyState::maybeRebuildModuleCache(
     }
 }
 
-void
-LedgerManagerImpl::publishSorobanMetrics()
+void LedgerManagerImpl::publishSorobanMetrics()
 {
     if (!hasLastClosedSorobanNetworkConfig())
     {
@@ -1170,9 +1114,8 @@ LedgerManagerImpl::publishSorobanMetrics()
 }
 
 // called by txherder
-void
-LedgerManagerImpl::valueExternalized(LedgerCloseData const& ledgerData,
-                                     bool isLatestSlot)
+void LedgerManagerImpl::valueExternalized(LedgerCloseData const& ledgerData,
+                                          bool isLatestSlot)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -1213,17 +1156,15 @@ LedgerManagerImpl::valueExternalized(LedgerCloseData const& ledgerData,
     }
 }
 
-void
-LedgerManagerImpl::startCatchup(CatchupConfiguration configuration,
-                                std::shared_ptr<HistoryArchive> archive)
+void LedgerManagerImpl::startCatchup(CatchupConfiguration configuration,
+                                     std::shared_ptr<HistoryArchive> archive)
 {
     ZoneScoped;
     setState(LM_CATCHING_UP_STATE);
     mApp.getLedgerApplyManager().startCatchup(configuration, archive);
 }
 
-uint64_t
-LedgerManagerImpl::secondsSinceLastLedgerClose() const
+uint64_t LedgerManagerImpl::secondsSinceLastLedgerClose() const
 {
     uint64_t ct = getLastClosedLedgerHeader().header.scpValue.closeTime;
     if (ct == 0)
@@ -1234,16 +1175,14 @@ LedgerManagerImpl::secondsSinceLastLedgerClose() const
     return (now > ct) ? (now - ct) : 0;
 }
 
-void
-LedgerManagerImpl::syncMetrics()
+void LedgerManagerImpl::syncMetrics()
 {
     mApplyState.getMetrics().mLedgerAge.set_count(
         secondsSinceLastLedgerClose());
     mApp.syncOwnMetrics();
 }
 
-void
-LedgerManagerImpl::emitNextMeta()
+void LedgerManagerImpl::emitNextMeta()
 {
     ZoneScoped;
 
@@ -1272,9 +1211,8 @@ LedgerManagerImpl::emitNextMeta()
     mNextMetaToEmit.reset();
 }
 
-void
-maybeSimulateSleep(Config const& cfg, size_t opSize,
-                   LogSlowExecution& closeTime)
+void maybeSimulateSleep(Config const& cfg, size_t opSize,
+                        LogSlowExecution& closeTime)
 {
     if (!cfg.OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING.empty())
     {
@@ -1301,16 +1239,14 @@ maybeSimulateSleep(Config const& cfg, size_t opSize,
     }
 }
 
-asio::io_context&
-getMetaIOContext(Application& app)
+asio::io_context& getMetaIOContext(Application& app)
 {
     return app.getConfig().parallelLedgerClose()
                ? app.getLedgerCloseIOContext()
                : app.getClock().getIOContext();
 }
 
-void
-LedgerManagerImpl::ledgerCloseComplete(
+void LedgerManagerImpl::ledgerCloseComplete(
     uint32_t lcl, bool calledViaExternalize, LedgerCloseData const& ledgerData,
     bool upgradeApplied,
     std::shared_ptr<InMemorySorobanState const> inMemorySnapshotForInvariant)
@@ -1360,8 +1296,7 @@ LedgerManagerImpl::ledgerCloseComplete(
     }
 }
 
-void
-LedgerManagerImpl::advanceLedgerStateAndPublish(
+void LedgerManagerImpl::advanceLedgerStateAndPublish(
     uint32_t ledgerSeq, bool calledViaExternalize,
     LedgerCloseData const& ledgerData,
     CompleteConstLedgerStatePtr newLedgerState, bool upgradeApplied,
@@ -1414,9 +1349,8 @@ LedgerManagerImpl::advanceLedgerStateAndPublish(
 // application happening on the main thread -- it can happen on either).
 // It is called from the LedgerApplyManager and will post its results
 // back to the main thread when done, if running on the apply thread.
-void
-LedgerManagerImpl::applyLedger(LedgerCloseData const& ledgerData,
-                               bool calledViaExternalize)
+void LedgerManagerImpl::applyLedger(LedgerCloseData const& ledgerData,
+                                    bool calledViaExternalize)
 {
     if (mApp.isStopping())
     {
@@ -1825,8 +1759,7 @@ LedgerManagerImpl::applyLedger(LedgerCloseData const& ledgerData,
     FrameMark;
 }
 
-void
-LedgerManagerImpl::setLastClosedLedger(
+void LedgerManagerImpl::setLastClosedLedger(
     LedgerHeaderHistoryEntry const& lastClosed, bool rebuildInMemoryState)
 {
     // NB: this method is a sort of half-apply that runs on main thread and
@@ -1870,8 +1803,7 @@ LedgerManagerImpl::setLastClosedLedger(
     mApplyState.markEndOfSetupPhase();
 }
 
-void
-LedgerManagerImpl::manuallyAdvanceLedgerHeader(LedgerHeader const& header)
+void LedgerManagerImpl::manuallyAdvanceLedgerHeader(LedgerHeader const& header)
 {
     if (!mApp.getConfig().MANUAL_CLOSE || !mApp.getConfig().RUN_STANDALONE)
     {
@@ -1891,8 +1823,7 @@ LedgerManagerImpl::manuallyAdvanceLedgerHeader(LedgerHeader const& header)
     mApplyState.markEndOfCommitting();
 }
 
-void
-LedgerManagerImpl::setupLedgerCloseMetaStream()
+void LedgerManagerImpl::setupLedgerCloseMetaStream()
 {
     ZoneScoped;
 
@@ -1924,8 +1855,7 @@ LedgerManagerImpl::setupLedgerCloseMetaStream()
         }
     }
 }
-void
-LedgerManagerImpl::maybeResetLedgerCloseMetaDebugStream(uint32_t ledgerSeq)
+void LedgerManagerImpl::maybeResetLedgerCloseMetaDebugStream(uint32_t ledgerSeq)
 {
     ZoneScoped;
 
@@ -2021,16 +1951,14 @@ LedgerManagerImpl::maybeResetLedgerCloseMetaDebugStream(uint32_t ledgerSeq)
     }
 }
 
-SearchableSnapshotConstPtr
-LedgerManagerImpl::getLastClosedSnapshot() const
+SearchableSnapshotConstPtr LedgerManagerImpl::getLastClosedSnapshot() const
 {
     releaseAssert(threadIsMain());
     releaseAssert(mLastClosedLedgerState);
     return mLastClosedLedgerState->getBucketSnapshot();
 }
 
-void
-LedgerManagerImpl::advanceLastClosedLedgerState(
+void LedgerManagerImpl::advanceLastClosedLedgerState(
     CompleteConstLedgerStatePtr newLedgerState)
 {
     releaseAssert(threadIsMain());
@@ -2075,8 +2003,7 @@ LedgerManagerImpl::advanceBucketListSnapshotAndMakeLedgerState(
 }
 }
 
-std::vector<MutableTxResultPtr>
-LedgerManagerImpl::processFeesSeqNums(
+std::vector<MutableTxResultPtr> LedgerManagerImpl::processFeesSeqNums(
     ApplicableTxSetFrame const& txSet, AbstractLedgerTxn& ltxOuter,
     std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta,
     LedgerCloseData const& ledgerData)
@@ -2196,10 +2123,9 @@ LedgerManagerImpl::processFeesSeqNums(
     return txResults;
 }
 
-void
-LedgerManagerImpl::prefetchTxSourceIds(AbstractLedgerTxnParent& ltx,
-                                       ApplicableTxSetFrame const& txSet,
-                                       Config const& config)
+void LedgerManagerImpl::prefetchTxSourceIds(AbstractLedgerTxnParent& ltx,
+                                            ApplicableTxSetFrame const& txSet,
+                                            Config const& config)
 {
     ZoneScoped;
     if (config.PREFETCH_BATCH_SIZE > 0 && !config.allBucketsInMemory())
@@ -2216,10 +2142,9 @@ LedgerManagerImpl::prefetchTxSourceIds(AbstractLedgerTxnParent& ltx,
     }
 }
 
-void
-LedgerManagerImpl::prefetchTransactionData(AbstractLedgerTxnParent& ltx,
-                                           ApplicableTxSetFrame const& txSet,
-                                           Config const& config)
+void LedgerManagerImpl::prefetchTransactionData(
+    AbstractLedgerTxnParent& ltx, ApplicableTxSetFrame const& txSet,
+    Config const& config)
 {
     ZoneScoped;
     if (config.PREFETCH_BATCH_SIZE > 0 && !config.allBucketsInMemory())
@@ -2236,8 +2161,7 @@ LedgerManagerImpl::prefetchTransactionData(AbstractLedgerTxnParent& ltx,
     }
 }
 
-std::unique_ptr<ThreadParallelApplyLedgerState>
-LedgerManagerImpl::applyThread(
+std::unique_ptr<ThreadParallelApplyLedgerState> LedgerManagerImpl::applyThread(
     AppConnector& app,
     std::unique_ptr<ThreadParallelApplyLedgerState> threadState,
     Cluster const& cluster, Config const& config, ParallelLedgerInfo ledgerInfo,
@@ -2276,8 +2200,8 @@ LedgerManagerImpl::applyThread(
     return threadState;
 }
 
-ParallelLedgerInfo
-getParallelLedgerInfo(AppConnector& app, LedgerHeader const& lh)
+ParallelLedgerInfo getParallelLedgerInfo(AppConnector& app,
+                                         LedgerHeader const& lh)
 {
     return {lh.ledgerVersion, lh.ledgerSeq, lh.baseReserve,
             lh.scpValue.closeTime, app.getNetworkID()};
@@ -2330,8 +2254,7 @@ LedgerManagerImpl::applySorobanStageClustersInParallel(
     return threadStates;
 }
 
-void
-LedgerManagerImpl::checkAllTxBundleInvariants(
+void LedgerManagerImpl::checkAllTxBundleInvariants(
     AppConnector& app, ApplyStage const& stage, Config const& config,
     ParallelLedgerInfo const& ledgerInfo, LedgerHeader const& header)
 {
@@ -2373,8 +2296,7 @@ LedgerManagerImpl::checkAllTxBundleInvariants(
     }
 }
 
-void
-LedgerManagerImpl::applySorobanStage(
+void LedgerManagerImpl::applySorobanStage(
     AppConnector& app, LedgerHeader const& header,
     GlobalParallelApplyLedgerState& globalParState, ApplyStage const& stage,
     Hash const& sorobanBasePrngSeed)
@@ -2391,11 +2313,10 @@ LedgerManagerImpl::applySorobanStage(
     globalParState.commitChangesFromThreads(app, threadStates, stage);
 }
 
-void
-LedgerManagerImpl::applySorobanStages(AppConnector& app, AbstractLedgerTxn& ltx,
-                                      std::vector<ApplyStage> const& stages,
-                                      SorobanNetworkConfig const& sorobanConfig,
-                                      Hash const& sorobanBasePrngSeed)
+void LedgerManagerImpl::applySorobanStages(
+    AppConnector& app, AbstractLedgerTxn& ltx,
+    std::vector<ApplyStage> const& stages,
+    SorobanNetworkConfig const& sorobanConfig, Hash const& sorobanBasePrngSeed)
 {
     ZoneScoped;
     GlobalParallelApplyLedgerState globalParState(
@@ -2411,8 +2332,7 @@ LedgerManagerImpl::applySorobanStages(AppConnector& app, AbstractLedgerTxn& ltx,
     globalParState.commitChangesToLedgerTxn(ltx);
 }
 
-void
-LedgerManagerImpl::processResultAndMeta(
+void LedgerManagerImpl::processResultAndMeta(
     std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta,
     uint32_t txIndex, TransactionMetaBuilder& txMetaBuilder,
     TransactionFrameBase const& tx, MutableTransactionResultBase const& result,
@@ -2463,8 +2383,7 @@ LedgerManagerImpl::processResultAndMeta(
     }
 }
 
-TransactionResultSet
-LedgerManagerImpl::applyTransactions(
+TransactionResultSet LedgerManagerImpl::applyTransactions(
     ApplicableTxSetFrame const& txSet,
     std::vector<MutableTxResultPtr> const& mutableTxResults,
     AbstractLedgerTxn& ltx,
@@ -2570,8 +2489,7 @@ LedgerManagerImpl::applyTransactions(
     return txResultSet;
 }
 
-void
-LedgerManagerImpl::applyParallelPhase(
+void LedgerManagerImpl::applyParallelPhase(
     TxSetPhaseFrame const& phase, std::vector<stellar::ApplyStage>& applyStages,
     std::vector<stellar::MutableTxResultPtr> const& mutableTxResults,
     uint32_t& index, stellar::AbstractLedgerTxn& ltx, bool enableTxMeta,
@@ -2629,8 +2547,7 @@ LedgerManagerImpl::applyParallelPhase(
     // meta will be processed in processPostTxSetApply
 }
 
-void
-LedgerManagerImpl::applySequentialPhase(
+void LedgerManagerImpl::applySequentialPhase(
     TxSetPhaseFrame const& phase,
     std::vector<MutableTxResultPtr> const& mutableTxResults, uint32_t& index,
     AbstractLedgerTxn& ltx, bool enableTxMeta,
@@ -2688,8 +2605,7 @@ LedgerManagerImpl::applySequentialPhase(
     }
 }
 
-void
-LedgerManagerImpl::processPostTxSetApply(
+void LedgerManagerImpl::processPostTxSetApply(
     std::vector<TxSetPhaseFrame> const& phases,
     std::vector<ApplyStage> const& applyStages, AbstractLedgerTxn& ltx,
     std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta,
@@ -2736,9 +2652,8 @@ LedgerManagerImpl::processPostTxSetApply(
         // non-parallel phase.
     }
 }
-void
-LedgerManagerImpl::logTxApplyMetrics(AbstractLedgerTxn& ltx, size_t numTxs,
-                                     size_t numOps)
+void LedgerManagerImpl::logTxApplyMetrics(AbstractLedgerTxn& ltx, size_t numTxs,
+                                          size_t numOps)
 {
     auto ledgerSeq = ltx.loadHeader().current().ledgerSeq;
     auto hitRate = mApp.getLedgerTxnRoot().getPrefetchHitRate() * 100;
@@ -2751,8 +2666,7 @@ LedgerManagerImpl::logTxApplyMetrics(AbstractLedgerTxn& ltx, size_t numTxs,
     TracyPlot("ledger.prefetch.hit-rate", hitRate);
 }
 
-HistoryArchiveState
-LedgerManagerImpl::storePersistentStateAndLedgerHeaderInDB(
+HistoryArchiveState LedgerManagerImpl::storePersistentStateAndLedgerHeaderInDB(
     LedgerHeader const& header, bool appendToCheckpoint)
 {
     ZoneScoped;
@@ -2801,8 +2715,7 @@ LedgerManagerImpl::storePersistentStateAndLedgerHeaderInDB(
 }
 
 // NB: This is a separate method so a testing subclass can override it.
-void
-LedgerManagerImpl::finalizeLedgerTxnChanges(
+void LedgerManagerImpl::finalizeLedgerTxnChanges(
     SearchableSnapshotConstPtr lclSnapshot,
     SearchableHotArchiveSnapshotConstPtr lclHotArchiveSnapshot,
     AbstractLedgerTxn& ltx,
@@ -2978,8 +2891,7 @@ LedgerManagerImpl::sealLedgerTxnAndStoreInBucketsAndDB(
     return res;
 }
 
-void
-LedgerManagerImpl::ApplyState::evictFromModuleCache(
+void LedgerManagerImpl::ApplyState::evictFromModuleCache(
     uint32_t ledgerVersion, EvictedStateVectors const& evictedState)
 {
     ZoneScoped;
@@ -3014,8 +2926,7 @@ LedgerManagerImpl::ApplyState::evictFromModuleCache(
     }
 }
 
-void
-LedgerManagerImpl::ApplyState::addAnyContractsToModuleCache(
+void LedgerManagerImpl::ApplyState::addAnyContractsToModuleCache(
     uint32_t ledgerVersion, std::vector<LedgerEntry> const& le)
 {
     ZoneScoped;

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -428,8 +428,8 @@ class LedgerManagerImpl : public LedgerManager
     void publishSorobanMetrics();
 
     // Update cached last closed ledger state values managed by this class.
-    void
-    advanceLastClosedLedgerState(CompleteConstLedgerStatePtr newLedgerState);
+    void advanceLastClosedLedgerState(
+        CompleteConstLedgerStatePtr newLedgerState);
 
     // Internal helper for loading last known ledger and an option to skip
     // building the 'full' state (including in-memory Soroban state, module
@@ -556,8 +556,7 @@ class LedgerManagerImpl : public LedgerManager
 
     SorobanMetrics& getSorobanMetrics() override;
     SearchableSnapshotConstPtr getLastClosedSnapshot() const override;
-    virtual bool
-    isApplying() const override
+    virtual bool isApplying() const override
     {
         return mCurrentlyApplyingLedger;
     }
@@ -567,8 +566,7 @@ class LedgerManagerImpl : public LedgerManager
     void handleUpgradeAffectingSorobanInMemoryStateSize(
         AbstractLedgerTxn& upgradeLtx) override;
 
-    void
-    assertSetupPhase() const override
+    void assertSetupPhase() const override
     {
         mApplyState.assertSetupPhase();
     }

--- a/src/ledger/LedgerRange.cpp
+++ b/src/ledger/LedgerRange.cpp
@@ -16,14 +16,12 @@ LedgerRange::LedgerRange(uint32_t first, uint32_t count)
     releaseAssert(count == 0 || mFirst > 0);
 }
 
-std::string
-LedgerRange::toString() const
+std::string LedgerRange::toString() const
 {
     return fmt::format(FMT_STRING("[{:d},{:d})"), mFirst, mFirst + mCount);
 }
 
-bool
-operator==(LedgerRange const& x, LedgerRange const& y)
+bool operator==(LedgerRange const& x, LedgerRange const& y)
 {
     if (x.mFirst != y.mFirst)
     {
@@ -36,8 +34,7 @@ operator==(LedgerRange const& x, LedgerRange const& y)
     return true;
 }
 
-bool
-operator!=(LedgerRange const& x, LedgerRange const& y)
+bool operator!=(LedgerRange const& x, LedgerRange const& y)
 {
     return !(x == y);
 }

--- a/src/ledger/LedgerRange.h
+++ b/src/ledger/LedgerRange.h
@@ -25,8 +25,7 @@ struct LedgerRange final
     uint32_t const mCount;
 
     LedgerRange(uint32_t first, uint32_t count);
-    static LedgerRange
-    inclusive(uint32_t first, uint32_t last)
+    static LedgerRange inclusive(uint32_t first, uint32_t last)
     {
         // LedgerRange is half-open: in exchange for being able to represent
         // empty ranges, it can't represent ranges that include UINT32_MAX.
@@ -37,16 +36,14 @@ struct LedgerRange final
 
     // Return first+count, which is the _exclusive_ range limit.
     // Best to use this in a loop header to properly handle count=0.
-    uint32_t
-    limit() const
+    uint32_t limit() const
     {
         return mFirst + mCount;
     }
 
     // Return first+count-1 unless count == 0, in which case throw.
     // This is the _inclusive_ range limit, meaningful iff count != 0.
-    uint32_t
-    last() const
+    uint32_t last() const
     {
         if (mCount == 0)
         {

--- a/src/ledger/LedgerStateSnapshot.cpp
+++ b/src/ledger/LedgerStateSnapshot.cpp
@@ -30,8 +30,7 @@ LedgerEntryWrapper::LedgerEntryWrapper(std::shared_ptr<LedgerEntry const> entry)
 {
 }
 
-LedgerEntry const&
-LedgerEntryWrapper::current() const
+LedgerEntry const& LedgerEntryWrapper::current() const
 {
     switch (mEntry.index())
     {
@@ -50,8 +49,7 @@ LedgerEntryWrapper::current() const
     }
 }
 
-LedgerEntryWrapper::
-operator bool() const
+LedgerEntryWrapper::operator bool() const
 {
     switch (mEntry.index())
     {
@@ -76,8 +74,7 @@ LedgerHeaderWrapper::LedgerHeaderWrapper(std::shared_ptr<LedgerHeader> header)
 {
 }
 
-LedgerHeader&
-LedgerHeaderWrapper::currentToModify()
+LedgerHeader& LedgerHeaderWrapper::currentToModify()
 {
     switch (mHeader.index())
     {
@@ -90,8 +87,7 @@ LedgerHeaderWrapper::currentToModify()
     }
 }
 
-LedgerHeader const&
-LedgerHeaderWrapper::current() const
+LedgerHeader const& LedgerHeaderWrapper::current() const
 {
     switch (mHeader.index())
     {
@@ -112,14 +108,12 @@ LedgerTxnReadOnly::~LedgerTxnReadOnly()
 {
 }
 
-LedgerHeaderWrapper
-LedgerTxnReadOnly::getLedgerHeader() const
+LedgerHeaderWrapper LedgerTxnReadOnly::getLedgerHeader() const
 {
     return LedgerHeaderWrapper(mLedgerTxn.loadHeader());
 }
 
-LedgerEntryWrapper
-LedgerTxnReadOnly::getAccount(AccountID const& account) const
+LedgerEntryWrapper LedgerTxnReadOnly::getAccount(AccountID const& account) const
 {
     return LedgerEntryWrapper(loadAccountWithoutRecord(mLedgerTxn, account));
 }
@@ -153,14 +147,12 @@ LedgerTxnReadOnly::getAccount(LedgerHeaderWrapper const& header,
     return getAccount(account);
 }
 
-LedgerEntryWrapper
-LedgerTxnReadOnly::load(LedgerKey const& key) const
+LedgerEntryWrapper LedgerTxnReadOnly::load(LedgerKey const& key) const
 {
     return LedgerEntryWrapper(mLedgerTxn.loadWithoutRecord(key));
 }
 
-void
-LedgerTxnReadOnly::executeWithMaybeInnerSnapshot(
+void LedgerTxnReadOnly::executeWithMaybeInnerSnapshot(
     std::function<void(LedgerSnapshot const& ls)> f) const
 {
     LedgerTxn inner(mLedgerTxn);
@@ -179,8 +171,7 @@ BucketSnapshotState::~BucketSnapshotState()
 {
 }
 
-LedgerHeaderWrapper
-BucketSnapshotState::getLedgerHeader() const
+LedgerHeaderWrapper BucketSnapshotState::getLedgerHeader() const
 {
     return LedgerHeaderWrapper(std::get<1>(mLedgerHeader.mHeader));
 }
@@ -206,14 +197,12 @@ BucketSnapshotState::getAccount(LedgerHeaderWrapper const& header,
     return getAccount(AccountID);
 }
 
-LedgerEntryWrapper
-BucketSnapshotState::load(LedgerKey const& key) const
+LedgerEntryWrapper BucketSnapshotState::load(LedgerKey const& key) const
 {
     return LedgerEntryWrapper(mSnapshot->load(key));
 }
 
-void
-BucketSnapshotState::executeWithMaybeInnerSnapshot(
+void BucketSnapshotState::executeWithMaybeInnerSnapshot(
     std::function<void(LedgerSnapshot const& ls)> f) const
 {
     throw std::runtime_error(
@@ -249,33 +238,28 @@ LedgerSnapshot::LedgerSnapshot(SearchableSnapshotConstPtr snapshot)
 {
 }
 
-LedgerHeaderWrapper
-LedgerSnapshot::getLedgerHeader() const
+LedgerHeaderWrapper LedgerSnapshot::getLedgerHeader() const
 {
     return mGetter->getLedgerHeader();
 }
 
-LedgerEntryWrapper
-LedgerSnapshot::getAccount(AccountID const& account) const
+LedgerEntryWrapper LedgerSnapshot::getAccount(AccountID const& account) const
 {
     return mGetter->getAccount(account);
 }
 
-LedgerEntryWrapper
-LedgerSnapshot::load(LedgerKey const& key) const
+LedgerEntryWrapper LedgerSnapshot::load(LedgerKey const& key) const
 {
     return mGetter->load(key);
 }
 
-void
-LedgerSnapshot::executeWithMaybeInnerSnapshot(
+void LedgerSnapshot::executeWithMaybeInnerSnapshot(
     std::function<void(LedgerSnapshot const& ls)> f) const
 {
     return mGetter->executeWithMaybeInnerSnapshot(f);
 }
 
-void
-CompleteConstLedgerState::checkInvariant() const
+void CompleteConstLedgerState::checkInvariant() const
 {
     releaseAssert(mLastClosedHistoryArchiveState.currentLedger ==
                   mLastClosedLedgerHeader.header.ledgerSeq);
@@ -305,8 +289,7 @@ CompleteConstLedgerState::CompleteConstLedgerState(
     checkInvariant();
 }
 
-SearchableSnapshotConstPtr
-CompleteConstLedgerState::getBucketSnapshot() const
+SearchableSnapshotConstPtr CompleteConstLedgerState::getBucketSnapshot() const
 {
     return mBucketSnapshot;
 }
@@ -317,14 +300,12 @@ CompleteConstLedgerState::getHotArchiveSnapshot() const
     return mHotArchiveSnapshot;
 }
 
-SorobanNetworkConfig const&
-CompleteConstLedgerState::getSorobanConfig() const
+SorobanNetworkConfig const& CompleteConstLedgerState::getSorobanConfig() const
 {
     return mSorobanConfig.value();
 }
 
-bool
-CompleteConstLedgerState::hasSorobanConfig() const
+bool CompleteConstLedgerState::hasSorobanConfig() const
 {
     return mSorobanConfig.has_value();
 }

--- a/src/ledger/LedgerStateSnapshot.h
+++ b/src/ledger/LedgerStateSnapshot.h
@@ -60,8 +60,7 @@ class LedgerHeaderWrapper
     explicit LedgerHeaderWrapper(std::shared_ptr<LedgerHeader> header);
     LedgerHeader& currentToModify();
     LedgerHeader const& current() const;
-    LedgerTxnHeader const&
-    getLedgerTxnHeader() const
+    LedgerTxnHeader const& getLedgerTxnHeader() const
     {
         releaseAssert(std::holds_alternative<LedgerTxnHeader>(mHeader));
         return std::get<0>(mHeader);
@@ -155,15 +154,14 @@ class LedgerSnapshot : public NonMovableOrCopyable
     explicit LedgerSnapshot(SearchableSnapshotConstPtr snapshot);
     LedgerHeaderWrapper getLedgerHeader() const;
     LedgerEntryWrapper getAccount(AccountID const& account) const;
-    LedgerEntryWrapper
-    getAccount(LedgerHeaderWrapper const& header,
-               TransactionFrame const& tx) const
+    LedgerEntryWrapper getAccount(LedgerHeaderWrapper const& header,
+                                  TransactionFrame const& tx) const
     {
         return mGetter->getAccount(header, tx);
     }
-    LedgerEntryWrapper
-    getAccount(LedgerHeaderWrapper const& header, TransactionFrame const& tx,
-               AccountID const& AccountID) const
+    LedgerEntryWrapper getAccount(LedgerHeaderWrapper const& header,
+                                  TransactionFrame const& tx,
+                                  AccountID const& AccountID) const
     {
         return mGetter->getAccount(header, tx, AccountID);
     }

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -41,8 +41,7 @@ LedgerEntryPtr::Live(std::shared_ptr<InternalLedgerEntry> const& lePtr)
     return {lePtr, EntryPtrState::LIVE};
 }
 
-LedgerEntryPtr
-LedgerEntryPtr::Delete()
+LedgerEntryPtr LedgerEntryPtr::Delete()
 {
     return {nullptr, EntryPtrState::DELETED};
 }
@@ -67,8 +66,7 @@ LedgerEntryPtr::LedgerEntryPtr(
     }
 }
 
-InternalLedgerEntry&
-LedgerEntryPtr::operator*() const
+InternalLedgerEntry& LedgerEntryPtr::operator*() const
 {
     if (!mEntryPtr)
     {
@@ -78,8 +76,7 @@ LedgerEntryPtr::operator*() const
     return *mEntryPtr;
 }
 
-InternalLedgerEntry*
-LedgerEntryPtr::operator->() const
+InternalLedgerEntry* LedgerEntryPtr::operator->() const
 {
     if (!mEntryPtr)
     {
@@ -89,14 +86,12 @@ LedgerEntryPtr::operator->() const
     return mEntryPtr.get();
 }
 
-std::shared_ptr<InternalLedgerEntry>
-LedgerEntryPtr::get() const
+std::shared_ptr<InternalLedgerEntry> LedgerEntryPtr::get() const
 {
     return mEntryPtr;
 }
 
-void
-LedgerEntryPtr::mergeFrom(LedgerEntryPtr const& entryPtr)
+void LedgerEntryPtr::mergeFrom(LedgerEntryPtr const& entryPtr)
 {
     switch (mState)
     {
@@ -146,26 +141,22 @@ LedgerEntryPtr::mergeFrom(LedgerEntryPtr const& entryPtr)
     mEntryPtr = entryPtr.get();
 }
 
-EntryPtrState
-LedgerEntryPtr::getState() const
+EntryPtrState LedgerEntryPtr::getState() const
 {
     return mState;
 }
 
-bool
-LedgerEntryPtr::isInit() const
+bool LedgerEntryPtr::isInit() const
 {
     return mState == EntryPtrState::INIT;
 }
 
-bool
-LedgerEntryPtr::isLive() const
+bool LedgerEntryPtr::isLive() const
 {
     return mState == EntryPtrState::LIVE;
 }
 
-bool
-LedgerEntryPtr::isDeleted() const
+bool LedgerEntryPtr::isDeleted() const
 {
     return mState == EntryPtrState::DELETED;
 }
@@ -192,15 +183,13 @@ RestoredEntries::getEntryOpt(LedgerKey const& key) const
     }
 }
 
-bool
-RestoredEntries::entryWasRestored(LedgerKey const& k) const
+bool RestoredEntries::entryWasRestored(LedgerKey const& k) const
 {
     return entryWasRestoredFromMap(k, liveBucketList) ||
            entryWasRestoredFromMap(k, hotArchive);
 }
 
-bool
-RestoredEntries::entryWasRestoredFromMap(
+bool RestoredEntries::entryWasRestoredFromMap(
     LedgerKey const& k, UnorderedMap<LedgerKey, LedgerEntry> const& map)
 {
     auto it = map.find(k);
@@ -218,11 +207,11 @@ RestoredEntries::entryWasRestoredFromMap(
     return false;
 }
 
-void
-RestoredEntries::addRestoreToMap(LedgerKey const& key, LedgerEntry const& entry,
-                                 LedgerKey const& ttlKey,
-                                 LedgerEntry const& ttlEntry,
-                                 UnorderedMap<LedgerKey, LedgerEntry>& map)
+void RestoredEntries::addRestoreToMap(LedgerKey const& key,
+                                      LedgerEntry const& entry,
+                                      LedgerKey const& ttlKey,
+                                      LedgerEntry const& ttlEntry,
+                                      UnorderedMap<LedgerKey, LedgerEntry>& map)
 {
     releaseAssert(isSorobanEntry(key));
     releaseAssert(ttlKey.type() == TTL);
@@ -232,27 +221,24 @@ RestoredEntries::addRestoreToMap(LedgerKey const& key, LedgerEntry const& entry,
     releaseAssert(ttlInserted);
 }
 
-void
-RestoredEntries::addHotArchiveRestore(LedgerKey const& key,
-                                      LedgerEntry const& entry,
-                                      LedgerKey const& ttlKey,
-                                      LedgerEntry const& ttlEntry)
+void RestoredEntries::addHotArchiveRestore(LedgerKey const& key,
+                                           LedgerEntry const& entry,
+                                           LedgerKey const& ttlKey,
+                                           LedgerEntry const& ttlEntry)
 {
     addRestoreToMap(key, entry, ttlKey, ttlEntry, hotArchive);
 }
 
-void
-RestoredEntries::addLiveBucketlistRestore(LedgerKey const& key,
-                                          LedgerEntry const& entry,
-                                          LedgerKey const& ttlKey,
-                                          LedgerEntry const& ttlEntry)
+void RestoredEntries::addLiveBucketlistRestore(LedgerKey const& key,
+                                               LedgerEntry const& entry,
+                                               LedgerKey const& ttlKey,
+                                               LedgerEntry const& ttlEntry)
 {
     addRestoreToMap(key, entry, ttlKey, ttlEntry, liveBucketList);
 }
 
-void
-RestoredEntries::addRestoresFrom(RestoredEntries const& other,
-                                 bool allowDuplicates)
+void RestoredEntries::addRestoresFrom(RestoredEntries const& other,
+                                      bool allowDuplicates)
 {
     ZoneScoped;
     // This method is called from three different call sites. In 2 of them it is
@@ -288,36 +274,31 @@ RestoredEntries::addRestoresFrom(RestoredEntries const& other,
     }
 }
 
-bool
-operator==(OfferDescriptor const& lhs, OfferDescriptor const& rhs)
+bool operator==(OfferDescriptor const& lhs, OfferDescriptor const& rhs)
 {
     return lhs.price == rhs.price && lhs.offerID == rhs.offerID;
 }
 
-bool
-IsBetterOfferComparator::operator()(OfferDescriptor const& lhs,
-                                    OfferDescriptor const& rhs) const
+bool IsBetterOfferComparator::operator()(OfferDescriptor const& lhs,
+                                         OfferDescriptor const& rhs) const
 {
     return isBetterOffer(lhs, rhs);
 }
 
-bool
-operator==(AssetPair const& lhs, AssetPair const& rhs)
+bool operator==(AssetPair const& lhs, AssetPair const& rhs)
 {
     return lhs.buying == rhs.buying && lhs.selling == rhs.selling;
 }
 
-size_t
-AssetPairHash::operator()(AssetPair const& key) const
+size_t AssetPairHash::operator()(AssetPair const& key) const
 {
     std::hash<Asset> hashAsset;
     return hashAsset(key.buying) ^ (hashAsset(key.selling) << 1);
 }
 
 #ifdef BEST_OFFER_DEBUGGING
-void
-compareOffers(std::shared_ptr<LedgerEntry const> debugBest,
-              std::shared_ptr<LedgerEntry const> best)
+void compareOffers(std::shared_ptr<LedgerEntry const> debugBest,
+                   std::shared_ptr<LedgerEntry const> best)
 {
     if ((bool)debugBest ^ (bool)best)
     {
@@ -368,39 +349,33 @@ EntryIterator::getImpl() const
     return mImpl;
 }
 
-EntryIterator&
-EntryIterator::operator++()
+EntryIterator& EntryIterator::operator++()
 {
     getImpl()->advance();
     return *this;
 }
 
-EntryIterator::
-operator bool() const
+EntryIterator::operator bool() const
 {
     return !getImpl()->atEnd();
 }
 
-InternalLedgerEntry const&
-EntryIterator::entry() const
+InternalLedgerEntry const& EntryIterator::entry() const
 {
     return getImpl()->entry();
 }
 
-LedgerEntryPtr const&
-EntryIterator::entryPtr() const
+LedgerEntryPtr const& EntryIterator::entryPtr() const
 {
     return getImpl()->entryPtr();
 }
 
-bool
-EntryIterator::entryExists() const
+bool EntryIterator::entryExists() const
 {
     return getImpl()->entryExists();
 }
 
-InternalLedgerKey const&
-EntryIterator::key() const
+InternalLedgerKey const& EntryIterator::key() const
 {
     return getImpl()->key();
 }
@@ -455,8 +430,7 @@ LedgerTxn::~LedgerTxn()
     }
 }
 
-std::unique_ptr<LedgerTxn::Impl> const&
-LedgerTxn::getImpl() const
+std::unique_ptr<LedgerTxn::Impl> const& LedgerTxn::getImpl() const
 {
     if (!mImpl)
     {
@@ -465,14 +439,12 @@ LedgerTxn::getImpl() const
     return mImpl;
 }
 
-void
-LedgerTxn::addChild(AbstractLedgerTxn& child, TransactionMode mode)
+void LedgerTxn::addChild(AbstractLedgerTxn& child, TransactionMode mode)
 {
     getImpl()->addChild(child);
 }
 
-void
-LedgerTxn::Impl::addChild(AbstractLedgerTxn& child)
+void LedgerTxn::Impl::addChild(AbstractLedgerTxn& child)
 {
     abortIfWrongThread("addChild");
     throwIfSealed();
@@ -504,8 +476,7 @@ LedgerTxn::Impl::addChild(AbstractLedgerTxn& child)
     mActiveHeader.reset();
 }
 
-void
-LedgerTxn::Impl::throwIfChild() const
+void LedgerTxn::Impl::throwIfChild() const
 {
     if (mChild)
     {
@@ -513,8 +484,7 @@ LedgerTxn::Impl::throwIfChild() const
     }
 }
 
-void
-LedgerTxn::Impl::throwIfSealed() const
+void LedgerTxn::Impl::throwIfSealed() const
 {
     if (mIsSealed)
     {
@@ -522,8 +492,7 @@ LedgerTxn::Impl::throwIfSealed() const
     }
 }
 
-void
-LedgerTxn::Impl::abortIfWrongThread(const char* functionName) const
+void LedgerTxn::Impl::abortIfWrongThread(const char* functionName) const
 {
     if (mActiveThreadId != std::this_thread::get_id())
     {
@@ -533,8 +502,7 @@ LedgerTxn::Impl::abortIfWrongThread(const char* functionName) const
     }
 }
 
-void
-LedgerTxn::Impl::throwIfNotExactConsistency() const
+void LedgerTxn::Impl::throwIfNotExactConsistency() const
 {
     if (mConsistency != LedgerTxnConsistency::EXACT)
     {
@@ -542,8 +510,7 @@ LedgerTxn::Impl::throwIfNotExactConsistency() const
     }
 }
 
-void
-LedgerTxn::Impl::throwIfErasingConfig(InternalLedgerKey const& key) const
+void LedgerTxn::Impl::throwIfErasingConfig(InternalLedgerKey const& key) const
 {
     abortIfWrongThread("throwIfErasingConfig");
     if (key.type() == InternalLedgerEntryType::LEDGER_ENTRY &&
@@ -553,15 +520,13 @@ LedgerTxn::Impl::throwIfErasingConfig(InternalLedgerKey const& key) const
     }
 }
 
-void
-LedgerTxn::commit() noexcept
+void LedgerTxn::commit() noexcept
 {
     getImpl()->commit();
     mImpl.reset();
 }
 
-void
-LedgerTxn::Impl::commit() noexcept
+void LedgerTxn::Impl::commit() noexcept
 {
     abortIfWrongThread("commit");
     maybeUpdateLastModifiedThenInvokeThenSeal([&](EntryMap const& entries) {
@@ -572,16 +537,15 @@ LedgerTxn::Impl::commit() noexcept
     });
 }
 
-void
-LedgerTxn::commitChild(EntryIterator iter,
-                       RestoredEntries const& restoredEntries,
-                       LedgerTxnConsistency cons) noexcept
+void LedgerTxn::commitChild(EntryIterator iter,
+                            RestoredEntries const& restoredEntries,
+                            LedgerTxnConsistency cons) noexcept
 {
     getImpl()->commitChild(std::move(iter), restoredEntries, cons);
 }
 
-static LedgerTxnConsistency
-joinConsistencyLevels(LedgerTxnConsistency c1, LedgerTxnConsistency c2)
+static LedgerTxnConsistency joinConsistencyLevels(LedgerTxnConsistency c1,
+                                                  LedgerTxnConsistency c2)
 {
     switch (c1)
     {
@@ -594,10 +558,9 @@ joinConsistencyLevels(LedgerTxnConsistency c1, LedgerTxnConsistency c2)
     }
 }
 
-void
-LedgerTxn::Impl::commitChild(EntryIterator iter,
-                             RestoredEntries const& restoredEntries,
-                             LedgerTxnConsistency cons) noexcept
+void LedgerTxn::Impl::commitChild(EntryIterator iter,
+                                  RestoredEntries const& restoredEntries,
+                                  LedgerTxnConsistency cons) noexcept
 {
     abortIfWrongThread("commitChild");
     // Assignment of xdrpp objects does not have the strong exception safety
@@ -713,14 +676,13 @@ LedgerTxn::Impl::commitChild(EntryIterator iter,
     mChild = nullptr;
 }
 
-LedgerTxnEntry
-LedgerTxn::create(InternalLedgerEntry const& entry)
+LedgerTxnEntry LedgerTxn::create(InternalLedgerEntry const& entry)
 {
     return getImpl()->create(*this, entry);
 }
 
-LedgerTxnEntry
-LedgerTxn::Impl::create(LedgerTxn& self, InternalLedgerEntry const& entry)
+LedgerTxnEntry LedgerTxn::Impl::create(LedgerTxn& self,
+                                       InternalLedgerEntry const& entry)
 {
     abortIfWrongThread("create");
     throwIfSealed();
@@ -753,14 +715,12 @@ LedgerTxn::Impl::create(LedgerTxn& self, InternalLedgerEntry const& entry)
     return ltxe;
 }
 
-void
-LedgerTxn::createWithoutLoading(InternalLedgerEntry const& entry)
+void LedgerTxn::createWithoutLoading(InternalLedgerEntry const& entry)
 {
     getImpl()->createWithoutLoading(entry);
 }
 
-void
-LedgerTxn::Impl::createWithoutLoading(InternalLedgerEntry const& entry)
+void LedgerTxn::Impl::createWithoutLoading(InternalLedgerEntry const& entry)
 {
     abortIfWrongThread("createWithoutLoading");
     throwIfSealed();
@@ -783,14 +743,12 @@ LedgerTxn::Impl::createWithoutLoading(InternalLedgerEntry const& entry)
         /* effectiveActive */ false);
 }
 
-void
-LedgerTxn::updateWithoutLoading(InternalLedgerEntry const& entry)
+void LedgerTxn::updateWithoutLoading(InternalLedgerEntry const& entry)
 {
     getImpl()->updateWithoutLoading(entry);
 }
 
-void
-LedgerTxn::Impl::updateWithoutLoading(InternalLedgerEntry const& entry)
+void LedgerTxn::Impl::updateWithoutLoading(InternalLedgerEntry const& entry)
 {
     abortIfWrongThread("updateWithoutLoading");
     throwIfSealed();
@@ -809,14 +767,12 @@ LedgerTxn::Impl::updateWithoutLoading(InternalLedgerEntry const& entry)
         /* effectiveActive */ false);
 }
 
-void
-LedgerTxn::deactivate(InternalLedgerKey const& key)
+void LedgerTxn::deactivate(InternalLedgerKey const& key)
 {
     getImpl()->deactivate(key);
 }
 
-void
-LedgerTxn::Impl::deactivate(InternalLedgerKey const& key)
+void LedgerTxn::Impl::deactivate(InternalLedgerKey const& key)
 {
     auto iter = mActive.find(key);
     if (iter == mActive.end())
@@ -831,14 +787,12 @@ LedgerTxn::Impl::deactivate(InternalLedgerKey const& key)
     mActive.erase(iter);
 }
 
-void
-LedgerTxn::deactivateHeader()
+void LedgerTxn::deactivateHeader()
 {
     getImpl()->deactivateHeader();
 }
 
-void
-LedgerTxn::Impl::deactivateHeader()
+void LedgerTxn::Impl::deactivateHeader()
 {
     if (!mActiveHeader)
     {
@@ -847,14 +801,12 @@ LedgerTxn::Impl::deactivateHeader()
     mActiveHeader.reset();
 }
 
-void
-LedgerTxn::erase(InternalLedgerKey const& key)
+void LedgerTxn::erase(InternalLedgerKey const& key)
 {
     getImpl()->erase(key);
 }
 
-void
-LedgerTxn::Impl::erase(InternalLedgerKey const& key)
+void LedgerTxn::Impl::erase(InternalLedgerKey const& key)
 {
     abortIfWrongThread("erase");
     throwIfSealed();
@@ -882,16 +834,14 @@ LedgerTxn::Impl::erase(InternalLedgerKey const& key)
     }
 }
 
-void
-LedgerTxn::markRestoredFromHotArchive(LedgerEntry const& ledgerEntry,
-                                      LedgerEntry const& ttlEntry)
+void LedgerTxn::markRestoredFromHotArchive(LedgerEntry const& ledgerEntry,
+                                           LedgerEntry const& ttlEntry)
 {
     getImpl()->markRestoredFromHotArchive(ledgerEntry, ttlEntry);
 }
 
-void
-LedgerTxn::Impl::markRestoredFromHotArchive(LedgerEntry const& ledgerEntry,
-                                            LedgerEntry const& ttlEntry)
+void LedgerTxn::Impl::markRestoredFromHotArchive(LedgerEntry const& ledgerEntry,
+                                                 LedgerEntry const& ttlEntry)
 {
     abortIfWrongThread("markRestoredFromHotArchive");
     throwIfSealed();
@@ -915,16 +865,14 @@ LedgerTxn::Impl::markRestoredFromHotArchive(LedgerEntry const& ledgerEntry,
     addKey(ttlEntry);
 }
 
-LedgerTxnEntry
-LedgerTxn::restoreFromLiveBucketList(LedgerEntry const& entry, uint32_t ttl)
+LedgerTxnEntry LedgerTxn::restoreFromLiveBucketList(LedgerEntry const& entry,
+                                                    uint32_t ttl)
 {
     return getImpl()->restoreFromLiveBucketList(*this, entry, ttl);
 }
 
-LedgerTxnEntry
-LedgerTxn::Impl::restoreFromLiveBucketList(LedgerTxn& self,
-                                           LedgerEntry const& entry,
-                                           uint32_t ttl)
+LedgerTxnEntry LedgerTxn::Impl::restoreFromLiveBucketList(
+    LedgerTxn& self, LedgerEntry const& entry, uint32_t ttl)
 {
     abortIfWrongThread("restoreFromLiveBucketList");
     throwIfSealed();
@@ -965,14 +913,12 @@ LedgerTxn::Impl::restoreFromLiveBucketList(LedgerTxn& self,
     return ttlLtxe;
 }
 
-void
-LedgerTxn::eraseWithoutLoading(InternalLedgerKey const& key)
+void LedgerTxn::eraseWithoutLoading(InternalLedgerKey const& key)
 {
     getImpl()->eraseWithoutLoading(key);
 }
 
-void
-LedgerTxn::Impl::eraseWithoutLoading(InternalLedgerKey const& key)
+void LedgerTxn::Impl::eraseWithoutLoading(InternalLedgerKey const& key)
 {
     abortIfWrongThread("eraseWithoutLoading");
     throwIfSealed();
@@ -995,14 +941,12 @@ LedgerTxn::Impl::eraseWithoutLoading(InternalLedgerKey const& key)
     mConsistency = LedgerTxnConsistency::EXTRA_DELETES;
 }
 
-UnorderedMap<LedgerKey, LedgerEntry>
-LedgerTxn::getAllOffers()
+UnorderedMap<LedgerKey, LedgerEntry> LedgerTxn::getAllOffers()
 {
     return getImpl()->getAllOffers();
 }
 
-UnorderedMap<LedgerKey, LedgerEntry>
-LedgerTxn::Impl::getAllOffers()
+UnorderedMap<LedgerKey, LedgerEntry> LedgerTxn::Impl::getAllOffers()
 {
     auto offers = mParent.getAllOffers();
     for (auto const& kv : mEntry)
@@ -1027,14 +971,12 @@ LedgerTxn::Impl::getAllOffers()
 }
 
 #ifdef BEST_OFFER_DEBUGGING
-bool
-LedgerTxn::bestOfferDebuggingEnabled() const
+bool LedgerTxn::bestOfferDebuggingEnabled() const
 {
     return getImpl()->bestOfferDebuggingEnabled();
 }
 
-bool
-LedgerTxn::Impl::bestOfferDebuggingEnabled() const
+bool LedgerTxn::Impl::bestOfferDebuggingEnabled() const
 {
     abortIfWrongThread("bestOfferDebuggingEnabled");
     return mParent.bestOfferDebuggingEnabled();
@@ -1132,8 +1074,8 @@ LedgerTxn::Impl::checkBestOffer(Asset const& buying, Asset const& selling,
 }
 #endif
 
-std::shared_ptr<LedgerEntry const>
-LedgerTxn::getBestOffer(Asset const& buying, Asset const& selling)
+std::shared_ptr<LedgerEntry const> LedgerTxn::getBestOffer(Asset const& buying,
+                                                           Asset const& selling)
 {
 #ifdef BEST_OFFER_DEBUGGING
     return getImpl()->checkBestOffer(buying, selling, nullptr,
@@ -1323,14 +1265,12 @@ LedgerTxn::Impl::getBestOffer(Asset const& buying, Asset const& selling,
     return selfBest;
 }
 
-LedgerEntryChanges
-LedgerTxn::getChanges()
+LedgerEntryChanges LedgerTxn::getChanges()
 {
     return getImpl()->getChanges();
 }
 
-LedgerEntryChanges
-LedgerTxn::Impl::getChanges()
+LedgerEntryChanges LedgerTxn::Impl::getChanges()
 {
     throwIfNotExactConsistency();
     LedgerEntryChanges changes;
@@ -1377,14 +1317,12 @@ LedgerTxn::Impl::getChanges()
     return changes;
 }
 
-LedgerTxnDelta
-LedgerTxn::getDelta()
+LedgerTxnDelta LedgerTxn::getDelta()
 {
     return getImpl()->getDelta();
 }
 
-LedgerTxnDelta
-LedgerTxn::Impl::getDelta()
+LedgerTxnDelta LedgerTxn::Impl::getDelta()
 {
     abortIfWrongThread("getDelta");
     throwIfNotExactConsistency();
@@ -1411,8 +1349,7 @@ LedgerTxn::Impl::getDelta()
     return delta;
 }
 
-EntryIterator
-LedgerTxn::Impl::getEntryIterator(EntryMap const& entries) const
+EntryIterator LedgerTxn::Impl::getEntryIterator(EntryMap const& entries) const
 {
     abortIfWrongThread("getEntryIterator");
     auto iterImpl =
@@ -1420,27 +1357,24 @@ LedgerTxn::Impl::getEntryIterator(EntryMap const& entries) const
     return EntryIterator(std::move(iterImpl));
 }
 
-LedgerHeader const&
-LedgerTxn::getHeader() const
+LedgerHeader const& LedgerTxn::getHeader() const
 {
     return getImpl()->getHeader();
 }
 
-LedgerHeader const&
-LedgerTxn::Impl::getHeader() const
+LedgerHeader const& LedgerTxn::Impl::getHeader() const
 {
     abortIfWrongThread("getHeader");
     return *mHeader;
 }
 
-std::vector<InflationWinner>
-LedgerTxn::getInflationWinners(size_t maxWinners, int64_t minVotes)
+std::vector<InflationWinner> LedgerTxn::getInflationWinners(size_t maxWinners,
+                                                            int64_t minVotes)
 {
     return getImpl()->getInflationWinners(maxWinners, minVotes);
 }
 
-std::map<AccountID, int64_t>
-LedgerTxn::Impl::getDeltaVotes() const
+std::map<AccountID, int64_t> LedgerTxn::Impl::getDeltaVotes() const
 {
     abortIfWrongThread("getDeltaVotes");
     int64_t const MIN_VOTES_TO_INCLUDE = 1000000000;
@@ -1477,8 +1411,7 @@ LedgerTxn::Impl::getDeltaVotes() const
     return deltaVotes;
 }
 
-std::map<AccountID, int64_t>
-LedgerTxn::Impl::getTotalVotes(
+std::map<AccountID, int64_t> LedgerTxn::Impl::getTotalVotes(
     std::vector<InflationWinner> const& parentWinners,
     std::map<AccountID, int64_t> const& deltaVotes, int64_t minVotes) const
 {
@@ -1501,8 +1434,7 @@ LedgerTxn::Impl::getTotalVotes(
     return totalVotes;
 }
 
-std::vector<InflationWinner>
-LedgerTxn::Impl::enumerateInflationWinners(
+std::vector<InflationWinner> LedgerTxn::Impl::enumerateInflationWinners(
     std::map<AccountID, int64_t> const& totalVotes, size_t maxWinners,
     int64_t minVotes) const
 {
@@ -1578,8 +1510,8 @@ LedgerTxn::Impl::getInflationWinners(size_t maxWinners, int64_t minVotes)
     return enumerateInflationWinners(totalVotes, maxWinners, minVotes);
 }
 
-std::vector<InflationWinner>
-LedgerTxn::queryInflationWinners(size_t maxWinners, int64_t minVotes)
+std::vector<InflationWinner> LedgerTxn::queryInflationWinners(size_t maxWinners,
+                                                              int64_t minVotes)
 {
     return getImpl()->queryInflationWinners(maxWinners, minVotes);
 }
@@ -1593,18 +1525,16 @@ LedgerTxn::Impl::queryInflationWinners(size_t maxWinners, int64_t minVotes)
     return getInflationWinners(maxWinners, minVotes);
 }
 
-void
-LedgerTxn::getAllEntries(std::vector<LedgerEntry>& initEntries,
-                         std::vector<LedgerEntry>& liveEntries,
-                         std::vector<LedgerKey>& deadEntries)
+void LedgerTxn::getAllEntries(std::vector<LedgerEntry>& initEntries,
+                              std::vector<LedgerEntry>& liveEntries,
+                              std::vector<LedgerKey>& deadEntries)
 {
     getImpl()->getAllEntries(initEntries, liveEntries, deadEntries);
 }
 
-void
-LedgerTxn::Impl::getAllEntries(std::vector<LedgerEntry>& initEntries,
-                               std::vector<LedgerEntry>& liveEntries,
-                               std::vector<LedgerKey>& deadEntries)
+void LedgerTxn::Impl::getAllEntries(std::vector<LedgerEntry>& initEntries,
+                                    std::vector<LedgerEntry>& liveEntries,
+                                    std::vector<LedgerKey>& deadEntries)
 {
     abortIfWrongThread("getAllEntries");
     std::vector<LedgerEntry> resInit, resLive;
@@ -1673,14 +1603,12 @@ LedgerTxn::Impl::getRestoredLiveBucketListKeys() const
     return mRestoredEntries.liveBucketList;
 }
 
-LedgerKeySet
-LedgerTxn::getAllTTLKeysWithoutSealing() const
+LedgerKeySet LedgerTxn::getAllTTLKeysWithoutSealing() const
 {
     return getImpl()->getAllTTLKeysWithoutSealing();
 }
 
-LedgerKeySet
-LedgerTxn::Impl::getAllTTLKeysWithoutSealing() const
+LedgerKeySet LedgerTxn::Impl::getAllTTLKeysWithoutSealing() const
 {
     abortIfWrongThread("getAllTTLKeysWithoutSealing");
     throwIfNotExactConsistency();
@@ -1849,14 +1777,13 @@ LedgerTxn::Impl::getPoolShareTrustLinesByAccountAndAsset(
     return trustLines;
 }
 
-LedgerTxnEntry
-LedgerTxn::load(InternalLedgerKey const& key)
+LedgerTxnEntry LedgerTxn::load(InternalLedgerKey const& key)
 {
     return getImpl()->load(*this, key);
 }
 
-LedgerTxnEntry
-LedgerTxn::Impl::load(LedgerTxn& self, InternalLedgerKey const& key)
+LedgerTxnEntry LedgerTxn::Impl::load(LedgerTxn& self,
+                                     InternalLedgerKey const& key)
 {
     abortIfWrongThread("load");
     throwIfSealed();
@@ -1901,8 +1828,7 @@ LedgerTxn::Impl::load(LedgerTxn& self, InternalLedgerKey const& key)
     return ltxe;
 }
 
-std::map<AccountID, std::vector<LedgerTxnEntry>>
-LedgerTxn::loadAllOffers()
+std::map<AccountID, std::vector<LedgerTxnEntry>> LedgerTxn::loadAllOffers()
 {
     return getImpl()->loadAllOffers(*this);
 }
@@ -1939,15 +1865,15 @@ LedgerTxn::Impl::loadAllOffers(LedgerTxn& self)
     }
 }
 
-LedgerTxnEntry
-LedgerTxn::loadBestOffer(Asset const& buying, Asset const& selling)
+LedgerTxnEntry LedgerTxn::loadBestOffer(Asset const& buying,
+                                        Asset const& selling)
 {
     return getImpl()->loadBestOffer(*this, buying, selling);
 }
 
-LedgerTxnEntry
-LedgerTxn::Impl::loadBestOffer(LedgerTxn& self, Asset const& buying,
-                               Asset const& selling)
+LedgerTxnEntry LedgerTxn::Impl::loadBestOffer(LedgerTxn& self,
+                                              Asset const& buying,
+                                              Asset const& selling)
 {
     abortIfWrongThread("loadBestOffer");
     throwIfSealed();
@@ -2022,14 +1948,12 @@ LedgerTxn::Impl::loadBestOffer(LedgerTxn& self, Asset const& buying,
     return res;
 }
 
-LedgerTxnHeader
-LedgerTxn::loadHeader()
+LedgerTxnHeader LedgerTxn::loadHeader()
 {
     return getImpl()->loadHeader(*this);
 }
 
-LedgerTxnHeader
-LedgerTxn::Impl::loadHeader(LedgerTxn& self)
+LedgerTxnHeader LedgerTxn::Impl::loadHeader(LedgerTxn& self)
 {
     abortIfWrongThread("loadHeader");
     throwIfSealed();
@@ -2054,10 +1978,8 @@ LedgerTxn::loadOffersByAccountAndAsset(AccountID const& accountID,
     return getImpl()->loadOffersByAccountAndAsset(*this, accountID, asset);
 }
 
-std::vector<LedgerTxnEntry>
-LedgerTxn::Impl::loadOffersByAccountAndAsset(LedgerTxn& self,
-                                             AccountID const& accountID,
-                                             Asset const& asset)
+std::vector<LedgerTxnEntry> LedgerTxn::Impl::loadOffersByAccountAndAsset(
+    LedgerTxn& self, AccountID const& accountID, Asset const& asset)
 {
     abortIfWrongThread("loadOffersByAccountAndAsset");
     throwIfSealed();
@@ -2127,8 +2049,7 @@ LedgerTxn::Impl::loadPoolShareTrustLinesByAccountAndAsset(
     }
 }
 
-ConstLedgerTxnEntry
-LedgerTxn::loadWithoutRecord(InternalLedgerKey const& key)
+ConstLedgerTxnEntry LedgerTxn::loadWithoutRecord(InternalLedgerKey const& key)
 {
     return getImpl()->loadWithoutRecord(*this, key);
 }
@@ -2170,15 +2091,13 @@ LedgerTxn::Impl::loadWithoutRecord(LedgerTxn& self,
     return ltxe;
 }
 
-void
-LedgerTxn::rollback() noexcept
+void LedgerTxn::rollback() noexcept
 {
     getImpl()->rollback();
     mImpl.reset();
 }
 
-void
-LedgerTxn::Impl::rollback() noexcept
+void LedgerTxn::Impl::rollback() noexcept
 {
     if (mChild)
     {
@@ -2196,27 +2115,23 @@ LedgerTxn::Impl::rollback() noexcept
     mParent.rollbackChild();
 }
 
-void
-LedgerTxn::rollbackChild() noexcept
+void LedgerTxn::rollbackChild() noexcept
 {
     getImpl()->rollbackChild();
 }
 
-void
-LedgerTxn::Impl::rollbackChild() noexcept
+void LedgerTxn::Impl::rollbackChild() noexcept
 {
     mChild = nullptr;
 }
 
-void
-LedgerTxn::unsealHeader(std::function<void(LedgerHeader&)> f)
+void LedgerTxn::unsealHeader(std::function<void(LedgerHeader&)> f)
 {
     getImpl()->unsealHeader(*this, f);
 }
 
-void
-LedgerTxn::Impl::unsealHeader(LedgerTxn& self,
-                              std::function<void(LedgerHeader&)> f)
+void LedgerTxn::Impl::unsealHeader(LedgerTxn& self,
+                                   std::function<void(LedgerHeader&)> f)
 {
     if (!mIsSealed)
     {
@@ -2232,60 +2147,51 @@ LedgerTxn::Impl::unsealHeader(LedgerTxn& self,
     f(header.current());
 }
 
-uint64_t
-LedgerTxn::countOffers(LedgerRange const& ledgers) const
+uint64_t LedgerTxn::countOffers(LedgerRange const& ledgers) const
 {
     throw std::runtime_error("called countOffers on non-root LedgerTxn");
 }
 
-void
-LedgerTxn::deleteOffersModifiedOnOrAfterLedger(uint32_t ledger) const
+void LedgerTxn::deleteOffersModifiedOnOrAfterLedger(uint32_t ledger) const
 {
     throw std::runtime_error(
         "called deleteOffersModifiedOnOrAfterLedger on non-root LedgerTxn");
 }
 
-void
-LedgerTxn::dropOffers()
+void LedgerTxn::dropOffers()
 {
     throw std::runtime_error("called dropOffers on non-root LedgerTxn");
 }
 
-double
-LedgerTxn::getPrefetchHitRate() const
+double LedgerTxn::getPrefetchHitRate() const
 {
     return getImpl()->getPrefetchHitRate();
 }
 
 #ifdef BUILD_TESTS
-void
-LedgerTxn::resetForFuzzer()
+void LedgerTxn::resetForFuzzer()
 {
     abort();
 }
 #endif // BUILD_TESTS
 
-double
-LedgerTxn::Impl::getPrefetchHitRate() const
+double LedgerTxn::Impl::getPrefetchHitRate() const
 {
     abortIfWrongThread("getPrefetchHitRate");
     return mParent.getPrefetchHitRate();
 }
 
-uint32_t
-LedgerTxn::prefetch(UnorderedSet<LedgerKey> const& keys)
+uint32_t LedgerTxn::prefetch(UnorderedSet<LedgerKey> const& keys)
 {
     return getImpl()->prefetch(keys);
 }
 
-uint32_t
-LedgerTxn::Impl::prefetch(UnorderedSet<LedgerKey> const& keys)
+uint32_t LedgerTxn::Impl::prefetch(UnorderedSet<LedgerKey> const& keys)
 {
     return mParent.prefetch(keys);
 }
 
-void
-LedgerTxn::Impl::maybeUpdateLastModified() noexcept
+void LedgerTxn::Impl::maybeUpdateLastModified() noexcept
 {
     abortIfWrongThread("maybeUpdateLastModified");
     throwIfSealed();
@@ -2305,8 +2211,7 @@ LedgerTxn::Impl::maybeUpdateLastModified() noexcept
     }
 }
 
-void
-LedgerTxn::Impl::maybeUpdateLastModifiedThenInvokeThenSeal(
+void LedgerTxn::Impl::maybeUpdateLastModifiedThenInvokeThenSeal(
     std::function<void(EntryMap const&)> f) noexcept
 {
     if (!mIsSealed)
@@ -2326,8 +2231,7 @@ LedgerTxn::Impl::maybeUpdateLastModifiedThenInvokeThenSeal(
     }
 }
 
-void
-LedgerTxn::Impl::removeFromOrderBookIfExists(LedgerEntry const& le)
+void LedgerTxn::Impl::removeFromOrderBookIfExists(LedgerEntry const& le)
 {
     abortIfWrongThread("removeFromOrderBookIfExists");
     auto const& oe = le.data.offer();
@@ -2357,8 +2261,8 @@ LedgerTxn::Impl::removeFromOrderBookIfExists(LedgerEntry const& le)
     }
 }
 
-LedgerTxn::Impl::OrderBook*
-LedgerTxn::Impl::findOrderBook(Asset const& buying, Asset const& selling)
+LedgerTxn::Impl::OrderBook* LedgerTxn::Impl::findOrderBook(Asset const& buying,
+                                                           Asset const& selling)
 {
     abortIfWrongThread("findOrderBook");
     auto mobIterBuying = mMultiOrderBook.find(buying);
@@ -2375,9 +2279,8 @@ LedgerTxn::Impl::findOrderBook(Asset const& buying, Asset const& selling)
     return nullptr;
 }
 
-void
-LedgerTxn::Impl::updateEntryIfRecorded(InternalLedgerKey const& key,
-                                       bool effectiveActive)
+void LedgerTxn::Impl::updateEntryIfRecorded(InternalLedgerKey const& key,
+                                            bool effectiveActive)
 {
     abortIfWrongThread("updateEntryIfRecorded");
     // This early return is just an optimization. updateEntryIfRecorded does not
@@ -2403,11 +2306,10 @@ LedgerTxn::Impl::updateEntryIfRecorded(InternalLedgerKey const& key,
     }
 }
 
-void
-LedgerTxn::Impl::updateEntry(InternalLedgerKey const& key,
-                             EntryMap::iterator const* keyHint,
-                             LedgerEntryPtr lePtr,
-                             bool effectiveActive) noexcept
+void LedgerTxn::Impl::updateEntry(InternalLedgerKey const& key,
+                                  EntryMap::iterator const* keyHint,
+                                  LedgerEntryPtr lePtr,
+                                  bool effectiveActive) noexcept
 {
     abortIfWrongThread("updateEntry");
     auto recordEntry = [&]() {
@@ -2480,15 +2382,13 @@ LedgerTxn::Impl::updateEntry(InternalLedgerKey const& key,
     recordEntry();
 }
 
-static bool
-isWorseThan(std::shared_ptr<OfferDescriptor const> const& lhs,
-            std::shared_ptr<OfferDescriptor const> const& rhs)
+static bool isWorseThan(std::shared_ptr<OfferDescriptor const> const& lhs,
+                        std::shared_ptr<OfferDescriptor const> const& rhs)
 {
     return rhs && (!lhs || isBetterOffer(*rhs, *lhs));
 }
 
-void
-LedgerTxn::Impl::updateWorstBestOffer(
+void LedgerTxn::Impl::updateWorstBestOffer(
     AssetPair const& assets, std::shared_ptr<OfferDescriptor const> offerDesc)
 {
     abortIfWrongThread("updateWorstBestOffer");
@@ -2505,14 +2405,12 @@ LedgerTxn::Impl::updateWorstBestOffer(
     }
 }
 
-void
-LedgerTxn::forAllWorstBestOffers(WorstOfferProcessor proc)
+void LedgerTxn::forAllWorstBestOffers(WorstOfferProcessor proc)
 {
     getImpl()->forAllWorstBestOffers(proc);
 }
 
-void
-LedgerTxn::Impl::forAllWorstBestOffers(WorstOfferProcessor proc)
+void LedgerTxn::Impl::forAllWorstBestOffers(WorstOfferProcessor proc)
 {
     abortIfWrongThread("forAllWorstBestOffers");
     for (auto& wo : mWorstBestOffer)
@@ -2522,14 +2420,12 @@ LedgerTxn::Impl::forAllWorstBestOffers(WorstOfferProcessor proc)
     }
 }
 
-bool
-LedgerTxn::hasSponsorshipEntry() const
+bool LedgerTxn::hasSponsorshipEntry() const
 {
     return getImpl()->hasSponsorshipEntry();
 }
 
-bool
-LedgerTxn::Impl::hasSponsorshipEntry() const
+bool LedgerTxn::Impl::hasSponsorshipEntry() const
 {
     abortIfWrongThread("hasSponsorshipEntry");
     throwIfNotExactConsistency();
@@ -2551,21 +2447,18 @@ LedgerTxn::Impl::hasSponsorshipEntry() const
     return false;
 }
 
-SessionWrapper&
-LedgerTxn::getSession() const
+SessionWrapper& LedgerTxn::getSession() const
 {
     throw std::runtime_error("LedgerTxn::getSession illegal call, can only be "
                              "called on LedgerTxnRoot");
 }
 
-void
-LedgerTxn::prepareNewObjects(size_t s)
+void LedgerTxn::prepareNewObjects(size_t s)
 {
     getImpl()->prepareNewObjects(s);
 }
 
-void
-LedgerTxn::Impl::prepareNewObjects(size_t s)
+void LedgerTxn::Impl::prepareNewObjects(size_t s)
 {
     abortIfWrongThread("prepareNewObjects");
     size_t newSize = mEntry.size();
@@ -2619,38 +2512,32 @@ LedgerTxn::Impl::EntryIteratorImpl::EntryIteratorImpl(IteratorType const& begin,
 {
 }
 
-void
-LedgerTxn::Impl::EntryIteratorImpl::advance()
+void LedgerTxn::Impl::EntryIteratorImpl::advance()
 {
     ++mIter;
 }
 
-bool
-LedgerTxn::Impl::EntryIteratorImpl::atEnd() const
+bool LedgerTxn::Impl::EntryIteratorImpl::atEnd() const
 {
     return mIter == mEnd;
 }
 
-InternalLedgerEntry const&
-LedgerTxn::Impl::EntryIteratorImpl::entry() const
+InternalLedgerEntry const& LedgerTxn::Impl::EntryIteratorImpl::entry() const
 {
     return *(mIter->second);
 }
 
-LedgerEntryPtr const&
-LedgerTxn::Impl::EntryIteratorImpl::entryPtr() const
+LedgerEntryPtr const& LedgerTxn::Impl::EntryIteratorImpl::entryPtr() const
 {
     return mIter->second;
 }
 
-bool
-LedgerTxn::Impl::EntryIteratorImpl::entryExists() const
+bool LedgerTxn::Impl::EntryIteratorImpl::entryExists() const
 {
     return !mIter->second.isDeleted();
 }
 
-InternalLedgerKey const&
-LedgerTxn::Impl::EntryIteratorImpl::key() const
+InternalLedgerKey const& LedgerTxn::Impl::EntryIteratorImpl::key() const
 {
     return mIter->first;
 }
@@ -2667,8 +2554,7 @@ ThreadInvariant::ThreadInvariant()
 {
 }
 
-void
-ThreadInvariant::abortIfWrongThread() const
+void ThreadInvariant::abortIfWrongThread() const
 {
     std::lock_guard<std::recursive_mutex> guard(mThreadInvariantMutex);
     if (mActiveThreadIdSet && mThreadID != std::this_thread::get_id())
@@ -2677,8 +2563,7 @@ ThreadInvariant::abortIfWrongThread() const
     }
 }
 
-void
-ThreadInvariant::setActiveThread()
+void ThreadInvariant::setActiveThread()
 {
     std::lock_guard<std::recursive_mutex> guard(mThreadInvariantMutex);
     abortIfWrongThread();
@@ -2686,8 +2571,7 @@ ThreadInvariant::setActiveThread()
     mActiveThreadIdSet = true;
 }
 
-void
-ThreadInvariant::clearActiveThread()
+void ThreadInvariant::clearActiveThread()
 {
     std::lock_guard<std::recursive_mutex> guard(mThreadInvariantMutex);
     abortIfWrongThread();
@@ -2751,8 +2635,7 @@ LedgerTxnRoot::Impl::~Impl()
     }
 }
 
-SessionWrapper&
-LedgerTxnRoot::Impl::getSession() const
+SessionWrapper& LedgerTxnRoot::Impl::getSession() const
 {
     if (mSession)
     {
@@ -2761,35 +2644,31 @@ LedgerTxnRoot::Impl::getSession() const
     return mApp.getDatabase().getSession();
 }
 
-SessionWrapper&
-LedgerTxnRoot::getSession() const
+SessionWrapper& LedgerTxnRoot::getSession() const
 {
     return mImpl->getSession();
 }
 
 #ifdef BUILD_TESTS
-void
-LedgerTxnRoot::Impl::resetForFuzzer()
+void LedgerTxnRoot::Impl::resetForFuzzer()
 {
     mBestOffers.clear();
     mEntryCache.clear();
 }
 
-void
-LedgerTxnRoot::resetForFuzzer()
+void LedgerTxnRoot::resetForFuzzer()
 {
     mImpl->resetForFuzzer();
 }
 #endif // BUILD_TESTS
 
-void
-LedgerTxnRoot::addChild(AbstractLedgerTxn& child, TransactionMode mode)
+void LedgerTxnRoot::addChild(AbstractLedgerTxn& child, TransactionMode mode)
 {
     mImpl->addChild(child, mode);
 }
 
-void
-LedgerTxnRoot::Impl::addChild(AbstractLedgerTxn& child, TransactionMode mode)
+void LedgerTxnRoot::Impl::addChild(AbstractLedgerTxn& child,
+                                   TransactionMode mode)
 {
     // Will call abortIfWrongThread
     mThreadInvariant.setActiveThread();
@@ -2815,8 +2694,7 @@ LedgerTxnRoot::Impl::addChild(AbstractLedgerTxn& child, TransactionMode mode)
     mChild = &child;
 }
 
-void
-LedgerTxnRoot::Impl::throwIfChild() const
+void LedgerTxnRoot::Impl::throwIfChild() const
 {
     if (mChild)
     {
@@ -2824,23 +2702,21 @@ LedgerTxnRoot::Impl::throwIfChild() const
     }
 }
 
-void
-LedgerTxnRoot::Impl::abortIfWrongThread(const char* functionName) const
+void LedgerTxnRoot::Impl::abortIfWrongThread(const char* functionName) const
 {
     mThreadInvariant.abortIfWrongThread();
 }
 
-void
-LedgerTxnRoot::commitChild(EntryIterator iter,
-                           RestoredEntries const& restoredEntries,
-                           LedgerTxnConsistency cons) noexcept
+void LedgerTxnRoot::commitChild(EntryIterator iter,
+                                RestoredEntries const& restoredEntries,
+                                LedgerTxnConsistency cons) noexcept
 {
     mImpl->commitChild(std::move(iter), restoredEntries, cons);
 }
 
-static void
-accum(EntryIterator const& iter, std::vector<EntryIterator>& upsertBuffer,
-      std::vector<EntryIterator>& deleteBuffer)
+static void accum(EntryIterator const& iter,
+                  std::vector<EntryIterator>& upsertBuffer,
+                  std::vector<EntryIterator>& deleteBuffer)
 {
     if (iter.entryExists())
         upsertBuffer.emplace_back(iter);
@@ -2849,8 +2725,7 @@ accum(EntryIterator const& iter, std::vector<EntryIterator>& upsertBuffer,
 }
 
 // Return true only if something is actually accumulated and not skipped over
-bool
-BulkLedgerEntryChangeAccumulator::accumulate(EntryIterator const& iter)
+bool BulkLedgerEntryChangeAccumulator::accumulate(EntryIterator const& iter)
 {
     // Right now, only LEDGER_ENTRY are recorded in the SQL database
     if (iter.key().type() != InternalLedgerEntryType::LEDGER_ENTRY)
@@ -2870,12 +2745,10 @@ BulkLedgerEntryChangeAccumulator::accumulate(EntryIterator const& iter)
     return true;
 }
 
-void
-LedgerTxnRoot::Impl::bulkApply(BulkLedgerEntryChangeAccumulator& bleca,
-                               size_t bufferThreshold,
-                               LedgerTxnConsistency cons)
+void LedgerTxnRoot::Impl::bulkApply(BulkLedgerEntryChangeAccumulator& bleca,
+                                    size_t bufferThreshold,
+                                    LedgerTxnConsistency cons)
 {
-
     auto& upsertOffers = bleca.getOffersToUpsert();
     if (upsertOffers.size() > bufferThreshold)
     {
@@ -2890,10 +2763,9 @@ LedgerTxnRoot::Impl::bulkApply(BulkLedgerEntryChangeAccumulator& bleca,
     }
 }
 
-void
-LedgerTxnRoot::Impl::commitChild(EntryIterator iter,
-                                 RestoredEntries const& /* restoredEntries */,
-                                 LedgerTxnConsistency cons) noexcept
+void LedgerTxnRoot::Impl::commitChild(
+    EntryIterator iter, RestoredEntries const& /* restoredEntries */,
+    LedgerTxnConsistency cons) noexcept
 {
     ZoneScoped;
     abortIfWrongThread("commitChild");
@@ -2971,14 +2843,12 @@ LedgerTxnRoot::Impl::commitChild(EntryIterator iter,
     mThreadInvariant.clearActiveThread();
 }
 
-uint64_t
-LedgerTxnRoot::countOffers(LedgerRange const& ledgers) const
+uint64_t LedgerTxnRoot::countOffers(LedgerRange const& ledgers) const
 {
     return mImpl->countOffers(ledgers);
 }
 
-uint64_t
-LedgerTxnRoot::Impl::countOffers(LedgerRange const& ledgers) const
+uint64_t LedgerTxnRoot::Impl::countOffers(LedgerRange const& ledgers) const
 {
     using namespace soci;
     throwIfChild();
@@ -2992,14 +2862,13 @@ LedgerTxnRoot::Impl::countOffers(LedgerRange const& ledgers) const
     return count;
 }
 
-void
-LedgerTxnRoot::deleteOffersModifiedOnOrAfterLedger(uint32_t ledger) const
+void LedgerTxnRoot::deleteOffersModifiedOnOrAfterLedger(uint32_t ledger) const
 {
     return mImpl->deleteOffersModifiedOnOrAfterLedger(ledger);
 }
 
-void
-LedgerTxnRoot::Impl::deleteOffersModifiedOnOrAfterLedger(uint32_t ledger) const
+void LedgerTxnRoot::Impl::deleteOffersModifiedOnOrAfterLedger(
+    uint32_t ledger) const
 {
     using namespace soci;
     throwIfChild();
@@ -3010,20 +2879,17 @@ LedgerTxnRoot::Impl::deleteOffersModifiedOnOrAfterLedger(uint32_t ledger) const
     getSession().session() << query, use(ledger);
 }
 
-void
-LedgerTxnRoot::dropOffers()
+void LedgerTxnRoot::dropOffers()
 {
     mImpl->dropOffers();
 }
 
-uint32_t
-LedgerTxnRoot::prefetch(UnorderedSet<LedgerKey> const& keys)
+uint32_t LedgerTxnRoot::prefetch(UnorderedSet<LedgerKey> const& keys)
 {
     return mImpl->prefetch(keys);
 }
 
-uint32_t
-LedgerTxnRoot::Impl::prefetch(UnorderedSet<LedgerKey> const& keys)
+uint32_t LedgerTxnRoot::Impl::prefetch(UnorderedSet<LedgerKey> const& keys)
 {
     ZoneScoped;
 #ifdef BUILD_TESTS
@@ -3080,14 +2946,12 @@ LedgerTxnRoot::Impl::prefetch(UnorderedSet<LedgerKey> const& keys)
     return total;
 }
 
-double
-LedgerTxnRoot::getPrefetchHitRate() const
+double LedgerTxnRoot::getPrefetchHitRate() const
 {
     return mImpl->getPrefetchHitRate();
 }
 
-double
-LedgerTxnRoot::Impl::getPrefetchHitRate() const
+double LedgerTxnRoot::Impl::getPrefetchHitRate() const
 {
     if (mPrefetchMisses == 0 && mPrefetchHits == 0)
     {
@@ -3097,25 +2961,21 @@ LedgerTxnRoot::Impl::getPrefetchHitRate() const
            (mPrefetchMisses + mPrefetchHits);
 }
 
-void
-LedgerTxnRoot::prepareNewObjects(size_t s)
+void LedgerTxnRoot::prepareNewObjects(size_t s)
 {
     mImpl->prepareNewObjects(s);
 }
 
-void
-LedgerTxnRoot::Impl::prepareNewObjects(size_t)
+void LedgerTxnRoot::Impl::prepareNewObjects(size_t)
 {
 }
 
-UnorderedMap<LedgerKey, LedgerEntry>
-LedgerTxnRoot::getAllOffers()
+UnorderedMap<LedgerKey, LedgerEntry> LedgerTxnRoot::getAllOffers()
 {
     return mImpl->getAllOffers();
 }
 
-UnorderedMap<LedgerKey, LedgerEntry>
-LedgerTxnRoot::Impl::getAllOffers()
+UnorderedMap<LedgerKey, LedgerEntry> LedgerTxnRoot::Impl::getAllOffers()
 {
     ZoneScoped;
     std::vector<LedgerEntry> offers;
@@ -3144,14 +3004,12 @@ LedgerTxnRoot::Impl::getAllOffers()
 }
 
 #ifdef BEST_OFFER_DEBUGGING
-bool
-LedgerTxnRoot::bestOfferDebuggingEnabled() const
+bool LedgerTxnRoot::bestOfferDebuggingEnabled() const
 {
     return mImpl->bestOfferDebuggingEnabled();
 }
 
-bool
-LedgerTxnRoot::Impl::bestOfferDebuggingEnabled() const
+bool LedgerTxnRoot::Impl::bestOfferDebuggingEnabled() const
 {
     return mBestOfferDebuggingEnabled;
 }
@@ -3298,8 +3156,7 @@ LedgerTxnRoot::Impl::loadNextBestOffersIntoCache(BestOffersEntryPtr cached,
     return iter;
 }
 
-void
-LedgerTxnRoot::Impl::populateEntryCacheFromBestOffers(
+void LedgerTxnRoot::Impl::populateEntryCacheFromBestOffers(
     std::deque<LedgerEntry>::const_iterator iter,
     std::deque<LedgerEntry>::const_iterator const& end)
 {
@@ -3320,8 +3177,7 @@ LedgerTxnRoot::Impl::populateEntryCacheFromBestOffers(
     prefetch(toPrefetch);
 }
 
-bool
-LedgerTxnRoot::Impl::areEntriesMissingInCacheForOffer(OfferEntry const& oe)
+bool LedgerTxnRoot::Impl::areEntriesMissingInCacheForOffer(OfferEntry const& oe)
 {
     if (!mEntryCache.exists(accountKey(oe.sellerID)))
     {
@@ -3520,14 +3376,12 @@ LedgerTxnRoot::Impl::getPoolShareTrustLinesByAccountAndAsset(
     return res;
 }
 
-LedgerHeader const&
-LedgerTxnRoot::getHeader() const
+LedgerHeader const& LedgerTxnRoot::getHeader() const
 {
     return mImpl->getHeader();
 }
 
-LedgerHeader const&
-LedgerTxnRoot::Impl::getHeader() const
+LedgerHeader const& LedgerTxnRoot::Impl::getHeader() const
 {
     return *mHeader;
 }
@@ -3661,14 +3515,12 @@ LedgerTxnRoot::getNewestVersionBelowRoot(InternalLedgerKey const& key) const
     return {false, nullptr};
 }
 
-void
-LedgerTxnRoot::rollbackChild() noexcept
+void LedgerTxnRoot::rollbackChild() noexcept
 {
     mImpl->rollbackChild();
 }
 
-void
-LedgerTxnRoot::Impl::rollbackChild() noexcept
+void LedgerTxnRoot::Impl::rollbackChild() noexcept
 {
     abortIfWrongThread("rollbackChild");
     if (mTransaction)
@@ -3731,8 +3583,7 @@ LedgerTxnRoot::Impl::getFromEntryCache(LedgerKey const& key) const
     }
 }
 
-void
-LedgerTxnRoot::Impl::putInEntryCache(
+void LedgerTxnRoot::Impl::putInEntryCache(
     LedgerKey const& key, std::shared_ptr<LedgerEntry const> const& entry,
     LoadType type) const
 {

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -867,8 +867,7 @@ class LedgerTxn : public AbstractLedgerTxn
     getOrderBook() const;
 
     void resetForFuzzer() override;
-    void
-    deactivateHeaderTestOnly()
+    void deactivateHeaderTestOnly()
     {
         deactivateHeader();
     }

--- a/src/ledger/LedgerTxnEntry.cpp
+++ b/src/ledger/LedgerTxnEntry.cpp
@@ -93,8 +93,7 @@ LedgerTxnEntry::LedgerTxnEntry(LedgerTxnEntry&& other)
 // Copy-and-swap implementation ensures that *this is properly destructed (and
 // deactivated) if this->mImpl != nullptr, but note that self-assignment must
 // still be handled explicitly since the copy would still deactivate the entry.
-LedgerTxnEntry&
-LedgerTxnEntry::operator=(LedgerTxnEntry&& other)
+LedgerTxnEntry& LedgerTxnEntry::operator=(LedgerTxnEntry&& other)
 {
     if (this != &other)
     {
@@ -106,8 +105,7 @@ LedgerTxnEntry::operator=(LedgerTxnEntry&& other)
     return *this;
 }
 
-LedgerTxnEntry::
-operator bool() const
+LedgerTxnEntry::operator bool() const
 {
     if (!mImpl.expired())
     {
@@ -125,82 +123,69 @@ operator bool() const
     throw std::runtime_error("Accessed deactivated entry");
 }
 
-LedgerEntry&
-LedgerTxnEntry::current()
+LedgerEntry& LedgerTxnEntry::current()
 {
     return getImpl()->current();
 }
 
-LedgerEntry const&
-LedgerTxnEntry::current() const
+LedgerEntry const& LedgerTxnEntry::current() const
 {
     return getImpl()->current();
 }
 
-LedgerEntry&
-LedgerTxnEntry::Impl::current()
+LedgerEntry& LedgerTxnEntry::Impl::current()
 {
     return mCurrent.ledgerEntry();
 }
 
-LedgerEntry const&
-LedgerTxnEntry::Impl::current() const
+LedgerEntry const& LedgerTxnEntry::Impl::current() const
 {
     return mCurrent.ledgerEntry();
 }
 
-InternalLedgerEntry&
-LedgerTxnEntry::currentGeneralized()
+InternalLedgerEntry& LedgerTxnEntry::currentGeneralized()
 {
     return getImpl()->currentGeneralized();
 }
 
-InternalLedgerEntry const&
-LedgerTxnEntry::currentGeneralized() const
+InternalLedgerEntry const& LedgerTxnEntry::currentGeneralized() const
 {
     return getImpl()->currentGeneralized();
 }
 
-InternalLedgerEntry&
-LedgerTxnEntry::Impl::currentGeneralized()
+InternalLedgerEntry& LedgerTxnEntry::Impl::currentGeneralized()
 {
     return mCurrent;
 }
 
-InternalLedgerEntry const&
-LedgerTxnEntry::Impl::currentGeneralized() const
+InternalLedgerEntry const& LedgerTxnEntry::Impl::currentGeneralized() const
 {
     return mCurrent;
 }
 
-void
-LedgerTxnEntry::deactivate()
+void LedgerTxnEntry::deactivate()
 {
     getImpl()->deactivate();
 }
 
-void
-LedgerTxnEntry::Impl::deactivate()
+void LedgerTxnEntry::Impl::deactivate()
 {
     auto key = mCurrent.toKey();
     mLedgerTxn.deactivate(key);
 }
 
-void
-LedgerTxnEntry::erase()
+void LedgerTxnEntry::erase()
 {
     getImpl()->erase();
 }
 
-void
-LedgerTxnEntry::Impl::erase()
+void LedgerTxnEntry::Impl::erase()
 {
     auto key = mCurrent.toKey();
     mLedgerTxn.erase(key);
 }
 
-std::shared_ptr<LedgerTxnEntry::Impl>
-LedgerTxnEntry::getImpl()
+std::shared_ptr<LedgerTxnEntry::Impl> LedgerTxnEntry::getImpl()
 {
     auto impl = mImpl.lock();
     if (!impl)
@@ -210,8 +195,7 @@ LedgerTxnEntry::getImpl()
     return impl;
 }
 
-std::shared_ptr<LedgerTxnEntry::Impl const>
-LedgerTxnEntry::getImpl() const
+std::shared_ptr<LedgerTxnEntry::Impl const> LedgerTxnEntry::getImpl() const
 {
     auto impl = mImpl.lock();
     if (!impl)
@@ -221,8 +205,7 @@ LedgerTxnEntry::getImpl() const
     return impl;
 }
 
-void
-LedgerTxnEntry::swap(LedgerTxnEntry& other)
+void LedgerTxnEntry::swap(LedgerTxnEntry& other)
 {
     mImpl.swap(other.mImpl);
 }
@@ -305,8 +288,7 @@ ConstLedgerTxnEntry::ConstLedgerTxnEntry(ConstLedgerTxnEntry&& other)
 // Copy-and-swap implementation ensures that *this is properly destructed (and
 // deactivated) if this->mImpl != nullptr, but note that self-assignment must
 // still be handled explicitly since the copy would still deactivate the entry.
-ConstLedgerTxnEntry&
-ConstLedgerTxnEntry::operator=(ConstLedgerTxnEntry&& other)
+ConstLedgerTxnEntry& ConstLedgerTxnEntry::operator=(ConstLedgerTxnEntry&& other)
 {
     if (this != &other)
     {
@@ -318,8 +300,7 @@ ConstLedgerTxnEntry::operator=(ConstLedgerTxnEntry&& other)
     return *this;
 }
 
-ConstLedgerTxnEntry::
-operator bool() const
+ConstLedgerTxnEntry::operator bool() const
 {
     if (!mImpl.expired())
     {
@@ -337,32 +318,27 @@ operator bool() const
     throw std::runtime_error("Accessed deactivated entry");
 }
 
-LedgerEntry const&
-ConstLedgerTxnEntry::current() const
+LedgerEntry const& ConstLedgerTxnEntry::current() const
 {
     return getImpl()->current();
 }
 
-LedgerEntry const&
-ConstLedgerTxnEntry::Impl::current() const
+LedgerEntry const& ConstLedgerTxnEntry::Impl::current() const
 {
     return mCurrent.ledgerEntry();
 }
 
-InternalLedgerEntry const&
-ConstLedgerTxnEntry::currentGeneralized() const
+InternalLedgerEntry const& ConstLedgerTxnEntry::currentGeneralized() const
 {
     return getImpl()->currentGeneralized();
 }
 
-InternalLedgerEntry const&
-ConstLedgerTxnEntry::Impl::currentGeneralized() const
+InternalLedgerEntry const& ConstLedgerTxnEntry::Impl::currentGeneralized() const
 {
     return mCurrent;
 }
 
-std::shared_ptr<ConstLedgerTxnEntry::Impl>
-ConstLedgerTxnEntry::getImpl()
+std::shared_ptr<ConstLedgerTxnEntry::Impl> ConstLedgerTxnEntry::getImpl()
 {
     auto impl = mImpl.lock();
     if (!impl)
@@ -383,21 +359,18 @@ ConstLedgerTxnEntry::getImpl() const
     return impl;
 }
 
-void
-ConstLedgerTxnEntry::deactivate()
+void ConstLedgerTxnEntry::deactivate()
 {
     getImpl()->deactivate();
 }
 
-void
-ConstLedgerTxnEntry::Impl::deactivate()
+void ConstLedgerTxnEntry::Impl::deactivate()
 {
     auto key = mCurrent.toKey();
     mLedgerTxn.deactivate(key);
 }
 
-void
-ConstLedgerTxnEntry::swap(ConstLedgerTxnEntry& other)
+void ConstLedgerTxnEntry::swap(ConstLedgerTxnEntry& other)
 {
     mImpl.swap(other.mImpl);
 }

--- a/src/ledger/LedgerTxnHeader.cpp
+++ b/src/ledger/LedgerTxnHeader.cpp
@@ -65,8 +65,7 @@ LedgerTxnHeader::LedgerTxnHeader(LedgerTxnHeader&& other)
 // Copy-and-swap implementation ensures that *this is properly destructed (and
 // deactivated) if this->mImpl != nullptr, but note that self-assignment must
 // still be handled explicitly since the copy would still deactivate the entry.
-LedgerTxnHeader&
-LedgerTxnHeader::operator=(LedgerTxnHeader&& other)
+LedgerTxnHeader& LedgerTxnHeader::operator=(LedgerTxnHeader&& other)
 {
     if (this != &other)
     {
@@ -77,50 +76,42 @@ LedgerTxnHeader::operator=(LedgerTxnHeader&& other)
     return *this;
 }
 
-LedgerTxnHeader::
-operator bool() const
+LedgerTxnHeader::operator bool() const
 {
     return !mImpl.expired();
 }
 
-LedgerHeader&
-LedgerTxnHeader::current()
+LedgerHeader& LedgerTxnHeader::current()
 {
     return getImpl()->current();
 }
 
-LedgerHeader const&
-LedgerTxnHeader::current() const
+LedgerHeader const& LedgerTxnHeader::current() const
 {
     return getImpl()->current();
 }
 
-LedgerHeader&
-LedgerTxnHeader::Impl::current()
+LedgerHeader& LedgerTxnHeader::Impl::current()
 {
     return mCurrent;
 }
 
-LedgerHeader const&
-LedgerTxnHeader::Impl::current() const
+LedgerHeader const& LedgerTxnHeader::Impl::current() const
 {
     return mCurrent;
 }
 
-void
-LedgerTxnHeader::deactivate()
+void LedgerTxnHeader::deactivate()
 {
     getImpl()->deactivate();
 }
 
-void
-LedgerTxnHeader::Impl::deactivate()
+void LedgerTxnHeader::Impl::deactivate()
 {
     mLedgerTxn.deactivateHeader();
 }
 
-std::shared_ptr<LedgerTxnHeader::Impl>
-LedgerTxnHeader::getImpl()
+std::shared_ptr<LedgerTxnHeader::Impl> LedgerTxnHeader::getImpl()
 {
     auto impl = mImpl.lock();
     if (!impl)
@@ -130,8 +121,7 @@ LedgerTxnHeader::getImpl()
     return impl;
 }
 
-std::shared_ptr<LedgerTxnHeader::Impl const>
-LedgerTxnHeader::getImpl() const
+std::shared_ptr<LedgerTxnHeader::Impl const> LedgerTxnHeader::getImpl() const
 {
     auto impl = mImpl.lock();
     if (!impl)
@@ -141,8 +131,7 @@ LedgerTxnHeader::getImpl() const
     return impl;
 }
 
-void
-LedgerTxnHeader::swap(LedgerTxnHeader& other)
+void LedgerTxnHeader::swap(LedgerTxnHeader& other)
 {
     mImpl.swap(other.mImpl);
 }

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -60,14 +60,12 @@ class BulkLedgerEntryChangeAccumulator
     std::vector<EntryIterator> mOffersToDelete;
 
   public:
-    std::vector<EntryIterator>&
-    getOffersToUpsert()
+    std::vector<EntryIterator>& getOffersToUpsert()
     {
         return mOffersToUpsert;
     }
 
-    std::vector<EntryIterator>&
-    getOffersToDelete()
+    std::vector<EntryIterator>& getOffersToDelete()
     {
         return mOffersToDelete;
     }
@@ -852,16 +850,13 @@ class LedgerTxnRoot::Impl
 #endif
 };
 
-template <typename T>
-std::string
-toOpaqueBase64(T const& input)
+template <typename T> std::string toOpaqueBase64(T const& input)
 {
     return decoder::encode_b64(xdr::xdr_to_opaque(input));
 }
 
 template <typename T>
-void
-fromOpaqueBase64(T& res, std::string const& opaqueBase64)
+void fromOpaqueBase64(T& res, std::string const& opaqueBase64)
 {
     std::vector<uint8_t> opaque;
     decoder::decode_b64(opaqueBase64, opaque);
@@ -870,8 +865,8 @@ fromOpaqueBase64(T& res, std::string const& opaqueBase64)
 
 #ifdef USE_POSTGRES
 template <typename T>
-inline void
-marshalToPGArrayItem(PGconn* conn, std::ostringstream& oss, const T& item)
+inline void marshalToPGArrayItem(PGconn* conn, std::ostringstream& oss,
+                                 const T& item)
 {
     // NB: This setprecision is very important to ensuring that a double
     // gets marshaled to enough decimal digits to reconstruct exactly the
@@ -881,9 +876,9 @@ marshalToPGArrayItem(PGconn* conn, std::ostringstream& oss, const T& item)
 }
 
 template <>
-inline void
-marshalToPGArrayItem<std::string>(PGconn* conn, std::ostringstream& oss,
-                                  const std::string& item)
+inline void marshalToPGArrayItem<std::string>(PGconn* conn,
+                                              std::ostringstream& oss,
+                                              const std::string& item)
 {
     std::vector<char> buf(item.size() * 2 + 1, '\0');
     int err = 0;
@@ -899,9 +894,9 @@ marshalToPGArrayItem<std::string>(PGconn* conn, std::ostringstream& oss,
 }
 
 template <typename T>
-inline void
-marshalToPGArray(PGconn* conn, std::string& out, const std::vector<T>& v,
-                 const std::vector<soci::indicator>* ind = nullptr)
+inline void marshalToPGArray(PGconn* conn, std::string& out,
+                             const std::vector<T>& v,
+                             const std::vector<soci::indicator>* ind = nullptr)
 {
     std::ostringstream oss;
     oss << '{';

--- a/src/ledger/LedgerTxnOfferSQL.cpp
+++ b/src/ledger/LedgerTxnOfferSQL.cpp
@@ -54,8 +54,7 @@ LedgerTxnRoot::Impl::loadOffer(LedgerKey const& key) const
                           : std::make_shared<LedgerEntry const>(offers.front());
 }
 
-std::vector<LedgerEntry>
-LedgerTxnRoot::Impl::loadAllOffers() const
+std::vector<LedgerEntry> LedgerTxnRoot::Impl::loadAllOffers() const
 {
     ZoneScoped;
     std::string sql = "SELECT sellerid, offerid, sellingasset, buyingasset, "
@@ -101,11 +100,9 @@ LedgerTxnRoot::Impl::loadBestOffers(std::deque<LedgerEntry>& offers,
     }
 }
 
-std::deque<LedgerEntry>::const_iterator
-LedgerTxnRoot::Impl::loadBestOffers(std::deque<LedgerEntry>& offers,
-                                    Asset const& buying, Asset const& selling,
-                                    OfferDescriptor const& worseThan,
-                                    size_t numOffers) const
+std::deque<LedgerEntry>::const_iterator LedgerTxnRoot::Impl::loadBestOffers(
+    std::deque<LedgerEntry>& offers, Asset const& buying, Asset const& selling,
+    OfferDescriptor const& worseThan, size_t numOffers) const
 {
     ZoneScoped;
     // ManageOffer and related operations won't work correctly with an offerID
@@ -164,8 +161,7 @@ LedgerTxnRoot::Impl::loadBestOffers(std::deque<LedgerEntry>& offers,
     }
 }
 
-bool
-isBetterOffer(OfferDescriptor const& lhs, OfferDescriptor const& rhs)
+bool isBetterOffer(OfferDescriptor const& lhs, OfferDescriptor const& rhs)
 {
     double lhsPrice = double(lhs.price.n) / double(lhs.price.d);
     double rhsPrice = double(rhs.price.n) / double(rhs.price.d);
@@ -183,8 +179,7 @@ isBetterOffer(OfferDescriptor const& lhs, OfferDescriptor const& rhs)
     }
 }
 
-bool
-isBetterOffer(OfferDescriptor const& lhs, LedgerEntry const& rhsEntry)
+bool isBetterOffer(OfferDescriptor const& lhs, LedgerEntry const& rhsEntry)
 {
     auto const& rhs = rhsEntry.data.offer();
     return isBetterOffer(lhs, {rhs.price, rhs.offerID});
@@ -192,8 +187,7 @@ isBetterOffer(OfferDescriptor const& lhs, LedgerEntry const& rhsEntry)
 
 // Note: The order induced by this function must match the order used in the
 // SQL query for loadBestOffers above.
-bool
-isBetterOffer(LedgerEntry const& lhsEntry, LedgerEntry const& rhsEntry)
+bool isBetterOffer(LedgerEntry const& lhsEntry, LedgerEntry const& rhsEntry)
 {
     auto const& lhs = lhsEntry.data.offer();
     auto const& rhs = rhsEntry.data.offer();
@@ -241,8 +235,7 @@ LedgerTxnRoot::Impl::loadOffersByAccountAndAsset(AccountID const& accountID,
     return offers;
 }
 
-static Asset
-processAsset(std::string const& asset)
+static Asset processAsset(std::string const& asset)
 {
     Asset res;
     std::vector<uint8_t> assetOpaque;
@@ -252,8 +245,8 @@ processAsset(std::string const& asset)
 }
 
 template <typename T>
-static typename T::const_iterator
-loadOffersHelper(StatementContext& prep, T& offers)
+static typename T::const_iterator loadOffersHelper(StatementContext& prep,
+                                                   T& offers)
 {
     ZoneScoped;
 
@@ -341,8 +334,7 @@ class BulkUpsertOffersOperation : public DatabaseTypeSpecificOperation<void>
     std::vector<std::string> mExtensions;
     std::vector<std::string> mLedgerExtensions;
 
-    void
-    accumulateEntry(LedgerEntry const& entry)
+    void accumulateEntry(LedgerEntry const& entry)
     {
         releaseAssert(entry.data.type() == OFFER);
         auto const& offer = entry.data.offer();
@@ -422,8 +414,7 @@ class BulkUpsertOffersOperation : public DatabaseTypeSpecificOperation<void>
         }
     }
 
-    void
-    doSociGenericOperation()
+    void doSociGenericOperation()
     {
         std::string sql =
             "INSERT INTO offers ( "
@@ -469,17 +460,15 @@ class BulkUpsertOffersOperation : public DatabaseTypeSpecificOperation<void>
         }
     }
 
-    void
-    doSqliteSpecificOperation(soci::sqlite3_session_backend* sq) override
+    void doSqliteSpecificOperation(soci::sqlite3_session_backend* sq) override
     {
         doSociGenericOperation();
     }
 
 #ifdef USE_POSTGRES
-    void
-    doPostgresSpecificOperation(soci::postgresql_session_backend* pg) override
+    void doPostgresSpecificOperation(
+        soci::postgresql_session_backend* pg) override
     {
-
         std::string strSellerIDs, strOfferIDs, strSellingAssets,
             strBuyingAssets, strAmounts, strPriceNs, strPriceDs, strPrices,
             strFlags, strLastModifieds, strExtensions, strLedgerExtensions;
@@ -583,8 +572,7 @@ class BulkDeleteOffersOperation : public DatabaseTypeSpecificOperation<void>
         }
     }
 
-    void
-    doSociGenericOperation()
+    void doSociGenericOperation()
     {
         std::string sql = "DELETE FROM offers WHERE offerid = :id";
         auto prep = mDB.getPreparedStatement(sql, mSession);
@@ -602,15 +590,14 @@ class BulkDeleteOffersOperation : public DatabaseTypeSpecificOperation<void>
         }
     }
 
-    void
-    doSqliteSpecificOperation(soci::sqlite3_session_backend* sq) override
+    void doSqliteSpecificOperation(soci::sqlite3_session_backend* sq) override
     {
         doSociGenericOperation();
     }
 
 #ifdef USE_POSTGRES
-    void
-    doPostgresSpecificOperation(soci::postgresql_session_backend* pg) override
+    void doPostgresSpecificOperation(
+        soci::postgresql_session_backend* pg) override
     {
         PGconn* conn = pg->conn_;
         std::string strOfferIDs;
@@ -637,8 +624,8 @@ class BulkDeleteOffersOperation : public DatabaseTypeSpecificOperation<void>
 #endif
 };
 
-void
-LedgerTxnRoot::Impl::bulkUpsertOffers(std::vector<EntryIterator> const& entries)
+void LedgerTxnRoot::Impl::bulkUpsertOffers(
+    std::vector<EntryIterator> const& entries)
 {
     ZoneScoped;
     ZoneValue(static_cast<int64_t>(entries.size()));
@@ -646,9 +633,8 @@ LedgerTxnRoot::Impl::bulkUpsertOffers(std::vector<EntryIterator> const& entries)
     mApp.getDatabase().doDatabaseTypeSpecificOperation(getSession(), op);
 }
 
-void
-LedgerTxnRoot::Impl::bulkDeleteOffers(std::vector<EntryIterator> const& entries,
-                                      LedgerTxnConsistency cons)
+void LedgerTxnRoot::Impl::bulkDeleteOffers(
+    std::vector<EntryIterator> const& entries, LedgerTxnConsistency cons)
 {
     ZoneScoped;
     ZoneValue(static_cast<int64_t>(entries.size()));
@@ -657,8 +643,7 @@ LedgerTxnRoot::Impl::bulkDeleteOffers(std::vector<EntryIterator> const& entries,
     mApp.getDatabase().doDatabaseTypeSpecificOperation(getSession(), op);
 }
 
-void
-LedgerTxnRoot::Impl::dropOffers()
+void LedgerTxnRoot::Impl::dropOffers()
 {
     throwIfChild();
     mEntryCache.clear();
@@ -711,8 +696,7 @@ class BulkLoadOffersOperation
     std::vector<int64_t> mOfferIDs;
     UnorderedSet<LedgerKey> mKeys;
 
-    std::vector<LedgerEntry>
-    executeAndFetch(soci::statement& st)
+    std::vector<LedgerEntry> executeAndFetch(soci::statement& st)
     {
         std::string sellerID, sellingAsset, buyingAsset;
         int64_t amount;

--- a/src/ledger/LedgerTypeUtils.cpp
+++ b/src/ledger/LedgerTypeUtils.cpp
@@ -14,21 +14,18 @@
 namespace stellar
 {
 
-bool
-isLive(LedgerEntry const& e, uint32_t cutoffLedger)
+bool isLive(LedgerEntry const& e, uint32_t cutoffLedger)
 {
     releaseAssert(e.data.type() == TTL);
     return e.data.ttl().liveUntilLedgerSeq >= cutoffLedger;
 }
 
-LedgerKey
-getTTLKey(LedgerEntry const& e)
+LedgerKey getTTLKey(LedgerEntry const& e)
 {
     return getTTLKey(LedgerEntryKey(e));
 }
 
-LedgerKey
-getTTLKey(LedgerKey const& e)
+LedgerKey getTTLKey(LedgerKey const& e)
 {
     releaseAssert(e.type() == CONTRACT_CODE || e.type() == CONTRACT_DATA);
     LedgerKey k;
@@ -37,8 +34,7 @@ getTTLKey(LedgerKey const& e)
     return k;
 }
 
-LedgerEntry
-getTTLEntryForTTLKey(LedgerKey const& ttlKey, uint32_t ttl)
+LedgerEntry getTTLEntryForTTLKey(LedgerKey const& ttlKey, uint32_t ttl)
 {
     releaseAssert(ttlKey.type() == TTL);
     LedgerEntry ttlEntry;
@@ -48,10 +44,9 @@ getTTLEntryForTTLKey(LedgerKey const& ttlKey, uint32_t ttl)
     return ttlEntry;
 }
 
-uint32_t
-ledgerEntrySizeForRent(LedgerEntry const& entry, uint32_t entryXdrSize,
-                       uint32_t ledgerVersion,
-                       SorobanNetworkConfig const& sorobanConfig)
+uint32_t ledgerEntrySizeForRent(LedgerEntry const& entry, uint32_t entryXdrSize,
+                                uint32_t ledgerVersion,
+                                SorobanNetworkConfig const& sorobanConfig)
 {
     bool isCodeEntry = isContractCodeEntry(entry.data);
     uint32_t entrySizeForRent = entryXdrSize;

--- a/src/ledger/LedgerTypeUtils.h
+++ b/src/ledger/LedgerTypeUtils.h
@@ -55,31 +55,23 @@ populateLoadedEntries(KeySetT const& keys,
     return res;
 }
 
-template <typename T>
-bool
-isSorobanEntry(T const& e)
+template <typename T> bool isSorobanEntry(T const& e)
 {
     return e.type() == CONTRACT_DATA || e.type() == CONTRACT_CODE;
 }
 
-template <typename T>
-bool
-isContractCodeEntry(T const& e)
+template <typename T> bool isContractCodeEntry(T const& e)
 {
     return e.type() == CONTRACT_CODE;
 }
 
-template <typename T>
-bool
-isTemporaryEntry(T const& e)
+template <typename T> bool isTemporaryEntry(T const& e)
 {
     return e.type() == CONTRACT_DATA &&
            e.contractData().durability == ContractDataDurability::TEMPORARY;
 }
 
-template <typename T>
-bool
-isPersistentEntry(T const& e)
+template <typename T> bool isPersistentEntry(T const& e)
 {
     return e.type() == CONTRACT_CODE ||
            (e.type() == CONTRACT_DATA &&

--- a/src/ledger/NetworkConfig.cpp
+++ b/src/ledger/NetworkConfig.cpp
@@ -20,10 +20,9 @@ namespace stellar
 {
 namespace
 {
-void
-createConfigSettingEntry(ConfigSettingEntry const& configSetting,
-                         AbstractLedgerTxn& ltxRoot,
-                         uint32_t versionToValidateAgainst)
+void createConfigSettingEntry(ConfigSettingEntry const& configSetting,
+                              AbstractLedgerTxn& ltxRoot,
+                              uint32_t versionToValidateAgainst)
 {
     ZoneScoped;
 
@@ -41,8 +40,7 @@ createConfigSettingEntry(ConfigSettingEntry const& configSetting,
     ltx.commit();
 }
 
-ConfigSettingEntry
-initialMaxContractSizeEntry(Config const& cfg)
+ConfigSettingEntry initialMaxContractSizeEntry(Config const& cfg)
 {
     ConfigSettingEntry entry(CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES);
 
@@ -57,8 +55,7 @@ initialMaxContractSizeEntry(Config const& cfg)
     return entry;
 }
 
-ConfigSettingEntry
-initialMaxContractDataKeySizeEntry(Config const& cfg)
+ConfigSettingEntry initialMaxContractDataKeySizeEntry(Config const& cfg)
 {
     ConfigSettingEntry entry(CONFIG_SETTING_CONTRACT_DATA_KEY_SIZE_BYTES);
 
@@ -73,8 +70,7 @@ initialMaxContractDataKeySizeEntry(Config const& cfg)
     return entry;
 }
 
-ConfigSettingEntry
-initialMaxContractDataEntrySizeEntry(Config const& cfg)
+ConfigSettingEntry initialMaxContractDataEntrySizeEntry(Config const& cfg)
 {
     ConfigSettingEntry entry(CONFIG_SETTING_CONTRACT_DATA_ENTRY_SIZE_BYTES);
 
@@ -89,8 +85,7 @@ initialMaxContractDataEntrySizeEntry(Config const& cfg)
     return entry;
 }
 
-ConfigSettingEntry
-initialContractComputeSettingsEntry(Config const& cfg)
+ConfigSettingEntry initialContractComputeSettingsEntry(Config const& cfg)
 {
     ConfigSettingEntry entry(CONFIG_SETTING_CONTRACT_COMPUTE_V0);
     auto& e = entry.contractCompute();
@@ -115,8 +110,7 @@ initialContractComputeSettingsEntry(Config const& cfg)
     return entry;
 }
 
-ConfigSettingEntry
-initialContractLedgerAccessSettingsEntry(Config const& cfg)
+ConfigSettingEntry initialContractLedgerAccessSettingsEntry(Config const& cfg)
 {
     ConfigSettingEntry entry(CONFIG_SETTING_CONTRACT_LEDGER_COST_V0);
     auto& e = entry.contractLedgerCost();
@@ -174,8 +168,7 @@ initialContractLedgerAccessSettingsEntry(Config const& cfg)
     return entry;
 }
 
-ConfigSettingEntry
-initialContractHistoricalDataSettingsEntry()
+ConfigSettingEntry initialContractHistoricalDataSettingsEntry()
 {
     ConfigSettingEntry entry(CONFIG_SETTING_CONTRACT_HISTORICAL_DATA_V0);
     auto& e = entry.contractHistoricalData();
@@ -185,8 +178,7 @@ initialContractHistoricalDataSettingsEntry()
     return entry;
 }
 
-ConfigSettingEntry
-initialContractEventsSettingsEntry(Config const& cfg)
+ConfigSettingEntry initialContractEventsSettingsEntry(Config const& cfg)
 {
     ConfigSettingEntry entry(CONFIG_SETTING_CONTRACT_EVENTS_V0);
     auto& e = entry.contractEvents();
@@ -204,8 +196,7 @@ initialContractEventsSettingsEntry(Config const& cfg)
     return entry;
 }
 
-ConfigSettingEntry
-initialContractBandwidthSettingsEntry(Config const& cfg)
+ConfigSettingEntry initialContractBandwidthSettingsEntry(Config const& cfg)
 {
     ConfigSettingEntry entry(CONFIG_SETTING_CONTRACT_BANDWIDTH_V0);
     auto& e = entry.contractBandwidth();
@@ -226,8 +217,7 @@ initialContractBandwidthSettingsEntry(Config const& cfg)
     return entry;
 }
 
-ConfigSettingEntry
-initialContractExecutionLanesSettingsEntry(Config const& cfg)
+ConfigSettingEntry initialContractExecutionLanesSettingsEntry(Config const& cfg)
 {
     ConfigSettingEntry entry(CONFIG_SETTING_CONTRACT_EXECUTION_LANES);
     auto& e = entry.contractExecutionLanes();
@@ -242,8 +232,7 @@ initialContractExecutionLanesSettingsEntry(Config const& cfg)
     return entry;
 }
 
-ConfigSettingEntry
-initialCpuCostParamsEntryForV20()
+ConfigSettingEntry initialCpuCostParamsEntryForV20()
 {
     ConfigSettingEntry entry(
         CONFIG_SETTING_CONTRACT_COST_PARAMS_CPU_INSTRUCTIONS);
@@ -337,8 +326,7 @@ initialCpuCostParamsEntryForV20()
     return entry;
 }
 
-void
-updateCpuCostParamsEntryForV21(AbstractLedgerTxn& ltxRoot)
+void updateCpuCostParamsEntryForV21(AbstractLedgerTxn& ltxRoot)
 {
     LedgerTxn ltx(ltxRoot);
 
@@ -440,8 +428,7 @@ updateCpuCostParamsEntryForV21(AbstractLedgerTxn& ltxRoot)
     ltx.commit();
 }
 
-void
-updateCpuCostParamsEntryForV22(AbstractLedgerTxn& ltxRoot)
+void updateCpuCostParamsEntryForV22(AbstractLedgerTxn& ltxRoot)
 {
     LedgerTxn ltx(ltxRoot);
 
@@ -553,8 +540,7 @@ updateCpuCostParamsEntryForV22(AbstractLedgerTxn& ltxRoot)
 }
 
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-void
-updateCpuCostParamsEntryForV25(AbstractLedgerTxn& ltxRoot)
+void updateCpuCostParamsEntryForV25(AbstractLedgerTxn& ltxRoot)
 {
     LedgerTxn ltx(ltxRoot);
 
@@ -631,8 +617,7 @@ updateCpuCostParamsEntryForV25(AbstractLedgerTxn& ltxRoot)
 }
 #endif
 
-ConfigSettingEntry
-initialStateArchivalSettings(Config const& cfg)
+ConfigSettingEntry initialStateArchivalSettings(Config const& cfg)
 {
     ConfigSettingEntry entry(CONFIG_SETTING_STATE_ARCHIVAL);
 
@@ -686,8 +671,7 @@ initialStateArchivalSettings(Config const& cfg)
     return entry;
 }
 
-ConfigSettingEntry
-initialMemCostParamsEntryForV20()
+ConfigSettingEntry initialMemCostParamsEntryForV20()
 {
     ConfigSettingEntry entry(CONFIG_SETTING_CONTRACT_COST_PARAMS_MEMORY_BYTES);
 
@@ -777,8 +761,7 @@ initialMemCostParamsEntryForV20()
     return entry;
 }
 
-void
-updateMemCostParamsEntryForV21(AbstractLedgerTxn& ltxRoot)
+void updateMemCostParamsEntryForV21(AbstractLedgerTxn& ltxRoot)
 {
     LedgerTxn ltx(ltxRoot);
 
@@ -881,8 +864,7 @@ updateMemCostParamsEntryForV21(AbstractLedgerTxn& ltxRoot)
     ltx.commit();
 }
 
-void
-updateMemCostParamsEntryForV22(AbstractLedgerTxn& ltxRoot)
+void updateMemCostParamsEntryForV22(AbstractLedgerTxn& ltxRoot)
 {
     LedgerTxn ltx(ltxRoot);
 
@@ -992,8 +974,7 @@ updateMemCostParamsEntryForV22(AbstractLedgerTxn& ltxRoot)
 }
 
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-void
-updateMemCostParamsEntryForV25(AbstractLedgerTxn& ltxRoot)
+void updateMemCostParamsEntryForV25(AbstractLedgerTxn& ltxRoot)
 {
     LedgerTxn ltx(ltxRoot);
 
@@ -1070,8 +1051,7 @@ updateMemCostParamsEntryForV25(AbstractLedgerTxn& ltxRoot)
 }
 #endif
 
-ConfigSettingEntry
-initialParallelComputeEntry()
+ConfigSettingEntry initialParallelComputeEntry()
 {
     ConfigSettingEntry entry(CONFIG_SETTING_CONTRACT_PARALLEL_COMPUTE_V0);
     entry.contractParallelCompute().ledgerMaxDependentTxClusters =
@@ -1079,8 +1059,7 @@ initialParallelComputeEntry()
     return entry;
 }
 
-ConfigSettingEntry
-initialLedgerCostExtEntry(uint32_t txMaxDiskReadEntries)
+ConfigSettingEntry initialLedgerCostExtEntry(uint32_t txMaxDiskReadEntries)
 {
     ConfigSettingEntry entry(CONFIG_SETTING_CONTRACT_LEDGER_COST_EXT_V0);
     // Initialize `txMaxFootprintEntries` with the value of the older
@@ -1093,8 +1072,7 @@ initialLedgerCostExtEntry(uint32_t txMaxDiskReadEntries)
     return entry;
 }
 
-ConfigSettingEntry
-initialScpTimingEntry()
+ConfigSettingEntry initialScpTimingEntry()
 {
     ConfigSettingEntry entry(CONFIG_SETTING_SCP_TIMING);
     entry.contractSCPTiming().ledgerTargetCloseTimeMilliseconds =
@@ -1111,8 +1089,7 @@ initialScpTimingEntry()
     return entry;
 }
 
-ConfigSettingEntry
-initialliveSorobanStateSizeWindow(Application& app)
+ConfigSettingEntry initialliveSorobanStateSizeWindow(Application& app)
 {
     ConfigSettingEntry entry(CONFIG_SETTING_LIVE_SOROBAN_STATE_SIZE_WINDOW);
 
@@ -1129,8 +1106,7 @@ initialliveSorobanStateSizeWindow(Application& app)
     return entry;
 }
 
-ConfigSettingEntry
-initialEvictionIterator(Config const& cfg)
+ConfigSettingEntry initialEvictionIterator(Config const& cfg)
 {
     ConfigSettingEntry entry(CONFIG_SETTING_EVICTION_ITERATOR);
     entry.evictionIterator().bucketFileOffset = 0;
@@ -1142,8 +1118,7 @@ initialEvictionIterator(Config const& cfg)
     return entry;
 }
 
-void
-updateRentCostParamsForV23(AbstractLedgerTxn& ltxRoot)
+void updateRentCostParamsForV23(AbstractLedgerTxn& ltxRoot)
 {
     LedgerTxn ltx(ltxRoot);
 
@@ -1201,9 +1176,8 @@ updateStateSizeWindowSetting(
     ltx.commit();
 }
 
-bool
-SorobanNetworkConfig::isValidConfigSettingEntry(ConfigSettingEntry const& cfg,
-                                                uint32_t ledgerVersion)
+bool SorobanNetworkConfig::isValidConfigSettingEntry(
+    ConfigSettingEntry const& cfg, uint32_t ledgerVersion)
 {
     bool valid = false;
     switch (cfg.configSettingID())
@@ -1370,15 +1344,13 @@ SorobanNetworkConfig::isValidConfigSettingEntry(ConfigSettingEntry const& cfg,
     return valid;
 }
 
-bool
-SorobanNetworkConfig::isNonUpgradeableConfigSettingEntry(
+bool SorobanNetworkConfig::isNonUpgradeableConfigSettingEntry(
     ConfigSettingEntry const& cfg)
 {
     return isNonUpgradeableConfigSettingEntry(cfg.configSettingID());
 }
 
-bool
-SorobanNetworkConfig::isNonUpgradeableConfigSettingEntry(
+bool SorobanNetworkConfig::isNonUpgradeableConfigSettingEntry(
     ConfigSettingID const& cfg)
 {
     // While the BucketList size window and eviction iterator are stored in a
@@ -1389,9 +1361,8 @@ SorobanNetworkConfig::isNonUpgradeableConfigSettingEntry(
            cfg == ConfigSettingID::CONFIG_SETTING_EVICTION_ITERATOR;
 }
 
-void
-SorobanNetworkConfig::createLedgerEntriesForV20(AbstractLedgerTxn& ltx,
-                                                Application& app)
+void SorobanNetworkConfig::createLedgerEntriesForV20(AbstractLedgerTxn& ltx,
+                                                     Application& app)
 {
     ZoneScoped;
 
@@ -1433,27 +1404,24 @@ SorobanNetworkConfig::createLedgerEntriesForV20(AbstractLedgerTxn& ltx,
                              versionToValidateAgainst);
 }
 
-void
-SorobanNetworkConfig::createCostTypesForV21(AbstractLedgerTxn& ltx,
-                                            Application& app)
+void SorobanNetworkConfig::createCostTypesForV21(AbstractLedgerTxn& ltx,
+                                                 Application& app)
 {
     ZoneScoped;
     updateCpuCostParamsEntryForV21(ltx);
     updateMemCostParamsEntryForV21(ltx);
 }
 
-void
-SorobanNetworkConfig::createCostTypesForV22(AbstractLedgerTxn& ltx,
-                                            Application& app)
+void SorobanNetworkConfig::createCostTypesForV22(AbstractLedgerTxn& ltx,
+                                                 Application& app)
 {
     ZoneScoped;
     updateCpuCostParamsEntryForV22(ltx);
     updateMemCostParamsEntryForV22(ltx);
 }
 
-void
-SorobanNetworkConfig::createCostTypesForV25(AbstractLedgerTxn& ltx,
-                                            Application& app)
+void SorobanNetworkConfig::createCostTypesForV25(AbstractLedgerTxn& ltx,
+                                                 Application& app)
 {
     ZoneScoped;
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
@@ -1462,9 +1430,8 @@ SorobanNetworkConfig::createCostTypesForV25(AbstractLedgerTxn& ltx,
 #endif // ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
 }
 
-void
-SorobanNetworkConfig::createAndUpdateLedgerEntriesForV23(AbstractLedgerTxn& ltx,
-                                                         Application& app)
+void SorobanNetworkConfig::createAndUpdateLedgerEntriesForV23(
+    AbstractLedgerTxn& ltx, Application& app)
 {
     ZoneScoped;
     createConfigSettingEntry(initialParallelComputeEntry(), ltx,
@@ -1489,8 +1456,7 @@ SorobanNetworkConfig::createAndUpdateLedgerEntriesForV23(AbstractLedgerTxn& ltx,
     updateRentCostParamsForV23(ltx);
 }
 
-void
-SorobanNetworkConfig::initializeGenesisLedgerForTesting(
+void SorobanNetworkConfig::initializeGenesisLedgerForTesting(
     uint32_t genesisLedgerProtocol, AbstractLedgerTxn& ltx, Application& app)
 {
     if (protocolVersionStartsFrom(genesisLedgerProtocol,
@@ -1578,15 +1544,13 @@ SorobanNetworkConfig::loadFromLedger(AbstractLedgerTxn& ltx)
 }
 
 #ifdef BUILD_TESTS
-SorobanNetworkConfig
-SorobanNetworkConfig::emptyConfig()
+SorobanNetworkConfig SorobanNetworkConfig::emptyConfig()
 {
     return SorobanNetworkConfig();
 }
 #endif
 
-void
-SorobanNetworkConfig::loadMaxContractSize(LedgerSnapshot const& ls)
+void SorobanNetworkConfig::loadMaxContractSize(LedgerSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -1599,8 +1563,7 @@ SorobanNetworkConfig::loadMaxContractSize(LedgerSnapshot const& ls)
     mMaxContractSizeBytes = le.data.configSetting().contractMaxSizeBytes();
 }
 
-void
-SorobanNetworkConfig::loadMaxContractDataKeySize(LedgerSnapshot const& ls)
+void SorobanNetworkConfig::loadMaxContractDataKeySize(LedgerSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -1614,8 +1577,8 @@ SorobanNetworkConfig::loadMaxContractDataKeySize(LedgerSnapshot const& ls)
         le.data.configSetting().contractDataKeySizeBytes();
 }
 
-void
-SorobanNetworkConfig::loadMaxContractDataEntrySize(LedgerSnapshot const& ls)
+void SorobanNetworkConfig::loadMaxContractDataEntrySize(
+    LedgerSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -1629,8 +1592,7 @@ SorobanNetworkConfig::loadMaxContractDataEntrySize(LedgerSnapshot const& ls)
         le.data.configSetting().contractDataEntrySizeBytes();
 }
 
-void
-SorobanNetworkConfig::loadComputeSettings(LedgerSnapshot const& ls)
+void SorobanNetworkConfig::loadComputeSettings(LedgerSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -1648,8 +1610,7 @@ SorobanNetworkConfig::loadComputeSettings(LedgerSnapshot const& ls)
     mTxMemoryLimit = configSetting.txMemoryLimit;
 }
 
-void
-SorobanNetworkConfig::loadLedgerAccessSettings(LedgerSnapshot const& ls)
+void SorobanNetworkConfig::loadLedgerAccessSettings(LedgerSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -1695,8 +1656,7 @@ SorobanNetworkConfig::loadLedgerAccessSettings(LedgerSnapshot const& ls)
     }
 }
 
-void
-SorobanNetworkConfig::loadHistoricalSettings(LedgerSnapshot const& ls)
+void SorobanNetworkConfig::loadHistoricalSettings(LedgerSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -1711,8 +1671,7 @@ SorobanNetworkConfig::loadHistoricalSettings(LedgerSnapshot const& ls)
     mFeeHistorical1KB = configSetting.feeHistorical1KB;
 }
 
-void
-SorobanNetworkConfig::loadContractEventsSettings(LedgerSnapshot const& ls)
+void SorobanNetworkConfig::loadContractEventsSettings(LedgerSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -1727,8 +1686,7 @@ SorobanNetworkConfig::loadContractEventsSettings(LedgerSnapshot const& ls)
     mTxMaxContractEventsSizeBytes = configSetting.txMaxContractEventsSizeBytes;
 }
 
-void
-SorobanNetworkConfig::loadBandwidthSettings(LedgerSnapshot const& ls)
+void SorobanNetworkConfig::loadBandwidthSettings(LedgerSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -1744,8 +1702,7 @@ SorobanNetworkConfig::loadBandwidthSettings(LedgerSnapshot const& ls)
     mFeeTransactionSize1KB = configSetting.feeTxSize1KB;
 }
 
-void
-SorobanNetworkConfig::loadCpuCostParams(LedgerSnapshot const& ls)
+void SorobanNetworkConfig::loadCpuCostParams(LedgerSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -1758,8 +1715,7 @@ SorobanNetworkConfig::loadCpuCostParams(LedgerSnapshot const& ls)
     mCpuCostParams = le.data.configSetting().contractCostParamsCpuInsns();
 }
 
-void
-SorobanNetworkConfig::loadMemCostParams(LedgerSnapshot const& ls)
+void SorobanNetworkConfig::loadMemCostParams(LedgerSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -1772,8 +1728,7 @@ SorobanNetworkConfig::loadMemCostParams(LedgerSnapshot const& ls)
     mMemCostParams = le.data.configSetting().contractCostParamsMemBytes();
 }
 
-void
-SorobanNetworkConfig::loadExecutionLanesSettings(LedgerSnapshot const& ls)
+void SorobanNetworkConfig::loadExecutionLanesSettings(LedgerSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -1788,8 +1743,8 @@ SorobanNetworkConfig::loadExecutionLanesSettings(LedgerSnapshot const& ls)
     mLedgerMaxTxCount = configSetting.ledgerMaxTxCount;
 }
 
-void
-SorobanNetworkConfig::loadLiveSorobanStateSizeWindow(LedgerSnapshot const& ls)
+void SorobanNetworkConfig::loadLiveSorobanStateSizeWindow(
+    LedgerSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -1818,8 +1773,7 @@ SorobanNetworkConfig::loadLiveSorobanStateSizeWindow(LedgerSnapshot const& ls)
     mAverageSorobanStateSize = sizeSum / window.size();
 }
 
-void
-SorobanNetworkConfig::loadEvictionIterator(LedgerSnapshot const& ls)
+void SorobanNetworkConfig::loadEvictionIterator(LedgerSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -1831,8 +1785,7 @@ SorobanNetworkConfig::loadEvictionIterator(LedgerSnapshot const& ls)
     mEvictionIterator = lsle.current().data.configSetting().evictionIterator();
 }
 
-void
-SorobanNetworkConfig::loadParallelComputeConfig(LedgerSnapshot const& ls)
+void SorobanNetworkConfig::loadParallelComputeConfig(LedgerSnapshot const& ls)
 {
     ZoneScoped;
     LedgerKey key(CONFIG_SETTING);
@@ -1846,8 +1799,7 @@ SorobanNetworkConfig::loadParallelComputeConfig(LedgerSnapshot const& ls)
     mLedgerMaxDependentTxClusters = configSetting.ledgerMaxDependentTxClusters;
 }
 
-void
-SorobanNetworkConfig::loadLedgerCostExtConfig(LedgerSnapshot const& ls)
+void SorobanNetworkConfig::loadLedgerCostExtConfig(LedgerSnapshot const& ls)
 {
     ZoneScoped;
     LedgerKey key(CONFIG_SETTING);
@@ -1861,8 +1813,7 @@ SorobanNetworkConfig::loadLedgerCostExtConfig(LedgerSnapshot const& ls)
     mFeeFlatRateWrite1KB = configSetting.feeWrite1KB;
 }
 
-void
-SorobanNetworkConfig::loadSCPTimingConfig(LedgerSnapshot const& ls)
+void SorobanNetworkConfig::loadSCPTimingConfig(LedgerSnapshot const& ls)
 {
     ZoneScoped;
     LedgerKey key(CONFIG_SETTING);
@@ -1884,26 +1835,22 @@ SorobanNetworkConfig::loadSCPTimingConfig(LedgerSnapshot const& ls)
         configSetting.ballotTimeoutIncrementMilliseconds;
 }
 
-uint32_t
-SorobanNetworkConfig::maxContractSizeBytes() const
+uint32_t SorobanNetworkConfig::maxContractSizeBytes() const
 {
     return mMaxContractSizeBytes;
 }
 
-uint32_t
-SorobanNetworkConfig::maxContractDataKeySizeBytes() const
+uint32_t SorobanNetworkConfig::maxContractDataKeySizeBytes() const
 {
     return mMaxContractDataKeySizeBytes;
 }
 
-uint32_t
-SorobanNetworkConfig::maxContractDataEntrySizeBytes() const
+uint32_t SorobanNetworkConfig::maxContractDataEntrySizeBytes() const
 {
     return mMaxContractDataEntrySizeBytes;
 }
 
-void
-SorobanNetworkConfig::loadStateArchivalSettings(LedgerSnapshot const& ls)
+void SorobanNetworkConfig::loadStateArchivalSettings(LedgerSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -1917,173 +1864,145 @@ SorobanNetworkConfig::loadStateArchivalSettings(LedgerSnapshot const& ls)
 }
 
 // Compute settings for contracts (instructions and memory).
-int64_t
-SorobanNetworkConfig::ledgerMaxInstructions() const
+int64_t SorobanNetworkConfig::ledgerMaxInstructions() const
 {
     return mLedgerMaxInstructions;
 }
 
-int64_t
-SorobanNetworkConfig::txMaxInstructions() const
+int64_t SorobanNetworkConfig::txMaxInstructions() const
 {
     return mTxMaxInstructions;
 }
 
-int64_t
-SorobanNetworkConfig::feeRatePerInstructionsIncrement() const
+int64_t SorobanNetworkConfig::feeRatePerInstructionsIncrement() const
 {
     return mFeeRatePerInstructionsIncrement;
 }
 
-uint32_t
-SorobanNetworkConfig::txMemoryLimit() const
+uint32_t SorobanNetworkConfig::txMemoryLimit() const
 {
     return mTxMemoryLimit;
 }
 
 // Ledger access settings for contracts.
-uint32_t
-SorobanNetworkConfig::ledgerMaxDiskReadEntries() const
+uint32_t SorobanNetworkConfig::ledgerMaxDiskReadEntries() const
 {
     return mLedgerMaxDiskReadEntries;
 }
 
-uint32_t
-SorobanNetworkConfig::ledgerMaxDiskReadBytes() const
+uint32_t SorobanNetworkConfig::ledgerMaxDiskReadBytes() const
 {
     return mLedgerMaxDiskReadBytes;
 }
 
-uint32_t
-SorobanNetworkConfig::ledgerMaxWriteLedgerEntries() const
+uint32_t SorobanNetworkConfig::ledgerMaxWriteLedgerEntries() const
 {
     return mLedgerMaxWriteLedgerEntries;
 }
 
-uint32_t
-SorobanNetworkConfig::ledgerMaxWriteBytes() const
+uint32_t SorobanNetworkConfig::ledgerMaxWriteBytes() const
 {
     return mLedgerMaxWriteBytes;
 }
 
-uint32_t
-SorobanNetworkConfig::txMaxDiskReadEntries() const
+uint32_t SorobanNetworkConfig::txMaxDiskReadEntries() const
 {
     return mTxMaxDiskReadEntries;
 }
 
-uint32_t
-SorobanNetworkConfig::txMaxDiskReadBytes() const
+uint32_t SorobanNetworkConfig::txMaxDiskReadBytes() const
 {
     return mTxMaxDiskReadBytes;
 }
 
-uint32_t
-SorobanNetworkConfig::txMaxWriteLedgerEntries() const
+uint32_t SorobanNetworkConfig::txMaxWriteLedgerEntries() const
 {
     return mTxMaxWriteLedgerEntries;
 }
 
-uint32_t
-SorobanNetworkConfig::txMaxWriteBytes() const
+uint32_t SorobanNetworkConfig::txMaxWriteBytes() const
 {
     return mTxMaxWriteBytes;
 }
 
-int64_t
-SorobanNetworkConfig::feeDiskReadLedgerEntry() const
+int64_t SorobanNetworkConfig::feeDiskReadLedgerEntry() const
 {
     return mFeeDiskReadLedgerEntry;
 }
 
-int64_t
-SorobanNetworkConfig::feeWriteLedgerEntry() const
+int64_t SorobanNetworkConfig::feeWriteLedgerEntry() const
 {
     return mFeeWriteLedgerEntry;
 }
 
-int64_t
-SorobanNetworkConfig::feeDiskRead1KB() const
+int64_t SorobanNetworkConfig::feeDiskRead1KB() const
 {
     return mFeeDiskRead1KB;
 }
 
-int64_t
-SorobanNetworkConfig::feeRent1KB() const
+int64_t SorobanNetworkConfig::feeRent1KB() const
 {
     return mFeeRent1KB;
 }
 
-int64_t
-SorobanNetworkConfig::sorobanStateTargetSizeBytes() const
+int64_t SorobanNetworkConfig::sorobanStateTargetSizeBytes() const
 {
     return mSorobanStateTargetSizeBytes;
 }
 
-int64_t
-SorobanNetworkConfig::rentFee1KBSorobanStateSizeLow() const
+int64_t SorobanNetworkConfig::rentFee1KBSorobanStateSizeLow() const
 {
     return mRentFee1KBSorobanStateSizeLow;
 }
-int64_t
-SorobanNetworkConfig::rentFee1KBSorobanStateSizeHigh() const
+int64_t SorobanNetworkConfig::rentFee1KBSorobanStateSizeHigh() const
 {
     return mRentFee1KBSorobanStateSizeHigh;
 }
-uint32_t
-SorobanNetworkConfig::sorobanStateRentFeeGrowthFactor() const
+uint32_t SorobanNetworkConfig::sorobanStateRentFeeGrowthFactor() const
 {
     return mSorobanStateRentFeeGrowthFactor;
 }
 
 // Historical data (pushed to core archives) settings for contracts.
-int64_t
-SorobanNetworkConfig::feeHistorical1KB() const
+int64_t SorobanNetworkConfig::feeHistorical1KB() const
 {
     return mFeeHistorical1KB;
 }
 
 // Maximum size of the emitted contract events.
-uint32_t
-SorobanNetworkConfig::txMaxContractEventsSizeBytes() const
+uint32_t SorobanNetworkConfig::txMaxContractEventsSizeBytes() const
 {
     return mTxMaxContractEventsSizeBytes;
 }
 
-int64_t
-SorobanNetworkConfig::feeContractEventsSize1KB() const
+int64_t SorobanNetworkConfig::feeContractEventsSize1KB() const
 {
     return mFeeContractEvents1KB;
 }
 
 // Bandwidth related data settings for contracts
-uint32_t
-SorobanNetworkConfig::ledgerMaxTransactionSizesBytes() const
+uint32_t SorobanNetworkConfig::ledgerMaxTransactionSizesBytes() const
 {
     return mLedgerMaxTransactionsSizeBytes;
 }
 
-uint32_t
-SorobanNetworkConfig::txMaxSizeBytes() const
+uint32_t SorobanNetworkConfig::txMaxSizeBytes() const
 {
     return mTxMaxSizeBytes;
 }
 
-int64_t
-SorobanNetworkConfig::feeTransactionSize1KB() const
+int64_t SorobanNetworkConfig::feeTransactionSize1KB() const
 {
     return mFeeTransactionSize1KB;
 }
 
 // General execution lanes settings for contracts
-uint32_t
-SorobanNetworkConfig::ledgerMaxTxCount() const
+uint32_t SorobanNetworkConfig::ledgerMaxTxCount() const
 {
     return mLedgerMaxTxCount;
 }
 
-void
-SorobanNetworkConfig::maybeUpdateSorobanStateSizeWindowSize(
+void SorobanNetworkConfig::maybeUpdateSorobanStateSizeWindowSize(
     AbstractLedgerTxn& ltx)
 {
     ZoneScoped;
@@ -2125,11 +2044,9 @@ SorobanNetworkConfig::maybeUpdateSorobanStateSizeWindowSize(
     });
 }
 
-void
-SorobanNetworkConfig::maybeSnapshotSorobanStateSize(uint32_t currLedger,
-                                                    uint64_t inMemoryStateSize,
-                                                    AbstractLedgerTxn& ltxRoot,
-                                                    Application& app)
+void SorobanNetworkConfig::maybeSnapshotSorobanStateSize(
+    uint32_t currLedger, uint64_t inMemoryStateSize, AbstractLedgerTxn& ltxRoot,
+    Application& app)
 {
     ZoneScoped;
 
@@ -2168,9 +2085,8 @@ SorobanNetworkConfig::maybeSnapshotSorobanStateSize(uint32_t currLedger,
     });
 }
 
-void
-SorobanNetworkConfig::updateRecomputedSorobanStateSize(uint64_t newSize,
-                                                       AbstractLedgerTxn& ltx)
+void SorobanNetworkConfig::updateRecomputedSorobanStateSize(
+    uint64_t newSize, AbstractLedgerTxn& ltx)
 {
     ZoneScoped;
     updateStateSizeWindowSetting(ltx, [newSize](auto& window) {
@@ -2181,39 +2097,33 @@ SorobanNetworkConfig::updateRecomputedSorobanStateSize(uint64_t newSize,
     });
 }
 
-uint64_t
-SorobanNetworkConfig::getAverageSorobanStateSize() const
+uint64_t SorobanNetworkConfig::getAverageSorobanStateSize() const
 {
     return mAverageSorobanStateSize;
 }
 
-ContractCostParams const&
-SorobanNetworkConfig::cpuCostParams() const
+ContractCostParams const& SorobanNetworkConfig::cpuCostParams() const
 {
     return mCpuCostParams;
 }
 
-ContractCostParams const&
-SorobanNetworkConfig::memCostParams() const
+ContractCostParams const& SorobanNetworkConfig::memCostParams() const
 {
     return mMemCostParams;
 }
 
-StateArchivalSettings const&
-SorobanNetworkConfig::stateArchivalSettings() const
+StateArchivalSettings const& SorobanNetworkConfig::stateArchivalSettings() const
 {
     return mStateArchivalSettings;
 }
 
-EvictionIterator const&
-SorobanNetworkConfig::evictionIterator() const
+EvictionIterator const& SorobanNetworkConfig::evictionIterator() const
 {
     return mEvictionIterator;
 }
 
-void
-SorobanNetworkConfig::updateEvictionIterator(AbstractLedgerTxn& ltxRoot,
-                                             EvictionIterator const& newIter)
+void SorobanNetworkConfig::updateEvictionIterator(
+    AbstractLedgerTxn& ltxRoot, EvictionIterator const& newIter)
 {
     ZoneScoped;
 
@@ -2228,56 +2138,47 @@ SorobanNetworkConfig::updateEvictionIterator(AbstractLedgerTxn& ltxRoot,
     ltx.commit();
 }
 
-uint32_t
-SorobanNetworkConfig::ledgerMaxDependentTxClusters() const
+uint32_t SorobanNetworkConfig::ledgerMaxDependentTxClusters() const
 {
     return mLedgerMaxDependentTxClusters;
 }
 
-uint32_t
-SorobanNetworkConfig::ledgerTargetCloseTimeMilliseconds() const
+uint32_t SorobanNetworkConfig::ledgerTargetCloseTimeMilliseconds() const
 {
     return mLedgerTargetCloseTimeMilliseconds;
 }
 
-uint32_t
-SorobanNetworkConfig::nominationTimeoutInitialMilliseconds() const
+uint32_t SorobanNetworkConfig::nominationTimeoutInitialMilliseconds() const
 {
     return mNominationTimeoutInitialMilliseconds;
 }
 
-uint32_t
-SorobanNetworkConfig::nominationTimeoutIncrementMilliseconds() const
+uint32_t SorobanNetworkConfig::nominationTimeoutIncrementMilliseconds() const
 {
     return mNominationTimeoutIncrementMilliseconds;
 }
 
-uint32_t
-SorobanNetworkConfig::ballotTimeoutInitialMilliseconds() const
+uint32_t SorobanNetworkConfig::ballotTimeoutInitialMilliseconds() const
 {
     return mBallotTimeoutInitialMilliseconds;
 }
 
-uint32_t
-SorobanNetworkConfig::ballotTimeoutIncrementMilliseconds() const
+uint32_t SorobanNetworkConfig::ballotTimeoutIncrementMilliseconds() const
 {
     return mBallotTimeoutIncrementMilliseconds;
 }
 
-uint32_t
-SorobanNetworkConfig::txMaxFootprintEntries() const
+uint32_t SorobanNetworkConfig::txMaxFootprintEntries() const
 {
     return mTxMaxFootprintEntries;
 }
 
-int64_t
-SorobanNetworkConfig::feeFlatRateWrite1KB() const
+int64_t SorobanNetworkConfig::feeFlatRateWrite1KB() const
 {
     return mFeeFlatRateWrite1KB;
 }
 
-Resource
-SorobanNetworkConfig::maxLedgerResources() const
+Resource SorobanNetworkConfig::maxLedgerResources() const
 {
     std::vector<int64_t> limits = {
         ledgerMaxTxCount(),
@@ -2293,8 +2194,7 @@ SorobanNetworkConfig::maxLedgerResources() const
 }
 
 #ifdef BUILD_TESTS
-void
-SorobanNetworkConfig::updateRecalibratedCostTypesForV20(
+void SorobanNetworkConfig::updateRecalibratedCostTypesForV20(
     AbstractLedgerTxn& ltxRoot)
 {
     LedgerTxn ltx(ltxRoot);
@@ -2410,8 +2310,7 @@ SorobanNetworkConfig::updateRecalibratedCostTypesForV20(
     ltx.commit();
 }
 
-bool
-SorobanNetworkConfig::operator==(SorobanNetworkConfig const& other) const
+bool SorobanNetworkConfig::operator==(SorobanNetworkConfig const& other) const
 {
     return mMaxContractSizeBytes == other.maxContractSizeBytes() &&
            mMaxContractDataKeySizeBytes ==
@@ -2483,9 +2382,8 @@ SorobanNetworkConfig::operator==(SorobanNetworkConfig const& other) const
 }
 #endif
 
-bool
-SorobanNetworkConfig::isValidCostParams(ContractCostParams const& params,
-                                        uint32_t ledgerVersion)
+bool SorobanNetworkConfig::isValidCostParams(ContractCostParams const& params,
+                                             uint32_t ledgerVersion)
 {
     auto getNumCostTypes = [](uint32_t ledgerVersion) -> uint32_t {
         if (protocolVersionIsBefore(ledgerVersion, ProtocolVersion::V_21))
@@ -2567,8 +2465,7 @@ SorobanNetworkConfig::rustBridgeRentFeeConfiguration() const
     return res;
 }
 
-void
-SorobanNetworkConfig::computeRentWriteFee(uint32_t protocolVersion)
+void SorobanNetworkConfig::computeRentWriteFee(uint32_t protocolVersion)
 {
     ZoneScoped;
 

--- a/src/ledger/NetworkConfig.h
+++ b/src/ledger/NetworkConfig.h
@@ -186,7 +186,6 @@ struct InitialSorobanNetworkConfig
 // any network.
 struct Protcol23UpgradedConfig
 {
-
     static constexpr int64_t SOROBAN_STATE_TARGET_SIZE_BYTES =
         3'000'000'000LL; // 3 GB
     static constexpr int64_t RENT_FEE_1KB_SOROBAN_STATE_SIZE_LOW = -17'000;

--- a/src/ledger/P23HotArchiveBug.cpp
+++ b/src/ledger/P23HotArchiveBug.cpp
@@ -21,8 +21,7 @@ namespace p23_hot_archive_bug
 {
 namespace
 {
-LedgerEntry
-decodeLedgerEntry(std::string const& encodedBase64)
+LedgerEntry decodeLedgerEntry(std::string const& encodedBase64)
 {
     LedgerEntry entry;
     fromOpaqueBase64(entry, encodedBase64);
@@ -32,8 +31,7 @@ decodeLedgerEntry(std::string const& encodedBase64)
 
 using namespace internal;
 
-void
-addHotArchiveBatchWithP23HotArchiveFix(
+void addHotArchiveBatchWithP23HotArchiveFix(
     AbstractLedgerTxn& ltx, Application& app, LedgerHeader header,
     std::vector<LedgerEntry> const& archivedEntries,
     std::vector<LedgerKey> const& restoredEntries)
@@ -106,8 +104,7 @@ addHotArchiveBatchWithP23HotArchiveFix(
         app, header, updatedArchivedEntries, restoredEntries);
 }
 
-bool
-Protocol23CorruptionDataVerifier::loadFromFile(std::string const& path)
+bool Protocol23CorruptionDataVerifier::loadFromFile(std::string const& path)
 {
     std::ifstream file(path);
     if (!file.is_open())
@@ -162,9 +159,8 @@ Protocol23CorruptionDataVerifier::loadFromFile(std::string const& path)
     return true;
 }
 
-bool
-Protocol23CorruptionDataVerifier::parseLine(std::string const& line,
-                                            size_t lineNumber)
+bool Protocol23CorruptionDataVerifier::parseLine(std::string const& line,
+                                                 size_t lineNumber)
 {
     // Parse CSV line: ledgerKey,correctLedgerEntry,corruptedLedgerEntry,
     // evictedLedgerSeq,restoredLedgerSeq
@@ -242,8 +238,7 @@ Protocol23CorruptionDataVerifier::parseLine(std::string const& line,
     }
 }
 
-void
-Protocol23CorruptionDataVerifier::verifyHardcodedData() const
+void Protocol23CorruptionDataVerifier::verifyHardcodedData() const
 {
     CLOG_INFO(Ledger,
               "Verifying hardcoded Protocol 23 corruption data against CSV...");
@@ -292,8 +287,7 @@ Protocol23CorruptionDataVerifier::verifyHardcodedData() const
               corruptedMap.size());
 }
 
-void
-Protocol23CorruptionDataVerifier::verifyRestorationOfCorruptedEntry(
+void Protocol23CorruptionDataVerifier::verifyRestorationOfCorruptedEntry(
     LedgerKey const& restoredKey, LedgerEntry const& restoredEntry,
     uint32_t ledgerSeq, uint32_t protocolVersion)
 {
@@ -333,8 +327,7 @@ Protocol23CorruptionDataVerifier::verifyRestorationOfCorruptedEntry(
     releaseAssert(mNotRestoredKeys.find(restoredKey) == mNotRestoredKeys.end());
 }
 
-void
-Protocol23CorruptionDataVerifier::verifyArchivalOfCorruptedEntry(
+void Protocol23CorruptionDataVerifier::verifyArchivalOfCorruptedEntry(
     EvictedStateVectors const& evictedState, Application& app,
     uint32_t ledgerSeq, uint32_t protocolVersion)
 {
@@ -404,8 +397,7 @@ Protocol23CorruptionDataVerifier::verifyArchivalOfCorruptedEntry(
     releaseAssert(incorrectlyEvictedKeys.empty());
 }
 
-void
-Protocol23CorruptionDataVerifier::verifyEntryFixesOnP24Upgrade(
+void Protocol23CorruptionDataVerifier::verifyEntryFixesOnP24Upgrade(
     std::vector<LedgerEntry> const& entryBatch) const
 {
     // General note: this check is much more strict than the set of checks
@@ -484,8 +476,7 @@ Protocol23CorruptionEventReconciler::Protocol23CorruptionEventReconciler(
 // the balances always fit in the [0, INT64_MAX] range.
 // We know that the only SAC entries that were incorrectly restored were
 // Balances, so we can be strict with our check here.
-std::pair<int64_t, SCAddress /*owner*/>
-getSACBalance(LedgerEntry const& le)
+std::pair<int64_t, SCAddress /*owner*/> getSACBalance(LedgerEntry const& le)
 {
     releaseAssert(le.data.type() == CONTRACT_DATA);
     auto const& cd = le.data.contractData();
@@ -586,8 +577,7 @@ Protocol23CorruptionEventReconciler::getSACReconciliationEventAndTrackDiff(
     return info;
 }
 
-bool
-Protocol23CorruptionEventReconciler::hasReconciliationAmount(
+bool Protocol23CorruptionEventReconciler::hasReconciliationAmount(
     Asset const& asset, SCAddress const& address, CxxI128 const& amount) const
 {
     auto addrIt = mReconciliationAmounts.find(address);

--- a/src/ledger/SharedModuleCacheCompiler.cpp
+++ b/src/ledger/SharedModuleCacheCompiler.cpp
@@ -38,8 +38,7 @@ SharedModuleCacheCompiler::~SharedModuleCacheCompiler()
     }
 }
 
-void
-SharedModuleCacheCompiler::pushWasm(xdr::xvector<uint8_t> const& vec)
+void SharedModuleCacheCompiler::pushWasm(xdr::xvector<uint8_t> const& vec)
 {
     std::unique_lock<std::mutex> lock(mMutex);
     mHaveSpace.wait(lock, [&] {
@@ -54,16 +53,14 @@ SharedModuleCacheCompiler::pushWasm(xdr::xvector<uint8_t> const& vec)
     LOG_DEBUG(DEFAULT_LOG, "Loaded contract with {} bytes of wasm code", size);
 }
 
-bool
-SharedModuleCacheCompiler::isFinishedCompiling(
+bool SharedModuleCacheCompiler::isFinishedCompiling(
     std::unique_lock<std::mutex>& lock)
 {
     releaseAssert(lock.owns_lock());
     return mLoadedAll && mBytesCompiled == mBytesLoaded;
 }
 
-void
-SharedModuleCacheCompiler::setFinishedLoading(size_t nContracts)
+void SharedModuleCacheCompiler::setFinishedLoading(size_t nContracts)
 {
     std::unique_lock lock(mMutex);
     mLoadedAll = true;
@@ -72,9 +69,8 @@ SharedModuleCacheCompiler::setFinishedLoading(size_t nContracts)
     mHaveContracts.notify_all();
 }
 
-bool
-SharedModuleCacheCompiler::popAndCompileWasm(size_t thread,
-                                             std::unique_lock<std::mutex>& lock)
+bool SharedModuleCacheCompiler::popAndCompileWasm(
+    size_t thread, std::unique_lock<std::mutex>& lock)
 {
     ZoneScoped;
 
@@ -133,8 +129,7 @@ SharedModuleCacheCompiler::popAndCompileWasm(size_t thread,
     return true;
 }
 
-void
-SharedModuleCacheCompiler::start()
+void SharedModuleCacheCompiler::start()
 {
     mStarted = std::chrono::steady_clock::now();
 
@@ -212,22 +207,19 @@ SharedModuleCacheCompiler::wait()
     return mModuleCache->shallow_clone();
 }
 
-size_t
-SharedModuleCacheCompiler::getBytesCompiled()
+size_t SharedModuleCacheCompiler::getBytesCompiled()
 {
     std::unique_lock lock(mMutex);
     return mBytesCompiled;
 }
 
-std::chrono::nanoseconds
-SharedModuleCacheCompiler::getCompileTime()
+std::chrono::nanoseconds SharedModuleCacheCompiler::getCompileTime()
 {
     std::unique_lock lock(mMutex);
     return mTotalCompileTime;
 }
 
-size_t
-SharedModuleCacheCompiler::getContractsCompiled()
+size_t SharedModuleCacheCompiler::getContractsCompiled()
 {
     std::unique_lock lock(mMutex);
     return mContractsCompiled;

--- a/src/ledger/SorobanMetrics.cpp
+++ b/src/ledger/SorobanMetrics.cpp
@@ -157,54 +157,45 @@ SorobanMetrics::SorobanMetrics(medida::MetricsRegistry& metrics)
 {
 }
 
-void
-SorobanMetrics::accumulateModelledCpuInsns(uint64_t insnsCount,
-                                           uint64_t insnsExclVmCount,
-                                           uint64_t hostFnExecTimeNsecs)
+void SorobanMetrics::accumulateModelledCpuInsns(uint64_t insnsCount,
+                                                uint64_t insnsExclVmCount,
+                                                uint64_t hostFnExecTimeNsecs)
 {
     mLedgerInsnsCount += insnsCount;
     mLedgerInsnsExclVmCount += insnsExclVmCount;
     mLedgerHostFnExecTimeNsecs += hostFnExecTimeNsecs;
 }
 
-void
-SorobanMetrics::accumulateLedgerTxCount(uint64_t txCount)
+void SorobanMetrics::accumulateLedgerTxCount(uint64_t txCount)
 {
     mCounterLedgerTxCount += txCount;
 }
-void
-SorobanMetrics::accumulateLedgerCpuInsn(uint64_t cpuInsn)
+void SorobanMetrics::accumulateLedgerCpuInsn(uint64_t cpuInsn)
 {
     mCounterLedgerCpuInsn += cpuInsn;
 }
-void
-SorobanMetrics::accumulateLedgerTxsSizeByte(uint64_t txsSizeByte)
+void SorobanMetrics::accumulateLedgerTxsSizeByte(uint64_t txsSizeByte)
 {
     mCounterLedgerTxsSizeByte += txsSizeByte;
 }
-void
-SorobanMetrics::accumulateLedgerReadEntry(uint64_t readEntry)
+void SorobanMetrics::accumulateLedgerReadEntry(uint64_t readEntry)
 {
     mCounterLedgerReadEntry += readEntry;
 }
-void
-SorobanMetrics::accumulateLedgerReadByte(uint64_t readByte)
+void SorobanMetrics::accumulateLedgerReadByte(uint64_t readByte)
 {
     mCounterLedgerReadByte += readByte;
 }
-void
-SorobanMetrics::accumulateLedgerWriteEntry(uint64_t writeEntry)
+void SorobanMetrics::accumulateLedgerWriteEntry(uint64_t writeEntry)
 {
     mCounterLedgerWriteEntry += writeEntry;
 }
-void
-SorobanMetrics::accumulateLedgerWriteByte(uint64_t writeByte)
+void SorobanMetrics::accumulateLedgerWriteByte(uint64_t writeByte)
 {
     mCounterLedgerWriteByte += writeByte;
 }
 
-void
-SorobanMetrics::publishAndResetLedgerWideMetrics()
+void SorobanMetrics::publishAndResetLedgerWideMetrics()
 {
     mLedgerTxCount.Update(mCounterLedgerTxCount);
     mLedgerCpuInsn.Update(mCounterLedgerCpuInsn);

--- a/src/ledger/TrustLineWrapper.cpp
+++ b/src/ledger/TrustLineWrapper.cpp
@@ -111,64 +111,54 @@ TrustLineWrapper::TrustLineWrapper(LedgerTxnEntry&& entry)
     }
 }
 
-TrustLineWrapper::
-operator bool() const
+TrustLineWrapper::operator bool() const
 {
     return (bool)mImpl && (bool)(*mImpl);
 }
 
-int64_t
-TrustLineWrapper::getBalance() const
+int64_t TrustLineWrapper::getBalance() const
 {
     return getImpl()->getBalance();
 }
 
-bool
-TrustLineWrapper::addBalance(LedgerTxnHeader const& header, int64_t delta)
+bool TrustLineWrapper::addBalance(LedgerTxnHeader const& header, int64_t delta)
 {
     return getImpl()->addBalance(header, delta);
 }
 
-int64_t
-TrustLineWrapper::getBuyingLiabilities(LedgerTxnHeader const& header)
+int64_t TrustLineWrapper::getBuyingLiabilities(LedgerTxnHeader const& header)
 {
     return getImpl()->getBuyingLiabilities(header);
 }
 
-int64_t
-TrustLineWrapper::getSellingLiabilities(LedgerTxnHeader const& header)
+int64_t TrustLineWrapper::getSellingLiabilities(LedgerTxnHeader const& header)
 {
     return getImpl()->getSellingLiabilities(header);
 }
 
-int64_t
-TrustLineWrapper::addBuyingLiabilities(LedgerTxnHeader const& header,
-                                       int64_t delta)
+int64_t TrustLineWrapper::addBuyingLiabilities(LedgerTxnHeader const& header,
+                                               int64_t delta)
 {
     return getImpl()->addBuyingLiabilities(header, delta);
 }
 
-int64_t
-TrustLineWrapper::addSellingLiabilities(LedgerTxnHeader const& header,
-                                        int64_t delta)
+int64_t TrustLineWrapper::addSellingLiabilities(LedgerTxnHeader const& header,
+                                                int64_t delta)
 {
     return getImpl()->addSellingLiabilities(header, delta);
 }
 
-bool
-TrustLineWrapper::isAuthorized() const
+bool TrustLineWrapper::isAuthorized() const
 {
     return getImpl()->isAuthorized();
 }
 
-bool
-TrustLineWrapper::isAuthorizedToMaintainLiabilities() const
+bool TrustLineWrapper::isAuthorizedToMaintainLiabilities() const
 {
     return getImpl()->isAuthorizedToMaintainLiabilities();
 }
 
-bool
-TrustLineWrapper::isClawbackEnabled() const
+bool TrustLineWrapper::isClawbackEnabled() const
 {
     return getImpl()->isClawbackEnabled();
 }
@@ -185,8 +175,7 @@ TrustLineWrapper::getMaxAmountReceive(LedgerTxnHeader const& header) const
     return getImpl()->getMaxAmountReceive(header);
 }
 
-void
-TrustLineWrapper::deactivate()
+void TrustLineWrapper::deactivate()
 {
     mImpl.reset();
 }
@@ -207,80 +196,68 @@ TrustLineWrapper::NonIssuerImpl::NonIssuerImpl(LedgerTxnEntry&& entry)
 {
 }
 
-TrustLineWrapper::NonIssuerImpl::
-operator bool() const
+TrustLineWrapper::NonIssuerImpl::operator bool() const
 {
     return (bool)mEntry;
 }
 
-int64_t
-TrustLineWrapper::NonIssuerImpl::getBalance() const
+int64_t TrustLineWrapper::NonIssuerImpl::getBalance() const
 {
     return mEntry.current().data.trustLine().balance;
 }
 
-bool
-TrustLineWrapper::NonIssuerImpl::addBalance(LedgerTxnHeader const& header,
-                                            int64_t delta)
+bool TrustLineWrapper::NonIssuerImpl::addBalance(LedgerTxnHeader const& header,
+                                                 int64_t delta)
 {
     return stellar::addBalance(header, mEntry, delta);
 }
 
-int64_t
-TrustLineWrapper::NonIssuerImpl::getBuyingLiabilities(
+int64_t TrustLineWrapper::NonIssuerImpl::getBuyingLiabilities(
     LedgerTxnHeader const& header)
 {
     return stellar::getBuyingLiabilities(header, mEntry);
 }
 
-int64_t
-TrustLineWrapper::NonIssuerImpl::getSellingLiabilities(
+int64_t TrustLineWrapper::NonIssuerImpl::getSellingLiabilities(
     LedgerTxnHeader const& header)
 {
     return stellar::getSellingLiabilities(header, mEntry);
 }
 
-int64_t
-TrustLineWrapper::NonIssuerImpl::addBuyingLiabilities(
+int64_t TrustLineWrapper::NonIssuerImpl::addBuyingLiabilities(
     LedgerTxnHeader const& header, int64_t delta)
 {
     return stellar::addBuyingLiabilities(header, mEntry, delta);
 }
 
-int64_t
-TrustLineWrapper::NonIssuerImpl::addSellingLiabilities(
+int64_t TrustLineWrapper::NonIssuerImpl::addSellingLiabilities(
     LedgerTxnHeader const& header, int64_t delta)
 {
     return stellar::addSellingLiabilities(header, mEntry, delta);
 }
 
-bool
-TrustLineWrapper::NonIssuerImpl::isAuthorized() const
+bool TrustLineWrapper::NonIssuerImpl::isAuthorized() const
 {
     return stellar::isAuthorized(mEntry);
 }
 
-bool
-TrustLineWrapper::NonIssuerImpl::isAuthorizedToMaintainLiabilities() const
+bool TrustLineWrapper::NonIssuerImpl::isAuthorizedToMaintainLiabilities() const
 {
     return stellar::isAuthorizedToMaintainLiabilities(mEntry);
 }
 
-bool
-TrustLineWrapper::NonIssuerImpl::isClawbackEnabled() const
+bool TrustLineWrapper::NonIssuerImpl::isClawbackEnabled() const
 {
     return stellar::isClawbackEnabledOnTrustline(mEntry);
 }
 
-int64_t
-TrustLineWrapper::NonIssuerImpl::getAvailableBalance(
+int64_t TrustLineWrapper::NonIssuerImpl::getAvailableBalance(
     LedgerTxnHeader const& header) const
 {
     return stellar::getAvailableBalance(header, mEntry);
 }
 
-int64_t
-TrustLineWrapper::NonIssuerImpl::getMaxAmountReceive(
+int64_t TrustLineWrapper::NonIssuerImpl::getMaxAmountReceive(
     LedgerTxnHeader const& header) const
 {
     return stellar::getMaxAmountReceive(header, mEntry);
@@ -293,80 +270,68 @@ TrustLineWrapper::IssuerImpl::IssuerImpl(AccountID const& accountID,
 {
 }
 
-TrustLineWrapper::IssuerImpl::
-operator bool() const
+TrustLineWrapper::IssuerImpl::operator bool() const
 {
     return true;
 }
 
-int64_t
-TrustLineWrapper::IssuerImpl::getBalance() const
+int64_t TrustLineWrapper::IssuerImpl::getBalance() const
 {
     return INT64_MAX;
 }
 
-bool
-TrustLineWrapper::IssuerImpl::addBalance(LedgerTxnHeader const& header,
-                                         int64_t delta)
+bool TrustLineWrapper::IssuerImpl::addBalance(LedgerTxnHeader const& header,
+                                              int64_t delta)
 {
     return true;
 }
 
-int64_t
-TrustLineWrapper::IssuerImpl::getBuyingLiabilities(
+int64_t TrustLineWrapper::IssuerImpl::getBuyingLiabilities(
     LedgerTxnHeader const& header)
 {
     return 0;
 }
 
-int64_t
-TrustLineWrapper::IssuerImpl::getSellingLiabilities(
+int64_t TrustLineWrapper::IssuerImpl::getSellingLiabilities(
     LedgerTxnHeader const& header)
 {
     return 0;
 }
 
-int64_t
-TrustLineWrapper::IssuerImpl::addBuyingLiabilities(
+int64_t TrustLineWrapper::IssuerImpl::addBuyingLiabilities(
     LedgerTxnHeader const& header, int64_t delta)
 {
     return true;
 }
 
-int64_t
-TrustLineWrapper::IssuerImpl::addSellingLiabilities(
+int64_t TrustLineWrapper::IssuerImpl::addSellingLiabilities(
     LedgerTxnHeader const& header, int64_t delta)
 {
     return true;
 }
 
-bool
-TrustLineWrapper::IssuerImpl::isAuthorized() const
+bool TrustLineWrapper::IssuerImpl::isAuthorized() const
 {
     return true;
 }
 
-bool
-TrustLineWrapper::IssuerImpl::isAuthorizedToMaintainLiabilities() const
+bool TrustLineWrapper::IssuerImpl::isAuthorizedToMaintainLiabilities() const
 {
     return true;
 }
 
-bool
-TrustLineWrapper::IssuerImpl::isClawbackEnabled() const
+bool TrustLineWrapper::IssuerImpl::isClawbackEnabled() const
 {
     throw std::runtime_error("issuer cannot clawback from itself");
 }
 
-int64_t
-TrustLineWrapper::IssuerImpl::getAvailableBalance(
+int64_t TrustLineWrapper::IssuerImpl::getAvailableBalance(
     LedgerTxnHeader const& header) const
 {
     return INT64_MAX;
 }
 
-int64_t
-TrustLineWrapper::IssuerImpl::getMaxAmountReceive(
+int64_t TrustLineWrapper::IssuerImpl::getMaxAmountReceive(
     LedgerTxnHeader const& header) const
 {
     return INT64_MAX;
@@ -443,26 +408,22 @@ ConstTrustLineWrapper::ConstTrustLineWrapper(ConstLedgerTxnEntry&& entry)
     }
 }
 
-ConstTrustLineWrapper::
-operator bool() const
+ConstTrustLineWrapper::operator bool() const
 {
     return (bool)mImpl && (bool)(*mImpl);
 }
 
-int64_t
-ConstTrustLineWrapper::getBalance() const
+int64_t ConstTrustLineWrapper::getBalance() const
 {
     return getImpl()->getBalance();
 }
 
-bool
-ConstTrustLineWrapper::isAuthorized() const
+bool ConstTrustLineWrapper::isAuthorized() const
 {
     return getImpl()->isAuthorized();
 }
 
-bool
-ConstTrustLineWrapper::isAuthorizedToMaintainLiabilities() const
+bool ConstTrustLineWrapper::isAuthorizedToMaintainLiabilities() const
 {
     return getImpl()->isAuthorizedToMaintainLiabilities();
 }
@@ -495,78 +456,68 @@ ConstTrustLineWrapper::NonIssuerImpl::NonIssuerImpl(ConstLedgerTxnEntry&& entry)
 {
 }
 
-ConstTrustLineWrapper::NonIssuerImpl::
-operator bool() const
+ConstTrustLineWrapper::NonIssuerImpl::operator bool() const
 {
     return (bool)mEntry;
 }
 
-int64_t
-ConstTrustLineWrapper::NonIssuerImpl::getBalance() const
+int64_t ConstTrustLineWrapper::NonIssuerImpl::getBalance() const
 {
     return mEntry.current().data.trustLine().balance;
 }
 
-bool
-ConstTrustLineWrapper::NonIssuerImpl::isAuthorized() const
+bool ConstTrustLineWrapper::NonIssuerImpl::isAuthorized() const
 {
     return stellar::isAuthorized(mEntry);
 }
 
-bool
-ConstTrustLineWrapper::NonIssuerImpl::isAuthorizedToMaintainLiabilities() const
+bool ConstTrustLineWrapper::NonIssuerImpl::isAuthorizedToMaintainLiabilities()
+    const
 {
     return stellar::isAuthorizedToMaintainLiabilities(mEntry);
 }
 
-int64_t
-ConstTrustLineWrapper::NonIssuerImpl::getAvailableBalance(
+int64_t ConstTrustLineWrapper::NonIssuerImpl::getAvailableBalance(
     LedgerTxnHeader const& header) const
 {
     return stellar::getAvailableBalance(header, mEntry);
 }
 
-int64_t
-ConstTrustLineWrapper::NonIssuerImpl::getMaxAmountReceive(
+int64_t ConstTrustLineWrapper::NonIssuerImpl::getMaxAmountReceive(
     LedgerTxnHeader const& header) const
 {
     return stellar::getMaxAmountReceive(header, mEntry);
 }
 
 // Implementation of ConstTrustLineWrapper::IssuerImpl ------------------------
-ConstTrustLineWrapper::IssuerImpl::
-operator bool() const
+ConstTrustLineWrapper::IssuerImpl::operator bool() const
 {
     return true;
 }
 
-int64_t
-ConstTrustLineWrapper::IssuerImpl::getBalance() const
+int64_t ConstTrustLineWrapper::IssuerImpl::getBalance() const
 {
     return INT64_MAX;
 }
 
-bool
-ConstTrustLineWrapper::IssuerImpl::isAuthorized() const
+bool ConstTrustLineWrapper::IssuerImpl::isAuthorized() const
 {
     return true;
 }
 
-bool
-ConstTrustLineWrapper::IssuerImpl::isAuthorizedToMaintainLiabilities() const
+bool ConstTrustLineWrapper::IssuerImpl::isAuthorizedToMaintainLiabilities()
+    const
 {
     return true;
 }
 
-int64_t
-ConstTrustLineWrapper::IssuerImpl::getAvailableBalance(
+int64_t ConstTrustLineWrapper::IssuerImpl::getAvailableBalance(
     LedgerTxnHeader const& header) const
 {
     return INT64_MAX;
 }
 
-int64_t
-ConstTrustLineWrapper::IssuerImpl::getMaxAmountReceive(
+int64_t ConstTrustLineWrapper::IssuerImpl::getMaxAmountReceive(
     LedgerTxnHeader const& header) const
 {
     return INT64_MAX;

--- a/src/ledger/test/InMemoryLedgerTxn.cpp
+++ b/src/ledger/test/InMemoryLedgerTxn.cpp
@@ -24,8 +24,7 @@ InMemoryLedgerTxn::FilteredEntryIteratorImpl::FilteredEntryIteratorImpl(
     }
 }
 
-void
-InMemoryLedgerTxn::FilteredEntryIteratorImpl::advance()
+void InMemoryLedgerTxn::FilteredEntryIteratorImpl::advance()
 {
     while (++mIter &&
            mIter.key().type() != InternalLedgerEntryType::LEDGER_ENTRY)
@@ -34,8 +33,7 @@ InMemoryLedgerTxn::FilteredEntryIteratorImpl::advance()
     }
 }
 
-bool
-InMemoryLedgerTxn::FilteredEntryIteratorImpl::atEnd() const
+bool InMemoryLedgerTxn::FilteredEntryIteratorImpl::atEnd() const
 {
     return !mIter;
 }
@@ -52,14 +50,12 @@ InMemoryLedgerTxn::FilteredEntryIteratorImpl::entryPtr() const
     return mIter.entryPtr();
 }
 
-SessionWrapper&
-InMemoryLedgerTxn::getSession() const
+SessionWrapper& InMemoryLedgerTxn::getSession() const
 {
     return mDb.getSession();
 }
 
-bool
-InMemoryLedgerTxn::FilteredEntryIteratorImpl::entryExists() const
+bool InMemoryLedgerTxn::FilteredEntryIteratorImpl::entryExists() const
 {
     return mIter.entryExists();
 }
@@ -87,8 +83,7 @@ InMemoryLedgerTxn::~InMemoryLedgerTxn()
 {
 }
 
-void
-InMemoryLedgerTxn::addChild(AbstractLedgerTxn& child, TransactionMode mode)
+void InMemoryLedgerTxn::addChild(AbstractLedgerTxn& child, TransactionMode mode)
 {
     if (mTransaction)
     {
@@ -102,9 +97,8 @@ InMemoryLedgerTxn::addChild(AbstractLedgerTxn& child, TransactionMode mode)
     }
 }
 
-void
-InMemoryLedgerTxn::updateLedgerKeyMap(InternalLedgerKey const& genKey,
-                                      bool add) noexcept
+void InMemoryLedgerTxn::updateLedgerKeyMap(InternalLedgerKey const& genKey,
+                                           bool add) noexcept
 {
     if (genKey.type() == InternalLedgerEntryType::LEDGER_ENTRY)
     {
@@ -139,8 +133,7 @@ InMemoryLedgerTxn::updateLedgerKeyMap(InternalLedgerKey const& genKey,
     }
 }
 
-void
-InMemoryLedgerTxn::updateLedgerKeyMap(EntryIterator iter)
+void InMemoryLedgerTxn::updateLedgerKeyMap(EntryIterator iter)
 {
     for (; (bool)iter; ++iter)
     {
@@ -186,10 +179,9 @@ InMemoryLedgerTxn::getFilteredEntryIterator(EntryIterator const& iter)
     return EntryIterator(std::move(filteredIterImpl));
 }
 
-void
-InMemoryLedgerTxn::commitChild(EntryIterator iter,
-                               RestoredEntries const& restoredEntries,
-                               LedgerTxnConsistency cons) noexcept
+void InMemoryLedgerTxn::commitChild(EntryIterator iter,
+                                    RestoredEntries const& restoredEntries,
+                                    LedgerTxnConsistency cons) noexcept
 {
     if (!mTransaction)
     {
@@ -216,8 +208,7 @@ InMemoryLedgerTxn::commitChild(EntryIterator iter,
     }
 }
 
-void
-InMemoryLedgerTxn::rollbackChild() noexcept
+void InMemoryLedgerTxn::rollbackChild() noexcept
 {
     try
     {
@@ -241,35 +232,30 @@ InMemoryLedgerTxn::rollbackChild() noexcept
     }
 }
 
-void
-InMemoryLedgerTxn::createWithoutLoading(InternalLedgerEntry const& entry)
+void InMemoryLedgerTxn::createWithoutLoading(InternalLedgerEntry const& entry)
 {
     LedgerTxn::createWithoutLoading(entry);
     updateLedgerKeyMap(entry.toKey(), true);
 }
 
-void
-InMemoryLedgerTxn::updateWithoutLoading(InternalLedgerEntry const& entry)
+void InMemoryLedgerTxn::updateWithoutLoading(InternalLedgerEntry const& entry)
 {
     LedgerTxn::updateWithoutLoading(entry);
     updateLedgerKeyMap(entry.toKey(), true);
 }
 
-void
-InMemoryLedgerTxn::eraseWithoutLoading(InternalLedgerKey const& key)
+void InMemoryLedgerTxn::eraseWithoutLoading(InternalLedgerKey const& key)
 {
     LedgerTxn::eraseWithoutLoading(key);
     updateLedgerKeyMap(key, false);
 }
 
-LedgerTxnEntry
-InMemoryLedgerTxn::create(InternalLedgerEntry const& entry)
+LedgerTxnEntry InMemoryLedgerTxn::create(InternalLedgerEntry const& entry)
 {
     throw std::runtime_error("called create on InMemoryLedgerTxn");
 }
 
-void
-InMemoryLedgerTxn::erase(InternalLedgerKey const& key)
+void InMemoryLedgerTxn::erase(InternalLedgerKey const& key)
 {
     throw std::runtime_error("called erase on InMemoryLedgerTxn");
 }
@@ -282,8 +268,7 @@ InMemoryLedgerTxn::restoreFromLiveBucketList(LedgerEntry const& entry,
         "called restoreFromLiveBucketList on InMemoryLedgerTxn");
 }
 
-LedgerTxnEntry
-InMemoryLedgerTxn::load(InternalLedgerKey const& key)
+LedgerTxnEntry InMemoryLedgerTxn::load(InternalLedgerKey const& key)
 {
     throw std::runtime_error("called load on InMemoryLedgerTxn");
 }
@@ -375,26 +360,23 @@ InMemoryLedgerTxn::getPoolShareTrustLinesByAccountAndAsset(
     return res;
 }
 
-void
-InMemoryLedgerTxn::dropOffers()
+void InMemoryLedgerTxn::dropOffers()
 {
     mRealRootForOffers.dropOffers();
 }
 
-uint64_t
-InMemoryLedgerTxn::countOffers(LedgerRange const& ledgers) const
+uint64_t InMemoryLedgerTxn::countOffers(LedgerRange const& ledgers) const
 {
     return mRealRootForOffers.countOffers(ledgers);
 }
 
-void
-InMemoryLedgerTxn::deleteOffersModifiedOnOrAfterLedger(uint32_t ledger) const
+void InMemoryLedgerTxn::deleteOffersModifiedOnOrAfterLedger(
+    uint32_t ledger) const
 {
     mRealRootForOffers.deleteOffersModifiedOnOrAfterLedger(ledger);
 }
 
-UnorderedMap<LedgerKey, LedgerEntry>
-InMemoryLedgerTxn::getAllOffers()
+UnorderedMap<LedgerKey, LedgerEntry> InMemoryLedgerTxn::getAllOffers()
 {
     return mRealRootForOffers.getAllOffers();
 }
@@ -413,8 +395,7 @@ InMemoryLedgerTxn::getBestOffer(Asset const& buying, Asset const& selling,
 }
 
 #ifdef BEST_OFFER_DEBUGGING
-bool
-InMemoryLedgerTxn::bestOfferDebuggingEnabled() const
+bool InMemoryLedgerTxn::bestOfferDebuggingEnabled() const
 {
     return mRealRootForOffers.bestOfferDebuggingEnabled();
 }

--- a/src/ledger/test/InMemoryLedgerTxnRoot.cpp
+++ b/src/ledger/test/InMemoryLedgerTxnRoot.cpp
@@ -27,26 +27,23 @@ InMemoryLedgerTxnRoot::InMemoryLedgerTxnRoot(
 {
 }
 
-void
-InMemoryLedgerTxnRoot::addChild(AbstractLedgerTxn& child, TransactionMode mode)
+void InMemoryLedgerTxnRoot::addChild(AbstractLedgerTxn& child,
+                                     TransactionMode mode)
 {
 }
 
-void
-InMemoryLedgerTxnRoot::commitChild(EntryIterator iter,
-                                   RestoredEntries const& restoredEntries,
-                                   LedgerTxnConsistency cons) noexcept
+void InMemoryLedgerTxnRoot::commitChild(EntryIterator iter,
+                                        RestoredEntries const& restoredEntries,
+                                        LedgerTxnConsistency cons) noexcept
 {
     printErrorAndAbort("committing to stub InMemoryLedgerTxnRoot");
 }
 
-void
-InMemoryLedgerTxnRoot::rollbackChild() noexcept
+void InMemoryLedgerTxnRoot::rollbackChild() noexcept
 {
 }
 
-UnorderedMap<LedgerKey, LedgerEntry>
-InMemoryLedgerTxnRoot::getAllOffers()
+UnorderedMap<LedgerKey, LedgerEntry> InMemoryLedgerTxnRoot::getAllOffers()
 {
     return UnorderedMap<LedgerKey, LedgerEntry>();
 }
@@ -78,8 +75,7 @@ InMemoryLedgerTxnRoot::getPoolShareTrustLinesByAccountAndAsset(
     return UnorderedMap<LedgerKey, LedgerEntry>();
 }
 
-LedgerHeader const&
-InMemoryLedgerTxnRoot::getHeader() const
+LedgerHeader const& InMemoryLedgerTxnRoot::getHeader() const
 {
     return *mHeader;
 }
@@ -116,66 +112,55 @@ InMemoryLedgerTxnRoot::getNewestVersionBelowRoot(
     return {false, nullptr};
 }
 
-uint64_t
-InMemoryLedgerTxnRoot::countOffers(LedgerRange const& ledgers) const
+uint64_t InMemoryLedgerTxnRoot::countOffers(LedgerRange const& ledgers) const
 {
     return 0;
 }
 
-void
-InMemoryLedgerTxnRoot::deleteOffersModifiedOnOrAfterLedger(
+void InMemoryLedgerTxnRoot::deleteOffersModifiedOnOrAfterLedger(
     uint32_t ledger) const
 {
 }
 
-void
-InMemoryLedgerTxnRoot::dropOffers()
+void InMemoryLedgerTxnRoot::dropOffers()
 {
 }
 
-double
-InMemoryLedgerTxnRoot::getPrefetchHitRate() const
+double InMemoryLedgerTxnRoot::getPrefetchHitRate() const
 {
     return 0.0;
 }
 
-uint32_t
-InMemoryLedgerTxnRoot::prefetch(UnorderedSet<LedgerKey> const&)
+uint32_t InMemoryLedgerTxnRoot::prefetch(UnorderedSet<LedgerKey> const&)
 {
     return 0;
 }
 
-void
-InMemoryLedgerTxnRoot::prepareNewObjects(size_t)
+void InMemoryLedgerTxnRoot::prepareNewObjects(size_t)
 {
 }
 
-SessionWrapper&
-InMemoryLedgerTxnRoot::getSession() const
+SessionWrapper& InMemoryLedgerTxnRoot::getSession() const
 {
     throw std::runtime_error("called InMemoryLedgerTxnRoot::getSession");
 }
 
 #ifdef BUILD_TESTS
-void
-InMemoryLedgerTxnRoot::resetForFuzzer()
+void InMemoryLedgerTxnRoot::resetForFuzzer()
 {
     abort();
 }
 #endif // BUILD_TESTS
 
 #ifdef BEST_OFFER_DEBUGGING
-bool
-InMemoryLedgerTxnRoot::bestOfferDebuggingEnabled() const
+bool InMemoryLedgerTxnRoot::bestOfferDebuggingEnabled() const
 {
     return mBestOfferDebuggingEnabled;
 }
 
-std::shared_ptr<LedgerEntry const>
-InMemoryLedgerTxnRoot::getBestOfferSlow(Asset const& buying,
-                                        Asset const& selling,
-                                        OfferDescriptor const* worseThan,
-                                        std::unordered_set<int64_t>& exclude)
+std::shared_ptr<LedgerEntry const> InMemoryLedgerTxnRoot::getBestOfferSlow(
+    Asset const& buying, Asset const& selling, OfferDescriptor const* worseThan,
+    std::unordered_set<int64_t>& exclude)
 {
     return nullptr;
 }

--- a/src/ledger/test/LedgerTestUtils.cpp
+++ b/src/ledger/test/LedgerTestUtils.cpp
@@ -27,9 +27,7 @@ namespace stellar
 namespace LedgerTestUtils
 {
 
-template <typename T>
-void
-clampLow(T low, T& v)
+template <typename T> void clampLow(T low, T& v)
 {
     if (v < low)
     {
@@ -37,9 +35,7 @@ clampLow(T low, T& v)
     }
 }
 
-template <typename T>
-void
-clampHigh(T high, T& v)
+template <typename T> void clampHigh(T high, T& v)
 {
     if (v > high)
     {
@@ -49,9 +45,7 @@ clampHigh(T high, T& v)
 
 // mutate string such that it doesn't contain control characters
 // and is at least minSize characters long
-template <typename T>
-void
-replaceControlCharacters(T& s, int minSize)
+template <typename T> void replaceControlCharacters(T& s, int minSize)
 {
     if (static_cast<int>(s.size()) < minSize)
     {
@@ -72,15 +66,13 @@ template void replaceControlCharacters(std::string& s, int minSize);
 template void replaceControlCharacters(string32& s, int minSize);
 template void replaceControlCharacters(string64& s, int minSize);
 
-static bool
-signerEqual(Signer const& s1, Signer const& s2)
+static bool signerEqual(Signer const& s1, Signer const& s2)
 {
     return s1.key == s2.key;
 }
 
 template <size_t MAX_SIZE>
-xdr::xvector<uint8_t, MAX_SIZE>
-generateOpaqueVector()
+xdr::xvector<uint8_t, MAX_SIZE> generateOpaqueVector()
 {
     static auto vecgen = autocheck::list_of(autocheck::generator<uint8_t>());
     stellar::uniform_int_distribution<size_t> distr(1, MAX_SIZE);
@@ -88,8 +80,7 @@ generateOpaqueVector()
     return xdr::xvector<uint8_t, MAX_SIZE>(vec.begin(), vec.end());
 }
 
-void
-randomlyModifyEntry(LedgerEntry& e)
+void randomlyModifyEntry(LedgerEntry& e)
 {
     switch (e.data.type())
     {
@@ -153,8 +144,7 @@ randomlyModifyEntry(LedgerEntry& e)
     }
 }
 
-void
-makeValid(AccountEntry& a)
+void makeValid(AccountEntry& a)
 {
     if (a.balance < 0)
     {
@@ -226,8 +216,7 @@ makeValid(AccountEntry& a)
     }
 }
 
-void
-makeValid(TrustLineEntry& tl)
+void makeValid(TrustLineEntry& tl)
 {
     if (tl.balance < 0)
     {
@@ -265,8 +254,7 @@ makeValid(TrustLineEntry& tl)
             std::abs(tl.ext.v1().liabilities.selling);
     }
 }
-void
-makeValid(OfferEntry& o)
+void makeValid(OfferEntry& o)
 {
     o.offerID = o.offerID & INT64_MAX;
     o.selling.type(ASSET_TYPE_CREDIT_ALPHANUM4);
@@ -286,14 +274,12 @@ makeValid(OfferEntry& o)
     o.flags = o.flags & MASK_OFFERENTRY_FLAGS;
 }
 
-void
-makeValid(DataEntry& d)
+void makeValid(DataEntry& d)
 {
     replaceControlCharacters(d.dataName, 1);
 }
 
-void
-makeValid(ClaimableBalanceEntry& c)
+void makeValid(ClaimableBalanceEntry& c)
 {
     c.amount = std::abs(c.amount);
     clampLow<int64>(1, c.amount);
@@ -315,8 +301,7 @@ makeValid(ClaimableBalanceEntry& c)
     }
 }
 
-void
-makeValid(LiquidityPoolEntry& lp)
+void makeValid(LiquidityPoolEntry& lp)
 {
     auto& cp = lp.body.constantProduct();
     cp.params.assetA.type(ASSET_TYPE_CREDIT_ALPHANUM4);
@@ -332,16 +317,14 @@ makeValid(LiquidityPoolEntry& lp)
     cp.poolSharesTrustLineCount = std::abs(cp.poolSharesTrustLineCount);
 }
 
-void
-makeValid(ConfigSettingEntry& ce)
+void makeValid(ConfigSettingEntry& ce)
 {
     auto ids = xdr::xdr_traits<ConfigSettingID>::enum_values();
     ce.configSettingID(static_cast<ConfigSettingID>(
         ids.at(ce.configSettingID() % ids.size())));
 }
 
-void
-makeValid(ContractDataEntry& cde)
+void makeValid(ContractDataEntry& cde)
 {
     int t = cde.durability;
     auto modulo = static_cast<int64_t>(
@@ -408,8 +391,7 @@ makeValid(ContractDataEntry& cde)
     fixSCErrors(cde.val);
 }
 
-void
-makeValid(ContractCodeEntry& cce)
+void makeValid(ContractCodeEntry& cce)
 {
     auto seed = rand_uniform<uint64_t>(0, UINT64_MAX);
     auto size = rand_uniform<size_t>(64, 150);
@@ -433,15 +415,13 @@ makeValid(ContractCodeEntry& cce)
     }
 }
 
-void
-makeValid(TTLEntry& cce)
+void makeValid(TTLEntry& cce)
 {
 }
 
-void
-makeValid(std::vector<LedgerHeaderHistoryEntry>& lhv,
-          LedgerHeaderHistoryEntry firstLedger,
-          HistoryManager::LedgerVerificationStatus state)
+void makeValid(std::vector<LedgerHeaderHistoryEntry>& lhv,
+               LedgerHeaderHistoryEntry firstLedger,
+               HistoryManager::LedgerVerificationStatus state)
 {
     // We want to avoid corrupting the 0th through 2nd entries, because we use
     // these corrupt sequences in history tests that differentiate between
@@ -634,14 +614,12 @@ static auto validTTLEntryGenerator = autocheck::map(
     },
     autocheck::generator<TTLEntry>());
 
-LedgerEntry
-generateValidLedgerEntry(size_t b)
+LedgerEntry generateValidLedgerEntry(size_t b)
 {
     return validLedgerEntryGenerator(b);
 }
 
-LedgerEntry
-generateValidLedgerEntryOfType(LedgerEntryType type)
+LedgerEntry generateValidLedgerEntryOfType(LedgerEntryType type)
 {
     auto entry = generateValidLedgerEntry();
     while (entry.data.type() != type)
@@ -651,15 +629,13 @@ generateValidLedgerEntryOfType(LedgerEntryType type)
     return entry;
 }
 
-std::vector<LedgerEntry>
-generateValidLedgerEntries(size_t n)
+std::vector<LedgerEntry> generateValidLedgerEntries(size_t n)
 {
     static auto vecgen = autocheck::list_of(validLedgerEntryGenerator);
     return vecgen(n);
 }
 
-std::vector<LedgerEntry>
-generateValidUniqueLedgerEntries(size_t n)
+std::vector<LedgerEntry> generateValidUniqueLedgerEntries(size_t n)
 {
     UnorderedSet<LedgerKey> keys;
     std::vector<LedgerEntry> entries;
@@ -677,8 +653,7 @@ generateValidUniqueLedgerEntries(size_t n)
     return entries;
 }
 
-LedgerEntry
-generateValidLedgerEntryWithExclusions(
+LedgerEntry generateValidLedgerEntryWithExclusions(
     std::unordered_set<LedgerEntryType> const& excludedTypes, size_t b)
 {
     while (true)
@@ -691,11 +666,9 @@ generateValidLedgerEntryWithExclusions(
     }
 }
 
-std::vector<LedgerEntry>
-generateValidLedgerEntriesWithExclusions(
+std::vector<LedgerEntry> generateValidLedgerEntriesWithExclusions(
     std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n)
 {
-
     if (n > 1000)
     {
         throw "generateValidLedgerEntryWithExclusions: must generate <= 1000 "
@@ -711,8 +684,7 @@ generateValidLedgerEntriesWithExclusions(
     return res;
 }
 
-std::vector<LedgerKey>
-generateValidLedgerEntryKeysWithExclusions(
+std::vector<LedgerKey> generateValidLedgerEntryKeysWithExclusions(
     std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n)
 {
     if (n > 1000)
@@ -732,8 +704,7 @@ generateValidLedgerEntryKeysWithExclusions(
     return keys;
 }
 
-std::vector<LedgerKey>
-generateUniqueValidSorobanLedgerEntryKeys(size_t n)
+std::vector<LedgerKey> generateUniqueValidSorobanLedgerEntryKeys(size_t n)
 {
     return LedgerTestUtils::generateValidUniqueLedgerEntryKeysWithExclusions(
         {OFFER, DATA, CLAIMABLE_BALANCE, LIQUIDITY_POOL, CONFIG_SETTING, TTL},
@@ -772,8 +743,7 @@ generateUniquePersistentLedgerKeys(size_t n, UnorderedSet<LedgerKey>& seenKeys)
     return res;
 }
 
-std::vector<LedgerKey>
-generateValidUniqueLedgerEntryKeysWithExclusions(
+std::vector<LedgerKey> generateValidUniqueLedgerEntryKeysWithExclusions(
     std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n,
     UnorderedSet<LedgerKey>& seenKeys)
 {
@@ -794,8 +764,7 @@ generateValidUniqueLedgerEntryKeysWithExclusions(
     return res;
 }
 
-std::vector<LedgerKey>
-generateValidUniqueLedgerEntryKeysWithExclusions(
+std::vector<LedgerKey> generateValidUniqueLedgerEntryKeysWithExclusions(
     std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n)
 {
     UnorderedSet<LedgerKey> seenKeys;
@@ -803,8 +772,7 @@ generateValidUniqueLedgerEntryKeysWithExclusions(
                                                             seenKeys);
 }
 
-std::vector<LedgerEntry>
-generateValidUniqueLedgerEntriesWithExclusions(
+std::vector<LedgerEntry> generateValidUniqueLedgerEntriesWithExclusions(
     std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n)
 {
     UnorderedSet<LedgerKey> seenKeys;
@@ -812,8 +780,7 @@ generateValidUniqueLedgerEntriesWithExclusions(
                                                           seenKeys);
 }
 
-std::vector<LedgerEntry>
-generateValidUniqueLedgerEntriesWithExclusions(
+std::vector<LedgerEntry> generateValidUniqueLedgerEntriesWithExclusions(
     std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n,
     UnorderedSet<LedgerKey>& seenKeys)
 {
@@ -834,8 +801,7 @@ generateValidUniqueLedgerEntriesWithExclusions(
     return res;
 }
 
-LedgerEntry
-generateValidLedgerEntryWithTypes(
+LedgerEntry generateValidLedgerEntryWithTypes(
     std::unordered_set<LedgerEntryType> const& types, size_t b)
 {
     while (true)
@@ -848,8 +814,7 @@ generateValidLedgerEntryWithTypes(
     }
 }
 
-std::vector<LedgerKey>
-generateValidUniqueLedgerKeysWithTypes(
+std::vector<LedgerKey> generateValidUniqueLedgerKeysWithTypes(
     std::unordered_set<LedgerEntryType> const& types, size_t n,
     UnorderedSet<LedgerKey>& seenKeys)
 {
@@ -857,7 +822,6 @@ generateValidUniqueLedgerKeysWithTypes(
     res.reserve(n);
     while (res.size() < n)
     {
-
         auto entry = generateValidLedgerEntryWithTypes(types);
         auto key = LedgerEntryKey(entry);
         if (seenKeys.find(key) != seenKeys.end())
@@ -871,8 +835,7 @@ generateValidUniqueLedgerKeysWithTypes(
     return res;
 }
 
-std::vector<LedgerEntry>
-generateValidUniqueLedgerEntriesWithTypes(
+std::vector<LedgerEntry> generateValidUniqueLedgerEntriesWithTypes(
     std::unordered_set<LedgerEntryType> const& types, size_t n)
 {
     UnorderedSet<LedgerKey> keys;
@@ -894,8 +857,7 @@ generateValidUniqueLedgerEntriesWithTypes(
     return entries;
 }
 
-std::vector<LedgerEntry>
-generateValidUniqueLedgerEntriesWithTypes(
+std::vector<LedgerEntry> generateValidUniqueLedgerEntriesWithTypes(
     std::unordered_set<LedgerEntryType> const& types, size_t n,
     UnorderedSet<LedgerKey>& seenKeys)
 {
@@ -916,21 +878,18 @@ generateValidUniqueLedgerEntriesWithTypes(
     return entries;
 }
 
-AccountEntry
-generateValidAccountEntry(size_t b)
+AccountEntry generateValidAccountEntry(size_t b)
 {
     return validAccountEntryGenerator(b);
 }
 
-std::vector<AccountEntry>
-generateValidAccountEntries(size_t n)
+std::vector<AccountEntry> generateValidAccountEntries(size_t n)
 {
     static auto vecgen = autocheck::list_of(validAccountEntryGenerator);
     return vecgen(n);
 }
 
-TrustLineEntry
-generateNonPoolShareValidTrustLineEntry(size_t b)
+TrustLineEntry generateNonPoolShareValidTrustLineEntry(size_t b)
 {
     auto tl = validTrustLineEntryGenerator(b);
     if (tl.asset.type() == ASSET_TYPE_POOL_SHARE)
@@ -942,47 +901,40 @@ generateNonPoolShareValidTrustLineEntry(size_t b)
     return tl;
 }
 
-TrustLineEntry
-generateValidTrustLineEntry(size_t b)
+TrustLineEntry generateValidTrustLineEntry(size_t b)
 {
     return validTrustLineEntryGenerator(b);
 }
 
-std::vector<TrustLineEntry>
-generateValidTrustLineEntries(size_t n)
+std::vector<TrustLineEntry> generateValidTrustLineEntries(size_t n)
 {
     static auto vecgen = autocheck::list_of(validTrustLineEntryGenerator);
     return vecgen(n);
 }
 
-OfferEntry
-generateValidOfferEntry(size_t b)
+OfferEntry generateValidOfferEntry(size_t b)
 {
     return validOfferEntryGenerator(b);
 }
 
-std::vector<OfferEntry>
-generateValidOfferEntries(size_t n)
+std::vector<OfferEntry> generateValidOfferEntries(size_t n)
 {
     static auto vecgen = autocheck::list_of(validOfferEntryGenerator);
     return vecgen(n);
 }
 
-DataEntry
-generateValidDataEntry(size_t b)
+DataEntry generateValidDataEntry(size_t b)
 {
     return validDataEntryGenerator(b);
 }
 
-std::vector<DataEntry>
-generateValidDataEntries(size_t n)
+std::vector<DataEntry> generateValidDataEntries(size_t n)
 {
     static auto vecgen = autocheck::list_of(validDataEntryGenerator);
     return vecgen(n);
 }
 
-ClaimableBalanceEntry
-generateValidClaimableBalanceEntry(size_t b)
+ClaimableBalanceEntry generateValidClaimableBalanceEntry(size_t b)
 {
     return validClaimableBalanceEntryGenerator(b);
 }
@@ -995,73 +947,62 @@ generateValidClaimableBalanceEntries(size_t n)
     return vecgen(n);
 }
 
-LiquidityPoolEntry
-generateValidLiquidityPoolEntry(size_t b)
+LiquidityPoolEntry generateValidLiquidityPoolEntry(size_t b)
 {
     return validLiquidityPoolEntryGenerator(b);
 }
 
-std::vector<LiquidityPoolEntry>
-generateValidLiquidityPoolEntries(size_t n)
+std::vector<LiquidityPoolEntry> generateValidLiquidityPoolEntries(size_t n)
 {
     static auto vecgen = autocheck::list_of(validLiquidityPoolEntryGenerator);
     return vecgen(n);
 }
 
-ConfigSettingEntry
-generateValidConfigSettingEntry(size_t b)
+ConfigSettingEntry generateValidConfigSettingEntry(size_t b)
 {
     return validConfigSettingEntryGenerator(b);
 }
 
-std::vector<ConfigSettingEntry>
-generateValidConfigSettingEntries(size_t n)
+std::vector<ConfigSettingEntry> generateValidConfigSettingEntries(size_t n)
 {
     static auto vecgen = autocheck::list_of(validConfigSettingEntryGenerator);
     return vecgen(n);
 }
 
-ContractDataEntry
-generateValidContractDataEntry(size_t b)
+ContractDataEntry generateValidContractDataEntry(size_t b)
 {
     return validContractDataEntryGenerator(b);
 }
 
-std::vector<ContractDataEntry>
-generateValidContractDataEntries(size_t n)
+std::vector<ContractDataEntry> generateValidContractDataEntries(size_t n)
 {
     static auto vecgen = autocheck::list_of(validContractDataEntryGenerator);
     return vecgen(n);
 }
 
-ContractCodeEntry
-generateValidContractCodeEntry(size_t b)
+ContractCodeEntry generateValidContractCodeEntry(size_t b)
 {
     return validContractCodeEntryGenerator(b);
 }
 
-std::vector<ContractCodeEntry>
-generateValidContractCodeEntries(size_t n)
+std::vector<ContractCodeEntry> generateValidContractCodeEntries(size_t n)
 {
     static auto vecgen = autocheck::list_of(validContractCodeEntryGenerator);
     return vecgen(n);
 }
 
-TTLEntry
-generateValidTTLEntry(size_t b)
+TTLEntry generateValidTTLEntry(size_t b)
 {
     return validTTLEntryGenerator(b);
 }
 
-std::vector<TTLEntry>
-generateValidTTLEntries(size_t n)
+std::vector<TTLEntry> generateValidTTLEntries(size_t n)
 {
     static auto vecgen = autocheck::list_of(validTTLEntryGenerator);
     return vecgen(n);
 }
 
-std::vector<LedgerHeaderHistoryEntry>
-generateLedgerHeadersForCheckpoint(
+std::vector<LedgerHeaderHistoryEntry> generateLedgerHeadersForCheckpoint(
     LedgerHeaderHistoryEntry firstLedger, uint32_t size,
     HistoryManager::LedgerVerificationStatus state)
 {
@@ -1072,8 +1013,7 @@ generateLedgerHeadersForCheckpoint(
     return res;
 }
 
-UpgradeType
-toUpgradeType(LedgerUpgrade const& upgrade)
+UpgradeType toUpgradeType(LedgerUpgrade const& upgrade)
 {
     auto v = xdr::xdr_to_opaque(upgrade);
     auto result = UpgradeType{v.begin(), v.end()};

--- a/src/ledger/test/LedgerTxnTests.cpp
+++ b/src/ledger/test/LedgerTxnTests.cpp
@@ -63,8 +63,7 @@ validate(AbstractLedgerTxn& ltx,
     REQUIRE(iter == delta.entry.end());
 }
 
-static LedgerEntry
-generateLedgerEntryWithSameKey(LedgerEntry const& leBase)
+static LedgerEntry generateLedgerEntryWithSameKey(LedgerEntry const& leBase)
 {
     LedgerEntry le;
     le.data.type(leBase.data.type());
@@ -1045,8 +1044,7 @@ TEST_CASE("LedgerTxn eraseWithoutLoading", "[ledgertxn]")
 #endif
 }
 
-static void
-applyLedgerTxnUpdates(
+static void applyLedgerTxnUpdates(
     AbstractLedgerTxn& ltx,
     std::map<AccountID, std::pair<AccountID, int64_t>> const& updates)
 {
@@ -1081,8 +1079,7 @@ applyLedgerTxnUpdates(
     }
 }
 
-static void
-testInflationWinners(
+static void testInflationWinners(
     AbstractLedgerTxnParent& ltxParent, size_t maxWinners, int64_t minBalance,
     std::vector<std::tuple<AccountID, int64_t>> const& expected,
     std::vector<std::map<AccountID,
@@ -1115,8 +1112,7 @@ testInflationWinners(
     }
 }
 
-static void
-testInflationWinners(
+static void testInflationWinners(
     size_t maxWinners, int64_t minBalance,
     std::vector<std::tuple<AccountID, int64_t>> const& expected,
     std::vector<std::map<AccountID, std::pair<AccountID, int64_t>>> const&
@@ -1668,8 +1664,7 @@ TEST_CASE("LedgerTxn loadWithoutRecord", "[ledgertxn]")
     }
 }
 
-static void
-applyLedgerTxnUpdates(
+static void applyLedgerTxnUpdates(
     AbstractLedgerTxn& ltx,
     std::map<std::pair<AccountID, int64_t>,
              std::tuple<Asset, Asset, int64_t>> const& updates)
@@ -1703,8 +1698,7 @@ applyLedgerTxnUpdates(
     }
 }
 
-static void
-testAllOffers(
+static void testAllOffers(
     AbstractLedgerTxnParent& ltxParent,
     std::map<AccountID,
              std::vector<std::tuple<int64_t, Asset, Asset, int64_t>>> const&
@@ -1756,8 +1750,7 @@ testAllOffers(
     }
 }
 
-static void
-testAllOffers(
+static void testAllOffers(
     std::map<AccountID,
              std::vector<std::tuple<int64_t, Asset, Asset, int64_t>>> const&
         expected,
@@ -1963,8 +1956,7 @@ TEST_CASE("LedgerTxn loadAllOffers", "[ledgertxn]")
 #endif
 }
 
-static void
-applyLedgerTxnUpdates(
+static void applyLedgerTxnUpdates(
     AbstractLedgerTxn& ltx,
     std::map<std::pair<AccountID, int64_t>,
              std::tuple<Asset, Asset, Price, int64_t>> const& updates)
@@ -1998,8 +1990,7 @@ applyLedgerTxnUpdates(
     }
 }
 
-static void
-testBestOffer(
+static void testBestOffer(
     AbstractLedgerTxnParent& ltxParent, Asset const& buying,
     Asset const& selling,
     std::vector<std::tuple<int64_t, Asset, Asset, Price, int64_t>> const&
@@ -2037,8 +2028,7 @@ testBestOffer(
     }
 }
 
-static void
-testBestOffer(
+static void testBestOffer(
     Asset const& buying, Asset const& selling,
     std::vector<std::tuple<int64_t, Asset, Asset, Price, int64_t>> const&
         expected,
@@ -2394,8 +2384,7 @@ TEST_CASE("LedgerTxn loadBestOffer", "[ledgertxn]")
 #endif
 }
 
-static void
-testOffersByAccountAndAsset(
+static void testOffersByAccountAndAsset(
     AbstractLedgerTxnParent& ltxParent, AccountID const& accountID,
     Asset const& asset,
     std::vector<std::tuple<int64_t, Asset, Asset, int64_t>> const& expected,
@@ -2433,8 +2422,7 @@ testOffersByAccountAndAsset(
     }
 }
 
-static void
-testOffersByAccountAndAsset(
+static void testOffersByAccountAndAsset(
     AccountID const& accountID, Asset const& asset,
     std::vector<std::tuple<int64_t, Asset, Asset, int64_t>> const& expected,
     std::vector<std::map<std::pair<AccountID, int64_t>,
@@ -3129,8 +3117,7 @@ typedef UnorderedMap<
     AssetPairHash>
     SortedOrderBook;
 
-static void
-checkOrderBook(LedgerTxn& ltx, OrderBook const& expected)
+static void checkOrderBook(LedgerTxn& ltx, OrderBook const& expected)
 {
     SortedOrderBook sortedExpected;
     for (auto const& kv : expected)
@@ -3163,8 +3150,7 @@ checkOrderBook(LedgerTxn& ltx, OrderBook const& expected)
     check(sortedExpected, ltxOb);
 }
 
-static LedgerEntry
-generateOfferWithSameAssets(LedgerEntry const& leBase)
+static LedgerEntry generateOfferWithSameAssets(LedgerEntry const& leBase)
 {
     LedgerEntry le;
     le.data.type(OFFER);
@@ -3175,8 +3161,7 @@ generateOfferWithSameAssets(LedgerEntry const& leBase)
     return le;
 }
 
-static LedgerEntry
-generateOfferWithSameKeyAndAssets(LedgerEntry const& leBase)
+static LedgerEntry generateOfferWithSameKeyAndAssets(LedgerEntry const& leBase)
 {
     LedgerEntry le = generateLedgerEntryWithSameKey(leBase);
     auto& oe = le.data.offer();
@@ -3794,15 +3779,14 @@ TEST_CASE("LedgerTxn best offers cache eviction", "[ledgertxn]")
 typedef std::map<std::tuple<AccountID, Asset, Asset>, int64_t> PoolShareUpdates;
 typedef std::map<std::pair<Asset, Asset>, int64_t> LiquidityPoolUpdates;
 
-static PoolID
-getPoolID(Asset const& assetA, Asset const& assetB)
+static PoolID getPoolID(Asset const& assetA, Asset const& assetB)
 {
     return sha256(xdr::xdr_to_opaque(LIQUIDITY_POOL_CONSTANT_PRODUCT, assetA,
                                      assetB, LIQUIDITY_POOL_FEE_V18));
 }
 
-static void
-applyLedgerTxnUpdates(AbstractLedgerTxn& ltx, PoolShareUpdates const& updates)
+static void applyLedgerTxnUpdates(AbstractLedgerTxn& ltx,
+                                  PoolShareUpdates const& updates)
 {
     for (auto const& kv : updates)
     {
@@ -3839,9 +3823,8 @@ applyLedgerTxnUpdates(AbstractLedgerTxn& ltx, PoolShareUpdates const& updates)
     }
 }
 
-static void
-applyLedgerTxnUpdates(AbstractLedgerTxn& ltx,
-                      LiquidityPoolUpdates const& updates)
+static void applyLedgerTxnUpdates(AbstractLedgerTxn& ltx,
+                                  LiquidityPoolUpdates const& updates)
 {
     for (auto const& kv : updates)
     {
@@ -3881,8 +3864,7 @@ applyLedgerTxnUpdates(AbstractLedgerTxn& ltx,
     }
 }
 
-static void
-testPoolShareTrustLinesByAccountAndAsset(
+static void testPoolShareTrustLinesByAccountAndAsset(
     AbstractLedgerTxnParent& ltxParent, AccountID const& accountID,
     Asset const& asset,
     std::vector<std::tuple<Asset, Asset, int64_t>> const& expected,
@@ -3924,8 +3906,7 @@ testPoolShareTrustLinesByAccountAndAsset(
     }
 }
 
-static void
-testPoolShareTrustLinesByAccountAndAsset(
+static void testPoolShareTrustLinesByAccountAndAsset(
     AccountID const& accountID, Asset const& asset,
     std::vector<std::tuple<Asset, Asset, int64_t>> const& expected,
     std::vector<std::pair<PoolShareUpdates, LiquidityPoolUpdates>> updates)

--- a/src/main/AppConnector.cpp
+++ b/src/main/AppConnector.cpp
@@ -19,29 +19,25 @@ AppConnector::AppConnector(Application& app)
 {
 }
 
-Herder&
-AppConnector::getHerder()
+Herder& AppConnector::getHerder()
 {
     releaseAssert(threadIsMain());
     return mApp.getHerder();
 }
 
-LedgerManager&
-AppConnector::getLedgerManager()
+LedgerManager& AppConnector::getLedgerManager()
 {
     releaseAssert(threadIsMain());
     return mApp.getLedgerManager();
 }
 
-OverlayManager&
-AppConnector::getOverlayManager()
+OverlayManager& AppConnector::getOverlayManager()
 {
     releaseAssert(threadIsMain());
     return mApp.getOverlayManager();
 }
 
-BanManager&
-AppConnector::getBanManager()
+BanManager& AppConnector::getBanManager()
 {
     releaseAssert(threadIsMain());
     return mApp.getBanManager();
@@ -54,110 +50,94 @@ AppConnector::getLastClosedSorobanNetworkConfig() const
     return mApp.getLedgerManager().getLastClosedSorobanNetworkConfig();
 }
 
-medida::MetricsRegistry&
-AppConnector::getMetrics() const
+medida::MetricsRegistry& AppConnector::getMetrics() const
 {
     return mApp.getMetrics();
 }
 
-SorobanMetrics&
-AppConnector::getSorobanMetrics() const
+SorobanMetrics& AppConnector::getSorobanMetrics() const
 {
     return mApp.getLedgerManager().getSorobanMetrics();
 }
 
-void
-AppConnector::checkOnOperationApply(Operation const& operation,
-                                    OperationResult const& opres,
-                                    LedgerTxnDelta const& ltxDelta,
-                                    std::vector<ContractEvent> const& events)
+void AppConnector::checkOnOperationApply(
+    Operation const& operation, OperationResult const& opres,
+    LedgerTxnDelta const& ltxDelta, std::vector<ContractEvent> const& events)
 {
     mApp.getInvariantManager().checkOnOperationApply(operation, opres, ltxDelta,
                                                      events, *this);
 }
 
-Hash const&
-AppConnector::getNetworkID() const
+Hash const& AppConnector::getNetworkID() const
 {
     // NetworkID is a const
     return mApp.getNetworkID();
 }
 
-void
-AppConnector::postOnMainThread(std::function<void()>&& f, std::string&& message,
-                               Scheduler::ActionType type)
+void AppConnector::postOnMainThread(std::function<void()>&& f,
+                                    std::string&& message,
+                                    Scheduler::ActionType type)
 {
     mApp.postOnMainThread(std::move(f), std::move(message), type);
 }
 
-void
-AppConnector::postOnOverlayThread(std::function<void()>&& f,
-                                  std::string const& message)
+void AppConnector::postOnOverlayThread(std::function<void()>&& f,
+                                       std::string const& message)
 {
     mApp.postOnOverlayThread(std::move(f), message);
 }
 
-void
-AppConnector::postOnBackgroundThread(std::function<void()>&& f,
-                                     std::string const& jobName)
+void AppConnector::postOnBackgroundThread(std::function<void()>&& f,
+                                          std::string const& jobName)
 {
     mApp.postOnBackgroundThread(std::move(f), jobName);
 }
 
-void
-AppConnector::postOnEvictionBackgroundThread(std::function<void()>&& f,
-                                             std::string const& jobName)
+void AppConnector::postOnEvictionBackgroundThread(std::function<void()>&& f,
+                                                  std::string const& jobName)
 {
     mApp.postOnEvictionBackgroundThread(std::move(f), jobName);
 }
 
-Config const&
-AppConnector::getConfig() const
+Config const& AppConnector::getConfig() const
 {
     return mConfig;
 }
 
-rust::Box<rust_bridge::SorobanModuleCache>
-AppConnector::getModuleCache()
+rust::Box<rust_bridge::SorobanModuleCache> AppConnector::getModuleCache()
 {
     return mApp.getLedgerManager().getModuleCache();
 }
 
-bool
-AppConnector::overlayShuttingDown() const
+bool AppConnector::overlayShuttingDown() const
 {
     return mApp.getOverlayManager().isShuttingDown();
 }
 
-VirtualClock::time_point
-AppConnector::now() const
+VirtualClock::time_point AppConnector::now() const
 {
     return mApp.getClock().now();
 }
 
-bool
-AppConnector::shouldYield() const
+bool AppConnector::shouldYield() const
 {
     releaseAssert(threadIsMain());
     return mApp.getClock().shouldYield();
 }
 
-OverlayMetrics&
-AppConnector::getOverlayMetrics()
+OverlayMetrics& AppConnector::getOverlayMetrics()
 {
     // OverlayMetrics class is thread-safe
     return mApp.getOverlayManager().getOverlayMetrics();
 }
 
-bool
-AppConnector::checkScheduledAndCache(
+bool AppConnector::checkScheduledAndCache(
     std::shared_ptr<CapacityTrackedMessage> msgTracker)
 {
     return mApp.getOverlayManager().checkScheduledAndCache(msgTracker);
 }
 
-bool
-AppConnector::threadIsType(Application::ThreadType type) const
+bool AppConnector::threadIsType(Application::ThreadType type) const
 {
     return mApp.threadIsType(type);
 }
@@ -170,16 +150,14 @@ AppConnector::copySearchableHotArchiveBucketListSnapshot()
         .copySearchableHotArchiveBucketListSnapshot();
 }
 
-SearchableSnapshotConstPtr
-AppConnector::copySearchableLiveBucketListSnapshot()
+SearchableSnapshotConstPtr AppConnector::copySearchableLiveBucketListSnapshot()
 {
     return mApp.getBucketManager()
         .getBucketSnapshotManager()
         .copySearchableLiveBucketListSnapshot();
 }
 
-void
-AppConnector::maybeCopySearchableBucketListSnapshot(
+void AppConnector::maybeCopySearchableBucketListSnapshot(
     SearchableSnapshotConstPtr& snapshot)
 {
     mApp.getBucketManager()
@@ -187,8 +165,7 @@ AppConnector::maybeCopySearchableBucketListSnapshot(
         .maybeCopySearchableBucketListSnapshot(snapshot);
 }
 
-SearchableSnapshotConstPtr&
-AppConnector::getOverlayThreadSnapshot()
+SearchableSnapshotConstPtr& AppConnector::getOverlayThreadSnapshot()
 {
     return mApp.getOverlayManager().getOverlayThreadSnapshot();
 }
@@ -206,8 +183,7 @@ AppConnector::getProtocol23CorruptionEventReconciler()
 }
 
 #ifdef BUILD_TESTS
-bool
-AppConnector::getRunInOverlayOnlyMode() const
+bool AppConnector::getRunInOverlayOnlyMode() const
 {
     return mApp.getRunInOverlayOnlyMode();
 }

--- a/src/main/AppConnector.h
+++ b/src/main/AppConnector.h
@@ -60,8 +60,8 @@ class AppConnector
     bool overlayShuttingDown() const;
     OverlayMetrics& getOverlayMetrics();
     // This method is always exclusively called from one thread
-    bool
-    checkScheduledAndCache(std::shared_ptr<CapacityTrackedMessage> msgTracker);
+    bool checkScheduledAndCache(
+        std::shared_ptr<CapacityTrackedMessage> msgTracker);
     SorobanNetworkConfig const& getLastClosedSorobanNetworkConfig() const;
     bool threadIsType(Application::ThreadType type) const;
 
@@ -72,8 +72,8 @@ class AppConnector
     SearchableSnapshotConstPtr copySearchableLiveBucketListSnapshot();
 
     // Refreshes `snapshot` if a newer snapshot is available. No-op otherwise.
-    void
-    maybeCopySearchableBucketListSnapshot(SearchableSnapshotConstPtr& snapshot);
+    void maybeCopySearchableBucketListSnapshot(
+        SearchableSnapshotConstPtr& snapshot);
 
     // Get a snapshot of ledger state for use by the overlay thread only. Must
     // only be called from the overlay thread.

--- a/src/main/Application.cpp
+++ b/src/main/Application.cpp
@@ -12,8 +12,7 @@ namespace stellar
 {
 using namespace std;
 
-void
-validateNetworkPassphrase(Application::pointer app)
+void validateNetworkPassphrase(Application::pointer app)
 {
     std::string networkPassphrase = app->getConfig().NETWORK_PASSPHRASE;
     if (networkPassphrase.empty())
@@ -39,9 +38,8 @@ validateNetworkPassphrase(Application::pointer app)
     }
 }
 
-Application::pointer
-Application::create(VirtualClock& clock, Config const& cfg, bool newDB,
-                    bool forceRebuild)
+Application::pointer Application::create(VirtualClock& clock, Config const& cfg,
+                                         bool newDB, bool forceRebuild)
 {
     return create<ApplicationImpl>(clock, cfg, newDB, forceRebuild);
 }

--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -345,9 +345,9 @@ class Application
     static pointer create(VirtualClock& clock, Config const& cfg,
                           bool newDB = true, bool forceRebuild = false);
     template <typename T, typename... Args>
-    static std::shared_ptr<T>
-    create(VirtualClock& clock, Config const& cfg, Args&&... args,
-           bool newDB = true, bool forceRebuild = false)
+    static std::shared_ptr<T> create(VirtualClock& clock, Config const& cfg,
+                                     Args&&... args, bool newDB = true,
+                                     bool forceRebuild = false)
     {
         auto ret = std::make_shared<T>(clock, cfg, std::forward<Args>(args)...);
         ret->initialize(newDB, forceRebuild);

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -208,8 +208,7 @@ ApplicationImpl::ApplicationImpl(VirtualClock& clock, Config const& cfg)
     }
 }
 
-static void
-maybeRebuildLedger(Application& app, bool applyBuckets)
+static void maybeRebuildLedger(Application& app, bool applyBuckets)
 {
     auto& ps = app.getPersistentState();
     if (ps.shouldRebuildForOfferTable())
@@ -241,8 +240,7 @@ maybeRebuildLedger(Application& app, bool applyBuckets)
     ps.clearRebuildForOfferTable();
 }
 
-void
-ApplicationImpl::initialize(bool createNewDB, bool forceRebuild)
+void ApplicationImpl::initialize(bool createNewDB, bool forceRebuild)
 {
     // Subtle: initialize the bucket manager first before initializing the
     // database. This is needed as some modes in core (such as in-memory) use a
@@ -347,8 +345,7 @@ ApplicationImpl::initialize(bool createNewDB, bool forceRebuild)
     LOG_DEBUG(DEFAULT_LOG, "Application constructed");
 }
 
-void
-ApplicationImpl::resetLedgerState()
+void ApplicationImpl::resetLedgerState()
 {
 #ifdef BUILD_TESTS
     mRootAccount.reset();
@@ -371,17 +368,15 @@ ApplicationImpl::resetLedgerState()
     }
 }
 
-void
-ApplicationImpl::newDB()
+void ApplicationImpl::newDB()
 {
     mDatabase->initialize();
     upgradeToCurrentSchemaAndMaybeRebuildLedger(false, true);
     mLedgerManager->startNewLedger();
 }
 
-void
-ApplicationImpl::upgradeToCurrentSchemaAndMaybeRebuildLedger(bool applyBuckets,
-                                                             bool forceRebuild)
+void ApplicationImpl::upgradeToCurrentSchemaAndMaybeRebuildLedger(
+    bool applyBuckets, bool forceRebuild)
 {
     if (forceRebuild)
     {
@@ -393,8 +388,7 @@ ApplicationImpl::upgradeToCurrentSchemaAndMaybeRebuildLedger(bool applyBuckets,
     maybeRebuildLedger(*this, applyBuckets);
 }
 
-void
-ApplicationImpl::reportCfgMetrics()
+void ApplicationImpl::reportCfgMetrics()
 {
     if (!mMetrics)
     {
@@ -456,8 +450,7 @@ ApplicationImpl::reportCfgMetrics()
     }
 }
 
-Json::Value
-ApplicationImpl::getJsonInfo(bool verbose)
+Json::Value ApplicationImpl::getJsonInfo(bool verbose)
 {
     auto root = Json::Value{};
 
@@ -553,8 +546,7 @@ ApplicationImpl::getJsonInfo(bool verbose)
     return root;
 }
 
-void
-ApplicationImpl::reportInfo(bool verbose)
+void ApplicationImpl::reportInfo(bool verbose)
 {
     mLedgerManager->partiallyLoadLastKnownLedgerForUtils();
     LOG_INFO(DEFAULT_LOG, "Reporting application info");
@@ -622,8 +614,7 @@ ApplicationImpl::scheduleSelfCheck(bool waitUntilNextCheckpoint)
     return ptr;
 }
 
-Hash const&
-ApplicationImpl::getNetworkID() const
+Hash const& ApplicationImpl::getNetworkID() const
 {
     return mNetworkID;
 }
@@ -645,14 +636,12 @@ ApplicationImpl::~ApplicationImpl()
     LOG_INFO(DEFAULT_LOG, "Application destroyed");
 }
 
-uint64_t
-ApplicationImpl::timeNow()
+uint64_t ApplicationImpl::timeNow()
 {
     return VirtualClock::to_time_t(getClock().system_now());
 }
 
-void
-ApplicationImpl::validateAndLogConfig()
+void ApplicationImpl::validateAndLogConfig()
 {
     if (mConfig.FORCE_SCP && !mConfig.NODE_IS_VALIDATOR)
     {
@@ -759,8 +748,7 @@ ApplicationImpl::validateAndLogConfig()
     mConfig.logBasicInfo();
 }
 
-void
-ApplicationImpl::startServices()
+void ApplicationImpl::startServices()
 {
     mInvariantManager->start(*mLedgerManager);
 
@@ -796,8 +784,7 @@ ApplicationImpl::startServices()
     }
 }
 
-void
-ApplicationImpl::start()
+void ApplicationImpl::start()
 {
     if (mStarted)
     {
@@ -821,8 +808,7 @@ ApplicationImpl::start()
     startServices();
 }
 
-void
-ApplicationImpl::idempotentShutdown(bool forgetBuckets)
+void ApplicationImpl::idempotentShutdown(bool forgetBuckets)
 {
     // Graceful shutdown sequence:
     // Perform a graceful shutdown by first signaling all managers to stop
@@ -870,8 +856,7 @@ ApplicationImpl::idempotentShutdown(bool forgetBuckets)
     joinAllThreads();
 }
 
-void
-ApplicationImpl::gracefulStop()
+void ApplicationImpl::gracefulStop()
 {
     releaseAssert(threadIsMain());
     if (mStopping)
@@ -889,14 +874,12 @@ ApplicationImpl::gracefulStop()
         VirtualTimer::onFailureNoop);
 }
 
-void
-ApplicationImpl::shutdownMainIOContext()
+void ApplicationImpl::shutdownMainIOContext()
 {
     mVirtualClock.shutdown();
 }
 
-void
-ApplicationImpl::shutdownWorkScheduler()
+void ApplicationImpl::shutdownWorkScheduler()
 {
     if (mWorkScheduler)
     {
@@ -904,8 +887,7 @@ ApplicationImpl::shutdownWorkScheduler()
     }
 }
 
-bool
-ApplicationImpl::shutdownThread(
+bool ApplicationImpl::shutdownThread(
     std::unique_ptr<std::thread>& threadPtr,
     std::unique_ptr<asio::io_context::work>& workPtr,
     std::string const& threadName)
@@ -928,8 +910,7 @@ ApplicationImpl::shutdownThread(
     return false;
 }
 
-void
-ApplicationImpl::joinAllThreads()
+void ApplicationImpl::joinAllThreads()
 {
     uint32_t joined = 0;
     joined +=
@@ -1021,8 +1002,7 @@ ApplicationImpl::manualClose(std::optional<uint32_t> const& manualLedgerSeq,
         "trigger consensus. Ensure NODE_IS_VALIDATOR is set to true.");
 }
 
-uint32_t
-ApplicationImpl::targetManualCloseLedgerSeqNum(
+uint32_t ApplicationImpl::targetManualCloseLedgerSeqNum(
     std::optional<uint32_t> const& explicitlyProvidedSeqNum)
 {
     auto const startLedgerSeq = getLedgerManager().getLastClosedLedgerNum();
@@ -1065,8 +1045,7 @@ ApplicationImpl::targetManualCloseLedgerSeqNum(
     return explicitlyProvidedSeqNum ? *explicitlyProvidedSeqNum : nextLedgerSeq;
 }
 
-void
-ApplicationImpl::setManualCloseVirtualTime(
+void ApplicationImpl::setManualCloseVirtualTime(
     std::optional<TimePoint> const& explicitlyProvidedCloseTime)
 {
     TimePoint constexpr firstSecondOfYear2200GMT = 7'258'118'400ULL;
@@ -1122,8 +1101,7 @@ ApplicationImpl::setManualCloseVirtualTime(
     getClock().setCurrentVirtualTime(VirtualClock::from_time_t(nextCloseTime));
 }
 
-void
-ApplicationImpl::advanceToLedgerBeforeManualCloseTarget(
+void ApplicationImpl::advanceToLedgerBeforeManualCloseTarget(
     uint32_t const& targetLedgerSeq)
 {
     if (targetLedgerSeq != getLedgerManager().getLastClosedLedgerNum() + 1)
@@ -1146,15 +1124,13 @@ ApplicationImpl::advanceToLedgerBeforeManualCloseTarget(
 }
 
 #ifdef BUILD_TESTS
-void
-ApplicationImpl::generateLoad(GeneratedLoadConfig cfg)
+void ApplicationImpl::generateLoad(GeneratedLoadConfig cfg)
 {
     getMetrics().NewMeter({"loadgen", "run", "start"}, "run").Mark();
     getLoadGenerator().generateLoad(cfg);
 }
 
-LoadGenerator&
-ApplicationImpl::getLoadGenerator()
+LoadGenerator& ApplicationImpl::getLoadGenerator()
 {
     if (!mLoadGenerator)
     {
@@ -1163,8 +1139,7 @@ ApplicationImpl::getLoadGenerator()
     return *mLoadGenerator;
 }
 
-std::shared_ptr<TestAccount>
-ApplicationImpl::getRoot()
+std::shared_ptr<TestAccount> ApplicationImpl::getRoot()
 {
     if (!mRootAccount)
     {
@@ -1175,21 +1150,18 @@ ApplicationImpl::getRoot()
     return mRootAccount;
 }
 
-bool
-ApplicationImpl::getRunInOverlayOnlyMode() const
+bool ApplicationImpl::getRunInOverlayOnlyMode() const
 {
     return mRunInOverlayOnlyMode;
 }
 
-void
-ApplicationImpl::setRunInOverlayOnlyMode(bool mode)
+void ApplicationImpl::setRunInOverlayOnlyMode(bool mode)
 {
     mRunInOverlayOnlyMode = mode;
 }
 #endif
 
-void
-ApplicationImpl::applyCfgCommands()
+void ApplicationImpl::applyCfgCommands()
 {
     for (auto cmd : mConfig.COMMANDS)
     {
@@ -1197,14 +1169,12 @@ ApplicationImpl::applyCfgCommands()
     }
 }
 
-Config const&
-ApplicationImpl::getConfig()
+Config const& ApplicationImpl::getConfig()
 {
     return mConfig;
 }
 
-Application::State
-ApplicationImpl::getState() const
+Application::State ApplicationImpl::getState() const
 {
     State s;
 
@@ -1242,8 +1212,7 @@ ApplicationImpl::getState() const
     return s;
 }
 
-std::string
-ApplicationImpl::getStateHuman() const
+std::string ApplicationImpl::getStateHuman() const
 {
     static std::array<const char*, APP_NUM_STATE> stateStrings =
         std::array{"Booting",     "Joining SCP", "Connected",
@@ -1251,34 +1220,29 @@ ApplicationImpl::getStateHuman() const
     return std::string(stateStrings[getState()]);
 }
 
-bool
-ApplicationImpl::isStopping() const
+bool ApplicationImpl::isStopping() const
 {
     return mStopping;
 }
 
-VirtualClock&
-ApplicationImpl::getClock()
+VirtualClock& ApplicationImpl::getClock()
 {
     return mVirtualClock;
 }
 
-medida::MetricsRegistry&
-ApplicationImpl::getMetrics()
+medida::MetricsRegistry& ApplicationImpl::getMetrics()
 {
     return *mMetrics;
 }
 
-bool
-ApplicationImpl::threadIsType(ThreadType type) const
+bool ApplicationImpl::threadIsType(ThreadType type) const
 {
     auto it = mThreadTypes.find(std::this_thread::get_id());
     releaseAssert(it != mThreadTypes.end());
     return it->second == type;
 }
 
-void
-ApplicationImpl::syncOwnMetrics()
+void ApplicationImpl::syncOwnMetrics()
 {
     // Flush crypto pure-global-cache stats. They don't belong
     // to a single app instance but first one to flush will claim
@@ -1318,8 +1282,7 @@ ApplicationImpl::syncOwnMetrics()
         .set_count(fs::getOpenHandleCount());
 }
 
-void
-ApplicationImpl::syncAllMetrics()
+void ApplicationImpl::syncAllMetrics()
 {
     mHerder->syncMetrics();
     mLedgerManager->syncMetrics();
@@ -1327,8 +1290,7 @@ ApplicationImpl::syncAllMetrics()
     syncOwnMetrics();
 }
 
-void
-ApplicationImpl::clearMetrics(std::string const& domain)
+void ApplicationImpl::clearMetrics(std::string const& domain)
 {
     MetricResetter resetter;
     auto const& metrics = mMetrics->GetAllMetrics();
@@ -1341,144 +1303,122 @@ ApplicationImpl::clearMetrics(std::string const& domain)
     }
 }
 
-TmpDirManager&
-ApplicationImpl::getTmpDirManager()
+TmpDirManager& ApplicationImpl::getTmpDirManager()
 {
     return getBucketManager().getTmpDirManager();
 }
 
-LedgerManager&
-ApplicationImpl::getLedgerManager()
+LedgerManager& ApplicationImpl::getLedgerManager()
 {
     return *mLedgerManager;
 }
 
-BucketManager&
-ApplicationImpl::getBucketManager()
+BucketManager& ApplicationImpl::getBucketManager()
 {
     return *mBucketManager;
 }
 
-LedgerApplyManager&
-ApplicationImpl::getLedgerApplyManager()
+LedgerApplyManager& ApplicationImpl::getLedgerApplyManager()
 {
     return *mLedgerApplyManager;
 }
 
-HistoryArchiveManager&
-ApplicationImpl::getHistoryArchiveManager()
+HistoryArchiveManager& ApplicationImpl::getHistoryArchiveManager()
 {
     return *mHistoryArchiveManager;
 }
 
-HistoryManager&
-ApplicationImpl::getHistoryManager()
+HistoryManager& ApplicationImpl::getHistoryManager()
 {
     return *mHistoryManager;
 }
 
-Maintainer&
-ApplicationImpl::getMaintainer()
+Maintainer& ApplicationImpl::getMaintainer()
 {
     return *mMaintainer;
 }
 
-ProcessManager&
-ApplicationImpl::getProcessManager()
+ProcessManager& ApplicationImpl::getProcessManager()
 {
     return *mProcessManager;
 }
 
-Herder&
-ApplicationImpl::getHerder()
+Herder& ApplicationImpl::getHerder()
 {
     return *mHerder;
 }
 
-HerderPersistence&
-ApplicationImpl::getHerderPersistence()
+HerderPersistence& ApplicationImpl::getHerderPersistence()
 {
     return *mHerderPersistence;
 }
 
-InvariantManager&
-ApplicationImpl::getInvariantManager()
+InvariantManager& ApplicationImpl::getInvariantManager()
 {
     return *mInvariantManager;
 }
 
-OverlayManager&
-ApplicationImpl::getOverlayManager()
+OverlayManager& ApplicationImpl::getOverlayManager()
 {
     return *mOverlayManager;
 }
 
-Database&
-ApplicationImpl::getDatabase() const
+Database& ApplicationImpl::getDatabase() const
 {
     return *mDatabase;
 }
 
-PersistentState&
-ApplicationImpl::getPersistentState()
+PersistentState& ApplicationImpl::getPersistentState()
 {
     return *mPersistentState;
 }
 
-CommandHandler&
-ApplicationImpl::getCommandHandler()
+CommandHandler& ApplicationImpl::getCommandHandler()
 {
     return *mCommandHandler;
 }
 
-WorkScheduler&
-ApplicationImpl::getWorkScheduler()
+WorkScheduler& ApplicationImpl::getWorkScheduler()
 {
     return *mWorkScheduler;
 }
 
-BanManager&
-ApplicationImpl::getBanManager()
+BanManager& ApplicationImpl::getBanManager()
 {
     return *mBanManager;
 }
 
-StatusManager&
-ApplicationImpl::getStatusManager()
+StatusManager& ApplicationImpl::getStatusManager()
 {
     return *mStatusManager;
 }
 
-asio::io_context&
-ApplicationImpl::getWorkerIOContext()
+asio::io_context& ApplicationImpl::getWorkerIOContext()
 {
     return mWorkerIOContext;
 }
 
-asio::io_context&
-ApplicationImpl::getEvictionIOContext()
+asio::io_context& ApplicationImpl::getEvictionIOContext()
 {
     releaseAssert(mEvictionIOContext);
     return *mEvictionIOContext;
 }
 
-asio::io_context&
-ApplicationImpl::getOverlayIOContext()
+asio::io_context& ApplicationImpl::getOverlayIOContext()
 {
     releaseAssert(mOverlayIOContext);
     return *mOverlayIOContext;
 }
 
-asio::io_context&
-ApplicationImpl::getLedgerCloseIOContext()
+asio::io_context& ApplicationImpl::getLedgerCloseIOContext()
 {
     releaseAssert(mLedgerCloseIOContext);
     return *mLedgerCloseIOContext;
 }
 
-void
-ApplicationImpl::postOnMainThread(std::function<void()>&& f, std::string&& name,
-                                  Scheduler::ActionType type)
+void ApplicationImpl::postOnMainThread(std::function<void()>&& f,
+                                       std::string&& name,
+                                       Scheduler::ActionType type)
 {
     JITTER_INJECT_DELAY();
     LogSlowExecution isSlow{name, LogSlowExecution::Mode::MANUAL,
@@ -1499,9 +1439,8 @@ ApplicationImpl::postOnMainThread(std::function<void()>&& f, std::string&& name,
         std::move(name), type);
 }
 
-void
-ApplicationImpl::postOnBackgroundThread(std::function<void()>&& f,
-                                        std::string jobName)
+void ApplicationImpl::postOnBackgroundThread(std::function<void()>&& f,
+                                             std::string jobName)
 {
     JITTER_INJECT_DELAY();
     LogSlowExecution isSlow{std::move(jobName), LogSlowExecution::Mode::MANUAL,
@@ -1513,9 +1452,8 @@ ApplicationImpl::postOnBackgroundThread(std::function<void()>&& f,
     });
 }
 
-void
-ApplicationImpl::postOnEvictionBackgroundThread(std::function<void()>&& f,
-                                                std::string jobName)
+void ApplicationImpl::postOnEvictionBackgroundThread(std::function<void()>&& f,
+                                                     std::string jobName)
 {
     JITTER_INJECT_DELAY();
 
@@ -1528,9 +1466,8 @@ ApplicationImpl::postOnEvictionBackgroundThread(std::function<void()>&& f,
     });
 }
 
-void
-ApplicationImpl::postOnOverlayThread(std::function<void()>&& f,
-                                     std::string jobName)
+void ApplicationImpl::postOnOverlayThread(std::function<void()>&& f,
+                                          std::string jobName)
 {
     JITTER_INJECT_DELAY();
     releaseAssert(mOverlayIOContext);
@@ -1543,9 +1480,8 @@ ApplicationImpl::postOnOverlayThread(std::function<void()>&& f,
     });
 }
 
-void
-ApplicationImpl::postOnLedgerCloseThread(std::function<void()>&& f,
-                                         std::string jobName)
+void ApplicationImpl::postOnLedgerCloseThread(std::function<void()>&& f,
+                                              std::string jobName)
 {
     JITTER_INJECT_DELAY();
     releaseAssert(mLedgerCloseIOContext);
@@ -1560,8 +1496,7 @@ ApplicationImpl::postOnLedgerCloseThread(std::function<void()>&& f,
     });
 }
 
-void
-ApplicationImpl::enableInvariantsFromConfig()
+void ApplicationImpl::enableInvariantsFromConfig()
 {
     for (auto name : mConfig.INVARIANT_CHECKS)
     {
@@ -1593,38 +1528,32 @@ ApplicationImpl::enableInvariantsFromConfig()
     }
 }
 
-std::unique_ptr<Herder>
-ApplicationImpl::createHerder()
+std::unique_ptr<Herder> ApplicationImpl::createHerder()
 {
     return Herder::create(*this);
 }
 
-std::unique_ptr<InvariantManager>
-ApplicationImpl::createInvariantManager()
+std::unique_ptr<InvariantManager> ApplicationImpl::createInvariantManager()
 {
     return InvariantManager::create(*this);
 }
 
-std::unique_ptr<OverlayManager>
-ApplicationImpl::createOverlayManager()
+std::unique_ptr<OverlayManager> ApplicationImpl::createOverlayManager()
 {
     return OverlayManager::create(*this);
 }
 
-std::unique_ptr<LedgerManager>
-ApplicationImpl::createLedgerManager()
+std::unique_ptr<LedgerManager> ApplicationImpl::createLedgerManager()
 {
     return LedgerManager::create(*this);
 }
 
-std::unique_ptr<Database>
-ApplicationImpl::createDatabase()
+std::unique_ptr<Database> ApplicationImpl::createDatabase()
 {
     return std::make_unique<Database>(*this);
 }
 
-AbstractLedgerTxnParent&
-ApplicationImpl::getLedgerTxnRoot()
+AbstractLedgerTxnParent& ApplicationImpl::getLedgerTxnRoot()
 {
 #ifdef BUILD_TESTS
     if (mConfig.MODE_USES_IN_MEMORY_LEDGER)
@@ -1636,8 +1565,7 @@ ApplicationImpl::getLedgerTxnRoot()
     return *mLedgerTxnRoot;
 }
 
-AppConnector&
-ApplicationImpl::getAppConnector()
+AppConnector& ApplicationImpl::getAppConnector()
 {
     return *mAppConnector;
 }

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -286,8 +286,8 @@ class ApplicationImpl : public Application
     void setManualCloseVirtualTime(
         std::optional<TimePoint> const& explicitlyProvidedCloseTime);
 
-    void
-    advanceToLedgerBeforeManualCloseTarget(uint32_t const& targetLedgerSeq);
+    void advanceToLedgerBeforeManualCloseTarget(
+        uint32_t const& targetLedgerSeq);
 
     void upgradeToCurrentSchemaAndMaybeRebuildLedger(bool applyBuckets,
                                                      bool forceRebuild);

--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -46,8 +46,7 @@ namespace stellar
 {
 namespace
 {
-void
-writeLedgerAggregationTable(
+void writeLedgerAggregationTable(
     std::ofstream& ofs,
     std::optional<xdrquery::XDRFieldExtractor> const& groupByExtractor,
     std::map<std::vector<xdrquery::ResultType>, xdrquery::XDRAccumulator> const&
@@ -98,8 +97,7 @@ writeLedgerAggregationTable(
 
 const std::string MINIMAL_DB_NAME = "minimal.db";
 
-bool
-canRebuildInMemoryLedgerFromBuckets(uint32_t startAtLedger, uint32_t lcl)
+bool canRebuildInMemoryLedgerFromBuckets(uint32_t startAtLedger, uint32_t lcl)
 {
     // Number of streaming ledgers ahead of LCL. Core will
     // rebuild the existing state if the difference between the start
@@ -111,16 +109,14 @@ canRebuildInMemoryLedgerFromBuckets(uint32_t startAtLedger, uint32_t lcl)
            startAtLedger - lcl <= RESTORE_STATE_LEDGER_WINDOW;
 }
 
-std::filesystem::path
-minimalDbPath(Config const& cfg)
+std::filesystem::path minimalDbPath(Config const& cfg)
 {
     std::filesystem::path dpath(cfg.BUCKET_DIR_PATH);
     dpath /= MINIMAL_DB_NAME;
     return dpath;
 }
 
-Application::pointer
-setupApp(Config& cfg, VirtualClock& clock)
+Application::pointer setupApp(Config& cfg, VirtualClock& clock)
 {
     LOG_INFO(DEFAULT_LOG, "Starting stellar-core {}", STELLAR_CORE_VERSION);
     Application::pointer app;
@@ -133,8 +129,7 @@ setupApp(Config& cfg, VirtualClock& clock)
     return app;
 }
 
-int
-runApp(Application::pointer app)
+int runApp(Application::pointer app)
 {
     // Certain in-memory modes in core may start the app before reaching this
     // point, but since start is idempotent, second call will just no-op
@@ -167,8 +162,7 @@ runApp(Application::pointer app)
     return 0;
 }
 
-bool
-applyBucketsForLCL(Application& app)
+bool applyBucketsForLCL(Application& app)
 {
     HistoryArchiveState has;
     has.fromString(app.getPersistentState().getState(
@@ -194,8 +188,7 @@ applyBucketsForLCL(Application& app)
     return work->getState() == BasicWork::State::WORK_SUCCESS;
 }
 
-void
-httpCommand(std::string const& command, unsigned short port)
+void httpCommand(std::string const& command, unsigned short port)
 {
     std::string ret;
     std::ostringstream path;
@@ -239,10 +232,9 @@ httpCommand(std::string const& command, unsigned short port)
     }
 }
 
-void
-setAuthenticatedLedgerHashPair(Application::pointer app,
-                               LedgerNumHashPair& authPair,
-                               uint32_t startLedger, std::string startHash)
+void setAuthenticatedLedgerHashPair(Application::pointer app,
+                                    LedgerNumHashPair& authPair,
+                                    uint32_t startLedger, std::string startHash)
 {
     auto const& lm = app->getLedgerManager();
 
@@ -291,8 +283,7 @@ setAuthenticatedLedgerHashPair(Application::pointer app,
     }
 }
 
-int
-selfCheck(Config cfg)
+int selfCheck(Config cfg)
 {
     VirtualClock clock;
     cfg.setNoListen();
@@ -373,8 +364,7 @@ selfCheck(Config cfg)
     }
 }
 
-int
-mergeBucketList(Config cfg, std::string const& outputDir)
+int mergeBucketList(Config cfg, std::string const& outputDir)
 {
     VirtualClock clock;
     cfg.setNoListen();
@@ -417,8 +407,7 @@ struct StateArchivalMetric
     uint64_t outdatedBytes{};
 };
 
-static void
-processArchivalMetrics(
+static void processArchivalMetrics(
     std::shared_ptr<LiveBucket const> const b,
     UnorderedMap<LedgerKey, StateArchivalMetric>& ledgerEntries,
     UnorderedMap<LedgerKey, std::pair<StateArchivalMetric, uint32_t>>& ttls)
@@ -478,8 +467,7 @@ processArchivalMetrics(
     }
 }
 
-int
-dumpStateArchivalStatistics(Config cfg)
+int dumpStateArchivalStatistics(Config cfg)
 {
     ZoneScoped;
     VirtualClock clock;
@@ -581,13 +569,13 @@ dumpStateArchivalStatistics(Config cfg)
     return 0;
 }
 
-int
-dumpLedger(Config cfg, std::string const& outputFile,
-           std::optional<std::string> filterQuery,
-           std::optional<uint32_t> lastModifiedLedgerCount,
-           std::optional<uint64_t> limit, std::optional<std::string> groupBy,
-           std::optional<std::string> aggregate, bool dumpHotArchive,
-           bool includeAllStates)
+int dumpLedger(Config cfg, std::string const& outputFile,
+               std::optional<std::string> filterQuery,
+               std::optional<uint32_t> lastModifiedLedgerCount,
+               std::optional<uint64_t> limit,
+               std::optional<std::string> groupBy,
+               std::optional<std::string> aggregate, bool dumpHotArchive,
+               bool includeAllStates)
 {
     if (groupBy && !aggregate)
     {
@@ -716,8 +704,7 @@ dumpLedger(Config cfg, std::string const& outputFile,
     return 0;
 }
 
-void
-dumpWasmBlob(Config cfg, std::string const& hash, std::string const& dir)
+void dumpWasmBlob(Config cfg, std::string const& hash, std::string const& dir)
 {
     VirtualClock clock;
     cfg.setNoListen();
@@ -775,8 +762,7 @@ dumpWasmBlob(Config cfg, std::string const& hash, std::string const& dir)
     }
 }
 
-void
-setForceSCPFlag()
+void setForceSCPFlag()
 {
     LOG_WARNING(DEFAULT_LOG, "* ");
     LOG_WARNING(DEFAULT_LOG,
@@ -786,8 +772,7 @@ setForceSCPFlag()
     LOG_WARNING(DEFAULT_LOG, "* ");
 }
 
-void
-initializeDatabase(Config cfg)
+void initializeDatabase(Config cfg)
 {
     VirtualClock clock;
     cfg.setNoListen();
@@ -799,8 +784,7 @@ initializeDatabase(Config cfg)
     LOG_INFO(DEFAULT_LOG, "*");
 }
 
-void
-showOfflineInfo(Config cfg, bool verbose)
+void showOfflineInfo(Config cfg, bool verbose)
 {
     // needs real time to display proper stats
     VirtualClock clock(VirtualClock::REAL_TIME);
@@ -809,9 +793,8 @@ showOfflineInfo(Config cfg, bool verbose)
     app->reportInfo(verbose);
 }
 
-bool
-checkQuorumIntersectionFromJson(std::filesystem::path const& jsonPath,
-                                std::optional<Config> const& cfg)
+bool checkQuorumIntersectionFromJson(std::filesystem::path const& jsonPath,
+                                     std::optional<Config> const& cfg)
 {
     std::atomic<bool> interrupt(false);
     auto qicPtr = QuorumIntersectionChecker::create(
@@ -820,8 +803,7 @@ checkQuorumIntersectionFromJson(std::filesystem::path const& jsonPath,
 }
 
 #ifdef BUILD_TESTS
-void
-loadXdr(Config cfg, std::string const& bucketFile)
+void loadXdr(Config cfg, std::string const& bucketFile)
 {
     VirtualClock clock;
     cfg.setNoListen();
@@ -832,8 +814,7 @@ loadXdr(Config cfg, std::string const& bucketFile)
     bucket.apply(*app);
 }
 
-int
-rebuildLedgerFromBuckets(Config cfg)
+int rebuildLedgerFromBuckets(Config cfg)
 {
     VirtualClock clock(VirtualClock::REAL_TIME);
     cfg.setNoListen();
@@ -846,8 +827,7 @@ rebuildLedgerFromBuckets(Config cfg)
 }
 #endif
 
-int
-reportLastHistoryCheckpoint(Config cfg, std::string const& outputFile)
+int reportLastHistoryCheckpoint(Config cfg, std::string const& outputFile)
 {
     VirtualClock clock(VirtualClock::REAL_TIME);
     cfg.setNoListen();
@@ -894,16 +874,15 @@ reportLastHistoryCheckpoint(Config cfg, std::string const& outputFile)
     return ok ? 0 : 1;
 }
 
-void
-genSeed()
+void genSeed()
 {
     auto key = SecretKey::random();
     std::cout << "Secret seed: " << key.getStrKeySeed().value << std::endl;
     std::cout << "Public: " << key.getStrKeyPublic() << std::endl;
 }
 
-int
-initializeHistories(Config cfg, std::vector<std::string> const& newHistories)
+int initializeHistories(Config cfg,
+                        std::vector<std::string> const& newHistories)
 {
     VirtualClock clock;
     cfg.setNoListen();
@@ -917,8 +896,8 @@ initializeHistories(Config cfg, std::vector<std::string> const& newHistories)
     return 0;
 }
 
-void
-writeCatchupInfo(Json::Value const& catchupInfo, std::string const& outputFile)
+void writeCatchupInfo(Json::Value const& catchupInfo,
+                      std::string const& outputFile)
 {
     std::string filename = outputFile.empty() ? "-" : outputFile;
     auto content = catchupInfo.toStyledString();
@@ -944,9 +923,8 @@ writeCatchupInfo(Json::Value const& catchupInfo, std::string const& outputFile)
     }
 }
 
-int
-catchup(Application::pointer app, CatchupConfiguration cc,
-        Json::Value& catchupInfo, std::shared_ptr<HistoryArchive> archive)
+int catchup(Application::pointer app, CatchupConfiguration cc,
+            Json::Value& catchupInfo, std::shared_ptr<HistoryArchive> archive)
 {
     app->start();
 
@@ -1016,8 +994,7 @@ catchup(Application::pointer app, CatchupConfiguration cc,
     return synced ? 0 : 3;
 }
 
-int
-publish(Application::pointer app)
+int publish(Application::pointer app)
 {
     app->start();
 
@@ -1048,8 +1025,7 @@ publish(Application::pointer app)
     return 0;
 }
 
-std::string
-minimalDBForInMemoryMode(Config const& cfg)
+std::string minimalDBForInMemoryMode(Config const& cfg)
 {
     return fmt::format(FMT_STRING("sqlite3://{}"),
                        minimalDbPath(cfg).generic_string());

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -139,17 +139,14 @@ CommandHandler::CommandHandler(Application& app) : mApp(app)
 #endif
 }
 
-void
-CommandHandler::addRoute(std::string const& name, HandlerRoute route)
+void CommandHandler::addRoute(std::string const& name, HandlerRoute route)
 {
-
     mServer->addRoute(
         name, std::bind(&CommandHandler::safeRouter, this, route, _1, _2));
 }
 
-void
-CommandHandler::safeRouter(CommandHandler::HandlerRoute route,
-                           std::string const& params, std::string& retStr)
+void CommandHandler::safeRouter(CommandHandler::HandlerRoute route,
+                                std::string const& params, std::string& retStr)
 {
     try
     {
@@ -166,8 +163,7 @@ CommandHandler::safeRouter(CommandHandler::HandlerRoute route,
     }
 }
 
-void
-CommandHandler::ensureProtocolVersion(
+void CommandHandler::ensureProtocolVersion(
     std::map<std::string, std::string> const& args, std::string const& argName,
     ProtocolVersion minVer)
 {
@@ -179,9 +175,8 @@ CommandHandler::ensureProtocolVersion(
     ensureProtocolVersion(argName, minVer);
 }
 
-void
-CommandHandler::ensureProtocolVersion(std::string const& errString,
-                                      ProtocolVersion minVer)
+void CommandHandler::ensureProtocolVersion(std::string const& errString,
+                                           ProtocolVersion minVer)
 {
     auto lhhe = mApp.getLedgerManager().getLastClosedLedgerHeader();
     if (protocolVersionIsBefore(lhhe.header.ledgerVersion, minVer))
@@ -193,8 +188,7 @@ CommandHandler::ensureProtocolVersion(std::string const& errString,
     }
 }
 
-std::string
-CommandHandler::manualCmd(std::string const& cmd)
+std::string CommandHandler::manualCmd(std::string const& cmd)
 {
     http::server::reply reply;
     http::server::request request;
@@ -204,8 +198,8 @@ CommandHandler::manualCmd(std::string const& cmd)
     return reply.content;
 }
 
-void
-CommandHandler::fileNotFound(std::string const& params, std::string& retStr)
+void CommandHandler::fileNotFound(std::string const& params,
+                                  std::string& retStr)
 {
     retStr = "<b>Welcome to stellar-core!</b><p>";
     retStr +=
@@ -245,9 +239,8 @@ parseOptionalParam(std::map<std::string, std::string> const& map,
 // If the key doesn't exist, return defaultValue.
 // Otherwise, throws an error.
 template <typename T>
-T
-parseOptionalParamOrDefault(std::map<std::string, std::string> const& map,
-                            std::string const& key, T const& defaultValue)
+T parseOptionalParamOrDefault(std::map<std::string, std::string> const& map,
+                              std::string const& key, T const& defaultValue)
 {
     std::optional<T> res = parseOptionalParam<T>(map, key);
     if (res)
@@ -261,10 +254,9 @@ parseOptionalParamOrDefault(std::map<std::string, std::string> const& map,
 }
 
 template <>
-bool
-parseOptionalParamOrDefault<bool>(std::map<std::string, std::string> const& map,
-                                  std::string const& key,
-                                  bool const& defaultValue)
+bool parseOptionalParamOrDefault<bool>(
+    std::map<std::string, std::string> const& map, std::string const& key,
+    bool const& defaultValue)
 {
     auto paramStr = parseOptionalParam<std::string>(map, key);
     if (!paramStr)
@@ -277,9 +269,8 @@ parseOptionalParamOrDefault<bool>(std::map<std::string, std::string> const& map,
 // Return a value only if the key exists and the value parses.
 // Otherwise, this throws an error.
 template <typename T>
-T
-parseRequiredParam(std::map<std::string, std::string> const& map,
-                   std::string const& key)
+T parseRequiredParam(std::map<std::string, std::string> const& map,
+                     std::string const& key)
 {
     auto res = parseOptionalParam<T>(map, key);
     if (!res)
@@ -291,8 +282,7 @@ parseRequiredParam(std::map<std::string, std::string> const& map,
     return *res;
 }
 
-void
-CommandHandler::manualClose(std::string const& params, std::string& retStr)
+void CommandHandler::manualClose(std::string const& params, std::string& retStr)
 {
     ZoneScoped;
     std::map<std::string, std::string> retMap;
@@ -311,8 +301,7 @@ CommandHandler::manualClose(std::string const& params, std::string& retStr)
     retStr = mApp.manualClose(manualLedgerSeq, manualCloseTime);
 }
 
-void
-CommandHandler::peers(std::string const& params, std::string& retStr)
+void CommandHandler::peers(std::string const& params, std::string& retStr)
 {
     ZoneScoped;
     std::map<std::string, std::string> retMap;
@@ -361,8 +350,7 @@ CommandHandler::peers(std::string const& params, std::string& retStr)
     retStr = root.toStyledString();
 }
 
-void
-CommandHandler::info(std::string const& params, std::string& retStr)
+void CommandHandler::info(std::string const& params, std::string& retStr)
 {
     ZoneScoped;
     std::map<std::string, std::string> retMap;
@@ -371,9 +359,8 @@ CommandHandler::info(std::string const& params, std::string& retStr)
     retStr = mApp.getJsonInfo(retMap["compact"] == "false").toStyledString();
 }
 
-static bool
-shouldEnable(std::set<std::string> const& toEnable,
-             medida::MetricName const& name)
+static bool shouldEnable(std::set<std::string> const& toEnable,
+                         medida::MetricName const& name)
 {
     // Enable individual metric name or a partition
     if (toEnable.find(name.domain()) == toEnable.end() &&
@@ -384,8 +371,7 @@ shouldEnable(std::set<std::string> const& toEnable,
     return true;
 }
 
-void
-CommandHandler::metrics(std::string const& params, std::string& retStr)
+void CommandHandler::metrics(std::string const& params, std::string& retStr)
 {
     ZoneScoped;
 
@@ -434,8 +420,7 @@ CommandHandler::metrics(std::string const& params, std::string& retStr)
     }
 }
 
-void
-CommandHandler::logRotate(std::string const& params, std::string& retStr)
+void CommandHandler::logRotate(std::string const& params, std::string& retStr)
 {
     ZoneScoped;
     retStr = "Log rotate...";
@@ -443,8 +428,7 @@ CommandHandler::logRotate(std::string const& params, std::string& retStr)
     Logging::rotate();
 }
 
-void
-CommandHandler::connect(std::string const& params, std::string& retStr)
+void CommandHandler::connect(std::string const& params, std::string& retStr)
 {
     ZoneScoped;
     std::map<std::string, std::string> retMap;
@@ -467,8 +451,7 @@ CommandHandler::connect(std::string const& params, std::string& retStr)
     }
 }
 
-void
-CommandHandler::dropPeer(std::string const& params, std::string& retStr)
+void CommandHandler::dropPeer(std::string const& params, std::string& retStr)
 {
     ZoneScoped;
     std::map<std::string, std::string> retMap;
@@ -513,8 +496,7 @@ CommandHandler::dropPeer(std::string const& params, std::string& retStr)
     }
 }
 
-void
-CommandHandler::bans(std::string const& params, std::string& retStr)
+void CommandHandler::bans(std::string const& params, std::string& retStr)
 {
     ZoneScoped;
     Json::Value root;
@@ -531,8 +513,7 @@ CommandHandler::bans(std::string const& params, std::string& retStr)
     retStr = root.toStyledString();
 }
 
-void
-CommandHandler::unban(std::string const& params, std::string& retStr)
+void CommandHandler::unban(std::string const& params, std::string& retStr)
 {
     ZoneScoped;
     std::map<std::string, std::string> retMap;
@@ -561,8 +542,7 @@ CommandHandler::unban(std::string const& params, std::string& retStr)
     }
 }
 
-void
-CommandHandler::upgrades(std::string const& params, std::string& retStr)
+void CommandHandler::upgrades(std::string const& params, std::string& retStr)
 {
     ZoneScoped;
     std::map<std::string, std::string> retMap;
@@ -642,9 +622,8 @@ CommandHandler::upgrades(std::string const& params, std::string& retStr)
     }
 }
 
-void
-CommandHandler::dumpProposedSettings(std::string const& params,
-                                     std::string& retStr)
+void CommandHandler::dumpProposedSettings(std::string const& params,
+                                          std::string& retStr)
 {
     ZoneScoped;
     std::map<std::string, std::string> retMap;
@@ -680,8 +659,7 @@ CommandHandler::dumpProposedSettings(std::string const& params,
     }
 }
 
-void
-CommandHandler::selfCheck(std::string const&, std::string& retStr)
+void CommandHandler::selfCheck(std::string const&, std::string& retStr)
 {
     ZoneScoped;
     // NB: this only runs the online "self-check" routine; running the
@@ -692,8 +670,7 @@ CommandHandler::selfCheck(std::string const&, std::string& retStr)
     mApp.scheduleSelfCheck(true);
 }
 
-void
-CommandHandler::quorum(std::string const& params, std::string& retStr)
+void CommandHandler::quorum(std::string const& params, std::string& retStr)
 {
     ZoneScoped;
     std::map<std::string, std::string> retMap;
@@ -729,8 +706,7 @@ CommandHandler::quorum(std::string const& params, std::string& retStr)
     retStr = root.toStyledString();
 }
 
-void
-CommandHandler::scpInfo(std::string const& params, std::string& retStr)
+void CommandHandler::scpInfo(std::string const& params, std::string& retStr)
 {
     ZoneScoped;
     std::map<std::string, std::string> retMap;
@@ -741,8 +717,7 @@ CommandHandler::scpInfo(std::string const& params, std::string& retStr)
     retStr = root.toStyledString();
 }
 
-void
-CommandHandler::sorobanInfo(std::string const& params, std::string& retStr)
+void CommandHandler::sorobanInfo(std::string const& params, std::string& retStr)
 {
     ZoneScoped;
     auto& lm = mApp.getLedgerManager();
@@ -940,8 +915,7 @@ CommandHandler::sorobanInfo(std::string const& params, std::string& retStr)
 }
 
 // "Must specify a log level: ll?level=<level>&partition=<name>";
-void
-CommandHandler::ll(std::string const& params, std::string& retStr)
+void CommandHandler::ll(std::string const& params, std::string& retStr)
 {
     ZoneScoped;
     Json::Value root;
@@ -977,8 +951,7 @@ CommandHandler::ll(std::string const& params, std::string& retStr)
     retStr = root.toStyledString();
 }
 
-void
-CommandHandler::tx(std::string const& params, std::string& retStr)
+void CommandHandler::tx(std::string const& params, std::string& retStr)
 {
     ZoneScoped;
     Json::Value root;
@@ -1045,8 +1018,7 @@ CommandHandler::tx(std::string const& params, std::string& retStr)
     retStr = Json::FastWriter().write(root);
 }
 
-void
-CommandHandler::maintenance(std::string const& params, std::string& retStr)
+void CommandHandler::maintenance(std::string const& params, std::string& retStr)
 {
     ZoneScoped;
     std::map<std::string, std::string> map;
@@ -1065,8 +1037,8 @@ CommandHandler::maintenance(std::string const& params, std::string& retStr)
     }
 }
 
-void
-CommandHandler::clearMetrics(std::string const& params, std::string& retStr)
+void CommandHandler::clearMetrics(std::string const& params,
+                                  std::string& retStr)
 {
     ZoneScoped;
     std::map<std::string, std::string> map;
@@ -1080,8 +1052,7 @@ CommandHandler::clearMetrics(std::string const& params, std::string& retStr)
     retStr = fmt::format(FMT_STRING("Cleared {} metrics!"), domain);
 }
 
-void
-CommandHandler::checkBooted() const
+void CommandHandler::checkBooted() const
 {
     if (mApp.getState() == Application::APP_CREATED_STATE ||
         mApp.getHerder().getState() == Herder::HERDER_BOOTING_STATE)
@@ -1091,8 +1062,7 @@ CommandHandler::checkBooted() const
     }
 }
 
-void
-CommandHandler::stopSurvey(std::string const&, std::string& retStr)
+void CommandHandler::stopSurvey(std::string const&, std::string& retStr)
 {
     ZoneScoped;
     auto& surveyManager = mApp.getOverlayManager().getSurveyManager();
@@ -1100,17 +1070,15 @@ CommandHandler::stopSurvey(std::string const&, std::string& retStr)
     retStr = "survey stopped";
 }
 
-void
-CommandHandler::getSurveyResult(std::string const&, std::string& retStr)
+void CommandHandler::getSurveyResult(std::string const&, std::string& retStr)
 {
     ZoneScoped;
     auto& surveyManager = mApp.getOverlayManager().getSurveyManager();
     retStr = surveyManager.getJsonResults().toStyledString();
 }
 
-void
-CommandHandler::startSurveyCollecting(std::string const& params,
-                                      std::string& retStr)
+void CommandHandler::startSurveyCollecting(std::string const& params,
+                                           std::string& retStr)
 {
     ZoneScoped;
     checkBooted();
@@ -1132,8 +1100,8 @@ CommandHandler::startSurveyCollecting(std::string const& params,
     }
 }
 
-void
-CommandHandler::stopSurveyCollecting(std::string const&, std::string& retStr)
+void CommandHandler::stopSurveyCollecting(std::string const&,
+                                          std::string& retStr)
 {
     ZoneScoped;
     checkBooted();
@@ -1150,9 +1118,8 @@ CommandHandler::stopSurveyCollecting(std::string const&, std::string& retStr)
     }
 }
 
-void
-CommandHandler::surveyTopologyTimeSliced(std::string const& params,
-                                         std::string& retStr)
+void CommandHandler::surveyTopologyTimeSliced(std::string const& params,
+                                              std::string& retStr)
 {
     ZoneScoped;
     checkBooted();
@@ -1178,8 +1145,8 @@ CommandHandler::surveyTopologyTimeSliced(std::string const& params,
 }
 
 #ifdef BUILD_TESTS
-void
-CommandHandler::generateLoad(std::string const& params, std::string& retStr)
+void CommandHandler::generateLoad(std::string const& params,
+                                  std::string& retStr)
 {
     ZoneScoped;
     if (mApp.getConfig().ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING)
@@ -1239,7 +1206,6 @@ CommandHandler::generateLoad(std::string const& params, std::string& retStr)
             cfg.setMinSorobanPercentSuccess(minPercentSuccess);
             if (cfg.mode != LoadGenMode::SOROBAN_UPLOAD)
             {
-
                 auto& sorobanCfg = cfg.getMutSorobanConfig();
                 sorobanCfg.nInstances =
                     parseOptionalParamOrDefault<uint32_t>(map, "instances", 0);
@@ -1367,8 +1333,7 @@ CommandHandler::generateLoad(std::string const& params, std::string& retStr)
     }
 }
 
-void
-CommandHandler::testAcc(std::string const& params, std::string& retStr)
+void CommandHandler::testAcc(std::string const& params, std::string& retStr)
 {
     ZoneScoped;
     using namespace txtest;
@@ -1408,8 +1373,7 @@ CommandHandler::testAcc(std::string const& params, std::string& retStr)
     retStr = root.toStyledString();
 }
 
-void
-CommandHandler::testTx(std::string const& params, std::string& retStr)
+void CommandHandler::testTx(std::string const& params, std::string& retStr)
 {
     ZoneScoped;
     using namespace txtest;
@@ -1475,9 +1439,8 @@ CommandHandler::testTx(std::string const& params, std::string& retStr)
     retStr = root.toStyledString();
 }
 
-void
-CommandHandler::toggleOverlayOnlyMode(std::string const& params,
-                                      std::string& retStr)
+void CommandHandler::toggleOverlayOnlyMode(std::string const& params,
+                                           std::string& retStr)
 {
     ZoneScoped;
 

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -63,8 +63,7 @@ namespace stellar
 
 static const uint32_t MAINTENANCE_LEDGER_COUNT = 1000000;
 
-void
-writeWithTextFlow(std::ostream& os, std::string const& text)
+void writeWithTextFlow(std::ostream& os, std::string const& text)
 {
     size_t consoleWidth = CLARA_TEXTFLOW_CONFIG_CONSOLE_WIDTH;
     os << clara::TextFlow::Column(text).width(consoleWidth) << "\n\n";
@@ -152,14 +151,12 @@ class ParserWithValidation
         mIsValid = isValid;
     }
 
-    const clara::Parser&
-    parser() const
+    const clara::Parser& parser() const
     {
         return mParser;
     }
 
-    std::string
-    validate() const
+    std::string validate() const
     {
         return mIsValid();
     }
@@ -170,8 +167,7 @@ class ParserWithValidation
 };
 
 template <typename T>
-std::function<std::string()>
-required(T& value, std::string const& name)
+std::function<std::string()> required(T& value, std::string const& name)
 {
     return [&value, name] {
         if (value.empty())
@@ -186,33 +182,28 @@ required(T& value, std::string const& name)
 }
 
 template <typename T>
-ParserWithValidation
-requiredArgParser(T& value, std::string const& name)
+ParserWithValidation requiredArgParser(T& value, std::string const& name)
 {
     return {clara::Arg(value, name).required(), required(value, name)};
 }
 
-ParserWithValidation
-fileNameParser(std::string& string)
+ParserWithValidation fileNameParser(std::string& string)
 {
     return requiredArgParser(string, "FILE-NAME");
 }
 
-clara::Opt
-processIDParser(int& num)
+clara::Opt processIDParser(int& num)
 {
     return clara::Opt{num, "PROCESS-ID"}["--process-id"](
         "for spawning multiple instances in fuzzing parallelization");
 }
 
-clara::Opt
-outputFileParser(std::string& string)
+clara::Opt outputFileParser(std::string& string)
 {
     return clara::Opt{string, "FILE-NAME"}["--output-file"]("output file");
 }
 
-clara::Opt
-trustedHashFileParser(std::optional<std::string>& string)
+clara::Opt trustedHashFileParser(std::optional<std::string>& string)
 {
     return clara::Opt{[&](std::string const& arg) { string = arg; },
                       "FILE-NAME"}["--trusted-hash-file"](
@@ -220,95 +211,81 @@ trustedHashFileParser(std::optional<std::string>& string)
         "verify-checkpoints");
 }
 
-clara::Opt
-outputDirParser(std::string& string)
+clara::Opt outputDirParser(std::string& string)
 {
     return clara::Opt{string, "DIR-NAME"}["--output-dir"]("output dir");
 }
 
-clara::Opt
-metaDirParser(std::string& string)
+clara::Opt metaDirParser(std::string& string)
 {
     return clara::Opt{string, "DIR-NAME"}["--meta-dir"](
         "external directory that contains debug meta");
 }
 
-clara::Opt
-logLevelParser(LogLevel& value)
+clara::Opt logLevelParser(LogLevel& value)
 {
     return clara::Opt{
         [&](std::string const& arg) { value = Logging::getLLfromString(arg); },
         "LEVEL"}["--ll"]("set the log level");
 }
 
-clara::Opt
-consoleParser(bool& console)
+clara::Opt consoleParser(bool& console)
 {
     return clara::Opt{console}["--console"]("enable logging to console");
 }
 
-clara::Opt
-metricsParser(std::vector<std::string>& value)
+clara::Opt metricsParser(std::vector<std::string>& value)
 {
     return clara::Opt{value, "METRIC-NAME"}["--metric"](
         "report metric METRIC-NAME on exit");
 }
 
-clara::Opt
-compactParser(bool& compact)
+clara::Opt compactParser(bool& compact)
 {
     return clara::Opt{compact}["--compact"]("no indent");
 }
 
-clara::Opt
-base64Parser(bool& base64)
+clara::Opt base64Parser(bool& base64)
 {
     return clara::Opt{base64}["--base64"]("batch process base64 encoded input");
 }
 
-clara::Opt
-codeParser(std::string& code)
+clara::Opt codeParser(std::string& code)
 {
     return clara::Opt{code, "CODE"}["--code"]("asset code");
 }
 
-clara::Opt
-issuerParser(std::string& issuer)
+clara::Opt issuerParser(std::string& issuer)
 {
     return clara::Opt{issuer, "ISSUER"}["--issuer"]("asset issuer");
 }
 
-clara::Opt
-disableBucketGCParser(bool& disableBucketGC)
+clara::Opt disableBucketGCParser(bool& disableBucketGC)
 {
     return clara::Opt{disableBucketGC}["--disable-bucket-gc"](
         "keeps all, even old, buckets on disk");
 }
 
-clara::Opt
-waitForConsensusParser(bool& waitForConsensus)
+clara::Opt waitForConsensusParser(bool& waitForConsensus)
 {
     return clara::Opt{waitForConsensus}["--wait-for-consensus"](
         "wait to hear from the network before voting, for validating nodes "
         "only");
 }
 
-clara::Opt
-historyArchiveParser(std::string& archive)
+clara::Opt historyArchiveParser(std::string& archive)
 {
     return clara::Opt(archive, "ARCHIVE-NAME")["--archive"](
         "Archive name to be used for catchup. Use 'any' to select randomly");
 }
 
-clara::Opt
-historyLedgerNumber(uint32_t& ledgerNum)
+clara::Opt historyLedgerNumber(uint32_t& ledgerNum)
 {
     return clara::Opt{ledgerNum, "HISTORY-LEDGER"}["--history-ledger"](
         "specify a ledger number to examine in history");
 }
 
-clara::Opt
-fromLedgerNumberParser(std::optional<uint32_t>& fromLedgerNum)
+clara::Opt fromLedgerNumberParser(std::optional<uint32_t>& fromLedgerNum)
 {
     return clara::Opt{
         [&](std::string const& arg) { fromLedgerNum = std::stoul(arg); },
@@ -316,15 +293,13 @@ fromLedgerNumberParser(std::optional<uint32_t>& fromLedgerNum)
         "specify a ledger number to start from");
 }
 
-clara::Opt
-historyHashParser(std::string& hash)
+clara::Opt historyHashParser(std::string& hash)
 {
     return clara::Opt(hash, "HISTORY_HASH")["--history-hash"](
         "specify a hash to trust for the provided ledger");
 }
 
-clara::Parser
-configurationParser(CommandLine::ConfigOption& configOption)
+clara::Parser configurationParser(CommandLine::ConfigOption& configOption)
 {
     return logLevelParser(configOption.mLogLevel) |
            metricsParser(configOption.mMetrics) |
@@ -336,15 +311,13 @@ configurationParser(CommandLine::ConfigOption& configOption)
                Config::STDIN_SPECIAL_NAME));
 }
 
-clara::Opt
-metadataOutputStreamParser(std::string& stream)
+clara::Opt metadataOutputStreamParser(std::string& stream)
 {
     return clara::Opt(stream, "STREAM")["--metadata-output-stream"](
         "Filename or file-descriptor number 'fd:N' to stream metadata to");
 }
 
-void
-maybeSetMetadataOutputStream(Config& cfg, std::string const& stream)
+void maybeSetMetadataOutputStream(Config& cfg, std::string const& stream)
 {
     if (!stream.empty())
     {
@@ -358,58 +331,50 @@ maybeSetMetadataOutputStream(Config& cfg, std::string const& stream)
     }
 }
 
-clara::Opt
-ledgerHashParser(std::string& ledgerHash)
+clara::Opt ledgerHashParser(std::string& ledgerHash)
 {
     return clara::Opt{ledgerHash, "HASH"}["--trusted-hash"](
         "Hash of the ledger to catchup to");
 }
 
-clara::Opt
-wasmHashParser(std::string& wasmHash)
+clara::Opt wasmHashParser(std::string& wasmHash)
 {
     return clara::Opt{wasmHash, "HASH"}["--wasm-hash"](
         "Hash of the a specific Wasm blob to dump, or 'ALL' to dump all");
 }
 
-clara::Opt
-forceUntrustedCatchup(bool& force)
+clara::Opt forceUntrustedCatchup(bool& force)
 {
     return clara::Opt{force}["--force-untrusted-catchup"](
         "force unverified catchup");
 }
 
-clara::Opt
-inMemoryParser(bool& inMemory)
+clara::Opt inMemoryParser(bool& inMemory)
 {
     return clara::Opt{inMemory}["--in-memory"](
         "(DEPRECATED) flag is ignored and will be removed soon.");
 }
 
-clara::Opt
-startAtLedgerParser(uint32_t& startAtLedger)
+clara::Opt startAtLedgerParser(uint32_t& startAtLedger)
 {
     return clara::Opt{startAtLedger, "LEDGER"}["--start-at-ledger"](
         "(DEPRECATED) flag is ignored and will be removed soon.");
 }
 
-clara::Opt
-startAtHashParser(std::string& startAtHash)
+clara::Opt startAtHashParser(std::string& startAtHash)
 {
     return clara::Opt{startAtHash, "HASH"}["--start-at-hash"](
         "(DEPRECATED) flag is ignored and will be removed soon.");
 }
 
-clara::Opt
-filterQueryParser(std::optional<std::string>& filterQuery)
+clara::Opt filterQueryParser(std::optional<std::string>& filterQuery)
 {
     return clara::Opt{[&](std::string const& arg) { filterQuery = arg; },
                       "FILTER-QUERY"}["--filter-query"](
         "query to filter ledger entries");
 }
 
-clara::Opt
-lastModifiedLedgerCountParser(
+clara::Opt lastModifiedLedgerCountParser(
     std::optional<std::uint32_t>& lastModifiedLedgerCount)
 {
     return clara::Opt{[&](std::string const& arg) {
@@ -420,47 +385,42 @@ lastModifiedLedgerCountParser(
         "ledgers ago");
 }
 
-clara::Opt
-groupByParser(std::optional<std::string>& groupBy)
+clara::Opt groupByParser(std::optional<std::string>& groupBy)
 {
     return clara::Opt{[&](std::string const& arg) { groupBy = arg; },
                       "GROUP-BY-EXPR"}["--group-by"](
         "comma-separated fields to group the results by");
 }
 
-clara::Opt
-aggregateParser(std::optional<std::string>& aggregate)
+clara::Opt aggregateParser(std::optional<std::string>& aggregate)
 {
     return clara::Opt{[&](std::string const& arg) { aggregate = arg; },
                       "AGGREGATE-EXPR"}["--agg"](
         "comma-separated aggregate expressions");
 }
 
-clara::Opt
-limitParser(std::optional<std::uint64_t>& limit)
+clara::Opt limitParser(std::optional<std::uint64_t>& limit)
 {
     return clara::Opt{[&](std::string const& arg) { limit = std::stoull(arg); },
                       "LIMIT"}["--limit"](
         "process only this many recent ledger entries (not *most* recent)");
 }
 
-clara::Opt
-dumpHotArchiveParser(bool& dumpHotArchive)
+clara::Opt dumpHotArchiveParser(bool& dumpHotArchive)
 {
     return clara::Opt{dumpHotArchive}["--hot-archive"](
         "run query on Hot Archive instead of the Live ledger state");
 }
 
-clara::Opt
-includeAllStatesParser(bool& include)
+clara::Opt includeAllStatesParser(bool& include)
 {
     return clara::Opt{include}["--include-all-states"](
         "include all non-dead states of the entry into query results");
 }
 
-int
-runWithHelp(CommandLineArgs const& args,
-            std::vector<ParserWithValidation> parsers, std::function<int()> f)
+int runWithHelp(CommandLineArgs const& args,
+                std::vector<ParserWithValidation> parsers,
+                std::function<int()> f)
 {
     auto isHelp = false;
     auto parser = clara::Parser{} | clara::Help(isHelp);
@@ -502,9 +462,8 @@ runWithHelp(CommandLineArgs const& args,
     return f();
 }
 
-CatchupConfiguration
-parseCatchup(std::string const& catchup, std::string const& hash,
-             bool extraValidation)
+CatchupConfiguration parseCatchup(std::string const& catchup,
+                                  std::string const& hash, bool extraValidation)
 {
     auto static errorMessage =
         "catchup value should be passed as <DESTINATION-LEDGER/LEDGER-COUNT>, "
@@ -548,26 +507,22 @@ CommandLine::Command::Command(std::string const& name,
 {
 }
 
-int
-CommandLine::Command::run(CommandLineArgs const& args) const
+int CommandLine::Command::run(CommandLineArgs const& args) const
 {
     return mRunFunc(args);
 }
 
-std::string
-CommandLine::Command::name() const
+std::string CommandLine::Command::name() const
 {
     return mName;
 }
 
-std::string
-CommandLine::Command::description() const
+std::string CommandLine::Command::description() const
 {
     return mDescription;
 }
 
-Config
-CommandLine::ConfigOption::getConfig(bool logToFile) const
+Config CommandLine::ConfigOption::getConfig(bool logToFile) const
 {
     Config config;
     auto configFile =
@@ -683,8 +638,8 @@ CommandLine::selectCommand(std::string const& commandName)
     return std::nullopt;
 }
 
-void
-CommandLine::writeToStream(std::string const& exeName, std::ostream& os) const
+void CommandLine::writeToStream(std::string const& exeName,
+                                std::ostream& os) const
 {
 #ifdef BUILD_TESTS
     // Printing this line enables automatic test discovery in VSCode, and
@@ -717,8 +672,7 @@ CommandLine::writeToStream(std::string const& exeName, std::ostream& os) const
 }
 }
 
-int
-diagBucketStats(CommandLineArgs const& args)
+int diagBucketStats(CommandLineArgs const& args)
 {
     std::string bucketFile;
     bool aggAccountStats = false;
@@ -734,8 +688,7 @@ diagBucketStats(CommandLineArgs const& args)
         });
 }
 
-int
-runReplayDebugMeta(CommandLineArgs const& args)
+int runReplayDebugMeta(CommandLineArgs const& args)
 {
     // targetLedger=0 means replay all available tx meta
     uint32_t targetLedger = 0;
@@ -775,8 +728,7 @@ runReplayDebugMeta(CommandLineArgs const& args)
         });
 }
 
-int
-runCatchup(CommandLineArgs const& args)
+int runCatchup(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
     std::string catchupString;
@@ -930,8 +882,7 @@ runCatchup(CommandLineArgs const& args)
         });
 }
 
-int
-runPublish(CommandLineArgs const& args)
+int runPublish(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
 
@@ -945,8 +896,7 @@ runPublish(CommandLineArgs const& args)
     });
 }
 
-int
-runWriteVerifiedCheckpointHashes(CommandLineArgs const& args)
+int runWriteVerifiedCheckpointHashes(CommandLineArgs const& args)
 {
     std::string outputFile;
     std::optional<std::string> trustedHashFile;
@@ -1021,8 +971,7 @@ runWriteVerifiedCheckpointHashes(CommandLineArgs const& args)
         });
 }
 
-int
-runConvertId(CommandLineArgs const& args)
+int runConvertId(CommandLineArgs const& args)
 {
     std::string id;
 
@@ -1032,8 +981,7 @@ runConvertId(CommandLineArgs const& args)
     });
 }
 
-int
-runDumpXDR(CommandLineArgs const& args)
+int runDumpXDR(CommandLineArgs const& args)
 {
     std::string xdr;
     bool compact = false;
@@ -1045,8 +993,7 @@ runDumpXDR(CommandLineArgs const& args)
                        });
 }
 
-int
-runDumpWasm(CommandLineArgs const& args)
+int runDumpWasm(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
     std::string hash;
@@ -1061,8 +1008,7 @@ runDumpWasm(CommandLineArgs const& args)
                        });
 }
 
-int
-runEncodeAsset(CommandLineArgs const& args)
+int runEncodeAsset(CommandLineArgs const& args)
 {
     std::string code, issuer;
 
@@ -1099,8 +1045,7 @@ runEncodeAsset(CommandLineArgs const& args)
     });
 }
 
-int
-runForceSCP(CommandLineArgs const& args)
+int runForceSCP(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
     auto reset = false;
@@ -1117,8 +1062,7 @@ runForceSCP(CommandLineArgs const& args)
                        });
 }
 
-int
-runGenSeed(CommandLineArgs const& args)
+int runGenSeed(CommandLineArgs const& args)
 {
     return runWithHelp(args, {}, [&] {
         genSeed();
@@ -1126,8 +1070,7 @@ runGenSeed(CommandLineArgs const& args)
     });
 }
 
-int
-runHttpCommand(CommandLineArgs const& args)
+int runHttpCommand(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
     std::string command;
@@ -1142,8 +1085,7 @@ runHttpCommand(CommandLineArgs const& args)
                        });
 }
 
-int
-runSelfCheck(CommandLineArgs const& args)
+int runSelfCheck(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
 
@@ -1151,8 +1093,7 @@ runSelfCheck(CommandLineArgs const& args)
                        [&] { return selfCheck(configOption.getConfig()); });
 }
 
-int
-runMergeBucketList(CommandLineArgs const& args)
+int runMergeBucketList(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
     std::string outputDir{"."};
@@ -1164,8 +1105,7 @@ runMergeBucketList(CommandLineArgs const& args)
         [&] { return mergeBucketList(configOption.getConfig(), outputDir); });
 }
 
-int
-runDumpStateArchivalStatistics(CommandLineArgs const& args)
+int runDumpStateArchivalStatistics(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
     return runWithHelp(args, {configurationParser(configOption)}, [&] {
@@ -1173,8 +1113,7 @@ runDumpStateArchivalStatistics(CommandLineArgs const& args)
     });
 }
 
-int
-runDumpLedger(CommandLineArgs const& args)
+int runDumpLedger(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
     std::string outputFile;
@@ -1201,8 +1140,7 @@ runDumpLedger(CommandLineArgs const& args)
         });
 }
 
-int
-runNewDB(CommandLineArgs const& args)
+int runNewDB(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
     [[maybe_unused]] bool minimalForInMemoryMode = false;
@@ -1223,8 +1161,7 @@ runNewDB(CommandLineArgs const& args)
                        });
 }
 
-int
-runUpgradeDB(CommandLineArgs const& args)
+int runUpgradeDB(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
 
@@ -1237,8 +1174,7 @@ runUpgradeDB(CommandLineArgs const& args)
     });
 }
 
-int
-getSettingsUpgradeTransactions(CommandLineArgs const& args)
+int getSettingsUpgradeTransactions(CommandLineArgs const& args)
 {
     std::string netId;
 
@@ -1368,8 +1304,7 @@ getSettingsUpgradeTransactions(CommandLineArgs const& args)
         });
 }
 
-int
-runPrintPublishQueue(CommandLineArgs const& args)
+int runPrintPublishQueue(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
 
@@ -1389,8 +1324,7 @@ runPrintPublishQueue(CommandLineArgs const& args)
     });
 }
 
-int
-runCheckQuorumIntersection(CommandLineArgs const& args)
+int runCheckQuorumIntersection(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
     std::optional<Config> cfg = std::nullopt;
@@ -1521,8 +1455,7 @@ runCheckQuorumIntersection(CommandLineArgs const& args)
         });
 }
 
-int
-runNewHist(CommandLineArgs const& args)
+int runNewHist(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
     std::vector<std::string> newHistories;
@@ -1536,8 +1469,7 @@ runNewHist(CommandLineArgs const& args)
                        });
 }
 
-int
-runOfflineInfo(CommandLineArgs const& args)
+int runOfflineInfo(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
 
@@ -1547,8 +1479,7 @@ runOfflineInfo(CommandLineArgs const& args)
     });
 }
 
-int
-runPrintXdr(CommandLineArgs const& args)
+int runPrintXdr(CommandLineArgs const& args)
 {
     std::string xdr;
     std::string fileType{"auto"};
@@ -1571,8 +1502,7 @@ runPrintXdr(CommandLineArgs const& args)
                        });
 }
 
-int
-runReportLastHistoryCheckpoint(CommandLineArgs const& args)
+int runReportLastHistoryCheckpoint(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
     std::string outputFile;
@@ -1585,8 +1515,7 @@ runReportLastHistoryCheckpoint(CommandLineArgs const& args)
         });
 }
 
-int
-run(CommandLineArgs const& args)
+int run(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
     auto disableBucketGC = false;
@@ -1683,8 +1612,7 @@ run(CommandLineArgs const& args)
         });
 }
 
-int
-runSecToPub(CommandLineArgs const& args)
+int runSecToPub(CommandLineArgs const& args)
 {
     return runWithHelp(args, {}, [&] {
         priv2pub();
@@ -1692,8 +1620,7 @@ runSecToPub(CommandLineArgs const& args)
     });
 }
 
-int
-runSignTransaction(CommandLineArgs const& args)
+int runSignTransaction(CommandLineArgs const& args)
 {
     std::string transaction;
     std::string netId;
@@ -1713,8 +1640,7 @@ runSignTransaction(CommandLineArgs const& args)
         });
 }
 
-int
-runVersion(CommandLineArgs const&)
+int runVersion(CommandLineArgs const&)
 {
     rust::Vec<SorobanVersionInfo> rustVersions =
         rust_bridge::get_soroban_version_info(
@@ -1758,8 +1684,7 @@ runVersion(CommandLineArgs const&)
 }
 
 #ifdef BUILD_TESTS
-int
-runLoadXDR(CommandLineArgs const& args)
+int runLoadXDR(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
     std::string xdr;
@@ -1771,8 +1696,7 @@ runLoadXDR(CommandLineArgs const& args)
         });
 }
 
-int
-runRebuildLedgerFromBuckets(CommandLineArgs const& args)
+int runRebuildLedgerFromBuckets(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
 
@@ -1782,8 +1706,8 @@ runRebuildLedgerFromBuckets(CommandLineArgs const& args)
     });
 }
 
-ParserWithValidation
-fuzzerModeParser(std::string& fuzzerModeArg, FuzzerMode& fuzzerMode)
+ParserWithValidation fuzzerModeParser(std::string& fuzzerModeArg,
+                                      FuzzerMode& fuzzerMode)
 {
     auto validateFuzzerMode = [&] {
         if (iequals(fuzzerModeArg, "overlay"))
@@ -1807,8 +1731,7 @@ fuzzerModeParser(std::string& fuzzerModeArg, FuzzerMode& fuzzerMode)
             validateFuzzerMode};
 }
 
-int
-runFuzz(CommandLineArgs const& args)
+int runFuzz(CommandLineArgs const& args)
 {
     LogLevel logLevel{LogLevel::LVL_FATAL};
     std::vector<std::string> metrics;
@@ -1837,8 +1760,7 @@ runFuzz(CommandLineArgs const& args)
                        });
 }
 
-int
-runGenFuzz(CommandLineArgs const& args)
+int runGenFuzz(CommandLineArgs const& args)
 {
     LogLevel logLevel{LogLevel::LVL_FATAL};
     std::string fileName;
@@ -1864,8 +1786,8 @@ runGenFuzz(CommandLineArgs const& args)
         });
 }
 
-ParserWithValidation
-applyLoadModeParser(std::string& modeArg, ApplyLoadMode& mode)
+ParserWithValidation applyLoadModeParser(std::string& modeArg,
+                                         ApplyLoadMode& mode)
 {
     auto validateMode = [&] {
         if (iequals(modeArg, "ledger-limits"))
@@ -1888,8 +1810,7 @@ applyLoadModeParser(std::string& modeArg, ApplyLoadMode& mode)
             validateMode};
 }
 
-int
-runApplyLoad(CommandLineArgs const& args)
+int runApplyLoad(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
     ApplyLoadMode mode{ApplyLoadMode::LIMIT_BASED};
@@ -2108,8 +2029,7 @@ runApplyLoad(CommandLineArgs const& args)
         });
 }
 
-int
-runGenerateSyntheticLoad(CommandLineArgs const& args)
+int runGenerateSyntheticLoad(CommandLineArgs const& args)
 {
     CLOG_WARNING(Perf, "This command will run new-db and start a test network "
                        "to generate synthentic load");
@@ -2160,8 +2080,7 @@ runGenerateSyntheticLoad(CommandLineArgs const& args)
 }
 #endif
 
-int
-handleCommandLine(int argc, char* const* argv)
+int handleCommandLine(int argc, char* const* argv)
 {
     auto commandLine = CommandLine{
         {{"catchup",

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2014 Stellar Development Foundation and contributors. Licensed
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
@@ -84,9 +83,8 @@ namespace
 // require majority
 // (>50%). If thresholdLevel is ALL_REQUIRED, require 100%, otherwise assume
 // byzantine failures (~67%)
-unsigned int
-computeDefaultThreshold(SCPQuorumSet const& qset,
-                        ValidationThresholdLevels thresholdLevel)
+unsigned int computeDefaultThreshold(SCPQuorumSet const& qset,
+                                     ValidationThresholdLevels thresholdLevel)
 {
     unsigned int res = 0;
     unsigned int topSize = static_cast<unsigned int>(qset.validators.size() +
@@ -375,8 +373,7 @@ namespace
 
 using ConfigItem = std::pair<std::string, std::shared_ptr<cpptoml::base>>;
 
-bool
-readBool(ConfigItem const& item)
+bool readBool(ConfigItem const& item)
 {
     if (!item.second->as<bool>())
     {
@@ -386,8 +383,7 @@ readBool(ConfigItem const& item)
     return item.second->as<bool>()->get();
 }
 
-double
-readDouble(ConfigItem const& item)
+double readDouble(ConfigItem const& item)
 {
     if (!item.second->as<double>())
     {
@@ -397,8 +393,7 @@ readDouble(ConfigItem const& item)
     return item.second->as<double>()->get();
 }
 
-std::string
-readString(ConfigItem const& item)
+std::string readString(ConfigItem const& item)
 {
     if (!item.second->as<std::string>())
     {
@@ -408,9 +403,7 @@ readString(ConfigItem const& item)
     return item.second->as<std::string>()->get();
 }
 
-template <typename T>
-std::vector<T>
-readArray(ConfigItem const& item)
+template <typename T> std::vector<T> readArray(ConfigItem const& item)
 {
     auto result = std::vector<T>{};
     if (!item.second->is_array())
@@ -461,9 +454,8 @@ castInt(int64_t v, std::string const& name, T min, T max)
 }
 
 template <typename T>
-T
-readInt(ConfigItem const& item, T min = std::numeric_limits<T>::min(),
-        T max = std::numeric_limits<T>::max())
+T readInt(ConfigItem const& item, T min = std::numeric_limits<T>::min(),
+          T max = std::numeric_limits<T>::max())
 {
     if (!item.second->as<int64_t>())
     {
@@ -474,9 +466,9 @@ readInt(ConfigItem const& item, T min = std::numeric_limits<T>::min(),
 }
 
 template <typename T>
-std::vector<T>
-readIntArray(ConfigItem const& item, T min = std::numeric_limits<T>::min(),
-             T max = std::numeric_limits<T>::max())
+std::vector<T> readIntArray(ConfigItem const& item,
+                            T min = std::numeric_limits<T>::min(),
+                            T max = std::numeric_limits<T>::max())
 {
     auto resultInt64 = readArray<int64_t>(item);
     auto result = std::vector<T>{};
@@ -487,9 +479,7 @@ readIntArray(ConfigItem const& item, T min = std::numeric_limits<T>::min(),
     return result;
 }
 
-template <typename T>
-std::vector<T>
-readXdrEnumArray(ConfigItem const& item)
+template <typename T> std::vector<T> readXdrEnumArray(ConfigItem const& item)
 {
     UnorderedMap<std::string, T> enumNames;
     for (auto enumVal : xdr::xdr_traits<T>::enum_values())
@@ -526,9 +516,8 @@ readXdrEnumArray(ConfigItem const& item)
 }
 }
 
-void
-Config::loadQset(std::shared_ptr<cpptoml::table> group, SCPQuorumSet& qset,
-                 uint32 level)
+void Config::loadQset(std::shared_ptr<cpptoml::table> group, SCPQuorumSet& qset,
+                      uint32 level)
 {
     if (!group)
     {
@@ -605,9 +594,8 @@ Config::loadQset(std::shared_ptr<cpptoml::table> group, SCPQuorumSet& qset,
     }
 }
 
-void
-Config::addHistoryArchive(std::string const& name, std::string const& get,
-                          std::string const& put, std::string const& mkdir)
+void Config::addHistoryArchive(std::string const& name, std::string const& get,
+                               std::string const& put, std::string const& mkdir)
 {
     auto r = HISTORY.insert(std::make_pair(
         name, HistoryArchiveConfiguration{name, get, put, mkdir}));
@@ -621,14 +609,12 @@ Config::addHistoryArchive(std::string const& name, std::string const& get,
 static std::array<std::string, 4> const kQualities = {"LOW", "MEDIUM", "HIGH",
                                                       "CRITICAL"};
 
-std::string
-Config::toString(ValidatorQuality q) const
+std::string Config::toString(ValidatorQuality q) const
 {
     return kQualities[static_cast<int>(q)];
 }
 
-ValidatorQuality
-Config::parseQuality(std::string const& q) const
+ValidatorQuality Config::parseQuality(std::string const& q) const
 {
     auto it = std::find(kQualities.begin(), kQualities.end(), q);
 
@@ -647,8 +633,7 @@ Config::parseQuality(std::string const& q) const
     return res;
 }
 
-std::vector<ValidatorEntry>
-Config::parseValidators(
+std::vector<ValidatorEntry> Config::parseValidators(
     std::shared_ptr<cpptoml::base> validators,
     UnorderedMap<std::string, ValidatorQuality> const& domainQualityMap)
 {
@@ -823,8 +808,7 @@ Config::parseDomainsQuality(std::shared_ptr<cpptoml::base> domainsQuality)
     return res;
 }
 
-void
-Config::load(std::string const& filename)
+void Config::load(std::string const& filename)
 {
     if (filename != Config::STDIN_SPECIAL_NAME && !fs::exists(filename))
     {
@@ -863,8 +847,7 @@ Config::load(std::string const& filename)
     }
 }
 
-void
-Config::load(std::istream& in)
+void Config::load(std::istream& in)
 {
     std::shared_ptr<cpptoml::table> t;
     cpptoml::parser p(in);
@@ -872,8 +855,7 @@ Config::load(std::istream& in)
     processConfig(t);
 }
 
-void
-Config::addSelfToValidators(
+void Config::addSelfToValidators(
     std::vector<ValidatorEntry>& validators,
     UnorderedMap<std::string, ValidatorQuality> const& domainQualityMap)
 {
@@ -903,8 +885,7 @@ Config::addSelfToValidators(
     validators.emplace_back(self);
 }
 
-void
-Config::verifyHistoryValidatorsBlocking(
+void Config::verifyHistoryValidatorsBlocking(
     std::vector<ValidatorEntry> const& validators)
 {
     std::vector<NodeID> archives;
@@ -933,11 +914,9 @@ Config::verifyHistoryValidatorsBlocking(
 }
 
 template <typename T>
-void
-Config::verifyLoadGenDistribution(std::vector<T> const& values,
-                                  std::vector<uint32_t> const& distribution,
-                                  std::string const& valuesName,
-                                  std::string const& distributionName)
+void Config::verifyLoadGenDistribution(
+    std::vector<T> const& values, std::vector<uint32_t> const& distribution,
+    std::string const& valuesName, std::string const& distributionName)
 {
     if (values.size() != distribution.size())
     {
@@ -970,8 +949,7 @@ Config::verifyLoadGenDistribution(std::vector<T> const& values,
     }
 }
 
-void
-Config::processOpApplySleepTimeForTestingConfigs()
+void Config::processOpApplySleepTimeForTestingConfigs()
 {
     if (OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING.size() !=
         OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING.size())
@@ -1007,8 +985,7 @@ Config::processOpApplySleepTimeForTestingConfigs()
     }
 }
 
-void
-Config::processConfig(std::shared_ptr<cpptoml::table> t)
+void Config::processConfig(std::shared_ptr<cpptoml::table> t)
 {
     auto logIfSet = [](auto& item, auto const& message) {
         if (item.second->template as<bool>())
@@ -2082,8 +2059,7 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
     }
 }
 
-void
-Config::adjust()
+void Config::adjust()
 {
     if (MAX_ADDITIONAL_PEER_CONNECTIONS == -1)
     {
@@ -2217,8 +2193,7 @@ Config::adjust()
                   MAX_PENDING_CONNECTIONS);
 }
 
-void
-Config::logBasicInfo() const
+void Config::logBasicInfo() const
 {
     LOG_INFO(DEFAULT_LOG, "Connection effective settings:");
     LOG_INFO(DEFAULT_LOG, "TARGET_PEER_CONNECTIONS: {}",
@@ -2241,8 +2216,7 @@ Config::logBasicInfo() const
              EXPERIMENTAL_PARALLEL_LEDGER_APPLY ? "true" : "false");
 }
 
-void
-Config::validateConfig(ValidationThresholdLevels thresholdLevel)
+void Config::validateConfig(ValidationThresholdLevels thresholdLevel)
 {
     std::set<NodeID> nodes;
     LocalNode::forAllNodes(QUORUM_SET, [&](NodeID const& n) {
@@ -2324,15 +2298,14 @@ Config::validateConfig(ValidationThresholdLevels thresholdLevel)
     }
 }
 
-void
-Config::parseNodeID(std::string configStr, PublicKey& retKey)
+void Config::parseNodeID(std::string configStr, PublicKey& retKey)
 {
     SecretKey k;
     parseNodeID(configStr, retKey, k, false);
 }
 
-void
-Config::addValidatorName(std::string const& pubKeyStr, std::string const& name)
+void Config::addValidatorName(std::string const& pubKeyStr,
+                              std::string const& name)
 {
     PublicKey k;
     std::string cName = "$";
@@ -2348,9 +2321,8 @@ Config::addValidatorName(std::string const& pubKeyStr, std::string const& name)
     }
 }
 
-void
-Config::parseNodeID(std::string configStr, PublicKey& retKey, SecretKey& sKey,
-                    bool isSeed)
+void Config::parseNodeID(std::string configStr, PublicKey& retKey,
+                         SecretKey& sKey, bool isSeed)
 {
     if (configStr.size() < 2)
     {
@@ -2398,10 +2370,9 @@ Config::parseNodeID(std::string configStr, PublicKey& retKey, SecretKey& sKey,
     }
 }
 
-void
-Config::parseNodeIDsIntoSet(std::shared_ptr<cpptoml::table> t,
-                            std::string const& configStr,
-                            std::set<PublicKey>& keySet)
+void Config::parseNodeIDsIntoSet(std::shared_ptr<cpptoml::table> t,
+                                 std::string const& configStr,
+                                 std::set<PublicKey>& keySet)
 {
     if (t->contains(configStr))
     {
@@ -2419,8 +2390,7 @@ Config::parseNodeIDsIntoSet(std::shared_ptr<cpptoml::table> t,
     }
 }
 
-std::string
-Config::toShortString(PublicKey const& pk) const
+std::string Config::toShortString(PublicKey const& pk) const
 {
     std::string ret = KeyUtils::toStrKey(pk);
     auto it = VALIDATOR_NAMES.find(ret);
@@ -2430,8 +2400,7 @@ Config::toShortString(PublicKey const& pk) const
         return it->second;
 }
 
-std::string
-Config::toStrKey(PublicKey const& pk, bool fullKey) const
+std::string Config::toStrKey(PublicKey const& pk, bool fullKey) const
 {
     std::string res;
     if (fullKey)
@@ -2445,8 +2414,7 @@ Config::toStrKey(PublicKey const& pk, bool fullKey) const
     return res;
 }
 
-bool
-Config::resolveNodeID(std::string const& s, PublicKey& retKey) const
+bool Config::resolveNodeID(std::string const& s, PublicKey& retKey) const
 {
     auto expanded = expandNodeID(s);
     if (expanded.empty())
@@ -2465,8 +2433,7 @@ Config::resolveNodeID(std::string const& s, PublicKey& retKey) const
     return true;
 }
 
-std::string
-Config::expandNodeID(const std::string& s) const
+std::string Config::expandNodeID(const std::string& s) const
 {
     if (s.length() < 2)
     {
@@ -2501,20 +2468,17 @@ Config::expandNodeID(const std::string& s) const
     }
 }
 
-bool
-Config::modeDoesCatchupWithBucketList() const
+bool Config::modeDoesCatchupWithBucketList() const
 {
     return MODE_DOES_CATCHUP;
 }
 
-bool
-Config::allBucketsInMemory() const
+bool Config::allBucketsInMemory() const
 {
     return BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT == 0;
 }
 
-bool
-Config::parallelLedgerClose() const
+bool Config::parallelLedgerClose() const
 {
     // Standalone mode expects synchronous ledger application
     return EXPERIMENTAL_PARALLEL_LEDGER_APPLY &&
@@ -2522,8 +2486,7 @@ Config::parallelLedgerClose() const
            !RUN_STANDALONE;
 }
 
-void
-Config::setNoListen()
+void Config::setNoListen()
 {
     // prevent opening up a port for other peers
     RUN_STANDALONE = true;
@@ -2532,8 +2495,7 @@ Config::setNoListen()
     MANUAL_CLOSE = true;
 }
 
-void
-Config::setNoPublish()
+void Config::setNoPublish()
 {
     for (auto& item : HISTORY)
     {
@@ -2541,8 +2503,7 @@ Config::setNoPublish()
     }
 }
 
-bool
-Config::skipHighCriticalValidatorChecks() const
+bool Config::skipHighCriticalValidatorChecks() const
 {
 #ifdef BUILD_TESTS
     return SKIP_HIGH_CRITICAL_VALIDATOR_CHECKS_FOR_TESTING;
@@ -2550,8 +2511,7 @@ Config::skipHighCriticalValidatorChecks() const
     return false;
 }
 
-SCPQuorumSet
-Config::generateQuorumSetHelper(
+SCPQuorumSet Config::generateQuorumSetHelper(
     std::vector<ValidatorEntry>::const_iterator begin,
     std::vector<ValidatorEntry>::const_iterator end,
     ValidatorQuality curQuality)
@@ -2634,8 +2594,7 @@ Config::generateQuorumSet(std::vector<ValidatorEntry> const& validators)
     return res;
 }
 
-std::string
-Config::toString(SCPQuorumSet const& qset)
+std::string Config::toString(SCPQuorumSet const& qset)
 {
     auto json = LocalNode::toJson(
         qset, [&](PublicKey const& k) { return toShortString(k); });
@@ -2643,8 +2602,7 @@ Config::toString(SCPQuorumSet const& qset)
     return fw.write(json);
 }
 
-size_t
-Config::getSorobanByteAllowance() const
+size_t Config::getSorobanByteAllowance() const
 {
 #ifdef BUILD_TESTS
     // Return a big number, but not big enough that it will overflow
@@ -2660,8 +2618,7 @@ Config::getSorobanByteAllowance() const
     return MAX_SOROBAN_BYTE_ALLOWANCE;
 }
 
-size_t
-Config::getClassicByteAllowance() const
+size_t Config::getClassicByteAllowance() const
 {
 #ifdef BUILD_TESTS
     // Return a big number, but not big enough that it will overflow
@@ -2677,8 +2634,8 @@ Config::getClassicByteAllowance() const
     return MAX_CLASSIC_BYTE_ALLOWANCE;
 }
 
-void
-Config::setValidatorWeightConfig(std::vector<ValidatorEntry> const& validators)
+void Config::setValidatorWeightConfig(
+    std::vector<ValidatorEntry> const& validators)
 {
     releaseAssert(!VALIDATOR_WEIGHT_CONFIG.has_value());
 
@@ -2745,8 +2702,7 @@ Config::setValidatorWeightConfig(std::vector<ValidatorEntry> const& validators)
 }
 
 #ifdef BUILD_TESTS
-void
-Config::generateQuorumSetForTesting(
+void Config::generateQuorumSetForTesting(
     std::vector<ValidatorEntry> const& validators)
 {
     QUORUM_SET = generateQuorumSet(validators);

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -70,7 +70,6 @@ struct ValidatorWeightConfig
 
 class Config : public std::enable_shared_from_this<Config>
 {
-
     void validateConfig(ValidationThresholdLevels thresholdLevel);
     void loadQset(std::shared_ptr<cpptoml::table> group, SCPQuorumSet& qset,
                   uint32 level);
@@ -130,8 +129,8 @@ class Config : public std::enable_shared_from_this<Config>
 
     // Sets VALIDATOR_WEIGHT_CONFIG based on the content of `validators`. No-op
     // if this node is not a validator.
-    void
-    setValidatorWeightConfig(std::vector<ValidatorEntry> const& validators);
+    void setValidatorWeightConfig(
+        std::vector<ValidatorEntry> const& validators);
 
   public:
     static const uint32 CURRENT_LEDGER_PROTOCOL_VERSION;
@@ -897,8 +896,8 @@ class Config : public std::enable_shared_from_this<Config>
 
     // Set QUORUM_SET using automatic quorum set configuration based on
     // `validators`.
-    void
-    generateQuorumSetForTesting(std::vector<ValidatorEntry> const& validators);
+    void generateQuorumSetForTesting(
+        std::vector<ValidatorEntry> const& validators);
 
 #endif
 

--- a/src/main/Diagnostics.cpp
+++ b/src/main/Diagnostics.cpp
@@ -12,8 +12,7 @@ namespace stellar
 namespace diagnostics
 {
 
-void
-bucketStats(std::string const& filename, bool aggregateAccounts)
+void bucketStats(std::string const& filename, bool aggregateAccounts)
 {
     XDRInputFileStream in;
     in.open(filename);

--- a/src/main/Maintainer.cpp
+++ b/src/main/Maintainer.cpp
@@ -23,8 +23,7 @@ Maintainer::Maintainer(Application& app) : mApp{app}, mTimer{mApp}
 {
 }
 
-void
-Maintainer::start()
+void Maintainer::start()
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -54,16 +53,14 @@ Maintainer::start()
     }
 }
 
-void
-Maintainer::scheduleMaintenance()
+void Maintainer::scheduleMaintenance()
 {
     releaseAssert(threadIsMain());
     mTimer.expires_from_now(mApp.getConfig().AUTOMATIC_MAINTENANCE_PERIOD);
     mTimer.async_wait([this]() { tick(); }, VirtualTimer::onFailureNoop);
 }
 
-void
-Maintainer::tick()
+void Maintainer::tick()
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -71,8 +68,7 @@ Maintainer::tick()
     scheduleMaintenance();
 }
 
-void
-Maintainer::performMaintenance(uint32_t count)
+void Maintainer::performMaintenance(uint32_t count)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());

--- a/src/main/PersistentState.cpp
+++ b/src/main/PersistentState.cpp
@@ -45,9 +45,8 @@ PersistentState::PersistentState(Application& app) : mApp(app)
     releaseAssert(threadIsMain());
 }
 
-void
-PersistentState::deleteTxSets(std::unordered_set<Hash> hashesToDelete,
-                              std::string table)
+void PersistentState::deleteTxSets(std::unordered_set<Hash> hashesToDelete,
+                                   std::string table)
 {
     releaseAssert(threadIsMain());
     soci::transaction tx(mApp.getDatabase().getRawSession());
@@ -66,8 +65,7 @@ PersistentState::deleteTxSets(std::unordered_set<Hash> hashesToDelete,
     tx.commit();
 }
 
-void
-PersistentState::migrateToSlotStateTable()
+void PersistentState::migrateToSlotStateTable()
 {
     // No soci::transaction needed, because the migration in Database.cpp wraps
     // everything in one transaction anyway.
@@ -126,8 +124,7 @@ PersistentState::migrateToSlotStateTable()
     }
 }
 
-void
-PersistentState::dropAll(Database& db)
+void PersistentState::dropAll(Database& db)
 {
     releaseAssert(threadIsMain());
     db.getRawSession() << "DROP TABLE IF EXISTS storestate;";
@@ -139,8 +136,8 @@ PersistentState::dropAll(Database& db)
     st2.execute(true);
 }
 
-std::string
-PersistentState::getStoreStateName(PersistentState::Entry n, uint32 subscript)
+std::string PersistentState::getStoreStateName(PersistentState::Entry n,
+                                               uint32 subscript)
 {
     if (n < 0 || n >= kLastEntry)
     {
@@ -154,16 +151,14 @@ PersistentState::getStoreStateName(PersistentState::Entry n, uint32 subscript)
     return res;
 }
 
-std::string
-PersistentState::getStoreStateNameForTxSet(Hash const& txSetHash)
+std::string PersistentState::getStoreStateNameForTxSet(Hash const& txSetHash)
 {
     auto res = mapping[kTxSet];
     res += binToHex(txSetHash);
     return res;
 }
 
-bool
-PersistentState::hasTxSet(Hash const& txSetHash)
+bool PersistentState::hasTxSet(Hash const& txSetHash)
 {
     releaseAssert(threadIsMain());
 
@@ -183,15 +178,14 @@ PersistentState::hasTxSet(Hash const& txSetHash)
     return res > 0;
 }
 
-std::string
-PersistentState::getDBForEntry(PersistentState::Entry entry)
+std::string PersistentState::getDBForEntry(PersistentState::Entry entry)
 {
     releaseAssert(entry != kLastEntry);
     return entry <= kRebuildLedger ? kLCLTableName : kSlotTableName;
 }
 
-std::string
-PersistentState::getState(PersistentState::Entry entry, SessionWrapper& session)
+std::string PersistentState::getState(PersistentState::Entry entry,
+                                      SessionWrapper& session)
 {
     ZoneScoped;
     releaseAssert(threadIsMain() ||
@@ -199,9 +193,9 @@ PersistentState::getState(PersistentState::Entry entry, SessionWrapper& session)
     return getFromDb(getStoreStateName(entry), session, getDBForEntry(entry));
 }
 
-void
-PersistentState::setState(PersistentState::Entry entry,
-                          std::string const& value, SessionWrapper& session)
+void PersistentState::setState(PersistentState::Entry entry,
+                               std::string const& value,
+                               SessionWrapper& session)
 {
     ZoneScoped;
     releaseAssert(threadIsMain() ||
@@ -230,8 +224,7 @@ PersistentState::getSCPStateAllSlots(std::string table)
     return states;
 }
 
-void
-PersistentState::setSCPStateForSlot(uint64 slot, std::string const& value)
+void PersistentState::setSCPStateForSlot(uint64 slot, std::string const& value)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -242,8 +235,7 @@ PersistentState::setSCPStateForSlot(uint64 slot, std::string const& value)
              mApp.getDatabase().getSession(), kSlotTableName);
 }
 
-void
-PersistentState::setSCPStateV1ForSlot(
+void PersistentState::setSCPStateV1ForSlot(
     uint64 slot, std::string const& value,
     std::unordered_map<Hash, std::string> const& txSets)
 {
@@ -260,8 +252,7 @@ PersistentState::setSCPStateV1ForSlot(
     tx.commit();
 }
 
-bool
-PersistentState::shouldRebuildForOfferTable()
+bool PersistentState::shouldRebuildForOfferTable()
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -271,8 +262,7 @@ PersistentState::shouldRebuildForOfferTable()
                 .empty();
 }
 
-void
-PersistentState::clearRebuildForOfferTable()
+void PersistentState::clearRebuildForOfferTable()
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -281,8 +271,7 @@ PersistentState::clearRebuildForOfferTable()
              mApp.getDatabase().getSession(), kLCLTableName);
 }
 
-void
-PersistentState::setRebuildForOfferTable()
+void PersistentState::setRebuildForOfferTable()
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -290,9 +279,9 @@ PersistentState::setRebuildForOfferTable()
              mApp.getDatabase().getSession(), kLCLTableName);
 }
 
-void
-PersistentState::updateDb(std::string const& entry, std::string const& value,
-                          SessionWrapper& sess, std::string const& tableName)
+void PersistentState::updateDb(std::string const& entry,
+                               std::string const& value, SessionWrapper& sess,
+                               std::string const& tableName)
 {
     ZoneScoped;
     releaseAssert(threadIsMain() ||
@@ -369,8 +358,7 @@ PersistentState::getTxSetsForAllSlots(std::string table)
     return result;
 }
 
-std::unordered_set<Hash>
-PersistentState::getTxSetHashesForAllSlots()
+std::unordered_set<Hash> PersistentState::getTxSetHashesForAllSlots()
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -405,9 +393,9 @@ PersistentState::getTxSetHashesForAllSlots()
     return result;
 }
 
-std::string
-PersistentState::getFromDb(std::string const& entry, SessionWrapper& sess,
-                           std::string const& tableName)
+std::string PersistentState::getFromDb(std::string const& entry,
+                                       SessionWrapper& sess,
+                                       std::string const& tableName)
 {
     ZoneScoped;
     releaseAssert(threadIsMain() ||

--- a/src/main/PersistentState.h
+++ b/src/main/PersistentState.h
@@ -49,9 +49,9 @@ class PersistentState
     getTxSetsForAllSlots(std::string table = kSlotTableName);
     std::unordered_set<Hash> getTxSetHashesForAllSlots();
 
-    void
-    setSCPStateV1ForSlot(uint64 slot, std::string const& value,
-                         std::unordered_map<Hash, std::string> const& txSets);
+    void setSCPStateV1ForSlot(
+        uint64 slot, std::string const& value,
+        std::unordered_map<Hash, std::string> const& txSets);
 
     bool shouldRebuildForOfferTable();
     void clearRebuildForOfferTable();

--- a/src/main/QueryServer.cpp
+++ b/src/main/QueryServer.cpp
@@ -98,9 +98,8 @@ QueryServer::QueryServer(const std::string& address, unsigned short port,
     }
 }
 
-bool
-QueryServer::notFound(std::string const& params, std::string const& body,
-                      std::string& retStr)
+bool QueryServer::notFound(std::string const& params, std::string const& body,
+                           std::string& retStr)
 {
     retStr = "<b>Welcome to stellar-core!</b><p>";
     retStr +=
@@ -115,16 +114,14 @@ QueryServer::notFound(std::string const& params, std::string const& body,
     return true;
 }
 
-void
-QueryServer::addRoute(std::string const& name, HandlerRoute route)
+void QueryServer::addRoute(std::string const& name, HandlerRoute route)
 {
     mServer.addRoute(
         name, std::bind(&QueryServer::safeRouter, this, route, _1, _2, _3));
 }
 
-bool
-QueryServer::safeRouter(HandlerRoute route, std::string const& params,
-                        std::string const& body, std::string& retStr)
+bool QueryServer::safeRouter(HandlerRoute route, std::string const& params,
+                             std::string const& body, std::string& retStr)
 {
     try
     {
@@ -144,9 +141,9 @@ QueryServer::safeRouter(HandlerRoute route, std::string const& params,
     return false;
 }
 
-bool
-QueryServer::getLedgerEntryRaw(std::string const& params,
-                               std::string const& body, std::string& retStr)
+bool QueryServer::getLedgerEntryRaw(std::string const& params,
+                                    std::string const& body,
+                                    std::string& retStr)
 {
     ZoneScoped;
     Json::Value root;
@@ -224,9 +221,8 @@ QueryServer::getLedgerEntryRaw(std::string const& params,
 // 2. For any Soroban keys not in the live BucketList, load them from the Hot
 //    Archive
 // 3. Load TTL keys for any live Soroban entries found in 1.
-bool
-QueryServer::getLedgerEntry(std::string const& params, std::string const& body,
-                            std::string& retStr)
+bool QueryServer::getLedgerEntry(std::string const& params,
+                                 std::string const& body, std::string& retStr)
 {
     ZoneScoped;
     Json::Value root;

--- a/src/main/SettingsUpgradeUtils.cpp
+++ b/src/main/SettingsUpgradeUtils.cpp
@@ -186,8 +186,7 @@ getCreateTx(PublicKey const& publicKey, LedgerKey const& contractCodeLedgerKey,
     return {txEnv, contractSourceRefLedgerKey, contractID};
 }
 
-void
-validateConfigUpgradeSet(ConfigUpgradeSet const& upgradeSet)
+void validateConfigUpgradeSet(ConfigUpgradeSet const& upgradeSet)
 {
     for (auto const& entry : upgradeSet.updatedEntry)
     {
@@ -217,7 +216,6 @@ getInvokeTx(PublicKey const& publicKey, LedgerKey const& contractCodeLedgerKey,
             ConfigUpgradeSet const& upgradeSet, SequenceNumber seqNum,
             int64_t addResourceFee)
 {
-
     validateConfigUpgradeSet(upgradeSet);
 
     TransactionEnvelope txEnv;

--- a/src/main/dumpxdr.cpp
+++ b/src/main/dumpxdr.cpp
@@ -47,9 +47,7 @@ using namespace std::placeholders;
 namespace stellar
 {
 
-template <typename T>
-void
-dumpstream(XDRInputFileStream& in, bool compact)
+template <typename T> void dumpstream(XDRInputFileStream& in, bool compact)
 {
     T tmp;
     cereal::JSONOutputArchive archive(
@@ -62,8 +60,7 @@ dumpstream(XDRInputFileStream& in, bool compact)
     }
 }
 
-void
-dumpXdrStream(std::string const& filename, bool compact)
+void dumpXdrStream(std::string const& filename, bool compact)
 {
     std::regex rx(
         R"(.*\b(debug-tx-set|(?:(ledger|bucket|transactions|results|meta|scp)-?.*))\.xdr(?:\.dirty)?$)");
@@ -127,9 +124,8 @@ dumpXdrStream(std::string const& filename, bool compact)
                                  xdr_strerror(errno)); \
     } while (0)
 
-void
-readFile(const std::string& filename, bool base64,
-         std::function<void(xdr::opaque_vec<>)> proc)
+void readFile(const std::string& filename, bool base64,
+              std::function<void(xdr::opaque_vec<>)> proc)
 {
     using namespace std;
     ifstream file;
@@ -177,16 +173,15 @@ readFile(const std::string& filename, bool base64,
 }
 
 template <typename T>
-void
-printOneXdr(xdr::opaque_vec<> const& o, std::string const& desc, bool compact)
+void printOneXdr(xdr::opaque_vec<> const& o, std::string const& desc,
+                 bool compact)
 {
     T tmp;
     xdr::xdr_from_opaque(o, tmp);
     std::cout << xdrToCerealString(tmp, desc, compact) << std::endl;
 }
 
-void
-printTransactionMeta(xdr::opaque_vec<> const& o, bool compact)
+void printTransactionMeta(xdr::opaque_vec<> const& o, bool compact)
 {
     TransactionMeta tmp;
     xdr::xdr_from_opaque(o, tmp);
@@ -195,9 +190,8 @@ printTransactionMeta(xdr::opaque_vec<> const& o, bool compact)
               << std::endl;
 }
 
-void
-printXdr(std::string const& filename, std::string const& filetype, bool base64,
-         bool compact, bool rawMode)
+void printXdr(std::string const& filename, std::string const& filetype,
+              bool base64, bool compact, bool rawMode)
 {
 // need to use this pattern as there is no good way to get a human readable
 // type name from a type
@@ -267,8 +261,7 @@ printXdr(std::string const& filename, std::string const& filetype, bool base64,
 }
 
 #if HAVE_TERMIOS
-static int
-set_echo_flag(int fd, bool flag)
+static int set_echo_flag(int fd, bool flag)
 {
     struct termios tios;
     if (tcgetattr(fd, &tios))
@@ -283,8 +276,7 @@ set_echo_flag(int fd, bool flag)
 #endif
 
 #ifdef _WIN32
-static std::string
-getSecureCreds(std::string const& prompt)
+static std::string getSecureCreds(std::string const& prompt)
 {
     std::string res;
     CREDUI_INFO cui;
@@ -339,8 +331,7 @@ constexpr ssize_t (&mywrite)(int, const void*, size_t) = ::write;
 #define mywrite write
 #endif // not (gcc 4+ and glibc)
 
-std::string
-readSecret(const std::string& prompt, bool force_tty)
+std::string readSecret(const std::string& prompt, bool force_tty)
 {
     std::string ret;
 
@@ -391,9 +382,8 @@ readSecret(const std::string& prompt, bool force_tty)
 #endif
 }
 
-void
-signtxns(std::vector<TransactionEnvelope>& txEnvs, std::string netId,
-         bool base64, bool txn_stdin, bool dump_hex_txid)
+void signtxns(std::vector<TransactionEnvelope>& txEnvs, std::string netId,
+              bool base64, bool txn_stdin, bool dump_hex_txid)
 {
     SecretKey sk(SecretKey::fromStrKeySeed(readSecret(
         fmt::format(FMT_STRING("Secret key seed [network id: '{}']: "), netId),
@@ -449,8 +439,7 @@ signtxns(std::vector<TransactionEnvelope>& txEnvs, std::string netId,
     }
 }
 
-void
-signtxn(std::string const& filename, std::string netId, bool base64)
+void signtxn(std::string const& filename, std::string netId, bool base64)
 {
     using namespace std;
 
@@ -483,8 +472,7 @@ signtxn(std::string const& filename, std::string netId, bool base64)
     }
 }
 
-void
-priv2pub()
+void priv2pub()
 {
     using namespace std;
     try

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -34,8 +34,7 @@ namespace stellar
 
 template <typename T> inline void xdr_validate_enum(T);
 
-static void
-printCurrentException()
+static void printCurrentException()
 {
     std::exception_ptr eptr = std::current_exception();
     if (eptr)
@@ -133,16 +132,14 @@ printCurrentException()
     }
 }
 
-static void
-printBacktraceAndAbort()
+static void printBacktraceAndAbort()
 {
     printCurrentException();
     printCurrentBacktrace();
     std::abort();
 }
 
-static void
-outOfMemory()
+static void outOfMemory()
 {
     std::fprintf(stderr, "Unable to allocate memory\n");
     std::fflush(stderr);
@@ -162,8 +159,7 @@ extern const std::vector<std::pair<std::filesystem::path, std::string>>
     XDR_FILES_SHA256;
 }
 
-void
-checkXDRFileIdentity()
+void checkXDRFileIdentity()
 {
     using namespace stellar::rust_bridge;
 
@@ -227,8 +223,7 @@ checkXDRFileIdentity()
     }
 }
 
-void
-checkStellarCoreMajorVersionProtocolIdentity()
+void checkStellarCoreMajorVersionProtocolIdentity()
 {
     // This extracts a major version number from the git version string embedded
     // in the binary if, and only if, that version string has the form of a
@@ -295,8 +290,7 @@ checkStellarCoreMajorVersionProtocolIdentity()
 #ifdef ASAN_ENABLED
 #error "ASAN_ENABLED and USE_TRACY_MEMORY_TRACKING are mutually exclusive"
 #else
-void*
-operator new(std::size_t count)
+void* operator new(std::size_t count)
 {
     auto ptr = malloc(count);
     if (ptr == nullptr)
@@ -309,15 +303,13 @@ operator new(std::size_t count)
     return ptr;
 }
 
-void
-operator delete(void* ptr) noexcept
+void operator delete(void* ptr) noexcept
 {
     TracySecureFree(ptr);
     free(ptr);
 }
 
-void*
-operator new[](std::size_t count)
+void* operator new[](std::size_t count)
 {
     auto ptr = malloc(count);
     if (ptr == nullptr)
@@ -328,8 +320,7 @@ operator new[](std::size_t count)
     return ptr;
 }
 
-void
-operator delete[](void* ptr) noexcept
+void operator delete[](void* ptr) noexcept
 {
     TracySecureFree(ptr);
     free(ptr);
@@ -337,8 +328,7 @@ operator delete[](void* ptr) noexcept
 #endif // !ASAN_ENABLED
 #endif // USE_TRACY_MEMORY_TRACKING
 
-int
-main(int argc, char* const* argv)
+int main(int argc, char* const* argv)
 {
     using namespace stellar;
     BacktraceManager btGuard;
@@ -359,7 +349,6 @@ main(int argc, char* const* argv)
 
     try
     {
-
         checkStellarCoreMajorVersionProtocolIdentity();
         rust_bridge::check_sensible_soroban_config_for_protocol(
             Config::CURRENT_LEDGER_PROTOCOL_VERSION);

--- a/src/main/test/ApplicationUtilsTests.cpp
+++ b/src/main/test/ApplicationUtilsTests.cpp
@@ -35,8 +35,7 @@ class TemporaryFileDamager
         mVictimSaved.replace_filename(mVictim.filename().string() + "-saved");
         std::filesystem::copy_file(mVictim, mVictimSaved);
     }
-    virtual void
-    damageVictim()
+    virtual void damageVictim()
     {
         // Default damage just truncates the file.
         std::ofstream out(mVictim);

--- a/src/main/test/ConfigTests.cpp
+++ b/src/main/test/ConfigTests.cpp
@@ -17,8 +17,7 @@ using namespace stellar;
 namespace
 {
 
-bool
-keyMatches(PublicKey& key, const std::vector<std::string>& keys)
+bool keyMatches(PublicKey& key, const std::vector<std::string>& keys)
 {
     auto keyStr = KeyUtils::toStrKey<PublicKey>(key);
     return std::any_of(std::begin(keys), std::end(keys),

--- a/src/main/test/SelfCheckTests.cpp
+++ b/src/main/test/SelfCheckTests.cpp
@@ -24,8 +24,7 @@ class SelfCheckMultiArchiveHistoryConfigurator
     : public TmpDirHistoryConfigurator
 {
   public:
-    Config&
-    configure(Config& cfg, bool writable) const override
+    Config& configure(Config& cfg, bool writable) const override
     {
         REQUIRE(writable);
         TmpDirHistoryConfigurator::configure(cfg, writable);

--- a/src/overlay/BanManagerImpl.cpp
+++ b/src/overlay/BanManagerImpl.cpp
@@ -14,8 +14,7 @@ namespace stellar
 
 using namespace std;
 
-std::unique_ptr<BanManager>
-BanManager::create(Application& app)
+std::unique_ptr<BanManager> BanManager::create(Application& app)
 {
     return std::make_unique<BanManagerImpl>(app);
 }
@@ -28,8 +27,7 @@ BanManagerImpl::~BanManagerImpl()
 {
 }
 
-void
-BanManagerImpl::banNode(NodeID nodeID)
+void BanManagerImpl::banNode(NodeID nodeID)
 {
     ZoneScoped;
     if (isBanned(nodeID))
@@ -53,8 +51,7 @@ BanManagerImpl::banNode(NodeID nodeID)
     }
 }
 
-void
-BanManagerImpl::unbanNode(NodeID nodeID)
+void BanManagerImpl::unbanNode(NodeID nodeID)
 {
     ZoneScoped;
     auto nodeIDString = KeyUtils::toStrKey(nodeID);
@@ -71,8 +68,7 @@ BanManagerImpl::unbanNode(NodeID nodeID)
     }
 }
 
-bool
-BanManagerImpl::isBanned(NodeID nodeID)
+bool BanManagerImpl::isBanned(NodeID nodeID)
 {
     ZoneScoped;
     auto nodeIDString = KeyUtils::toStrKey(nodeID);
@@ -91,8 +87,7 @@ BanManagerImpl::isBanned(NodeID nodeID)
     }
 }
 
-std::vector<std::string>
-BanManagerImpl::getBans()
+std::vector<std::string> BanManagerImpl::getBans()
 {
     ZoneScoped;
     std::vector<std::string> result;
@@ -114,8 +109,7 @@ BanManagerImpl::getBans()
     return result;
 }
 
-void
-BanManager::dropAll(Database& db)
+void BanManager::dropAll(Database& db)
 {
     db.getRawSession() << "DROP TABLE IF EXISTS ban";
 

--- a/src/overlay/Floodgate.cpp
+++ b/src/overlay/Floodgate.cpp
@@ -37,8 +37,7 @@ Floodgate::Floodgate(Application& app)
 }
 
 // remove old flood records
-void
-Floodgate::clearBelow(uint32_t maxLedger)
+void Floodgate::clearBelow(uint32_t maxLedger)
 {
     ZoneScoped;
     for (auto it = mFloodMap.cbegin(); it != mFloodMap.cend();)
@@ -55,8 +54,7 @@ Floodgate::clearBelow(uint32_t maxLedger)
     mFloodMapSize.set_count(mFloodMap.size());
 }
 
-bool
-Floodgate::addRecord(Peer::pointer peer, Hash const& index)
+bool Floodgate::addRecord(Peer::pointer peer, Hash const& index)
 {
     ZoneScoped;
     if (mShuttingDown)
@@ -81,9 +79,8 @@ Floodgate::addRecord(Peer::pointer peer, Hash const& index)
 }
 
 // send message to anyone you haven't gotten it from
-bool
-Floodgate::broadcast(std::shared_ptr<StellarMessage const> msg,
-                     std::optional<Hash> const& hash)
+bool Floodgate::broadcast(std::shared_ptr<StellarMessage const> msg,
+                          std::optional<Hash> const& hash)
 {
     releaseAssert(threadIsMain());
     ZoneScoped;
@@ -166,8 +163,7 @@ Floodgate::broadcast(std::shared_ptr<StellarMessage const> msg,
     return broadcasted;
 }
 
-std::set<Peer::pointer>
-Floodgate::getPeersKnows(Hash const& h)
+std::set<Peer::pointer> Floodgate::getPeersKnows(Hash const& h)
 {
     std::set<Peer::pointer> res;
     auto record = mFloodMap.find(h);
@@ -186,15 +182,13 @@ Floodgate::getPeersKnows(Hash const& h)
     return res;
 }
 
-void
-Floodgate::shutdown()
+void Floodgate::shutdown()
 {
     mShuttingDown = true;
     mFloodMap.clear();
 }
 
-void
-Floodgate::forgetRecord(Hash const& h)
+void Floodgate::forgetRecord(Hash const& h)
 {
     mFloodMap.erase(h);
 }

--- a/src/overlay/FlowControl.cpp
+++ b/src/overlay/FlowControl.cpp
@@ -16,8 +16,7 @@
 namespace stellar
 {
 
-size_t
-FlowControl::getOutboundQueueByteLimit(MutexLocker& lockGuard) const
+size_t FlowControl::getOutboundQueueByteLimit(MutexLocker& lockGuard) const
 {
 #ifdef BUILD_TESTS
     if (mOutboundQueueLimit)
@@ -42,33 +41,29 @@ FlowControl::FlowControl(AppConnector& connector, bool useBackgroundThread)
     releaseAssert(threadIsMain());
 }
 
-bool
-FlowControl::hasOutboundCapacity(StellarMessage const& msg,
-                                 MutexLocker& lockGuard) const
+bool FlowControl::hasOutboundCapacity(StellarMessage const& msg,
+                                      MutexLocker& lockGuard) const
 {
     releaseAssert(!threadIsMain() || !mUseBackgroundThread);
     return mFlowControlCapacity.hasOutboundCapacity(msg) &&
            mFlowControlBytesCapacity.hasOutboundCapacity(msg);
 }
 
-bool
-FlowControl::noOutboundCapacityTimeout(VirtualClock::time_point now,
-                                       std::chrono::seconds timeout) const
+bool FlowControl::noOutboundCapacityTimeout(VirtualClock::time_point now,
+                                            std::chrono::seconds timeout) const
 {
     MutexLocker guard(mFlowControlMutex);
     return mNoOutboundCapacity && now - *mNoOutboundCapacity >= timeout;
 }
 
-void
-FlowControl::setPeerID(NodeID const& peerID)
+void FlowControl::setPeerID(NodeID const& peerID)
 {
     releaseAssert(threadIsMain());
     MutexLocker guard(mFlowControlMutex);
     mNodeID = peerID;
 }
 
-void
-FlowControl::maybeReleaseCapacity(StellarMessage const& msg)
+void FlowControl::maybeReleaseCapacity(StellarMessage const& msg)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -96,8 +91,7 @@ FlowControl::maybeReleaseCapacity(StellarMessage const& msg)
     }
 }
 
-void
-FlowControl::processSentMessages(
+void FlowControl::processSentMessages(
     FloodQueues<ConstStellarMessagePtr> const& sentMessages)
 {
     ZoneScoped;
@@ -214,9 +208,8 @@ FlowControl::getNextBatchToSend()
     return batchToSend;
 }
 
-void
-FlowControl::updateMsgMetrics(std::shared_ptr<StellarMessage const> msg,
-                              VirtualClock::time_point const& timePlaced)
+void FlowControl::updateMsgMetrics(std::shared_ptr<StellarMessage const> msg,
+                                   VirtualClock::time_point const& timePlaced)
 {
     // The lock isn't strictly needed here, but is added for consistency and
     // future-proofing this function
@@ -260,8 +253,7 @@ FlowControl::updateMsgMetrics(std::shared_ptr<StellarMessage const> msg,
     }
 }
 
-void
-FlowControl::handleTxSizeIncrease(uint32_t increase)
+void FlowControl::handleTxSizeIncrease(uint32_t increase)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -271,8 +263,7 @@ FlowControl::handleTxSizeIncrease(uint32_t increase)
     mFlowControlBytesCapacity.handleTxSizeIncrease(increase);
 }
 
-bool
-FlowControl::beginMessageProcessing(StellarMessage const& msg)
+bool FlowControl::beginMessageProcessing(StellarMessage const& msg)
 {
     ZoneScoped;
     releaseAssert(!threadIsMain() || !mUseBackgroundThread);
@@ -282,8 +273,7 @@ FlowControl::beginMessageProcessing(StellarMessage const& msg)
            mFlowControlBytesCapacity.lockLocalCapacity(msg);
 }
 
-SendMoreCapacity
-FlowControl::endMessageProcessing(StellarMessage const& msg)
+SendMoreCapacity FlowControl::endMessageProcessing(StellarMessage const& msg)
 {
     ZoneScoped;
     MutexLocker guard(mFlowControlMutex);
@@ -324,29 +314,25 @@ FlowControl::endMessageProcessing(StellarMessage const& msg)
     return res;
 }
 
-bool
-FlowControl::canRead(MutexLocker const& guard) const
+bool FlowControl::canRead(MutexLocker const& guard) const
 {
     return mFlowControlBytesCapacity.canRead() &&
            mFlowControlCapacity.canRead();
 }
 
-bool
-FlowControl::canRead() const
+bool FlowControl::canRead() const
 {
     MutexLocker guard(mFlowControlMutex);
     return canRead(guard);
 }
 
-uint32_t
-FlowControl::getNumMessages(StellarMessage const& msg)
+uint32_t FlowControl::getNumMessages(StellarMessage const& msg)
 {
     releaseAssert(msg.type() == SEND_MORE_EXTENDED);
     return msg.sendMoreExtendedMessage().numMessages;
 }
 
-uint32_t
-FlowControl::getMessagePriority(StellarMessage const& msg)
+uint32_t FlowControl::getMessagePriority(StellarMessage const& msg)
 {
     switch (msg.type())
     {
@@ -369,9 +355,8 @@ FlowControl::getMessagePriority(StellarMessage const& msg)
     }
 }
 
-bool
-FlowControl::isSendMoreValid(StellarMessage const& msg,
-                             std::string& errorMsg) const
+bool FlowControl::isSendMoreValid(StellarMessage const& msg,
+                                  std::string& errorMsg) const
 {
     releaseAssert(threadIsMain());
     MutexLocker guard(mFlowControlMutex);
@@ -408,8 +393,8 @@ FlowControl::isSendMoreValid(StellarMessage const& msg,
     return true;
 }
 
-void
-FlowControl::addMsgAndMaybeTrimQueue(std::shared_ptr<StellarMessage const> msg)
+void FlowControl::addMsgAndMaybeTrimQueue(
+    std::shared_ptr<StellarMessage const> msg)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -563,8 +548,7 @@ FlowControl::addMsgAndMaybeTrimQueue(std::shared_ptr<StellarMessage const> msg)
     }
 }
 
-Json::Value
-FlowControl::getFlowControlJsonInfo(bool compact) const
+Json::Value FlowControl::getFlowControlJsonInfo(bool compact) const
 {
     releaseAssert(threadIsMain());
     MutexLocker guard(mFlowControlMutex);
@@ -606,8 +590,7 @@ FlowControl::getFlowControlJsonInfo(bool compact) const
     return res;
 }
 
-bool
-FlowControl::maybeThrottleRead()
+bool FlowControl::maybeThrottleRead()
 {
     MutexLocker guard(mFlowControlMutex);
     if (!canRead(guard))
@@ -620,8 +603,7 @@ FlowControl::maybeThrottleRead()
     return false;
 }
 
-void
-FlowControl::stopThrottling()
+void FlowControl::stopThrottling()
 {
     MutexLocker guard(mFlowControlMutex);
     releaseAssert(mLastThrottle);
@@ -632,8 +614,7 @@ FlowControl::stopThrottling()
     mLastThrottle.reset();
 }
 
-bool
-FlowControl::isThrottled() const
+bool FlowControl::isThrottled() const
 {
     MutexLocker guard(mFlowControlMutex);
     return static_cast<bool>(mLastThrottle);

--- a/src/overlay/FlowControl.h
+++ b/src/overlay/FlowControl.h
@@ -132,20 +132,18 @@ class FlowControl
         LOCKS_EXCLUDED(mFlowControlMutex);
 
 #ifdef BUILD_TESTS
-    FlowControlCapacity&
-    getCapacity() NO_THREAD_SAFETY_ANALYSIS
+    FlowControlCapacity& getCapacity() NO_THREAD_SAFETY_ANALYSIS
     {
         return mFlowControlCapacity;
     }
 
-    FlowControlCapacity&
-    getCapacityBytes() NO_THREAD_SAFETY_ANALYSIS
+    FlowControlCapacity& getCapacityBytes() NO_THREAD_SAFETY_ANALYSIS
     {
         return mFlowControlBytesCapacity;
     }
 
-    void
-    addToQueueAndMaybeTrimForTesting(std::shared_ptr<StellarMessage const> msg)
+    void addToQueueAndMaybeTrimForTesting(
+        std::shared_ptr<StellarMessage const> msg)
         LOCKS_EXCLUDED(mFlowControlMutex)
     {
         addMsgAndMaybeTrimQueue(msg);
@@ -157,21 +155,19 @@ class FlowControl
         return mOutboundQueues;
     }
 
-    size_t
-    getTxQueueByteCountForTesting() const LOCKS_EXCLUDED(mFlowControlMutex)
+    size_t getTxQueueByteCountForTesting() const
+        LOCKS_EXCLUDED(mFlowControlMutex)
     {
         MutexLocker lockGuard(mFlowControlMutex);
         return mTxQueueByteCount;
     }
     std::optional<size_t> mOutboundQueueLimit GUARDED_BY(mFlowControlMutex);
-    void
-    setOutboundQueueLimit(size_t bytes) LOCKS_EXCLUDED(mFlowControlMutex)
+    void setOutboundQueueLimit(size_t bytes) LOCKS_EXCLUDED(mFlowControlMutex)
     {
         MutexLocker lockGuard(mFlowControlMutex);
         mOutboundQueueLimit = std::make_optional<size_t>(bytes);
     }
-    size_t
-    getOutboundQueueByteLimit() const LOCKS_EXCLUDED(mFlowControlMutex)
+    size_t getOutboundQueueByteLimit() const LOCKS_EXCLUDED(mFlowControlMutex)
     {
         MutexLocker lockGuard(mFlowControlMutex);
         return getOutboundQueueByteLimit(lockGuard);
@@ -218,8 +214,8 @@ class FlowControl
     // is called once async_write completes and invokes a handler that calls
     // this function). This function will appropriatly trim outbound queues and
     // release capacity used by the messages that were sent.
-    void
-    processSentMessages(FloodQueues<ConstStellarMessagePtr> const& sentMessages)
+    void processSentMessages(
+        FloodQueues<ConstStellarMessagePtr> const& sentMessages)
         LOCKS_EXCLUDED(mFlowControlMutex);
 };
 

--- a/src/overlay/FlowControlCapacity.cpp
+++ b/src/overlay/FlowControlCapacity.cpp
@@ -32,8 +32,8 @@ FlowControlMessageCapacity::getCapacityLimits() const
             std::make_optional<uint64_t>(mConfig.PEER_READING_CAPACITY)};
 }
 
-void
-FlowControlMessageCapacity::releaseOutboundCapacity(StellarMessage const& msg)
+void FlowControlMessageCapacity::releaseOutboundCapacity(
+    StellarMessage const& msg)
 {
     ZoneScoped;
     releaseAssert(msg.type() == SEND_MORE_EXTENDED);
@@ -46,8 +46,7 @@ FlowControlMessageCapacity::releaseOutboundCapacity(StellarMessage const& msg)
     mOutboundCapacity += numMessages;
 }
 
-bool
-FlowControlMessageCapacity::canRead() const
+bool FlowControlMessageCapacity::canRead() const
 {
     ZoneScoped;
     releaseAssert(mCapacity.mTotalCapacity);
@@ -74,8 +73,7 @@ FlowControlByteCapacity::getMsgResourceCount(StellarMessage const& msg) const
     return msgBodySize(msg);
 }
 
-void
-FlowControlByteCapacity::releaseOutboundCapacity(StellarMessage const& msg)
+void FlowControlByteCapacity::releaseOutboundCapacity(StellarMessage const& msg)
 {
     ZoneScoped;
     releaseAssert(msg.type() == SEND_MORE_EXTENDED);
@@ -88,15 +86,13 @@ FlowControlByteCapacity::releaseOutboundCapacity(StellarMessage const& msg)
     mOutboundCapacity += msg.sendMoreExtendedMessage().numBytes;
 };
 
-bool
-FlowControlByteCapacity::canRead() const
+bool FlowControlByteCapacity::canRead() const
 {
     releaseAssert(!mCapacity.mTotalCapacity);
     return true;
 }
 
-void
-FlowControlByteCapacity::handleTxSizeIncrease(uint32_t increase)
+void FlowControlByteCapacity::handleTxSizeIncrease(uint32_t increase)
 {
     mCapacity.mFloodCapacity += increase;
     mCapacityLimits.mFloodCapacity += increase;
@@ -109,8 +105,7 @@ FlowControlCapacity::FlowControlCapacity(Config const& cfg,
     releaseAssert(threadIsMain());
 }
 
-void
-FlowControlCapacity::checkCapacityInvariants() const
+void FlowControlCapacity::checkCapacityInvariants() const
 {
     ZoneScoped;
     releaseAssert(getCapacityLimits().mFloodCapacity >=
@@ -127,8 +122,7 @@ FlowControlCapacity::checkCapacityInvariants() const
     }
 }
 
-void
-FlowControlCapacity::lockOutboundCapacity(StellarMessage const& msg)
+void FlowControlCapacity::lockOutboundCapacity(StellarMessage const& msg)
 {
     ZoneScoped;
     if (OverlayManager::isFloodMessage(msg))
@@ -138,8 +132,7 @@ FlowControlCapacity::lockOutboundCapacity(StellarMessage const& msg)
     }
 }
 
-bool
-FlowControlCapacity::lockLocalCapacity(StellarMessage const& msg)
+bool FlowControlCapacity::lockLocalCapacity(StellarMessage const& msg)
 {
     ZoneScoped;
     checkCapacityInvariants();
@@ -169,8 +162,7 @@ FlowControlCapacity::lockLocalCapacity(StellarMessage const& msg)
     return true;
 }
 
-uint64_t
-FlowControlCapacity::releaseLocalCapacity(StellarMessage const& msg)
+uint64_t FlowControlCapacity::releaseLocalCapacity(StellarMessage const& msg)
 {
     ZoneScoped;
 
@@ -196,15 +188,13 @@ FlowControlCapacity::releaseLocalCapacity(StellarMessage const& msg)
     return releasedFloodCapacity;
 }
 
-bool
-FlowControlCapacity::hasOutboundCapacity(StellarMessage const& msg) const
+bool FlowControlCapacity::hasOutboundCapacity(StellarMessage const& msg) const
 {
     ZoneScoped;
     return mOutboundCapacity >= getMsgResourceCount(msg);
 }
 
-uint64_t
-FlowControlCapacity::msgBodySize(StellarMessage const& msg)
+uint64_t FlowControlCapacity::msgBodySize(StellarMessage const& msg)
 {
     ZoneScoped;
     return static_cast<uint64_t>(xdr::xdr_size(msg));

--- a/src/overlay/FlowControlCapacity.h
+++ b/src/overlay/FlowControlCapacity.h
@@ -45,14 +45,12 @@ class FlowControlCapacity
 
     bool hasOutboundCapacity(StellarMessage const& msg) const;
     void checkCapacityInvariants() const;
-    ReadingCapacity
-    getCapacity() const
+    ReadingCapacity getCapacity() const
     {
         return mCapacity;
     }
 
-    uint64_t
-    getOutboundCapacity() const
+    uint64_t getOutboundCapacity() const
     {
         return mOutboundCapacity;
     }
@@ -62,8 +60,7 @@ class FlowControlCapacity
     static uint64_t msgBodySize(StellarMessage const& msg);
 
 #ifdef BUILD_TESTS
-    void
-    setOutboundCapacity(uint64_t newCapacity)
+    void setOutboundCapacity(uint64_t newCapacity)
     {
         mOutboundCapacity = newCapacity;
     }

--- a/src/overlay/Hmac.cpp
+++ b/src/overlay/Hmac.cpp
@@ -7,8 +7,7 @@
 #include "util/types.h"
 #include <xdrpp/marshal.h>
 
-bool
-Hmac::setSendMackey(HmacSha256Key const& key)
+bool Hmac::setSendMackey(HmacSha256Key const& key)
 {
     ZoneScoped;
     LOCK_GUARD(mMutex, guard);
@@ -20,8 +19,7 @@ Hmac::setSendMackey(HmacSha256Key const& key)
     return true;
 }
 
-bool
-Hmac::setRecvMackey(HmacSha256Key const& key)
+bool Hmac::setRecvMackey(HmacSha256Key const& key)
 {
     ZoneScoped;
     LOCK_GUARD(mMutex, guard);
@@ -33,9 +31,8 @@ Hmac::setRecvMackey(HmacSha256Key const& key)
     return true;
 }
 
-bool
-Hmac::checkAuthenticatedMessage(AuthenticatedMessage const& msg,
-                                std::string& errorMsg)
+bool Hmac::checkAuthenticatedMessage(AuthenticatedMessage const& msg,
+                                     std::string& errorMsg)
 {
     ZoneScoped;
     LOCK_GUARD(mMutex, guard);
@@ -61,9 +58,8 @@ Hmac::checkAuthenticatedMessage(AuthenticatedMessage const& msg,
     return true;
 }
 
-void
-Hmac::setAuthenticatedMessageBody(AuthenticatedMessage& aMsg,
-                                  StellarMessage const& msg)
+void Hmac::setAuthenticatedMessageBody(AuthenticatedMessage& aMsg,
+                                       StellarMessage const& msg)
 
 {
     ZoneScoped;
@@ -80,8 +76,7 @@ Hmac::setAuthenticatedMessageBody(AuthenticatedMessage& aMsg,
 }
 
 #ifdef BUILD_TESTS
-void
-Hmac::damageRecvMacKey()
+void Hmac::damageRecvMacKey()
 {
     auto bytes = randomBytes(mRecvMacKey.key.size());
     std::copy(bytes.begin(), bytes.end(), mRecvMacKey.key.begin());

--- a/src/overlay/ItemFetcher.cpp
+++ b/src/overlay/ItemFetcher.cpp
@@ -19,8 +19,7 @@ ItemFetcher::ItemFetcher(Application& app, AskPeer askPeer)
 {
 }
 
-void
-ItemFetcher::fetch(Hash const& itemHash, const SCPEnvelope& envelope)
+void ItemFetcher::fetch(Hash const& itemHash, const SCPEnvelope& envelope)
 {
     ZoneScoped;
     CLOG_TRACE(Overlay, "fetch {}", hexAbbrev(itemHash));
@@ -40,8 +39,7 @@ ItemFetcher::fetch(Hash const& itemHash, const SCPEnvelope& envelope)
     }
 }
 
-void
-ItemFetcher::stopFetch(Hash const& itemHash, SCPEnvelope const& envelope)
+void ItemFetcher::stopFetch(Hash const& itemHash, SCPEnvelope const& envelope)
 {
     ZoneScoped;
     const auto& iter = mTrackers.find(itemHash);
@@ -65,8 +63,7 @@ ItemFetcher::stopFetch(Hash const& itemHash, SCPEnvelope const& envelope)
     }
 }
 
-uint64
-ItemFetcher::getLastSeenSlotIndex(Hash const& itemHash) const
+uint64 ItemFetcher::getLastSeenSlotIndex(Hash const& itemHash) const
 {
     auto iter = mTrackers.find(itemHash);
     if (iter == mTrackers.end())
@@ -77,8 +74,7 @@ ItemFetcher::getLastSeenSlotIndex(Hash const& itemHash) const
     return iter->second->getLastSeenSlotIndex();
 }
 
-std::vector<SCPEnvelope>
-ItemFetcher::fetchingFor(Hash const& itemHash) const
+std::vector<SCPEnvelope> ItemFetcher::fetchingFor(Hash const& itemHash) const
 {
     auto result = std::vector<SCPEnvelope>{};
     auto iter = mTrackers.find(itemHash);
@@ -94,8 +90,7 @@ ItemFetcher::fetchingFor(Hash const& itemHash) const
     return result;
 }
 
-void
-ItemFetcher::stopFetchingBelow(uint64 slotIndex, uint64 slotToKeep)
+void ItemFetcher::stopFetchingBelow(uint64 slotIndex, uint64 slotToKeep)
 {
     // only perform this cleanup from the top of the stack as it causes
     // all sorts of evil side effects
@@ -106,8 +101,7 @@ ItemFetcher::stopFetchingBelow(uint64 slotIndex, uint64 slotToKeep)
         "ItemFetcher: stopFetchingBelow");
 }
 
-void
-ItemFetcher::stopFetchingBelowInternal(uint64 slotIndex, uint64 slotToKeep)
+void ItemFetcher::stopFetchingBelowInternal(uint64 slotIndex, uint64 slotToKeep)
 {
     ZoneScoped;
     for (auto iter = mTrackers.begin(); iter != mTrackers.end();)
@@ -123,8 +117,7 @@ ItemFetcher::stopFetchingBelowInternal(uint64 slotIndex, uint64 slotToKeep)
     }
 }
 
-void
-ItemFetcher::doesntHave(Hash const& itemHash, Peer::pointer peer)
+void ItemFetcher::doesntHave(Hash const& itemHash, Peer::pointer peer)
 {
     ZoneScoped;
     const auto& iter = mTrackers.find(itemHash);
@@ -134,8 +127,7 @@ ItemFetcher::doesntHave(Hash const& itemHash, Peer::pointer peer)
     }
 }
 
-void
-ItemFetcher::recv(Hash itemHash, medida::Timer& timer)
+void ItemFetcher::recv(Hash itemHash, medida::Timer& timer)
 {
     ZoneScoped;
     const auto& iter = mTrackers.find(itemHash);
@@ -165,8 +157,7 @@ ItemFetcher::recv(Hash itemHash, medida::Timer& timer)
 }
 
 #ifdef BUILD_TESTS
-std::shared_ptr<Tracker>
-ItemFetcher::getTracker(Hash const& h)
+std::shared_ptr<Tracker> ItemFetcher::getTracker(Hash const& h)
 {
     auto it = mTrackers.find(h);
     if (it == mTrackers.end())

--- a/src/overlay/OverlayManager.h
+++ b/src/overlay/OverlayManager.h
@@ -86,8 +86,7 @@ class OverlayManager
     // fills msgID with msg's hash
     virtual bool recvFloodedMsgID(Peer::pointer peer, Hash const& msgID) = 0;
 
-    bool
-    recvFloodedMsg(StellarMessage const& msg, Peer::pointer peer)
+    bool recvFloodedMsg(StellarMessage const& msg, Peer::pointer peer)
     {
         return recvFloodedMsgID(peer, xdrBlake2(msg));
     }

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -47,8 +47,8 @@ constexpr std::chrono::seconds OUT_OF_SYNC_RECONNECT_DELAY(60);
 constexpr uint32_t INITIAL_PEER_FLOOD_READING_CAPACITY_BYTES{300000};
 constexpr uint32_t INITIAL_FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES{100000};
 
-bool
-OverlayManagerImpl::canAcceptOutboundPeer(PeerBareAddress const& address) const
+bool OverlayManagerImpl::canAcceptOutboundPeer(
+    PeerBareAddress const& address) const
 {
     if (availableOutboundPendingSlots() <= 0)
     {
@@ -117,8 +117,7 @@ OverlayManagerImpl::PeersList::byAddress(PeerBareAddress const& address) const
     return {};
 }
 
-void
-OverlayManagerImpl::PeersList::removePeer(Peer* peer)
+void OverlayManagerImpl::PeersList::removePeer(Peer* peer)
 {
     ZoneScoped;
     CLOG_TRACE(Overlay, "Removing peer {}", peer->toString());
@@ -158,8 +157,7 @@ OverlayManagerImpl::PeersList::removePeer(Peer* peer)
     CLOG_WARNING(Overlay, "{}", REPORT_INTERNAL_BUG);
 }
 
-bool
-OverlayManagerImpl::PeersList::moveToAuthenticated(Peer::pointer peer)
+bool OverlayManagerImpl::PeersList::moveToAuthenticated(Peer::pointer peer)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -202,8 +200,7 @@ OverlayManagerImpl::PeersList::moveToAuthenticated(Peer::pointer peer)
     return true;
 }
 
-bool
-OverlayManagerImpl::PeersList::acceptAuthenticatedPeer(Peer::pointer peer)
+bool OverlayManagerImpl::PeersList::acceptAuthenticatedPeer(Peer::pointer peer)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -273,8 +270,7 @@ OverlayManagerImpl::PeersList::acceptAuthenticatedPeer(Peer::pointer peer)
     return false;
 }
 
-void
-OverlayManagerImpl::PeersList::shutdown()
+void OverlayManagerImpl::PeersList::shutdown()
 {
     ZoneScoped;
     auto pendingPeersToStop = mPending;
@@ -294,8 +290,7 @@ OverlayManagerImpl::PeersList::shutdown()
     }
 }
 
-std::unique_ptr<OverlayManager>
-OverlayManager::create(Application& app)
+std::unique_ptr<OverlayManager> OverlayManager::create(Application& app)
 {
     return std::make_unique<OverlayManagerImpl>(app);
 }
@@ -335,8 +330,7 @@ OverlayManagerImpl::~OverlayManagerImpl()
 {
 }
 
-void
-OverlayManagerImpl::start()
+void OverlayManagerImpl::start()
 {
     mDoor.start();
     mTimer.expires_from_now(std::chrono::seconds(2));
@@ -357,8 +351,7 @@ OverlayManagerImpl::start()
     mTxDemandsManager.start();
 }
 
-uint32_t
-OverlayManagerImpl::getFlowControlBytesTotal() const
+uint32_t OverlayManagerImpl::getFlowControlBytesTotal() const
 {
     releaseAssert(threadIsMain());
     auto const maxTxSize = mApp.getHerder().getMaxTxSize();
@@ -384,8 +377,7 @@ OverlayManagerImpl::getFlowControlBytesTotal() const
     return cfg.PEER_FLOOD_READING_CAPACITY_BYTES;
 }
 
-uint32_t
-OverlayManager::getFlowControlBytesBatch(Config const& cfg)
+uint32_t OverlayManager::getFlowControlBytesBatch(Config const& cfg)
 {
     if (cfg.PEER_FLOOD_READING_CAPACITY_BYTES == 0 &&
         cfg.FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES == 0)
@@ -397,16 +389,14 @@ OverlayManager::getFlowControlBytesBatch(Config const& cfg)
     return cfg.FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES;
 }
 
-void
-OverlayManagerImpl::connectTo(PeerBareAddress const& address)
+void OverlayManagerImpl::connectTo(PeerBareAddress const& address)
 {
     ZoneScoped;
     connectToImpl(address, false);
 }
 
-bool
-OverlayManagerImpl::connectToImpl(PeerBareAddress const& address,
-                                  bool forceoutbound)
+bool OverlayManagerImpl::connectToImpl(PeerBareAddress const& address,
+                                       bool forceoutbound)
 {
     releaseAssert(threadIsMain());
     CLOG_TRACE(Overlay, "Initiate connect to {}", address.toString());
@@ -431,8 +421,7 @@ OverlayManagerImpl::connectToImpl(PeerBareAddress const& address,
     }
 }
 
-OverlayManagerImpl::PeersList&
-OverlayManagerImpl::getPeersList(Peer* peer)
+OverlayManagerImpl::PeersList& OverlayManagerImpl::getPeersList(Peer* peer)
 {
     ZoneScoped;
     switch (peer->getRole())
@@ -447,9 +436,9 @@ OverlayManagerImpl::getPeersList(Peer* peer)
     }
 }
 
-void
-OverlayManagerImpl::storePeerList(std::vector<PeerBareAddress> const& addresses,
-                                  bool setPreferred, bool startup)
+void OverlayManagerImpl::storePeerList(
+    std::vector<PeerBareAddress> const& addresses, bool setPreferred,
+    bool startup)
 {
     ZoneScoped;
     auto type = setPreferred ? PeerType::PREFERRED : PeerType::OUTBOUND;
@@ -482,8 +471,7 @@ OverlayManagerImpl::storePeerList(std::vector<PeerBareAddress> const& addresses,
     }
 }
 
-void
-OverlayManagerImpl::storeConfigPeers()
+void OverlayManagerImpl::storeConfigPeers()
 {
     ZoneScoped;
     // Synchronously resolve and store peers from the config
@@ -493,16 +481,14 @@ OverlayManagerImpl::storeConfigPeers()
                   true);
 }
 
-void
-OverlayManagerImpl::purgeDeadPeers()
+void OverlayManagerImpl::purgeDeadPeers()
 {
     ZoneScoped;
     getPeerManager().removePeersWithManyFailures(
         Config::REALLY_DEAD_NUM_FAILURES_CUTOFF);
 }
 
-void
-OverlayManagerImpl::triggerPeerResolution()
+void OverlayManagerImpl::triggerPeerResolution()
 {
     ZoneScoped;
     releaseAssert(!mResolvedPeers.valid());
@@ -574,17 +560,15 @@ OverlayManagerImpl::getPeersToConnectTo(int maxNum, PeerType peerType)
     return mPeerSources[peerType]->getRandomPeers(std::min(maxNum, 50), keep);
 }
 
-int
-OverlayManagerImpl::connectTo(int maxNum, PeerType peerType)
+int OverlayManagerImpl::connectTo(int maxNum, PeerType peerType)
 {
     ZoneScoped;
     return connectTo(getPeersToConnectTo(maxNum, peerType),
                      peerType == PeerType::INBOUND);
 }
 
-int
-OverlayManagerImpl::connectTo(std::vector<PeerBareAddress> const& peers,
-                              bool forceoutbound)
+int OverlayManagerImpl::connectTo(std::vector<PeerBareAddress> const& peers,
+                                  bool forceoutbound)
 {
     ZoneScoped;
     auto count = 0;
@@ -598,8 +582,7 @@ OverlayManagerImpl::connectTo(std::vector<PeerBareAddress> const& peers,
     return count;
 }
 
-void
-OverlayManagerImpl::updateTimerAndMaybeDropRandomPeer(bool shouldDrop)
+void OverlayManagerImpl::updateTimerAndMaybeDropRandomPeer(bool shouldDrop)
 {
     // If we haven't heard from the network for a while, try randomly
     // disconnecting a peer in hopes of picking a better one. (preferred peers
@@ -654,8 +637,7 @@ OverlayManagerImpl::updateTimerAndMaybeDropRandomPeer(bool shouldDrop)
 }
 
 // called every PEER_AUTHENTICATION_TIMEOUT + 1=3 seconds
-void
-OverlayManagerImpl::tick()
+void OverlayManagerImpl::tick()
 {
     ZoneScoped;
     CLOG_TRACE(Overlay, "OverlayManagerImpl tick");
@@ -792,8 +774,7 @@ OverlayManagerImpl::tick()
     }
 }
 
-int
-OverlayManagerImpl::availableOutboundPendingSlots() const
+int OverlayManagerImpl::availableOutboundPendingSlots() const
 {
     if (mOutboundPeers.mPending.size() <
         mApp.getConfig().MAX_OUTBOUND_PENDING_CONNECTIONS)
@@ -808,8 +789,7 @@ OverlayManagerImpl::availableOutboundPendingSlots() const
     }
 }
 
-int
-OverlayManagerImpl::availableOutboundAuthenticatedSlots() const
+int OverlayManagerImpl::availableOutboundAuthenticatedSlots() const
 {
     auto adjustedTarget =
         mInboundPeers.mAuthenticated.size() == 0 &&
@@ -829,8 +809,7 @@ OverlayManagerImpl::availableOutboundAuthenticatedSlots() const
     }
 }
 
-int
-OverlayManagerImpl::nonPreferredAuthenticatedCount() const
+int OverlayManagerImpl::nonPreferredAuthenticatedCount() const
 {
     unsigned short nonPreferredCount{0};
     for (auto const& p : mOutboundPeers.mAuthenticated)
@@ -853,8 +832,7 @@ OverlayManagerImpl::getConnectedPeer(PeerBareAddress const& address)
     return outbound ? outbound : mInboundPeers.byAddress(address);
 }
 
-void
-OverlayManagerImpl::clearLedgersBelow(uint32_t ledgerSeq, uint32_t lclSeq)
+void OverlayManagerImpl::clearLedgersBelow(uint32_t ledgerSeq, uint32_t lclSeq)
 {
     mFloodGate.clearBelow(ledgerSeq);
     mSurveyManager->clearOldLedgers(lclSeq);
@@ -864,16 +842,14 @@ OverlayManagerImpl::clearLedgersBelow(uint32_t ledgerSeq, uint32_t lclSeq)
     }
 }
 
-void
-OverlayManagerImpl::updateSizeCounters()
+void OverlayManagerImpl::updateSizeCounters()
 {
     mOverlayMetrics.mPendingPeersSize.set_count(getPendingPeersCount());
     mOverlayMetrics.mAuthenticatedPeersSize.set_count(
         getAuthenticatedPeersCount());
 }
 
-void
-OverlayManagerImpl::maybeAddInboundConnection(Peer::pointer peer)
+void OverlayManagerImpl::maybeAddInboundConnection(Peer::pointer peer)
 {
     ZoneScoped;
     mInboundPeers.mConnectionsAttempted.Mark();
@@ -903,8 +879,7 @@ OverlayManagerImpl::maybeAddInboundConnection(Peer::pointer peer)
     }
 }
 
-bool
-OverlayManagerImpl::isPossiblyPreferred(std::string const& ip) const
+bool OverlayManagerImpl::isPossiblyPreferred(std::string const& ip) const
 {
     return std::any_of(
         std::begin(mConfigurationPreferredPeers),
@@ -912,8 +887,7 @@ OverlayManagerImpl::isPossiblyPreferred(std::string const& ip) const
         [&](PeerBareAddress const& address) { return address.getIP() == ip; });
 }
 
-bool
-OverlayManagerImpl::haveSpaceForConnection(std::string const& ip) const
+bool OverlayManagerImpl::haveSpaceForConnection(std::string const& ip) const
 {
     auto totalAuthenticated = getInboundAuthenticatedPeers().size();
     auto totalTracked = *getLiveInboundPeersCounter();
@@ -955,8 +929,7 @@ OverlayManagerImpl::haveSpaceForConnection(std::string const& ip) const
     return haveSpace;
 }
 
-bool
-OverlayManagerImpl::addOutboundConnection(Peer::pointer peer)
+bool OverlayManagerImpl::addOutboundConnection(Peer::pointer peer)
 {
     ZoneScoped;
     releaseAssert(peer->getRole() == Peer::WE_CALLED_REMOTE);
@@ -978,8 +951,7 @@ OverlayManagerImpl::addOutboundConnection(Peer::pointer peer)
     return true;
 }
 
-void
-OverlayManagerImpl::removePeer(Peer* peer)
+void OverlayManagerImpl::removePeer(Peer* peer)
 {
     releaseAssert(threadIsMain());
     ZoneScoped;
@@ -989,16 +961,14 @@ OverlayManagerImpl::removePeer(Peer* peer)
     updateSizeCounters();
 }
 
-bool
-OverlayManagerImpl::moveToAuthenticated(Peer::pointer peer)
+bool OverlayManagerImpl::moveToAuthenticated(Peer::pointer peer)
 {
     auto result = getPeersList(peer.get()).moveToAuthenticated(peer);
     updateSizeCounters();
     return result;
 }
 
-bool
-OverlayManagerImpl::acceptAuthenticatedPeer(Peer::pointer peer)
+bool OverlayManagerImpl::acceptAuthenticatedPeer(Peer::pointer peer)
 {
     return getPeersList(peer.get()).acceptAuthenticatedPeer(peer);
 }
@@ -1015,8 +985,7 @@ OverlayManagerImpl::getOutboundPendingPeers() const
     return mOutboundPeers.mPending;
 }
 
-std::vector<Peer::pointer>
-OverlayManagerImpl::getPendingPeers() const
+std::vector<Peer::pointer> OverlayManagerImpl::getPendingPeers() const
 {
     auto result = mOutboundPeers.mPending;
     result.insert(std::end(result), std::begin(mInboundPeers.mPending),
@@ -1045,28 +1014,24 @@ OverlayManagerImpl::getAuthenticatedPeers() const
     return result;
 }
 
-std::shared_ptr<int>
-OverlayManagerImpl::getLiveInboundPeersCounter() const
+std::shared_ptr<int> OverlayManagerImpl::getLiveInboundPeersCounter() const
 {
     return mLiveInboundPeersCounter;
 }
 
-int
-OverlayManagerImpl::getPendingPeersCount() const
+int OverlayManagerImpl::getPendingPeersCount() const
 {
     return static_cast<int>(mInboundPeers.mPending.size() +
                             mOutboundPeers.mPending.size());
 }
 
-int
-OverlayManagerImpl::getAuthenticatedPeersCount() const
+int OverlayManagerImpl::getAuthenticatedPeersCount() const
 {
     return static_cast<int>(mInboundPeers.mAuthenticated.size() +
                             mOutboundPeers.mAuthenticated.size());
 }
 
-bool
-OverlayManagerImpl::isPreferred(Peer* peer) const
+bool OverlayManagerImpl::isPreferred(Peer* peer) const
 {
     std::string pstr = peer->toString();
 
@@ -1103,8 +1068,7 @@ static const xdr::opaque_array<32> TX_BATCH_HASH = [] {
     return bytes;
 }();
 
-std::shared_ptr<StellarMessage>
-OverlayManager::createTxBatch()
+std::shared_ptr<StellarMessage> OverlayManager::createTxBatch()
 {
     // In testing, allow legacy TX_SET messages to represent a "batch" of
     // transactions to flood by hard-coding a special previousLedgerHash.
@@ -1114,8 +1078,7 @@ OverlayManager::createTxBatch()
     return msg;
 }
 
-bool
-OverlayManager::isFloodMessage(StellarMessage const& msg)
+bool OverlayManager::isFloodMessage(StellarMessage const& msg)
 {
     bool isFlood = msg.type() == SCP_MESSAGE || msg.type() == TRANSACTION ||
                    msg.type() == FLOOD_DEMAND || msg.type() == FLOOD_ADVERT;
@@ -1127,8 +1090,7 @@ OverlayManager::isFloodMessage(StellarMessage const& msg)
 
     return isFlood;
 }
-std::vector<Peer::pointer>
-OverlayManagerImpl::getRandomAuthenticatedPeers()
+std::vector<Peer::pointer> OverlayManagerImpl::getRandomAuthenticatedPeers()
 {
     std::vector<Peer::pointer> result;
     result.reserve(mInboundPeers.mAuthenticated.size() +
@@ -1159,8 +1121,7 @@ OverlayManagerImpl::getRandomOutboundAuthenticatedPeers()
     return result;
 }
 
-void
-OverlayManagerImpl::extractPeersFromMap(
+void OverlayManagerImpl::extractPeersFromMap(
     std::map<NodeID, Peer::pointer> const& peerMap,
     std::vector<Peer::pointer>& result)
 {
@@ -1171,21 +1132,18 @@ OverlayManagerImpl::extractPeersFromMap(
                    std::back_inserter(result), extractPeer);
 }
 
-void
-OverlayManagerImpl::shufflePeerList(std::vector<Peer::pointer>& peerList)
+void OverlayManagerImpl::shufflePeerList(std::vector<Peer::pointer>& peerList)
 {
     stellar::shuffle(peerList.begin(), peerList.end(), getGlobalRandomEngine());
 }
 
-bool
-OverlayManagerImpl::recvFloodedMsgID(Peer::pointer peer, Hash const& msgID)
+bool OverlayManagerImpl::recvFloodedMsgID(Peer::pointer peer, Hash const& msgID)
 {
     ZoneScoped;
     return mFloodGate.addRecord(peer, msgID);
 }
 
-bool
-OverlayManagerImpl::checkScheduledAndCache(
+bool OverlayManagerImpl::checkScheduledAndCache(
     std::shared_ptr<CapacityTrackedMessage> tracker)
 {
 #ifndef BUILD_TESTS
@@ -1209,9 +1167,8 @@ OverlayManagerImpl::checkScheduledAndCache(
     return false;
 }
 
-void
-OverlayManagerImpl::recvTransaction(TransactionFrameBasePtr transaction,
-                                    Peer::pointer peer, Hash const& index)
+void OverlayManagerImpl::recvTransaction(TransactionFrameBasePtr transaction,
+                                         Peer::pointer peer, Hash const& index)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -1258,23 +1215,21 @@ OverlayManagerImpl::recvTransaction(TransactionFrameBasePtr transaction,
     }
 }
 
-void
-OverlayManagerImpl::forgetFloodedMsg(Hash const& msgID)
+void OverlayManagerImpl::forgetFloodedMsg(Hash const& msgID)
 {
     ZoneScoped;
     mFloodGate.forgetRecord(msgID);
 }
 
-void
-OverlayManagerImpl::recvTxDemand(FloodDemand const& dmd, Peer::pointer peer)
+void OverlayManagerImpl::recvTxDemand(FloodDemand const& dmd,
+                                      Peer::pointer peer)
 {
     ZoneScoped;
     mTxDemandsManager.recvTxDemand(dmd, peer);
 }
 
-bool
-OverlayManagerImpl::broadcastMessage(std::shared_ptr<StellarMessage const> msg,
-                                     std::optional<Hash> const hash)
+bool OverlayManagerImpl::broadcastMessage(
+    std::shared_ptr<StellarMessage const> msg, std::optional<Hash> const hash)
 {
     ZoneScoped;
     auto res = mFloodGate.broadcast(msg, hash);
@@ -1285,44 +1240,37 @@ OverlayManagerImpl::broadcastMessage(std::shared_ptr<StellarMessage const> msg,
     return res;
 }
 
-void
-OverlayManager::dropAll(Database& db)
+void OverlayManager::dropAll(Database& db)
 {
     PeerManager::dropAll(db);
 }
 
-std::set<Peer::pointer>
-OverlayManagerImpl::getPeersKnows(Hash const& h)
+std::set<Peer::pointer> OverlayManagerImpl::getPeersKnows(Hash const& h)
 {
     return mFloodGate.getPeersKnows(h);
 }
 
-OverlayMetrics&
-OverlayManagerImpl::getOverlayMetrics()
+OverlayMetrics& OverlayManagerImpl::getOverlayMetrics()
 {
     return mOverlayMetrics;
 }
 
-PeerAuth&
-OverlayManagerImpl::getPeerAuth()
+PeerAuth& OverlayManagerImpl::getPeerAuth()
 {
     return mAuth;
 }
 
-PeerManager&
-OverlayManagerImpl::getPeerManager()
+PeerManager& OverlayManagerImpl::getPeerManager()
 {
     return mPeerManager;
 }
 
-SurveyManager&
-OverlayManagerImpl::getSurveyManager()
+SurveyManager& OverlayManagerImpl::getSurveyManager()
 {
     return *mSurveyManager;
 }
 
-void
-OverlayManagerImpl::shutdown()
+void OverlayManagerImpl::shutdown()
 {
     if (mShuttingDown)
     {
@@ -1343,15 +1291,13 @@ OverlayManagerImpl::shutdown()
     mPeerIPTimer.cancel();
 }
 
-bool
-OverlayManagerImpl::isShuttingDown() const
+bool OverlayManagerImpl::isShuttingDown() const
 {
     return mShuttingDown;
 }
 
-void
-OverlayManagerImpl::recordMessageMetric(StellarMessage const& stellarMsg,
-                                        Peer::pointer peer)
+void OverlayManagerImpl::recordMessageMetric(StellarMessage const& stellarMsg,
+                                             Peer::pointer peer)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -1430,8 +1376,7 @@ OverlayManagerImpl::recordMessageMetric(StellarMessage const& stellarMsg,
     }
 }
 
-SearchableSnapshotConstPtr&
-OverlayManagerImpl::getOverlayThreadSnapshot()
+SearchableSnapshotConstPtr& OverlayManagerImpl::getOverlayThreadSnapshot()
 {
     releaseAssert(mApp.threadIsType(Application::ThreadType::OVERLAY));
     if (!mOverlayThreadSnapshot)

--- a/src/overlay/OverlayManagerImpl.h
+++ b/src/overlay/OverlayManagerImpl.h
@@ -117,9 +117,9 @@ class OverlayManagerImpl : public OverlayManager
                          Peer::pointer peer, Hash const& index) override;
     void forgetFloodedMsg(Hash const& msgID) override;
     void recvTxDemand(FloodDemand const& dmd, Peer::pointer peer) override;
-    bool
-    broadcastMessage(std::shared_ptr<StellarMessage const> msg,
-                     std::optional<Hash> const hash = std::nullopt) override;
+    bool broadcastMessage(
+        std::shared_ptr<StellarMessage const> msg,
+        std::optional<Hash> const hash = std::nullopt) override;
     void connectTo(PeerBareAddress const& address) override;
 
     void maybeAddInboundConnection(Peer::pointer peer) override;

--- a/src/overlay/OverlayUtils.cpp
+++ b/src/overlay/OverlayUtils.cpp
@@ -5,8 +5,7 @@
 namespace stellar
 {
 
-void
-logErrorOrThrow(std::string const& message)
+void logErrorOrThrow(std::string const& message)
 {
     CLOG_ERROR(Overlay, "{}", message);
 #ifdef BUILD_TESTS

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -59,8 +59,7 @@ namespace
 // Check the signature(s) in `tx`, adding the result to the signature cache in
 // the process. This function requires that background signature verification
 // is enabled and the current thread is the overlay thread.
-void
-populateSignatureCache(AppConnector& app, TransactionFrameBaseConstPtr tx)
+void populateSignatureCache(AppConnector& app, TransactionFrameBaseConstPtr tx)
 {
     ZoneScoped;
     releaseAssert(app.getConfig().EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION &&
@@ -214,8 +213,7 @@ CapacityTrackedMessage::CapacityTrackedMessage(std::weak_ptr<Peer> peer,
 #endif
 }
 
-std::optional<Hash>
-CapacityTrackedMessage::maybeGetHash() const
+std::optional<Hash> CapacityTrackedMessage::maybeGetHash() const
 {
     return mMaybeHash;
 }
@@ -239,14 +237,12 @@ CapacityTrackedMessage::~CapacityTrackedMessage()
     }
 }
 
-StellarMessage const&
-CapacityTrackedMessage::getMessage() const
+StellarMessage const& CapacityTrackedMessage::getMessage() const
 {
     return mMsg;
 }
 
-void
-Peer::sendHello()
+void Peer::sendHello()
 {
     releaseAssert(threadIsMain());
     ZoneScoped;
@@ -269,8 +265,7 @@ Peer::sendHello()
     sendMessage(msgPtr);
 }
 
-void
-Peer::beginMessageProcessing(StellarMessage const& msg)
+void Peer::beginMessageProcessing(StellarMessage const& msg)
 {
     releaseAssert(mFlowControl);
     auto success = mFlowControl->beginMessageProcessing(msg);
@@ -281,8 +276,7 @@ Peer::beginMessageProcessing(StellarMessage const& msg)
     }
 }
 
-void
-Peer::endMessageProcessing(StellarMessage const& msg)
+void Peer::endMessageProcessing(StellarMessage const& msg)
 {
     RECURSIVE_LOCK_GUARD(mStateMutex, guard);
 
@@ -325,15 +319,13 @@ Peer::endMessageProcessing(StellarMessage const& msg)
     }
 }
 
-AuthCert
-Peer::getAuthCert()
+AuthCert Peer::getAuthCert()
 {
     releaseAssert(threadIsMain());
     return mAppConnector.getOverlayManager().getPeerAuth().getAuthCert();
 }
 
-std::chrono::seconds
-Peer::getIOTimeout() const
+std::chrono::seconds Peer::getIOTimeout() const
 {
     releaseAssert(threadIsMain());
     RECURSIVE_LOCK_GUARD(mStateMutex, guard);
@@ -352,8 +344,7 @@ Peer::getIOTimeout() const
     }
 }
 
-void
-Peer::receivedBytes(size_t byteCount, bool gotFullMessage)
+void Peer::receivedBytes(size_t byteCount, bool gotFullMessage)
 {
     mLastRead = mAppConnector.now();
     if (gotFullMessage)
@@ -365,8 +356,7 @@ Peer::receivedBytes(size_t byteCount, bool gotFullMessage)
     mPeerMetrics.mByteRead += byteCount;
 }
 
-void
-Peer::startRecurrentTimer()
+void Peer::startRecurrentTimer()
 {
     releaseAssert(threadIsMain());
     RECURSIVE_LOCK_GUARD(mStateMutex, guard);
@@ -387,17 +377,15 @@ Peer::startRecurrentTimer()
     });
 }
 
-void
-Peer::initialize(PeerBareAddress const& address)
+void Peer::initialize(PeerBareAddress const& address)
 {
     releaseAssert(threadIsMain());
     mAddress = address;
     startRecurrentTimer();
 }
 
-void
-Peer::shutdownAndRemovePeer(std::string const& reason,
-                            DropDirection dropDirection)
+void Peer::shutdownAndRemovePeer(std::string const& reason,
+                                 DropDirection dropDirection)
 {
     releaseAssert(threadIsMain());
     RECURSIVE_LOCK_GUARD(mStateMutex, guard);
@@ -428,8 +416,7 @@ Peer::shutdownAndRemovePeer(std::string const& reason,
     mAppConnector.getOverlayManager().removePeer(this);
 }
 
-void
-Peer::recurrentTimerExpired(asio::error_code const& error)
+void Peer::recurrentTimerExpired(asio::error_code const& error)
 {
     releaseAssert(threadIsMain());
 
@@ -464,8 +451,7 @@ Peer::recurrentTimerExpired(asio::error_code const& error)
     }
 }
 
-void
-Peer::startExecutionDelayedTimer(
+void Peer::startExecutionDelayedTimer(
     VirtualClock::duration d, std::function<void()> const& onSuccess,
     std::function<void(asio::error_code)> const& onFailure)
 {
@@ -474,8 +460,7 @@ Peer::startExecutionDelayedTimer(
     mDelayedExecutionTimer.async_wait(onSuccess, onFailure);
 }
 
-Json::Value
-Peer::getJsonInfo(bool compact) const
+Json::Value Peer::getJsonInfo(bool compact) const
 {
     releaseAssert(threadIsMain());
     Json::Value res;
@@ -528,8 +513,7 @@ Peer::getJsonInfo(bool compact) const
     return res;
 }
 
-void
-Peer::sendAuth()
+void Peer::sendAuth()
 {
     releaseAssert(threadIsMain());
 
@@ -541,15 +525,13 @@ Peer::sendAuth()
     sendMessage(msgPtr);
 }
 
-std::string const&
-Peer::toString()
+std::string const& Peer::toString()
 {
     releaseAssert(threadIsMain());
     return mAddress.toString();
 }
 
-void
-Peer::cancelTimers()
+void Peer::cancelTimers()
 {
     releaseAssert(threadIsMain());
     mRecurringTimer.cancel();
@@ -560,8 +542,7 @@ Peer::cancelTimers()
     }
 }
 
-void
-Peer::clearBelow(uint32_t seq)
+void Peer::clearBelow(uint32_t seq)
 {
     releaseAssert(threadIsMain());
     if (mTxAdverts)
@@ -570,8 +551,7 @@ Peer::clearBelow(uint32_t seq)
     }
 }
 
-void
-Peer::connectHandler(asio::error_code const& error)
+void Peer::connectHandler(asio::error_code const& error)
 {
     RECURSIVE_LOCK_GUARD(mStateMutex, guard);
     if (error)
@@ -597,9 +577,8 @@ Peer::connectHandler(asio::error_code const& error)
     }
 }
 
-void
-Peer::maybeExecuteInBackground(std::string const& jobName,
-                               std::function<void(std::shared_ptr<Peer>)> f)
+void Peer::maybeExecuteInBackground(
+    std::string const& jobName, std::function<void(std::shared_ptr<Peer>)> f)
 {
     if (useBackgroundThread() &&
         !mAppConnector.threadIsType(Application::ThreadType::OVERLAY))
@@ -616,8 +595,7 @@ Peer::maybeExecuteInBackground(std::string const& jobName,
     }
 }
 
-void
-Peer::sendDontHave(MessageType type, uint256 const& itemID)
+void Peer::sendDontHave(MessageType type, uint256 const& itemID)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -629,8 +607,7 @@ Peer::sendDontHave(MessageType type, uint256 const& itemID)
     sendMessage(msgPtr);
 }
 
-void
-Peer::sendSCPQuorumSet(SCPQuorumSetPtr qSet)
+void Peer::sendSCPQuorumSet(SCPQuorumSetPtr qSet)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -641,8 +618,7 @@ Peer::sendSCPQuorumSet(SCPQuorumSetPtr qSet)
     sendMessage(msgPtr);
 }
 
-void
-Peer::sendGetTxSet(uint256 const& setID)
+void Peer::sendGetTxSet(uint256 const& setID)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -654,8 +630,7 @@ Peer::sendGetTxSet(uint256 const& setID)
     sendMessage(msgPtr);
 }
 
-void
-Peer::sendGetQuorumSet(uint256 const& setID)
+void Peer::sendGetQuorumSet(uint256 const& setID)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -667,8 +642,7 @@ Peer::sendGetQuorumSet(uint256 const& setID)
     sendMessage(msgPtr);
 }
 
-void
-Peer::sendGetScpState(uint32 ledgerSeq)
+void Peer::sendGetScpState(uint32 ledgerSeq)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -679,8 +653,7 @@ Peer::sendGetScpState(uint32 ledgerSeq)
     sendMessage(msgPtr);
 }
 
-void
-Peer::sendPeers()
+void Peer::sendPeers()
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -706,8 +679,7 @@ Peer::sendPeers()
     }
 }
 
-void
-Peer::sendError(ErrorCode error, std::string const& message)
+void Peer::sendError(ErrorCode error, std::string const& message)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -719,8 +691,7 @@ Peer::sendError(ErrorCode error, std::string const& message)
     sendMessage(msgPtr);
 }
 
-void
-Peer::sendErrorAndDrop(ErrorCode error, std::string const& message)
+void Peer::sendErrorAndDrop(ErrorCode error, std::string const& message)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -728,8 +699,7 @@ Peer::sendErrorAndDrop(ErrorCode error, std::string const& message)
     drop(message, DropDirection::WE_DROPPED_REMOTE);
 }
 
-void
-Peer::sendSendMore(uint32_t numMessages, uint32_t numBytes)
+void Peer::sendSendMore(uint32_t numMessages, uint32_t numBytes)
 {
     ZoneScoped;
 
@@ -740,8 +710,7 @@ Peer::sendSendMore(uint32_t numMessages, uint32_t numBytes)
     sendMessage(m);
 }
 
-std::string
-Peer::msgSummary(StellarMessage const& msg)
+std::string Peer::msgSummary(StellarMessage const& msg)
 {
     switch (msg.type())
     {
@@ -817,8 +786,7 @@ Peer::msgSummary(StellarMessage const& msg)
     return "UNKNOWN";
 }
 
-void
-Peer::sendMessage(std::shared_ptr<StellarMessage const> msg, bool log)
+void Peer::sendMessage(std::shared_ptr<StellarMessage const> msg, bool log)
 {
     ZoneScoped;
 
@@ -909,8 +877,7 @@ Peer::sendMessage(std::shared_ptr<StellarMessage const> msg, bool log)
     }
 }
 
-void
-Peer::sendAuthenticatedMessage(
+void Peer::sendAuthenticatedMessage(
     std::shared_ptr<StellarMessage const> msg,
     std::optional<VirtualClock::time_point> timePlaced)
 {
@@ -952,62 +919,53 @@ Peer::sendAuthenticatedMessage(
     maybeExecuteInBackground("sendAuthenticatedMessage", cb);
 }
 
-bool
-Peer::isConnected(RecursiveLockGuard const& stateGuard) const
+bool Peer::isConnected(RecursiveLockGuard const& stateGuard) const
 {
     return mState != CONNECTING && mState != CLOSING;
 }
 
-bool
-Peer::isAuthenticated(RecursiveLockGuard const& stateGuard) const
+bool Peer::isAuthenticated(RecursiveLockGuard const& stateGuard) const
 {
     return mState == GOT_AUTH;
 }
 
 #ifdef BUILD_TESTS
-bool
-Peer::isAuthenticatedForTesting() const
+bool Peer::isAuthenticatedForTesting() const
 {
     RECURSIVE_LOCK_GUARD(mStateMutex, guard);
     return isAuthenticated(guard);
 }
-bool
-Peer::isConnectedForTesting() const
+bool Peer::isConnectedForTesting() const
 {
     RECURSIVE_LOCK_GUARD(mStateMutex, guard);
     return isConnected(guard);
 }
-bool
-Peer::shouldAbortForTesting() const
+bool Peer::shouldAbortForTesting() const
 {
     RECURSIVE_LOCK_GUARD(mStateMutex, guard);
     return shouldAbort(guard);
 }
 
-void
-Peer::populateSignatureCacheForTesting(AppConnector& app,
-                                       TransactionFrameBaseConstPtr tx)
+void Peer::populateSignatureCacheForTesting(AppConnector& app,
+                                            TransactionFrameBaseConstPtr tx)
 {
     populateSignatureCache(app, tx);
 }
 #endif
 
-std::chrono::seconds
-Peer::getLifeTime() const
+std::chrono::seconds Peer::getLifeTime() const
 {
     releaseAssert(threadIsMain());
     return std::chrono::duration_cast<std::chrono::seconds>(
         mAppConnector.now() - mCreationTime);
 }
 
-bool
-Peer::shouldAbort(RecursiveLockGuard const& stateGuard) const
+bool Peer::shouldAbort(RecursiveLockGuard const& stateGuard) const
 {
     return mState == CLOSING || mAppConnector.overlayShuttingDown();
 }
 
-bool
-Peer::recvAuthenticatedMessage(AuthenticatedMessage&& msg)
+bool Peer::recvAuthenticatedMessage(AuthenticatedMessage&& msg)
 {
     ZoneScoped;
     releaseAssert(!threadIsMain() || !useBackgroundThread());
@@ -1131,8 +1089,7 @@ Peer::recvAuthenticatedMessage(AuthenticatedMessage&& msg)
     return true;
 }
 
-void
-Peer::recvMessage(std::shared_ptr<CapacityTrackedMessage> msgTracker)
+void Peer::recvMessage(std::shared_ptr<CapacityTrackedMessage> msgTracker)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -1176,8 +1133,7 @@ Peer::recvMessage(std::shared_ptr<CapacityTrackedMessage> msgTracker)
     }
 }
 
-void
-Peer::recvSendMore(StellarMessage const& msg)
+void Peer::recvSendMore(StellarMessage const& msg)
 {
     releaseAssert(threadIsMain());
     releaseAssert(mFlowControl);
@@ -1192,8 +1148,7 @@ Peer::recvSendMore(StellarMessage const& msg)
         });
 }
 
-void
-Peer::recvRawMessage(std::shared_ptr<CapacityTrackedMessage> msgTracker)
+void Peer::recvRawMessage(std::shared_ptr<CapacityTrackedMessage> msgTracker)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -1401,8 +1356,7 @@ Peer::recvRawMessage(std::shared_ptr<CapacityTrackedMessage> msgTracker)
     }
 }
 
-void
-Peer::recvDontHave(StellarMessage const& msg)
+void Peer::recvDontHave(StellarMessage const& msg)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -1412,8 +1366,7 @@ Peer::recvDontHave(StellarMessage const& msg)
         msg.dontHave().type, msg.dontHave().reqHash, shared_from_this());
 }
 
-bool
-Peer::process(QueryInfo& queryInfo)
+bool Peer::process(QueryInfo& queryInfo)
 {
     auto const& cfg = mAppConnector.getConfig();
     std::chrono::seconds const QUERY_WINDOW =
@@ -1431,8 +1384,7 @@ Peer::process(QueryInfo& queryInfo)
 }
 
 #ifdef BUILD_TESTS
-void
-Peer::recvTxBatch(CapacityTrackedMessage const& msgTracker)
+void Peer::recvTxBatch(CapacityTrackedMessage const& msgTracker)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -1452,8 +1404,7 @@ Peer::recvTxBatch(CapacityTrackedMessage const& msgTracker)
 }
 #endif
 
-void
-Peer::recvGetTxSet(StellarMessage const& msg)
+void Peer::recvGetTxSet(StellarMessage const& msg)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -1498,8 +1449,7 @@ Peer::recvGetTxSet(StellarMessage const& msg)
     mTxSetQueryInfo.mNumQueries++;
 }
 
-void
-Peer::recvTxSet(StellarMessage const& msg)
+void Peer::recvTxSet(StellarMessage const& msg)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -1507,8 +1457,7 @@ Peer::recvTxSet(StellarMessage const& msg)
     mAppConnector.getHerder().recvTxSet(frame->getContentsHash(), frame);
 }
 
-void
-Peer::recvGeneralizedTxSet(StellarMessage const& msg)
+void Peer::recvGeneralizedTxSet(StellarMessage const& msg)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -1516,8 +1465,7 @@ Peer::recvGeneralizedTxSet(StellarMessage const& msg)
     mAppConnector.getHerder().recvTxSet(frame->getContentsHash(), frame);
 }
 
-void
-Peer::recvTransaction(CapacityTrackedMessage const& msg)
+void Peer::recvTransaction(CapacityTrackedMessage const& msg)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -1528,8 +1476,7 @@ Peer::recvTransaction(CapacityTrackedMessage const& msg)
         msg.maybeGetHash().value());
 }
 
-Hash
-Peer::pingIDfromTimePoint(VirtualClock::time_point const& tp)
+Hash Peer::pingIDfromTimePoint(VirtualClock::time_point const& tp)
 {
     releaseAssert(threadIsMain());
     auto sh = shortHash::xdrComputeHash(
@@ -1540,8 +1487,7 @@ Peer::pingIDfromTimePoint(VirtualClock::time_point const& tp)
     return res;
 }
 
-void
-Peer::pingPeer()
+void Peer::pingPeer()
 {
     releaseAssert(threadIsMain());
     RECURSIVE_LOCK_GUARD(mStateMutex, guard);
@@ -1553,8 +1499,7 @@ Peer::pingPeer()
     }
 }
 
-void
-Peer::maybeProcessPingResponse(Hash const& id)
+void Peer::maybeProcessPingResponse(Hash const& id)
 {
     releaseAssert(threadIsMain());
     if (mPingSentTime != PING_NOT_SENT)
@@ -1576,22 +1521,19 @@ Peer::maybeProcessPingResponse(Hash const& id)
     }
 }
 
-std::chrono::milliseconds
-Peer::getPing() const
+std::chrono::milliseconds Peer::getPing() const
 {
     releaseAssert(threadIsMain());
     return mLastPing;
 }
 
-bool
-Peer::canRead() const
+bool Peer::canRead() const
 {
     releaseAssert(mFlowControl);
     return mFlowControl->canRead();
 }
 
-void
-Peer::recvGetSCPQuorumSet(StellarMessage const& msg)
+void Peer::recvGetSCPQuorumSet(StellarMessage const& msg)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -1614,8 +1556,7 @@ Peer::recvGetSCPQuorumSet(StellarMessage const& msg)
     }
     mQSetQueryInfo.mNumQueries++;
 }
-void
-Peer::recvSCPQuorumSet(StellarMessage const& msg)
+void Peer::recvSCPQuorumSet(StellarMessage const& msg)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -1624,8 +1565,7 @@ Peer::recvSCPQuorumSet(StellarMessage const& msg)
     mAppConnector.getHerder().recvSCPQuorumSet(hash, msg.qSet());
 }
 
-void
-Peer::recvSCPMessage(CapacityTrackedMessage const& msg)
+void Peer::recvSCPMessage(CapacityTrackedMessage const& msg)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -1674,8 +1614,7 @@ Peer::recvSCPMessage(CapacityTrackedMessage const& msg)
     }
 }
 
-void
-Peer::recvGetSCPState(StellarMessage const& msg)
+void Peer::recvGetSCPState(StellarMessage const& msg)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -1683,8 +1622,7 @@ Peer::recvGetSCPState(StellarMessage const& msg)
     mAppConnector.getHerder().sendSCPStateToPeer(seq, shared_from_this());
 }
 
-void
-Peer::recvError(StellarMessage const& msg)
+void Peer::recvError(StellarMessage const& msg)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -1721,8 +1659,7 @@ Peer::recvError(StellarMessage const& msg)
          Peer::DropDirection::REMOTE_DROPPED_US);
 }
 
-void
-Peer::updatePeerRecordAfterEcho()
+void Peer::updatePeerRecordAfterEcho()
 {
     releaseAssert(threadIsMain());
     releaseAssert(!getAddress().isEmpty());
@@ -1747,8 +1684,7 @@ Peer::updatePeerRecordAfterEcho()
         /* preferredTypeKnown */ true);
 }
 
-void
-Peer::updatePeerRecordAfterAuthentication()
+void Peer::updatePeerRecordAfterAuthentication()
 {
     releaseAssert(threadIsMain());
     releaseAssert(!getAddress().isEmpty());
@@ -1763,8 +1699,7 @@ Peer::updatePeerRecordAfterAuthentication()
                mAppConnector.getConfig().toShortString(mPeerID), toString());
 }
 
-void
-Peer::recvHello(Hello const& elo)
+void Peer::recvHello(Hello const& elo)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -1903,14 +1838,12 @@ Peer::recvHello(Hello const& elo)
     }
 }
 
-void
-Peer::setState(RecursiveLockGuard const& stateGuard, PeerState newState)
+void Peer::setState(RecursiveLockGuard const& stateGuard, PeerState newState)
 {
     mState = newState;
 }
 
-void
-Peer::recvAuth(StellarMessage const& msg)
+void Peer::recvAuth(StellarMessage const& msg)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -1973,8 +1906,7 @@ Peer::recvAuth(StellarMessage const& msg)
     sendGetScpState(low);
 }
 
-void
-Peer::recvPeers(StellarMessage const& msg)
+void Peer::recvPeers(StellarMessage const& msg)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -2032,8 +1964,7 @@ Peer::recvPeers(StellarMessage const& msg)
     }
 }
 
-void
-Peer::recvSurveyRequestMessage(StellarMessage const& msg)
+void Peer::recvSurveyRequestMessage(StellarMessage const& msg)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -2042,8 +1973,7 @@ Peer::recvSurveyRequestMessage(StellarMessage const& msg)
         msg, shared_from_this());
 }
 
-void
-Peer::recvSurveyResponseMessage(StellarMessage const& msg)
+void Peer::recvSurveyResponseMessage(StellarMessage const& msg)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -2052,8 +1982,7 @@ Peer::recvSurveyResponseMessage(StellarMessage const& msg)
         msg, shared_from_this());
 }
 
-void
-Peer::recvSurveyStartCollectingMessage(StellarMessage const& msg)
+void Peer::recvSurveyStartCollectingMessage(StellarMessage const& msg)
 {
     ZoneScoped;
     mAppConnector.getOverlayManager()
@@ -2061,8 +1990,7 @@ Peer::recvSurveyStartCollectingMessage(StellarMessage const& msg)
         .relayStartSurveyCollecting(msg, shared_from_this());
 }
 
-void
-Peer::recvSurveyStopCollectingMessage(StellarMessage const& msg)
+void Peer::recvSurveyStopCollectingMessage(StellarMessage const& msg)
 {
     ZoneScoped;
     mAppConnector.getOverlayManager()
@@ -2070,8 +1998,7 @@ Peer::recvSurveyStopCollectingMessage(StellarMessage const& msg)
         .relayStopSurveyCollecting(msg, shared_from_this());
 }
 
-void
-Peer::recvFloodAdvert(StellarMessage const& msg)
+void Peer::recvFloodAdvert(StellarMessage const& msg)
 {
     releaseAssert(threadIsMain());
     releaseAssert(mTxAdverts);
@@ -2079,8 +2006,7 @@ Peer::recvFloodAdvert(StellarMessage const& msg)
     mTxAdverts->queueIncomingAdvert(msg.floodAdvert().txHashes, seq);
 }
 
-void
-Peer::recvFloodDemand(StellarMessage const& msg)
+void Peer::recvFloodDemand(StellarMessage const& msg)
 {
     releaseAssert(threadIsMain());
     // Pass the demand to OverlayManager for processing
@@ -2122,8 +2048,7 @@ Peer::PeerMetrics::PeerMetrics(VirtualClock::time_point connectedTime)
 {
 }
 
-void
-Peer::sendTxDemand(TxDemandVector&& demands)
+void Peer::sendTxDemand(TxDemandVector&& demands)
 {
     releaseAssert(threadIsMain());
     if (demands.size() > 0)
@@ -2142,8 +2067,7 @@ Peer::sendTxDemand(TxDemandVector&& demands)
     }
 }
 
-void
-Peer::handleMaxTxSizeIncrease(uint32_t increase)
+void Peer::handleMaxTxSizeIncrease(uint32_t increase)
 {
     releaseAssert(threadIsMain());
     if (increase > 0)
@@ -2155,8 +2079,7 @@ Peer::handleMaxTxSizeIncrease(uint32_t increase)
     }
 }
 
-bool
-Peer::sendAdvert(Hash const& hash)
+bool Peer::sendAdvert(Hash const& hash)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -2176,8 +2099,7 @@ Peer::sendAdvert(Hash const& hash)
     return true;
 }
 
-void
-Peer::retryAdvert(std::list<Hash>& hashes)
+void Peer::retryAdvert(std::list<Hash>& hashes)
 {
     releaseAssert(threadIsMain());
     if (!mTxAdverts)
@@ -2187,8 +2109,7 @@ Peer::retryAdvert(std::list<Hash>& hashes)
     mTxAdverts->retryIncomingAdvert(hashes);
 }
 
-bool
-Peer::hasAdvert()
+bool Peer::hasAdvert()
 {
     releaseAssert(threadIsMain());
     if (!mTxAdverts)
@@ -2198,8 +2119,7 @@ Peer::hasAdvert()
     return mTxAdverts->size() > 0;
 }
 
-Hash
-Peer::popAdvert()
+Hash Peer::popAdvert()
 {
     releaseAssert(threadIsMain());
     if (!mTxAdverts)

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -67,7 +67,6 @@ class CapacityTrackedMessage;
 class Peer : public std::enable_shared_from_this<Peer>,
              public NonMovableOrCopyable
 {
-
   public:
     static constexpr std::chrono::seconds PEER_SEND_MODE_IDLE_TIMEOUT =
         std::chrono::seconds(60);
@@ -98,8 +97,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
         uint32_t mNumQueries{0};
     };
 
-    static inline int
-    format_as(PeerState const& s)
+    static inline int format_as(PeerState const& s)
     {
         return static_cast<int>(s);
     }
@@ -110,8 +108,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
         WE_CALLED_REMOTE
     };
 
-    static inline std::string
-    format_as(PeerRole const& r)
+    static inline std::string format_as(PeerRole const& r)
     {
         return (r == REMOTE_CALLED_US) ? "REMOTE_CALLED_US"
                                        : "WE_CALLED_REMOTE";
@@ -207,8 +204,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
     bool canRead() const;
     // helper method to acknowledge that some bytes were received
     void receivedBytes(size_t byteCount, bool gotFullMessage);
-    virtual bool
-    useBackgroundThread() const
+    virtual bool useBackgroundThread() const
     {
         return mAppConnector.getConfig().BACKGROUND_OVERLAY_PROCESSING;
     }
@@ -225,8 +221,8 @@ class Peer : public std::enable_shared_from_this<Peer>,
         REQUIRES(mStateMutex);
     void setState(RecursiveLockGuard const& stateGuard, PeerState newState)
         REQUIRES(mStateMutex);
-    PeerState
-    getState(RecursiveLockGuard const& stateGuard) const REQUIRES(mStateMutex)
+    PeerState getState(RecursiveLockGuard const& stateGuard) const
+        REQUIRES(mStateMutex)
     {
         return mState;
     }
@@ -240,8 +236,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
     // background. Otherwise, synchronously execute on the main thread.
     void maybeExecuteInBackground(std::string const& jobName,
                                   std::function<void(std::shared_ptr<Peer>)> f);
-    VirtualTimer&
-    getRecurrentTimer()
+    VirtualTimer& getRecurrentTimer()
     {
         releaseAssert(threadIsMain());
         return mRecurringTimer;
@@ -328,8 +323,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
     virtual void sendMessage(xdr::msg_ptr&& xdrBytes,
                              std::shared_ptr<StellarMessage const> msg) = 0;
     virtual void scheduleRead() = 0;
-    virtual void
-    connected()
+    virtual void connected()
     {
     }
 
@@ -367,8 +361,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
     virtual void sendMessage(std::shared_ptr<StellarMessage const> msg,
                              bool log = true);
 
-    PeerRole
-    getRole() const
+    PeerRole getRole() const
     {
         releaseAssert(threadIsMain());
         return mRole;
@@ -377,29 +370,25 @@ class Peer : public std::enable_shared_from_this<Peer>,
     std::chrono::seconds getLifeTime() const;
     std::chrono::milliseconds getPing() const;
 
-    std::string const&
-    getRemoteVersion() const
+    std::string const& getRemoteVersion() const
     {
         releaseAssert(threadIsMain());
         return mRemoteVersion;
     }
 
-    uint32_t
-    getRemoteOverlayVersion() const
+    uint32_t getRemoteOverlayVersion() const
     {
         releaseAssert(threadIsMain());
         return mRemoteOverlayVersion;
     }
 
-    PeerBareAddress const&
-    getAddress()
+    PeerBareAddress const& getAddress()
     {
         releaseAssert(threadIsMain());
         return mAddress;
     }
 
-    NodeID
-    getPeerID() const
+    NodeID getPeerID() const
     {
         releaseAssert(threadIsMain());
         return mPeerID;
@@ -435,15 +424,13 @@ class Peer : public std::enable_shared_from_this<Peer>,
     bool isAuthenticated(RecursiveLockGuard const& stateGuard) const
         REQUIRES(mStateMutex);
 
-    PeerMetrics&
-    getPeerMetrics()
+    PeerMetrics& getPeerMetrics()
     {
         // PeerMetrics is thread-safe
         return mPeerMetrics;
     }
 
-    PeerMetrics const&
-    getPeerMetrics() const
+    PeerMetrics const& getPeerMetrics() const
     {
         return mPeerMetrics;
     }
@@ -455,29 +442,25 @@ class Peer : public std::enable_shared_from_this<Peer>,
     friend class CapacityTrackedMessage;
 
 #ifdef BUILD_TESTS
-    std::shared_ptr<FlowControl>
-    getFlowControl() const
+    std::shared_ptr<FlowControl> getFlowControl() const
     {
         return mFlowControl;
     }
     bool isAuthenticatedForTesting() const;
     bool shouldAbortForTesting() const;
     bool isConnectedForTesting() const;
-    void
-    sendAuthenticatedMessageForTesting(
+    void sendAuthenticatedMessageForTesting(
         std::shared_ptr<StellarMessage const> msg)
     {
         sendAuthenticatedMessage(std::move(msg));
     }
-    void
-    sendXdrMessageForTesting(xdr::msg_ptr xdrBytes,
-                             std::shared_ptr<StellarMessage const> msg)
+    void sendXdrMessageForTesting(xdr::msg_ptr xdrBytes,
+                                  std::shared_ptr<StellarMessage const> msg)
     {
         sendMessage(std::move(xdrBytes), msg);
     }
 
-    std::string
-    getDropReason() const
+    std::string getDropReason() const
     {
         RecursiveLockGuard guard(mStateMutex);
         return mDropReason;
@@ -490,8 +473,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
 #endif
 
     // Public thread-safe methods that access Peer's state
-    void
-    assertShuttingDown() const
+    void assertShuttingDown() const
     {
         RecursiveLockGuard guard(mStateMutex);
         releaseAssert(mState == CLOSING);
@@ -501,15 +483,13 @@ class Peer : public std::enable_shared_from_this<Peer>,
     // loaded, but once it's loaded, there are no guarantees on its value. If
     // the code block depends on isAuthenticated value being constant, use
     // `doIfAuthenticated`
-    bool
-    isAuthenticatedAtomic() const
+    bool isAuthenticatedAtomic() const
     {
         RecursiveLockGuard guard(mStateMutex);
         return isAuthenticated(guard);
     }
 
-    void
-    doIfAuthenticated(std::function<void()> f)
+    void doIfAuthenticated(std::function<void()> f)
     {
         RecursiveLockGuard guard(mStateMutex);
         if (isAuthenticated(guard))
@@ -539,8 +519,7 @@ class CapacityTrackedMessage : private NonMovableOrCopyable
     StellarMessage const& getMessage() const;
     ~CapacityTrackedMessage();
     std::optional<Hash> maybeGetHash() const;
-    std::unordered_map<Hash, TransactionFrameBasePtr> const&
-    getTxMap() const
+    std::unordered_map<Hash, TransactionFrameBasePtr> const& getTxMap() const
     {
         return mTxsMap;
     }

--- a/src/overlay/PeerAuth.cpp
+++ b/src/overlay/PeerAuth.cpp
@@ -18,8 +18,7 @@ namespace stellar
 // Certs expire every hour, are reissued every half hour.
 static const uint64_t expirationLimit = 3600;
 
-static AuthCert
-makeAuthCert(Application& app, Curve25519Public const& pub)
+static AuthCert makeAuthCert(Application& app, Curve25519Public const& pub)
 {
     AuthCert cert;
     // Certs are refreshed every half hour, good for an hour.
@@ -42,8 +41,7 @@ PeerAuth::PeerAuth(Application& app)
 {
 }
 
-AuthCert
-PeerAuth::getAuthCert()
+AuthCert PeerAuth::getAuthCert()
 {
     if (mCert.expiration < mApp.timeNow() + (expirationLimit / 2))
     {
@@ -52,8 +50,8 @@ PeerAuth::getAuthCert()
     return mCert;
 }
 
-bool
-PeerAuth::verifyRemoteAuthCert(NodeID const& remoteNode, AuthCert const& cert)
+bool PeerAuth::verifyRemoteAuthCert(NodeID const& remoteNode,
+                                    AuthCert const& cert)
 {
     if (cert.expiration < mApp.timeNow())
     {
@@ -68,9 +66,8 @@ PeerAuth::verifyRemoteAuthCert(NodeID const& remoteNode, AuthCert const& cert)
     return PubKeyUtils::verifySig(remoteNode, cert.sig, hash).valid;
 }
 
-HmacSha256Key
-PeerAuth::getSharedKey(Curve25519Public const& remotePublic,
-                       Peer::PeerRole role)
+HmacSha256Key PeerAuth::getSharedKey(Curve25519Public const& remotePublic,
+                                     Peer::PeerRole role)
 {
     auto key = PeerSharedKeyId{remotePublic, role};
     if (mSharedKeyCache.exists(key))
@@ -84,10 +81,10 @@ PeerAuth::getSharedKey(Curve25519Public const& remotePublic,
     return value;
 }
 
-HmacSha256Key
-PeerAuth::getSendingMacKey(Curve25519Public const& remotePublic,
-                           uint256 const& localNonce,
-                           uint256 const& remoteNonce, Peer::PeerRole role)
+HmacSha256Key PeerAuth::getSendingMacKey(Curve25519Public const& remotePublic,
+                                         uint256 const& localNonce,
+                                         uint256 const& remoteNonce,
+                                         Peer::PeerRole role)
 {
     std::vector<uint8_t> buf;
     if (role == Peer::WE_CALLED_REMOTE)
@@ -110,10 +107,10 @@ PeerAuth::getSendingMacKey(Curve25519Public const& remotePublic,
     return hkdfExpand(k, buf);
 }
 
-HmacSha256Key
-PeerAuth::getReceivingMacKey(Curve25519Public const& remotePublic,
-                             uint256 const& localNonce,
-                             uint256 const& remoteNonce, Peer::PeerRole role)
+HmacSha256Key PeerAuth::getReceivingMacKey(Curve25519Public const& remotePublic,
+                                           uint256 const& localNonce,
+                                           uint256 const& remoteNonce,
+                                           Peer::PeerRole role)
 {
     std::vector<uint8_t> buf;
     if (role == Peer::WE_CALLED_REMOTE)

--- a/src/overlay/PeerBareAddress.cpp
+++ b/src/overlay/PeerBareAddress.cpp
@@ -42,9 +42,9 @@ PeerBareAddress::PeerBareAddress(PeerAddress const& pa)
 {
 }
 
-PeerBareAddress
-PeerBareAddress::resolve(std::string const& ipPort, Application& app,
-                         unsigned short defaultPort)
+PeerBareAddress PeerBareAddress::resolve(std::string const& ipPort,
+                                         Application& app,
+                                         unsigned short defaultPort)
 {
     static std::regex re(
         "^(?:(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})|([[:alnum:].-]+))"
@@ -120,14 +120,12 @@ PeerBareAddress::resolve(std::string const& ipPort, Application& app,
     return PeerBareAddress{ip, port};
 }
 
-std::string const&
-PeerBareAddress::toString() const
+std::string const& PeerBareAddress::toString() const
 {
     return mStringValue;
 }
 
-bool
-PeerBareAddress::isPrivate() const
+bool PeerBareAddress::isPrivate() const
 {
     asio::error_code ec;
     asio::ip::address_v4 addr = asio::ip::address_v4::from_string(mIP, ec);
@@ -145,14 +143,12 @@ PeerBareAddress::isPrivate() const
     return false;
 }
 
-bool
-PeerBareAddress::isLocalhost() const
+bool PeerBareAddress::isLocalhost() const
 {
     return mIP == "127.0.0.1";
 }
 
-bool
-operator==(PeerBareAddress const& x, PeerBareAddress const& y)
+bool operator==(PeerBareAddress const& x, PeerBareAddress const& y)
 {
     if (x.mIP != y.mIP)
     {
@@ -166,14 +162,12 @@ operator==(PeerBareAddress const& x, PeerBareAddress const& y)
     return true;
 }
 
-bool
-operator!=(PeerBareAddress const& x, PeerBareAddress const& y)
+bool operator!=(PeerBareAddress const& x, PeerBareAddress const& y)
 {
     return !(x == y);
 }
 
-bool
-operator<(PeerBareAddress const& x, PeerBareAddress const& y)
+bool operator<(PeerBareAddress const& x, PeerBareAddress const& y)
 {
     if (x.mPort < y.mPort)
     {

--- a/src/overlay/PeerBareAddress.h
+++ b/src/overlay/PeerBareAddress.h
@@ -29,26 +29,22 @@ class PeerBareAddress
     resolve(std::string const& ipPort, Application& app,
             unsigned short defaultPort = DEFAULT_PEER_PORT);
 
-    bool
-    isEmpty() const
+    bool isEmpty() const
     {
         return mType == Type::EMPTY;
     }
 
-    Type
-    getType() const
+    Type getType() const
     {
         return mType;
     }
 
-    std::string const&
-    getIP() const
+    std::string const& getIP() const
     {
         return mIP;
     }
 
-    unsigned short
-    getPort() const
+    unsigned short getPort() const
     {
         return mPort;
     }

--- a/src/overlay/PeerDoor.cpp
+++ b/src/overlay/PeerDoor.cpp
@@ -23,8 +23,7 @@ PeerDoor::PeerDoor(Application& app)
 {
 }
 
-void
-PeerDoor::start()
+void PeerDoor::start()
 {
     releaseAssert(threadIsMain());
 
@@ -41,8 +40,7 @@ PeerDoor::start()
     }
 }
 
-void
-PeerDoor::close()
+void PeerDoor::close()
 {
     if (mAcceptor.is_open())
     {
@@ -52,8 +50,7 @@ PeerDoor::close()
     }
 }
 
-void
-PeerDoor::acceptNextPeer()
+void PeerDoor::acceptNextPeer()
 {
     if (mApp.getOverlayManager().isShuttingDown())
     {
@@ -79,8 +76,7 @@ PeerDoor::acceptNextPeer()
                            });
 }
 
-void
-PeerDoor::handleKnock(shared_ptr<TCPPeer::SocketType> socket)
+void PeerDoor::handleKnock(shared_ptr<TCPPeer::SocketType> socket)
 {
     releaseAssert(threadIsMain());
 

--- a/src/overlay/PeerManager.cpp
+++ b/src/overlay/PeerManager.cpp
@@ -29,8 +29,7 @@ enum PeerRecordFlags
     PEER_RECORD_FLAGS_PREFERRED = 1
 };
 
-bool
-operator==(PeerRecord const& x, PeerRecord const& y)
+bool operator==(PeerRecord const& x, PeerRecord const& y)
 {
     if (VirtualClock::tmToSystemPoint(x.mNextAttempt) !=
         VirtualClock::tmToSystemPoint(y.mNextAttempt))
@@ -47,8 +46,7 @@ operator==(PeerRecord const& x, PeerRecord const& y)
 namespace
 {
 
-void
-ipToXdr(std::string const& ip, xdr::opaque_array<4U>& ret)
+void ipToXdr(std::string const& ip, xdr::opaque_array<4U>& ret)
 {
     std::stringstream ss(ip);
     std::string item;
@@ -63,8 +61,7 @@ ipToXdr(std::string const& ip, xdr::opaque_array<4U>& ret)
 }
 }
 
-PeerAddress
-toXdr(PeerBareAddress const& address)
+PeerAddress toXdr(PeerBareAddress const& address)
 {
     PeerAddress result;
 
@@ -164,9 +161,8 @@ PeerManager::loadRandomPeers(PeerQuery const& query, size_t size)
     return result;
 }
 
-void
-PeerManager::removePeersWithManyFailures(size_t minNumFailures,
-                                         PeerBareAddress const* address)
+void PeerManager::removePeersWithManyFailures(size_t minNumFailures,
+                                              PeerBareAddress const* address)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -227,8 +223,7 @@ PeerManager::getPeersToSend(size_t size, PeerBareAddress const& address)
     return peers;
 }
 
-std::pair<PeerRecord, bool>
-PeerManager::load(PeerBareAddress const& address)
+std::pair<PeerRecord, bool> PeerManager::load(PeerBareAddress const& address)
 {
     ZoneScoped;
     auto result = PeerRecord{};
@@ -271,9 +266,8 @@ PeerManager::load(PeerBareAddress const& address)
     return std::make_pair(result, inDatabase);
 }
 
-void
-PeerManager::store(PeerBareAddress const& address, PeerRecord const& peerRecord,
-                   bool inDatabase)
+void PeerManager::store(PeerBareAddress const& address,
+                        PeerRecord const& peerRecord, bool inDatabase)
 {
     ZoneScoped;
     std::string query;
@@ -324,8 +318,7 @@ PeerManager::store(PeerBareAddress const& address, PeerRecord const& peerRecord,
     }
 }
 
-void
-PeerManager::update(PeerRecord& peer, TypeUpdate type)
+void PeerManager::update(PeerRecord& peer, TypeUpdate type)
 {
     switch (type)
     {
@@ -362,8 +355,7 @@ PeerManager::update(PeerRecord& peer, TypeUpdate type)
 namespace
 {
 
-static std::chrono::seconds
-computeBackoff(size_t numFailures)
+static std::chrono::seconds computeBackoff(size_t numFailures)
 {
     constexpr const uint32 SECONDS_PER_BACKOFF = 10;
     constexpr const size_t MAX_BACKOFF_EXPONENT = 10;
@@ -378,8 +370,8 @@ computeBackoff(size_t numFailures)
 }
 }
 
-void
-PeerManager::update(PeerRecord& peer, BackOffUpdate backOff, Application& app)
+void PeerManager::update(PeerRecord& peer, BackOffUpdate backOff,
+                         Application& app)
 {
     switch (backOff)
     {
@@ -409,8 +401,7 @@ PeerManager::update(PeerRecord& peer, BackOffUpdate backOff, Application& app)
     }
 }
 
-void
-PeerManager::ensureExists(PeerBareAddress const& address)
+void PeerManager::ensureExists(PeerBareAddress const& address)
 {
     ZoneScoped;
     auto peer = load(address);
@@ -421,9 +412,9 @@ PeerManager::ensureExists(PeerBareAddress const& address)
     }
 }
 
-static PeerManager::TypeUpdate
-getTypeUpdate(PeerRecord const& peer, PeerType observedType,
-              bool preferredTypeKnown)
+static PeerManager::TypeUpdate getTypeUpdate(PeerRecord const& peer,
+                                             PeerType observedType,
+                                             bool preferredTypeKnown)
 {
     PeerManager::TypeUpdate typeUpdate;
     bool isPreferredInDB = peer.mType == static_cast<int>(PeerType::PREFERRED);
@@ -467,9 +458,8 @@ getTypeUpdate(PeerRecord const& peer, PeerType observedType,
     return typeUpdate;
 }
 
-void
-PeerManager::update(PeerBareAddress const& address, PeerType observedType,
-                    bool preferredTypeKnown)
+void PeerManager::update(PeerBareAddress const& address, PeerType observedType,
+                         bool preferredTypeKnown)
 {
     ZoneScoped;
     auto peer = load(address);
@@ -479,8 +469,7 @@ PeerManager::update(PeerBareAddress const& address, PeerType observedType,
     store(address, peer.first, peer.second);
 }
 
-void
-PeerManager::update(PeerBareAddress const& address, BackOffUpdate backOff)
+void PeerManager::update(PeerBareAddress const& address, BackOffUpdate backOff)
 {
     ZoneScoped;
     auto peer = load(address);
@@ -488,9 +477,8 @@ PeerManager::update(PeerBareAddress const& address, BackOffUpdate backOff)
     store(address, peer.first, peer.second);
 }
 
-void
-PeerManager::update(PeerBareAddress const& address, PeerType observedType,
-                    bool preferredTypeKnown, BackOffUpdate backOff)
+void PeerManager::update(PeerBareAddress const& address, PeerType observedType,
+                         bool preferredTypeKnown, BackOffUpdate backOff)
 {
     ZoneScoped;
     auto peer = load(address);
@@ -578,15 +566,13 @@ PeerManager::loadPeers(size_t limit, size_t offset, std::string const& where,
     return result;
 }
 
-void
-PeerManager::dropAll(Database& db)
+void PeerManager::dropAll(Database& db)
 {
     db.getRawSession() << "DROP TABLE IF EXISTS peers;";
     db.getRawSession() << kSQLCreateStatement;
 }
 
-std::vector<std::pair<PeerBareAddress, PeerRecord>>
-PeerManager::loadAllPeers()
+std::vector<std::pair<PeerBareAddress, PeerRecord>> PeerManager::loadAllPeers()
 {
     ZoneScoped;
     std::vector<std::pair<PeerBareAddress, PeerRecord>> result;
@@ -629,8 +615,7 @@ PeerManager::loadAllPeers()
     return result;
 }
 
-void
-PeerManager::storePeers(
+void PeerManager::storePeers(
     std::vector<std::pair<PeerBareAddress, PeerRecord>> peers)
 {
     soci::transaction tx(mApp.getDatabase().getRawSession());

--- a/src/overlay/PeerSharedKeyId.cpp
+++ b/src/overlay/PeerSharedKeyId.cpp
@@ -7,14 +7,12 @@
 namespace stellar
 {
 
-bool
-operator==(PeerSharedKeyId const& x, PeerSharedKeyId const& y)
+bool operator==(PeerSharedKeyId const& x, PeerSharedKeyId const& y)
 {
     return (x.mECDHPublicKey == y.mECDHPublicKey) && (x.mRole == y.mRole);
 }
 
-bool
-operator!=(PeerSharedKeyId const& x, PeerSharedKeyId const& y)
+bool operator!=(PeerSharedKeyId const& x, PeerSharedKeyId const& y)
 {
     return !(x == y);
 }
@@ -23,8 +21,7 @@ operator!=(PeerSharedKeyId const& x, PeerSharedKeyId const& y)
 namespace std
 {
 
-size_t
-hash<stellar::PeerSharedKeyId>::operator()(
+size_t hash<stellar::PeerSharedKeyId>::operator()(
     stellar::PeerSharedKeyId const& x) const noexcept
 {
     return std::hash<stellar::Curve25519Public>{}(x.mECDHPublicKey) ^

--- a/src/overlay/RandomPeerSource.cpp
+++ b/src/overlay/RandomPeerSource.cpp
@@ -9,8 +9,8 @@ namespace stellar
 {
 
 using namespace soci;
-PeerQuery
-RandomPeerSource::maxFailures(size_t maxFailures, bool requireOutobund)
+PeerQuery RandomPeerSource::maxFailures(size_t maxFailures,
+                                        bool requireOutobund)
 {
     return {false, maxFailures,
             requireOutobund ? PeerTypeFilter::ANY_OUTBOUND
@@ -19,8 +19,7 @@ RandomPeerSource::maxFailures(size_t maxFailures, bool requireOutobund)
 
 namespace
 {
-PeerTypeFilter
-peerTypeToFilter(PeerType peerType)
+PeerTypeFilter peerTypeToFilter(PeerType peerType)
 {
     switch (peerType)
     {
@@ -45,8 +44,7 @@ peerTypeToFilter(PeerType peerType)
 }
 }
 
-PeerQuery
-RandomPeerSource::nextAttemptCutoff(PeerType requireExactType)
+PeerQuery RandomPeerSource::nextAttemptCutoff(PeerType requireExactType)
 {
     return {true, Config::REALLY_DEAD_NUM_FAILURES_CUTOFF,
             peerTypeToFilter(requireExactType)};
@@ -58,8 +56,7 @@ RandomPeerSource::RandomPeerSource(PeerManager& peerManager,
 {
 }
 
-std::vector<PeerBareAddress>
-RandomPeerSource::getRandomPeers(
+std::vector<PeerBareAddress> RandomPeerSource::getRandomPeers(
     size_t size, std::function<bool(PeerBareAddress const&)> pred)
 {
     if (size == 0)

--- a/src/overlay/SurveyDataManager.cpp
+++ b/src/overlay/SurveyDataManager.cpp
@@ -52,8 +52,7 @@ fillTimeSlicedPeerDataList(std::vector<TimeSlicedPeerData> const& peerData,
 }
 
 // Initialize a map of peer data with the initial metrics from `peers`
-void
-initializeCollectingPeerData(
+void initializeCollectingPeerData(
     std::map<NodeID, Peer::pointer> const& peers,
     std::unordered_map<NodeID, CollectingPeerData>& peerData)
 {
@@ -112,8 +111,7 @@ SurveyDataManager::SurveyDataManager(
 #endif
 }
 
-bool
-SurveyDataManager::startSurveyCollecting(
+bool SurveyDataManager::startSurveyCollecting(
     TimeSlicedSurveyStartCollectingMessage const& msg,
     std::map<NodeID, Peer::pointer> const& inboundPeers,
     std::map<NodeID, Peer::pointer> const& outboundPeers,
@@ -151,8 +149,7 @@ SurveyDataManager::startSurveyCollecting(
     return false;
 }
 
-bool
-SurveyDataManager::startReportingPhase(
+bool SurveyDataManager::startReportingPhase(
     std::map<NodeID, Peer::pointer> const& inboundPeers,
     std::map<NodeID, Peer::pointer> const& outboundPeers, Config const& config)
 {
@@ -180,8 +177,7 @@ SurveyDataManager::startReportingPhase(
     return true;
 }
 
-bool
-SurveyDataManager::stopSurveyCollecting(
+bool SurveyDataManager::stopSurveyCollecting(
     TimeSlicedSurveyStopCollectingMessage const& msg,
     std::map<NodeID, Peer::pointer> const& inboundPeers,
     std::map<NodeID, Peer::pointer> const& outboundPeers, Config const& config)
@@ -203,8 +199,8 @@ SurveyDataManager::stopSurveyCollecting(
     return false;
 }
 
-void
-SurveyDataManager::modifyNodeData(std::function<void(CollectingNodeData&)> f)
+void SurveyDataManager::modifyNodeData(
+    std::function<void(CollectingNodeData&)> f)
 {
     ZoneScoped;
 
@@ -221,9 +217,8 @@ SurveyDataManager::modifyNodeData(std::function<void(CollectingNodeData&)> f)
     }
 }
 
-void
-SurveyDataManager::modifyPeerData(Peer const& peer,
-                                  std::function<void(CollectingPeerData&)> f)
+void SurveyDataManager::modifyPeerData(
+    Peer const& peer, std::function<void(CollectingPeerData&)> f)
 {
     ZoneScoped;
 
@@ -244,8 +239,7 @@ SurveyDataManager::modifyPeerData(Peer const& peer,
     }
 }
 
-void
-SurveyDataManager::recordDroppedPeer(Peer const& peer)
+void SurveyDataManager::recordDroppedPeer(Peer const& peer)
 {
     ZoneScoped;
 
@@ -267,21 +261,19 @@ SurveyDataManager::recordDroppedPeer(Peer const& peer)
     }
 }
 
-std::optional<uint32_t>
-SurveyDataManager::getNonce() const
+std::optional<uint32_t> SurveyDataManager::getNonce() const
 {
     return mNonce;
 }
 
-bool
-SurveyDataManager::nonceIsReporting(uint32_t nonce) const
+bool SurveyDataManager::nonceIsReporting(uint32_t nonce) const
 {
     return mPhase == SurveyPhase::REPORTING && mNonce == nonce;
 }
 
-bool
-SurveyDataManager::fillSurveyData(TimeSlicedSurveyRequestMessage const& request,
-                                  TopologyResponseBodyV2& response)
+bool SurveyDataManager::fillSurveyData(
+    TimeSlicedSurveyRequestMessage const& request,
+    TopologyResponseBodyV2& response)
 {
     ZoneScoped;
 
@@ -306,8 +298,7 @@ SurveyDataManager::fillSurveyData(TimeSlicedSurveyRequestMessage const& request,
     return false;
 }
 
-std::optional<TimeSlicedNodeData> const&
-SurveyDataManager::getFinalNodeData()
+std::optional<TimeSlicedNodeData> const& SurveyDataManager::getFinalNodeData()
 {
     if (mPhase != SurveyPhase::REPORTING || !mFinalNodeData.has_value())
     {
@@ -336,23 +327,20 @@ SurveyDataManager::getFinalOutboundPeerData()
     return mFinalOutboundPeerData;
 }
 
-bool
-SurveyDataManager::surveyIsActive() const
+bool SurveyDataManager::surveyIsActive() const
 {
     return mPhase != SurveyPhase::INACTIVE;
 }
 
 #ifdef BUILD_TESTS
-void
-SurveyDataManager::setPhaseMaxDurationsForTesting(
+void SurveyDataManager::setPhaseMaxDurationsForTesting(
     std::chrono::minutes maxPhaseDuration)
 {
     mMaxPhaseDurationForTesting = maxPhaseDuration;
 }
 #endif
 
-void
-SurveyDataManager::updateSurveyPhase(
+void SurveyDataManager::updateSurveyPhase(
     std::map<NodeID, Peer::pointer> const& inboundPeers,
     std::map<NodeID, Peer::pointer> const& outboundPeers, Config const& config)
 {
@@ -398,8 +386,7 @@ SurveyDataManager::updateSurveyPhase(
     }
 }
 
-void
-SurveyDataManager::reset()
+void SurveyDataManager::reset()
 {
     mPhase = SurveyPhase::INACTIVE;
     mCollectStartTime.reset();
@@ -414,8 +401,7 @@ SurveyDataManager::reset()
     mFinalOutboundPeerData.clear();
 }
 
-void
-SurveyDataManager::emitInconsistencyError(std::string const& where)
+void SurveyDataManager::emitInconsistencyError(std::string const& where)
 {
     logErrorOrThrow(
         fmt::format("Encountered inconsistent survey data while executing "
@@ -425,8 +411,7 @@ SurveyDataManager::emitInconsistencyError(std::string const& where)
     reset();
 }
 
-void
-SurveyDataManager::finalizeNodeData(Config const& config)
+void SurveyDataManager::finalizeNodeData(Config const& config)
 {
     if (mFinalNodeData.has_value() || !mCollectingNodeData.has_value())
     {
@@ -471,8 +456,7 @@ SurveyDataManager::finalizeNodeData(Config const& config)
     mCollectingNodeData.reset();
 }
 
-void
-SurveyDataManager::finalizePeerData(
+void SurveyDataManager::finalizePeerData(
     std::map<NodeID, Peer::pointer> const peers,
     std::unordered_map<NodeID, CollectingPeerData> const& collectingPeerData,
     std::vector<TimeSlicedPeerData>& finalPeerData)
@@ -532,8 +516,7 @@ SurveyDataManager::finalizePeerData(
     }
 }
 
-std::chrono::minutes
-SurveyDataManager::getCollectingPhaseMaxDuration() const
+std::chrono::minutes SurveyDataManager::getCollectingPhaseMaxDuration() const
 {
 #ifdef BUILD_TESTS
     if (mMaxPhaseDurationForTesting.has_value())
@@ -545,8 +528,7 @@ SurveyDataManager::getCollectingPhaseMaxDuration() const
         COLLECTING_PHASE_MAX_DURATION);
 }
 
-std::chrono::minutes
-SurveyDataManager::getReportingPhaseMaxDuration() const
+std::chrono::minutes SurveyDataManager::getReportingPhaseMaxDuration() const
 {
 #ifdef BUILD_TESTS
     if (mMaxPhaseDurationForTesting.has_value())

--- a/src/overlay/SurveyDataManager.h
+++ b/src/overlay/SurveyDataManager.h
@@ -92,20 +92,20 @@ class SurveyDataManager : public NonMovableOrCopyable
     // already active. `inboundPeers` and `outboundPeers` should collectively
     // contain the `NodeID`s of all connected peers. Returns `true` if this
     // successfully starts a survey.
-    bool
-    startSurveyCollecting(TimeSlicedSurveyStartCollectingMessage const& msg,
-                          std::map<NodeID, Peer::pointer> const& inboundPeers,
-                          std::map<NodeID, Peer::pointer> const& outboundPeers,
-                          Application::State initialState);
+    bool startSurveyCollecting(
+        TimeSlicedSurveyStartCollectingMessage const& msg,
+        std::map<NodeID, Peer::pointer> const& inboundPeers,
+        std::map<NodeID, Peer::pointer> const& outboundPeers,
+        Application::State initialState);
 
     // Stop the collecting phase of a survey and enter the reporting phase.
     // Ignores request if no survey is active or if nonce does not match the
     // active survey. Returns `true` if this successfully stops a survey.
-    bool
-    stopSurveyCollecting(TimeSlicedSurveyStopCollectingMessage const& msg,
-                         std::map<NodeID, Peer::pointer> const& inboundPeers,
-                         std::map<NodeID, Peer::pointer> const& outboundPeers,
-                         Config const& config);
+    bool stopSurveyCollecting(
+        TimeSlicedSurveyStopCollectingMessage const& msg,
+        std::map<NodeID, Peer::pointer> const& inboundPeers,
+        std::map<NodeID, Peer::pointer> const& outboundPeers,
+        Config const& config);
 
     // Apply `f` to the data for this node. Does nothing if the survey is not in
     // the collecting phase.
@@ -201,10 +201,10 @@ class SurveyDataManager : public NonMovableOrCopyable
 
     // Transition to the reporting phase. Should only be called from the
     // collecting phase. Returns `false` if transition fails.
-    bool
-    startReportingPhase(std::map<NodeID, Peer::pointer> const& inboundPeers,
-                        std::map<NodeID, Peer::pointer> const& outboundPeers,
-                        Config const& config);
+    bool startReportingPhase(
+        std::map<NodeID, Peer::pointer> const& inboundPeers,
+        std::map<NodeID, Peer::pointer> const& outboundPeers,
+        Config const& config);
 
     // Function to call when the impossible occurs. Logs an error and resets
     // the survey. Use instead of `releaseAssert` as an overlay survey

--- a/src/overlay/SurveyManager.cpp
+++ b/src/overlay/SurveyManager.cpp
@@ -24,8 +24,7 @@ uint32_t const SurveyManager::SURVEY_THROTTLE_TIMEOUT_MULT(3);
 namespace
 {
 // Generate JSON for a single peer
-Json::Value
-peerStatsToJson(PeerStats const& peer)
+Json::Value peerStatsToJson(PeerStats const& peer)
 {
     Json::Value peerInfo;
     peerInfo["nodeId"] = KeyUtils::toStrKey(peer.id);
@@ -98,8 +97,7 @@ populatePeerResults(Json::Value& results, TimeSlicedNodeData const& node,
 
 // We just need a rough estimate of the close time, so use the default starting
 // values here instead of checking the actual network config.
-std::chrono::milliseconds
-getSurveyThrottleTimeoutMs(Application& app)
+std::chrono::milliseconds getSurveyThrottleTimeoutMs(Application& app)
 {
     auto const& cfg = app.getConfig();
     auto estimatedCloseTime =
@@ -131,8 +129,7 @@ SurveyManager::SurveyManager(Application& app)
 {
 }
 
-bool
-SurveyManager::startSurveyReporting()
+bool SurveyManager::startSurveyReporting()
 {
     if (mRunningSurveyReportingPhase)
     {
@@ -177,8 +174,7 @@ SurveyManager::startSurveyReporting()
     return true;
 }
 
-void
-SurveyManager::stopSurveyReporting()
+void SurveyManager::stopSurveyReporting()
 {
     // do nothing if survey isn't running in reporting phase
     if (!mRunningSurveyReportingPhase)
@@ -194,8 +190,7 @@ SurveyManager::stopSurveyReporting()
     CLOG_INFO(Overlay, "SurveyResults {}", getJsonResults().toStyledString());
 }
 
-bool
-SurveyManager::broadcastStartSurveyCollecting(uint32_t nonce)
+bool SurveyManager::broadcastStartSurveyCollecting(uint32_t nonce)
 {
     if (mSurveyDataManager.surveyIsActive())
     {
@@ -223,9 +218,8 @@ SurveyManager::broadcastStartSurveyCollecting(uint32_t nonce)
     return true;
 }
 
-void
-SurveyManager::relayStartSurveyCollecting(StellarMessage const& msg,
-                                          Peer::pointer peer)
+void SurveyManager::relayStartSurveyCollecting(StellarMessage const& msg,
+                                               Peer::pointer peer)
 {
     releaseAssert(msg.type() == TIME_SLICED_SURVEY_START_COLLECTING);
     auto const& signedStartCollecting =
@@ -273,8 +267,7 @@ SurveyManager::relayStartSurveyCollecting(StellarMessage const& msg,
     broadcast(msg);
 }
 
-bool
-SurveyManager::broadcastStopSurveyCollecting()
+bool SurveyManager::broadcastStopSurveyCollecting()
 {
     std::optional<uint32_t> maybeNonce = mSurveyDataManager.getNonce();
     if (!maybeNonce.has_value())
@@ -300,9 +293,8 @@ SurveyManager::broadcastStopSurveyCollecting()
     return true;
 }
 
-void
-SurveyManager::relayStopSurveyCollecting(StellarMessage const& msg,
-                                         Peer::pointer peer)
+void SurveyManager::relayStopSurveyCollecting(StellarMessage const& msg,
+                                              Peer::pointer peer)
 {
     releaseAssert(msg.type() == TIME_SLICED_SURVEY_STOP_COLLECTING);
     auto const& signedStopCollecting =
@@ -350,10 +342,9 @@ SurveyManager::relayStopSurveyCollecting(StellarMessage const& msg,
     broadcast(msg);
 }
 
-void
-SurveyManager::addNodeToRunningSurveyBacklog(NodeID const& nodeToSurvey,
-                                             uint32_t inboundPeersIndex,
-                                             uint32_t outboundPeersIndex)
+void SurveyManager::addNodeToRunningSurveyBacklog(NodeID const& nodeToSurvey,
+                                                  uint32_t inboundPeersIndex,
+                                                  uint32_t outboundPeersIndex)
 {
     if (!mRunningSurveyReportingPhase)
     {
@@ -401,9 +392,8 @@ SurveyManager::validateTimeSlicedSurveyResponse(
     }
 }
 
-void
-SurveyManager::relayOrProcessResponse(StellarMessage const& msg,
-                                      Peer::pointer peer)
+void SurveyManager::relayOrProcessResponse(StellarMessage const& msg,
+                                           Peer::pointer peer)
 {
     releaseAssert(msg.type() == TIME_SLICED_SURVEY_RESPONSE);
     auto const& signedResponse = msg.signedTimeSlicedSurveyResponseMessage();
@@ -457,9 +447,8 @@ SurveyManager::relayOrProcessResponse(StellarMessage const& msg,
     }
 }
 
-void
-SurveyManager::relayOrProcessRequest(StellarMessage const& msg,
-                                     Peer::pointer peer)
+void SurveyManager::relayOrProcessRequest(StellarMessage const& msg,
+                                          Peer::pointer peer)
 {
     releaseAssert(msg.type() == TIME_SLICED_SURVEY_REQUEST);
     auto const& signedRequest = msg.signedTimeSlicedSurveyRequestMessage();
@@ -516,10 +505,9 @@ SurveyManager::relayOrProcessRequest(StellarMessage const& msg,
     }
 }
 
-void
-SurveyManager::populateSurveyRequestMessage(NodeID const& nodeToSurvey,
-                                            SurveyMessageCommandType type,
-                                            SurveyRequestMessage& request) const
+void SurveyManager::populateSurveyRequestMessage(
+    NodeID const& nodeToSurvey, SurveyMessageCommandType type,
+    SurveyRequestMessage& request) const
 {
     request.ledgerNum = mApp.getHerder().trackingConsensusLedgerIndex();
     request.surveyorPeerID = mApp.getConfig().NODE_SEED.getPublicKey();
@@ -558,8 +546,7 @@ SurveyManager::createTimeSlicedSurveyRequest(NodeID const& nodeToSurvey) const
     return newMsg;
 }
 
-void
-SurveyManager::sendTopologyRequest(NodeID const& nodeToSurvey)
+void SurveyManager::sendTopologyRequest(NodeID const& nodeToSurvey)
 {
     if (!mRunningSurveyReportingPhase)
     {
@@ -578,9 +565,8 @@ SurveyManager::sendTopologyRequest(NodeID const& nodeToSurvey)
     }
 }
 
-void
-SurveyManager::processTimeSlicedTopologyResponse(NodeID const& surveyedPeerID,
-                                                 SurveyResponseBody const& body)
+void SurveyManager::processTimeSlicedTopologyResponse(
+    NodeID const& surveyedPeerID, SurveyResponseBody const& body)
 {
     auto& peerResults =
         mResults["topology"][KeyUtils::toStrKey(surveyedPeerID)];
@@ -592,8 +578,7 @@ SurveyManager::processTimeSlicedTopologyResponse(NodeID const& surveyedPeerID,
                         topologyBody.inboundPeers, topologyBody.outboundPeers);
 }
 
-bool
-SurveyManager::populateSurveyResponseMessage(
+bool SurveyManager::populateSurveyResponseMessage(
     SurveyRequestMessage const& request, SurveyResponseBody const& body,
     SurveyResponseMessage& response) const
 {
@@ -615,8 +600,7 @@ SurveyManager::populateSurveyResponseMessage(
     return true;
 }
 
-void
-SurveyManager::processTimeSlicedTopologyRequest(
+void SurveyManager::processTimeSlicedTopologyRequest(
     TimeSlicedSurveyRequestMessage const& request)
 {
     std::string const peerIdStr =
@@ -656,21 +640,18 @@ SurveyManager::processTimeSlicedTopologyRequest(
     broadcast(newMsg);
 }
 
-void
-SurveyManager::broadcast(StellarMessage const& msg) const
+void SurveyManager::broadcast(StellarMessage const& msg) const
 {
     mApp.getOverlayManager().broadcastMessage(
         std::make_shared<StellarMessage const>(msg));
 }
 
-void
-SurveyManager::clearOldLedgers(uint32_t lastClosedledgerSeq)
+void SurveyManager::clearOldLedgers(uint32_t lastClosedledgerSeq)
 {
     mMessageLimiter.clearOldLedgers(lastClosedledgerSeq);
 }
 
-Json::Value const&
-SurveyManager::getJsonResults()
+Json::Value const& SurveyManager::getJsonResults()
 {
     mResults["surveyInProgress"] = mRunningSurveyReportingPhase;
 
@@ -693,8 +674,7 @@ SurveyManager::getJsonResults()
     return mResults;
 }
 
-std::string
-SurveyManager::getMsgSummary(StellarMessage const& msg)
+std::string SurveyManager::getMsgSummary(StellarMessage const& msg)
 {
     std::string summary;
     SurveyMessageCommandType commandType;
@@ -721,8 +701,7 @@ SurveyManager::getMsgSummary(StellarMessage const& msg)
     return summary + commandTypeName(commandType);
 }
 
-void
-SurveyManager::topOffRequests()
+void SurveyManager::topOffRequests()
 {
     if (surveyIsFinishedReporting())
     {
@@ -774,8 +753,7 @@ SurveyManager::topOffRequests()
     mSurveyThrottleTimer->async_wait(handler, &VirtualTimer::onFailureNoop);
 }
 
-void
-SurveyManager::addPeerToBacklog(NodeID const& nodeToSurvey)
+void SurveyManager::addPeerToBacklog(NodeID const& nodeToSurvey)
 {
     // filter conditions-
     // 1. already queued
@@ -803,10 +781,10 @@ SurveyManager::addPeerToBacklog(NodeID const& nodeToSurvey)
     mPeersToSurveyQueue.emplace(nodeToSurvey);
 }
 
-bool
-SurveyManager::dropPeerIfSigInvalid(PublicKey const& key,
-                                    Signature const& signature,
-                                    ByteSlice const& bin, Peer::pointer peer)
+bool SurveyManager::dropPeerIfSigInvalid(PublicKey const& key,
+                                         Signature const& signature,
+                                         ByteSlice const& bin,
+                                         Peer::pointer peer)
 {
     bool success = PubKeyUtils::verifySig(key, signature, bin).valid;
 
@@ -819,8 +797,7 @@ SurveyManager::dropPeerIfSigInvalid(PublicKey const& key,
     return success;
 }
 
-std::string
-SurveyManager::commandTypeName(SurveyMessageCommandType type)
+std::string SurveyManager::commandTypeName(SurveyMessageCommandType type)
 {
     auto res = xdr::xdr_traits<SurveyMessageCommandType>::enum_name(type);
     if (res == nullptr)
@@ -830,8 +807,7 @@ SurveyManager::commandTypeName(SurveyMessageCommandType type)
     return std::string(res);
 }
 
-bool
-SurveyManager::surveyorPermitted(NodeID const& surveyorID) const
+bool SurveyManager::surveyorPermitted(NodeID const& surveyorID) const
 {
     auto const& surveyorKeys = mApp.getConfig().SURVEYOR_KEYS;
 
@@ -844,35 +820,30 @@ SurveyManager::surveyorPermitted(NodeID const& surveyorID) const
     return surveyorKeys.count(surveyorID) != 0;
 }
 
-void
-SurveyManager::modifyNodeData(std::function<void(CollectingNodeData&)> f)
+void SurveyManager::modifyNodeData(std::function<void(CollectingNodeData&)> f)
 {
     mSurveyDataManager.modifyNodeData(f);
 }
 
-void
-SurveyManager::modifyPeerData(Peer const& peer,
-                              std::function<void(CollectingPeerData&)> f)
+void SurveyManager::modifyPeerData(Peer const& peer,
+                                   std::function<void(CollectingPeerData&)> f)
 {
     mSurveyDataManager.modifyPeerData(peer, f);
 }
 
-void
-SurveyManager::recordDroppedPeer(Peer const& peer)
+void SurveyManager::recordDroppedPeer(Peer const& peer)
 {
     mSurveyDataManager.recordDroppedPeer(peer);
 }
 
-void
-SurveyManager::updateSurveyPhase(
+void SurveyManager::updateSurveyPhase(
     std::map<NodeID, Peer::pointer> const& inboundPeers,
     std::map<NodeID, Peer::pointer> const& outboundPeers, Config const& config)
 {
     mSurveyDataManager.updateSurveyPhase(inboundPeers, outboundPeers, config);
 }
 
-bool
-SurveyManager::surveyIsFinishedReporting()
+bool SurveyManager::surveyIsFinishedReporting()
 {
     if (!mRunningSurveyReportingPhase)
     {
@@ -889,8 +860,7 @@ SurveyManager::surveyIsFinishedReporting()
 }
 
 #ifdef BUILD_TESTS
-SurveyDataManager&
-SurveyManager::getSurveyDataManagerForTesting()
+SurveyDataManager& SurveyManager::getSurveyDataManagerForTesting()
 {
     return mSurveyDataManager;
 }

--- a/src/overlay/SurveyMessageLimiter.cpp
+++ b/src/overlay/SurveyMessageLimiter.cpp
@@ -19,8 +19,7 @@ SurveyMessageLimiter::SurveyMessageLimiter(Application& app,
 {
 }
 
-bool
-SurveyMessageLimiter::addAndValidateRequest(
+bool SurveyMessageLimiter::addAndValidateRequest(
     SurveyRequestMessage const& request,
     std::function<bool()> onSuccessValidation)
 {
@@ -96,8 +95,7 @@ SurveyMessageLimiter::addAndValidateRequest(
     return false;
 }
 
-bool
-SurveyMessageLimiter::recordAndValidateResponse(
+bool SurveyMessageLimiter::recordAndValidateResponse(
     SurveyResponseMessage const& response,
     std::function<bool()> onSuccessValidation)
 {
@@ -145,8 +143,7 @@ SurveyMessageLimiter::recordAndValidateResponse(
     return true;
 }
 
-bool
-SurveyMessageLimiter::validateStartSurveyCollecting(
+bool SurveyMessageLimiter::validateStartSurveyCollecting(
     TimeSlicedSurveyStartCollectingMessage const& startSurvey,
     SurveyDataManager& surveyDataManager,
     std::function<bool()> onSuccessValidation)
@@ -172,8 +169,7 @@ SurveyMessageLimiter::validateStartSurveyCollecting(
     return true;
 }
 
-bool
-SurveyMessageLimiter::validateStopSurveyCollecting(
+bool SurveyMessageLimiter::validateStopSurveyCollecting(
     TimeSlicedSurveyStopCollectingMessage const& stopSurvey,
     std::function<bool()> onSuccessValidation)
 {
@@ -191,8 +187,7 @@ SurveyMessageLimiter::validateStopSurveyCollecting(
     return true;
 }
 
-bool
-SurveyMessageLimiter::surveyLedgerNumValid(uint32_t ledgerNum)
+bool SurveyMessageLimiter::surveyLedgerNumValid(uint32_t ledgerNum)
 {
     uint32_t localLedgerNum = mApp.getHerder().trackingConsensusLedgerIndex();
     return ledgerNum + mNumLedgersBeforeIgnore >= localLedgerNum &&
@@ -200,8 +195,7 @@ SurveyMessageLimiter::surveyLedgerNumValid(uint32_t ledgerNum)
                localLedgerNum + std::max<uint32_t>(mNumLedgersBeforeIgnore, 1);
 }
 
-void
-SurveyMessageLimiter::clearOldLedgers(uint32_t lastClosedledgerSeq)
+void SurveyMessageLimiter::clearOldLedgers(uint32_t lastClosedledgerSeq)
 {
     for (auto it = mRecordMap.cbegin(); it != mRecordMap.cend();)
     {

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -48,8 +48,8 @@ TCPPeer::TCPPeer(Application& app, Peer::PeerRole role,
     }
 }
 
-TCPPeer::pointer
-TCPPeer::initiate(Application& app, PeerBareAddress const& address)
+TCPPeer::pointer TCPPeer::initiate(Application& app,
+                                   PeerBareAddress const& address)
 {
     releaseAssert(threadIsMain());
     releaseAssert(address.getType() == PeerBareAddress::Type::IPv4);
@@ -109,8 +109,8 @@ TCPPeer::initiate(Application& app, PeerBareAddress const& address)
     return result;
 }
 
-TCPPeer::pointer
-TCPPeer::accept(Application& app, shared_ptr<TCPPeer::SocketType> socket)
+TCPPeer::pointer TCPPeer::accept(Application& app,
+                                 shared_ptr<TCPPeer::SocketType> socket)
 {
     releaseAssert(threadIsMain());
 
@@ -223,9 +223,8 @@ TCPPeer::~TCPPeer()
     }
 }
 
-void
-TCPPeer::sendMessage(xdr::msg_ptr&& xdrBytes,
-                     std::shared_ptr<StellarMessage const> msgPtr)
+void TCPPeer::sendMessage(xdr::msg_ptr&& xdrBytes,
+                          std::shared_ptr<StellarMessage const> msgPtr)
 {
     releaseAssert(!threadIsMain() || !useBackgroundThread());
 
@@ -242,8 +241,7 @@ TCPPeer::sendMessage(xdr::msg_ptr&& xdrBytes,
     }
 }
 
-void
-TCPPeer::shutdown()
+void TCPPeer::shutdown()
 {
     releaseAssert(!threadIsMain() || !useBackgroundThread());
 
@@ -292,8 +290,7 @@ TCPPeer::shutdown()
     maybeExecuteInBackground("TCPPeer: close", socketClose);
 }
 
-void
-TCPPeer::messageSender()
+void TCPPeer::messageSender()
 {
     ZoneScoped;
     releaseAssert(!threadIsMain() || !useBackgroundThread());
@@ -393,9 +390,8 @@ TCPPeer::messageSender()
         });
 }
 
-void
-TCPPeer::TimestampedMessage::recordWriteTiming(OverlayMetrics& metrics,
-                                               PeerMetrics& peerMetrics)
+void TCPPeer::TimestampedMessage::recordWriteTiming(OverlayMetrics& metrics,
+                                                    PeerMetrics& peerMetrics)
 {
     auto qdelay = std::chrono::duration_cast<std::chrono::nanoseconds>(
         mIssuedTime - mEnqueuedTime);
@@ -407,10 +403,9 @@ TCPPeer::TimestampedMessage::recordWriteTiming(OverlayMetrics& metrics,
     peerMetrics.mMessageDelayInAsyncWriteTimer.Update(wdelay);
 }
 
-void
-TCPPeer::writeHandler(asio::error_code const& error,
-                      std::size_t bytes_transferred,
-                      size_t messages_transferred)
+void TCPPeer::writeHandler(asio::error_code const& error,
+                           std::size_t bytes_transferred,
+                           size_t messages_transferred)
 {
     ZoneScoped;
     releaseAssert(!threadIsMain() || !useBackgroundThread());
@@ -443,8 +438,7 @@ TCPPeer::writeHandler(asio::error_code const& error,
     }
 }
 
-void
-TCPPeer::noteErrorReadHeader(size_t nbytes, asio::error_code const& ec)
+void TCPPeer::noteErrorReadHeader(size_t nbytes, asio::error_code const& ec)
 {
     releaseAssert(!threadIsMain() || !useBackgroundThread());
     receivedBytes(nbytes, false);
@@ -454,8 +448,7 @@ TCPPeer::noteErrorReadHeader(size_t nbytes, asio::error_code const& ec)
     drop(msg, Peer::DropDirection::WE_DROPPED_REMOTE);
 }
 
-void
-TCPPeer::noteShortReadHeader(size_t nbytes)
+void TCPPeer::noteShortReadHeader(size_t nbytes)
 {
     releaseAssert(!threadIsMain() || !useBackgroundThread());
     receivedBytes(nbytes, false);
@@ -464,15 +457,13 @@ TCPPeer::noteShortReadHeader(size_t nbytes)
          Peer::DropDirection::WE_DROPPED_REMOTE);
 }
 
-void
-TCPPeer::noteFullyReadHeader()
+void TCPPeer::noteFullyReadHeader()
 {
     releaseAssert(!threadIsMain() || !useBackgroundThread());
     receivedBytes(HDRSZ, false);
 }
 
-void
-TCPPeer::noteErrorReadBody(size_t nbytes, asio::error_code const& ec)
+void TCPPeer::noteErrorReadBody(size_t nbytes, asio::error_code const& ec)
 {
     releaseAssert(!threadIsMain() || !useBackgroundThread());
 
@@ -483,8 +474,7 @@ TCPPeer::noteErrorReadBody(size_t nbytes, asio::error_code const& ec)
     drop(msg, Peer::DropDirection::WE_DROPPED_REMOTE);
 }
 
-void
-TCPPeer::noteShortReadBody(size_t nbytes)
+void TCPPeer::noteShortReadBody(size_t nbytes)
 {
     releaseAssert(!threadIsMain() || !useBackgroundThread());
 
@@ -493,16 +483,14 @@ TCPPeer::noteShortReadBody(size_t nbytes)
     drop("short read of message body", Peer::DropDirection::WE_DROPPED_REMOTE);
 }
 
-void
-TCPPeer::noteFullyReadBody(size_t nbytes)
+void TCPPeer::noteFullyReadBody(size_t nbytes)
 {
     releaseAssert(!threadIsMain() || !useBackgroundThread());
 
     receivedBytes(nbytes, true);
 }
 
-void
-TCPPeer::scheduleRead()
+void TCPPeer::scheduleRead()
 {
     // Post to the peer-specific Scheduler a call to ::startRead below;
     // this will be throttled to try to balance input rates across peers.
@@ -541,8 +529,7 @@ TCPPeer::scheduleRead()
     }
 }
 
-void
-TCPPeer::startRead()
+void TCPPeer::startRead()
 {
     ZoneScoped;
     releaseAssert(!threadIsMain() || !useBackgroundThread());
@@ -669,8 +656,7 @@ TCPPeer::startRead()
     }
 }
 
-size_t
-TCPPeer::getIncomingMsgLength()
+size_t TCPPeer::getIncomingMsgLength()
 {
     RECURSIVE_LOCK_GUARD(mStateMutex, guard);
     auto const& header = mThreadVars.getIncomingHeader();
@@ -702,15 +688,13 @@ TCPPeer::getIncomingMsgLength()
     return (length);
 }
 
-void
-TCPPeer::connected()
+void TCPPeer::connected()
 {
     startRead();
 }
 
-void
-TCPPeer::readHeaderHandler(asio::error_code const& error,
-                           std::size_t bytes_transferred)
+void TCPPeer::readHeaderHandler(asio::error_code const& error,
+                                std::size_t bytes_transferred)
 {
     releaseAssert(!threadIsMain() || !useBackgroundThread());
 
@@ -740,10 +724,9 @@ TCPPeer::readHeaderHandler(asio::error_code const& error,
     }
 }
 
-void
-TCPPeer::readBodyHandler(asio::error_code const& error,
-                         std::size_t bytes_transferred,
-                         std::size_t expected_length)
+void TCPPeer::readBodyHandler(asio::error_code const& error,
+                              std::size_t bytes_transferred,
+                              std::size_t expected_length)
 {
     releaseAssert(!threadIsMain() || !useBackgroundThread());
 
@@ -777,8 +760,7 @@ TCPPeer::readBodyHandler(asio::error_code const& error,
     }
 }
 
-bool
-TCPPeer::recvMessage()
+bool TCPPeer::recvMessage()
 {
     ZoneScoped;
     releaseAssert(!threadIsMain() || !useBackgroundThread());
@@ -832,8 +814,7 @@ TCPPeer::recvMessage()
 // `drop` can be initiated from any thread and is thread-safe. The method simply
 // schedules a callback on the main thread, that is going to clean up connection
 // lists and remove the peer.
-void
-TCPPeer::drop(std::string const& reason, DropDirection dropDirection)
+void TCPPeer::drop(std::string const& reason, DropDirection dropDirection)
 {
     // Attempts to set mDropStarted to true, returns previous value. If previous
     // value was false, this means we're initiating the drop for the first time

--- a/src/overlay/TCPPeer.h
+++ b/src/overlay/TCPPeer.h
@@ -42,38 +42,32 @@ class TCPPeer : public Peer
             : mUseBackgroundThread(useBackgroundThread)
         {
         }
-        std::deque<TimestampedMessage>&
-        getWriteQueue()
+        std::deque<TimestampedMessage>& getWriteQueue()
         {
             releaseAssert(!threadIsMain() || !mUseBackgroundThread);
             return mWriteQueue;
         }
-        std::vector<asio::const_buffer>&
-        getWriteBuffers()
+        std::vector<asio::const_buffer>& getWriteBuffers()
         {
             releaseAssert(!threadIsMain() || !mUseBackgroundThread);
             return mWriteBuffers;
         }
-        std::vector<uint8_t>&
-        getIncomingHeader()
+        std::vector<uint8_t>& getIncomingHeader()
         {
             releaseAssert(!threadIsMain() || !mUseBackgroundThread);
             return mIncomingHeader;
         }
-        std::vector<uint8_t>&
-        getIncomingBody()
+        std::vector<uint8_t>& getIncomingBody()
         {
             releaseAssert(!threadIsMain() || !mUseBackgroundThread);
             return mIncomingBody;
         }
-        bool
-        isWriting() const
+        bool isWriting() const
         {
             releaseAssert(!threadIsMain() || !mUseBackgroundThread);
             return mWriting;
         }
-        void
-        setWriting(bool value)
+        void setWriting(bool value)
         {
             releaseAssert(!threadIsMain() || !mUseBackgroundThread);
             mWriting = value;

--- a/src/overlay/Tracker.cpp
+++ b/src/overlay/Tracker.cpp
@@ -40,8 +40,7 @@ Tracker::~Tracker()
     cancel();
 }
 
-SCPEnvelope
-Tracker::pop()
+SCPEnvelope Tracker::pop()
 {
     auto env = mWaitingEnvelopes.back().second;
     mWaitingEnvelopes.pop_back();
@@ -49,8 +48,7 @@ Tracker::pop()
 }
 
 // returns false if no one cares about this guy anymore
-bool
-Tracker::clearEnvelopesBelow(uint64 slotIndex, uint64 slotToKeep)
+bool Tracker::clearEnvelopesBelow(uint64 slotIndex, uint64 slotToKeep)
 {
     ZoneScoped;
     for (auto iter = mWaitingEnvelopes.begin();
@@ -77,8 +75,7 @@ Tracker::clearEnvelopesBelow(uint64 slotIndex, uint64 slotToKeep)
     return false;
 }
 
-void
-Tracker::doesntHave(Peer::pointer peer)
+void Tracker::doesntHave(Peer::pointer peer)
 {
     if (mLastAskedPeer == peer)
     {
@@ -87,8 +84,7 @@ Tracker::doesntHave(Peer::pointer peer)
     }
 }
 
-void
-Tracker::tryNextPeer()
+void Tracker::tryNextPeer()
 {
     ZoneScoped;
     // will be called by some timer or when we get a
@@ -221,8 +217,7 @@ matchEnvelope(SCPEnvelope const& env)
     };
 }
 
-void
-Tracker::listen(const SCPEnvelope& env)
+void Tracker::listen(const SCPEnvelope& env)
 {
     ZoneScoped;
     mLastSeenSlotIndex = std::max(env.statement.slotIndex, mLastSeenSlotIndex);
@@ -247,8 +242,7 @@ Tracker::listen(const SCPEnvelope& env)
     mWaitingEnvelopes.push_back(std::make_pair(xdrBlake2(m), env));
 }
 
-void
-Tracker::discard(const SCPEnvelope& env)
+void Tracker::discard(const SCPEnvelope& env)
 {
     ZoneScoped;
     auto matcher = matchEnvelope(env);
@@ -258,15 +252,13 @@ Tracker::discard(const SCPEnvelope& env)
                             std::end(mWaitingEnvelopes));
 }
 
-void
-Tracker::cancel()
+void Tracker::cancel()
 {
     mTimer.cancel();
     mLastSeenSlotIndex = 0;
 }
 
-std::chrono::milliseconds
-Tracker::getDuration()
+std::chrono::milliseconds Tracker::getDuration()
 {
     return mFetchTime.checkElapsedTime();
 }

--- a/src/overlay/Tracker.h
+++ b/src/overlay/Tracker.h
@@ -67,8 +67,7 @@ class Tracker
     /**
      * Return true if does not wait for any envelope.
      */
-    bool
-    empty() const
+    bool empty() const
     {
         return mWaitingEnvelopes.empty();
     }
@@ -76,8 +75,7 @@ class Tracker
     /**
      * Return list of envelopes this tracker is waiting for.
      */
-    const std::vector<std::pair<Hash, SCPEnvelope>>&
-    waitingEnvelopes() const
+    const std::vector<std::pair<Hash, SCPEnvelope>>& waitingEnvelopes() const
     {
         return mWaitingEnvelopes;
     }
@@ -85,8 +83,7 @@ class Tracker
     /**
      * Return count of envelopes it is waiting for.
      */
-    size_t
-    size() const
+    size_t size() const
     {
         return mWaitingEnvelopes.size();
     }
@@ -141,8 +138,7 @@ class Tracker
     /**
      * Return biggest slot index seen since last reset.
      */
-    uint64
-    getLastSeenSlotIndex() const
+    uint64 getLastSeenSlotIndex() const
     {
         return mLastSeenSlotIndex;
     }
@@ -150,15 +146,13 @@ class Tracker
     /**
      * Reset value of biggest slot index seen.
      */
-    void
-    resetLastSeenSlotIndex()
+    void resetLastSeenSlotIndex()
     {
         mLastSeenSlotIndex = 0;
     }
 
 #ifdef BUILD_TESTS
-    Peer::pointer
-    getLastAskedPeer()
+    Peer::pointer getLastAskedPeer()
     {
         return mLastAskedPeer;
     }

--- a/src/overlay/TxAdverts.cpp
+++ b/src/overlay/TxAdverts.cpp
@@ -18,8 +18,7 @@ TxAdverts::TxAdverts(Application& app)
 {
 }
 
-void
-TxAdverts::flushAdvert()
+void TxAdverts::flushAdvert()
 {
     if (mOutgoingTxHashes.size() > 0)
     {
@@ -37,14 +36,12 @@ TxAdverts::flushAdvert()
     }
 }
 
-void
-TxAdverts::shutdown()
+void TxAdverts::shutdown()
 {
     mAdvertTimer.cancel();
 }
 
-void
-TxAdverts::start(
+void TxAdverts::start(
     std::function<void(std::shared_ptr<StellarMessage const>)> sendCb)
 {
     if (!sendCb)
@@ -54,8 +51,7 @@ TxAdverts::start(
     mSendCb = sendCb;
 }
 
-void
-TxAdverts::startAdvertTimer()
+void TxAdverts::startAdvertTimer()
 {
     mAdvertTimer.expires_from_now(mApp.getConfig().FLOOD_ADVERT_PERIOD_MS);
     mAdvertTimer.async_wait([this](asio::error_code const& error) {
@@ -66,8 +62,7 @@ TxAdverts::startAdvertTimer()
     });
 }
 
-void
-TxAdverts::queueOutgoingAdvert(Hash const& txHash)
+void TxAdverts::queueOutgoingAdvert(Hash const& txHash)
 {
     if (mOutgoingTxHashes.empty())
     {
@@ -86,26 +81,22 @@ TxAdverts::queueOutgoingAdvert(Hash const& txHash)
     }
 }
 
-bool
-TxAdverts::seenAdvert(Hash const& hash)
+bool TxAdverts::seenAdvert(Hash const& hash)
 {
     return mAdvertHistory.exists(hash);
 }
 
-void
-TxAdverts::rememberHash(Hash const& hash, uint32_t ledgerSeq)
+void TxAdverts::rememberHash(Hash const& hash, uint32_t ledgerSeq)
 {
     mAdvertHistory.put(hash, ledgerSeq);
 }
 
-size_t
-TxAdverts::size() const
+size_t TxAdverts::size() const
 {
     return mIncomingTxHashes.size() + mTxHashesToRetry.size();
 }
 
-void
-TxAdverts::retryIncomingAdvert(std::list<Hash>& list)
+void TxAdverts::retryIncomingAdvert(std::list<Hash>& list)
 {
     mTxHashesToRetry.splice(mTxHashesToRetry.end(), list);
     while (size() > mApp.getLedgerManager().getLastMaxTxSetSizeOps())
@@ -114,8 +105,8 @@ TxAdverts::retryIncomingAdvert(std::list<Hash>& list)
     }
 }
 
-void
-TxAdverts::queueIncomingAdvert(TxAdvertVector const& txHashes, uint32_t seq)
+void TxAdverts::queueIncomingAdvert(TxAdvertVector const& txHashes,
+                                    uint32_t seq)
 {
     for (auto const& hash : txHashes)
     {
@@ -145,8 +136,7 @@ TxAdverts::queueIncomingAdvert(TxAdvertVector const& txHashes, uint32_t seq)
     }
 }
 
-Hash
-TxAdverts::popIncomingAdvert()
+Hash TxAdverts::popIncomingAdvert()
 {
     if (size() <= 0)
     {
@@ -167,23 +157,20 @@ TxAdverts::popIncomingAdvert()
     }
 }
 
-void
-TxAdverts::clearBelow(uint32_t ledgerSeq)
+void TxAdverts::clearBelow(uint32_t ledgerSeq)
 {
     mAdvertHistory.erase_if(
         [&](uint32_t const& seq) { return seq < ledgerSeq; });
 }
 
-int64_t
-TxAdverts::getOpsFloodLedger(size_t maxOps, double rate)
+int64_t TxAdverts::getOpsFloodLedger(size_t maxOps, double rate)
 {
     double opsToFloodPerLedgerDbl = rate * static_cast<double>(maxOps);
     releaseAssertOrThrow(opsToFloodPerLedgerDbl >= 0.0);
     return static_cast<int64_t>(opsToFloodPerLedgerDbl);
 }
 
-size_t
-TxAdverts::getMaxAdvertSize() const
+size_t TxAdverts::getMaxAdvertSize() const
 {
     auto const& cfg = mApp.getConfig();
     auto ledgerCloseTime =

--- a/src/overlay/TxAdverts.h
+++ b/src/overlay/TxAdverts.h
@@ -61,13 +61,12 @@ class TxAdverts
 
     bool seenAdvert(Hash const& hash);
     void clearBelow(uint32_t ledgerSeq);
-    void
-    start(std::function<void(std::shared_ptr<StellarMessage const>)> sendCb);
+    void start(
+        std::function<void(std::shared_ptr<StellarMessage const>)> sendCb);
     void shutdown();
 
 #ifdef BUILD_TESTS
-    size_t
-    outgoingSize() const
+    size_t outgoingSize() const
     {
         return mOutgoingTxHashes.size();
     }

--- a/src/overlay/TxDemandsManager.cpp
+++ b/src/overlay/TxDemandsManager.cpp
@@ -29,20 +29,17 @@ TxDemandsManager::TxDemandsManager(Application& app)
 {
 }
 
-void
-TxDemandsManager::start()
+void TxDemandsManager::start()
 {
     demand();
 }
 
-void
-TxDemandsManager::shutdown()
+void TxDemandsManager::shutdown()
 {
     mDemandTimer.cancel();
 }
 
-size_t
-TxDemandsManager::getMaxDemandSize() const
+size_t TxDemandsManager::getMaxDemandSize() const
 {
     auto const& cfg = mApp.getConfig();
     auto ledgerCloseTime =
@@ -106,8 +103,7 @@ TxDemandsManager::demandStatus(Hash const& txHash, Peer::pointer peer) const
     return DemandStatus::DISCARD;
 }
 
-void
-TxDemandsManager::startDemandTimer()
+void TxDemandsManager::startDemandTimer()
 {
     mDemandTimer.expires_from_now(mApp.getConfig().FLOOD_DEMAND_PERIOD_MS);
     mDemandTimer.async_wait([this](asio::error_code const& error) {
@@ -118,8 +114,7 @@ TxDemandsManager::startDemandTimer()
     });
 }
 
-void
-TxDemandsManager::demand()
+void TxDemandsManager::demand()
 {
     ZoneScoped;
     if (mApp.getOverlayManager().isShuttingDown())
@@ -225,9 +220,8 @@ TxDemandsManager::demand()
     startDemandTimer();
 }
 
-void
-TxDemandsManager::recordTxPullLatency(Hash const& hash,
-                                      std::shared_ptr<Peer> peer)
+void TxDemandsManager::recordTxPullLatency(Hash const& hash,
+                                           std::shared_ptr<Peer> peer)
 {
     auto it = mDemandHistoryMap.find(hash);
     auto now = mApp.getClock().now();
@@ -267,8 +261,7 @@ TxDemandsManager::recordTxPullLatency(Hash const& hash,
     }
 }
 
-void
-TxDemandsManager::recvTxDemand(FloodDemand const& dmd, Peer::pointer peer)
+void TxDemandsManager::recvTxDemand(FloodDemand const& dmd, Peer::pointer peer)
 {
     ZoneScoped;
     auto& herder = mApp.getHerder();

--- a/src/overlay/test/ItemFetcherTests.cpp
+++ b/src/overlay/test/ItemFetcherTests.cpp
@@ -33,8 +33,7 @@ class HerderStub : public HerderImpl
     std::vector<int> received;
 
   private:
-    EnvelopeStatus
-    recvSCPEnvelope(SCPEnvelope const& envelope) override
+    EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope) override
     {
         received.push_back(envelope.statement.pledges.confirm().nPrepared);
         return Herder::ENVELOPE_STATUS_PROCESSED;
@@ -49,23 +48,20 @@ class ApplicationStub : public TestApplication
     {
     }
 
-    virtual HerderStub&
-    getHerder() override
+    virtual HerderStub& getHerder() override
     {
         auto& herder = ApplicationImpl::getHerder();
         return static_cast<HerderStub&>(herder);
     }
 
   private:
-    virtual std::unique_ptr<Herder>
-    createHerder() override
+    virtual std::unique_ptr<Herder> createHerder() override
     {
         return std::make_unique<HerderStub>(*this);
     }
 };
 
-SCPEnvelope
-makeEnvelope(int id)
+SCPEnvelope makeEnvelope(int id)
 {
     static int slotIndex{0};
 

--- a/src/overlay/test/LoopbackPeer.cpp
+++ b/src/overlay/test/LoopbackPeer.cpp
@@ -30,8 +30,7 @@ LoopbackPeer::LoopbackPeer(Application& app, PeerRole role) : Peer(app, role)
         std::make_shared<FlowControl>(mAppConnector, useBackgroundThread());
 }
 
-std::string
-LoopbackPeer::getIP() const
+std::string LoopbackPeer::getIP() const
 {
     return "127.0.0.1";
 }
@@ -79,8 +78,7 @@ LoopbackPeer::initiate(Application& app, Application& otherApp)
     return std::pair(peer, otherPeer);
 }
 
-AuthCert
-LoopbackPeer::getAuthCert()
+AuthCert LoopbackPeer::getAuthCert()
 {
     auto c = Peer::getAuthCert();
     if (mDamageCert)
@@ -90,14 +88,13 @@ LoopbackPeer::getAuthCert()
     return c;
 }
 
-void
-LoopbackPeer::scheduleRead()
+void LoopbackPeer::scheduleRead()
 {
     processInQueue();
 }
 
-void
-LoopbackPeer::sendMessage(xdr::msg_ptr&& msg, ConstStellarMessagePtr msgPtr)
+void LoopbackPeer::sendMessage(xdr::msg_ptr&& msg,
+                               ConstStellarMessagePtr msgPtr)
 {
     if (mRemote.expired())
     {
@@ -145,8 +142,7 @@ LoopbackPeer::sendMessage(xdr::msg_ptr&& msg, ConstStellarMessagePtr msgPtr)
     }
 }
 
-void
-LoopbackPeer::drop(std::string const& reason, DropDirection direction)
+void LoopbackPeer::drop(std::string const& reason, DropDirection direction)
 {
     if (mState == CLOSING)
     {
@@ -191,8 +187,7 @@ LoopbackPeer::drop(std::string const& reason, DropDirection direction)
     }
 }
 
-static bool
-damageMessage(stellar_default_random_engine& gen, xdr::msg_ptr& msg)
+static bool damageMessage(stellar_default_random_engine& gen, xdr::msg_ptr& msg)
 {
     size_t bitsFlipped = 0;
     char* d = msg->raw_data();
@@ -225,8 +220,7 @@ duplicateMessage(Peer::TimestampedMessage const& msg)
     return msg2;
 }
 
-void
-LoopbackPeer::processInQueue()
+void LoopbackPeer::processInQueue()
 {
     if (mFlowControl->maybeThrottleRead())
     {
@@ -249,8 +243,7 @@ LoopbackPeer::processInQueue()
     }
 }
 
-void
-LoopbackPeer::recvMessage(xdr::msg_ptr const& msg)
+void LoopbackPeer::recvMessage(xdr::msg_ptr const& msg)
 {
     ZoneScoped;
     if (shouldAbortForTesting())
@@ -277,8 +270,8 @@ LoopbackPeer::recvMessage(xdr::msg_ptr const& msg)
     }
 }
 
-void
-LoopbackPeer::recvMessage(std::shared_ptr<CapacityTrackedMessage> msgTracker)
+void LoopbackPeer::recvMessage(
+    std::shared_ptr<CapacityTrackedMessage> msgTracker)
 {
     mAppConnector.postOnMainThread(
         [self = shared_from_this(), msgTracker]() {
@@ -287,8 +280,7 @@ LoopbackPeer::recvMessage(std::shared_ptr<CapacityTrackedMessage> msgTracker)
         "LoopbackPeer: processInQueue");
 }
 
-void
-LoopbackPeer::deliverOne()
+void LoopbackPeer::deliverOne()
 {
     if (mRemote.expired())
     {
@@ -374,8 +366,7 @@ LoopbackPeer::deliverOne()
     }
 }
 
-void
-LoopbackPeer::deliverAll()
+void LoopbackPeer::deliverAll()
 {
     while (!mOutQueue.empty() && !mCorked)
     {
@@ -383,14 +374,12 @@ LoopbackPeer::deliverAll()
     }
 }
 
-void
-LoopbackPeer::dropAll()
+void LoopbackPeer::dropAll()
 {
     mOutQueue.clear();
 }
 
-size_t
-LoopbackPeer::getBytesQueued() const
+size_t LoopbackPeer::getBytesQueued() const
 {
     size_t t = 0;
     for (auto const& m : mOutQueue)
@@ -400,69 +389,58 @@ LoopbackPeer::getBytesQueued() const
     return t;
 }
 
-size_t
-LoopbackPeer::getMessagesQueued() const
+size_t LoopbackPeer::getMessagesQueued() const
 {
     return mOutQueue.size();
 }
 
-LoopbackPeer::Stats const&
-LoopbackPeer::getStats() const
+LoopbackPeer::Stats const& LoopbackPeer::getStats() const
 {
     return mStats;
 }
 
-bool
-LoopbackPeer::getCorked() const
+bool LoopbackPeer::getCorked() const
 {
     return mCorked;
 }
 
-void
-LoopbackPeer::setCorked(bool c)
+void LoopbackPeer::setCorked(bool c)
 {
     mCorked = c;
 }
 
-void
-LoopbackPeer::clearInAndOutQueues()
+void LoopbackPeer::clearInAndOutQueues()
 {
     mOutQueue.clear();
     mInQueue = std::queue<xdr::msg_ptr>();
 }
 
-bool
-LoopbackPeer::getStraggling() const
+bool LoopbackPeer::getStraggling() const
 {
     return mStraggling;
 }
 
-void
-LoopbackPeer::setStraggling(bool s)
+void LoopbackPeer::setStraggling(bool s)
 {
     mStraggling = s;
 }
 
-size_t
-LoopbackPeer::getMaxQueueDepth() const
+size_t LoopbackPeer::getMaxQueueDepth() const
 {
     return mMaxQueueDepth;
 }
 
-void
-LoopbackPeer::setMaxQueueDepth(size_t sz)
+void LoopbackPeer::setMaxQueueDepth(size_t sz)
 {
     mMaxQueueDepth = sz;
 }
 
-double
-LoopbackPeer::getDamageProbability() const
+double LoopbackPeer::getDamageProbability() const
 {
     return mDamageProb.p();
 }
 
-static void
-checkProbRange(double d)
+static void checkProbRange(double d)
 {
     if (d < 0.0 || d > 1.0)
     {
@@ -470,71 +448,60 @@ checkProbRange(double d)
     }
 }
 
-void
-LoopbackPeer::setDamageProbability(double d)
+void LoopbackPeer::setDamageProbability(double d)
 {
     checkProbRange(d);
     mDamageProb = bernoulli_distribution(d);
 }
 
-double
-LoopbackPeer::getDropProbability() const
+double LoopbackPeer::getDropProbability() const
 {
     return mDropProb.p();
 }
 
-void
-LoopbackPeer::setDamageCert(bool b)
+void LoopbackPeer::setDamageCert(bool b)
 {
     mDamageCert = b;
 }
 
-bool
-LoopbackPeer::getDamageCert() const
+bool LoopbackPeer::getDamageCert() const
 {
     return mDamageCert;
 }
 
-void
-LoopbackPeer::setDamageAuth(bool b)
+void LoopbackPeer::setDamageAuth(bool b)
 {
     mDamageAuth = b;
 }
 
-bool
-LoopbackPeer::getDamageAuth() const
+bool LoopbackPeer::getDamageAuth() const
 {
     return mDamageAuth;
 }
 
-void
-LoopbackPeer::setDropProbability(double d)
+void LoopbackPeer::setDropProbability(double d)
 {
     checkProbRange(d);
     mDropProb = bernoulli_distribution(d);
 }
 
-double
-LoopbackPeer::getDuplicateProbability() const
+double LoopbackPeer::getDuplicateProbability() const
 {
     return mDuplicateProb.p();
 }
 
-void
-LoopbackPeer::setDuplicateProbability(double d)
+void LoopbackPeer::setDuplicateProbability(double d)
 {
     checkProbRange(d);
     mDuplicateProb = bernoulli_distribution(d);
 }
 
-double
-LoopbackPeer::getReorderProbability() const
+double LoopbackPeer::getReorderProbability() const
 {
     return mReorderProb.p();
 }
 
-void
-LoopbackPeer::setReorderProbability(double d)
+void LoopbackPeer::setReorderProbability(double d)
 {
     checkProbRange(d);
     mReorderProb = bernoulli_distribution(d);
@@ -556,20 +523,17 @@ LoopbackPeerConnection::~LoopbackPeerConnection()
                      Peer::DropDirection::WE_DROPPED_REMOTE);
 }
 
-std::shared_ptr<LoopbackPeer>
-LoopbackPeerConnection::getInitiator() const
+std::shared_ptr<LoopbackPeer> LoopbackPeerConnection::getInitiator() const
 {
     return mInitiator;
 }
 
-std::shared_ptr<LoopbackPeer>
-LoopbackPeerConnection::getAcceptor() const
+std::shared_ptr<LoopbackPeer> LoopbackPeerConnection::getAcceptor() const
 {
     return mAcceptor;
 }
 
-bool
-LoopbackPeer::checkCapacity(std::shared_ptr<LoopbackPeer> otherPeer) const
+bool LoopbackPeer::checkCapacity(std::shared_ptr<LoopbackPeer> otherPeer) const
 {
     // Outbound capacity is equal to the config on the other node
     return otherPeer->getConfig().PEER_FLOOD_READING_CAPACITY ==

--- a/src/overlay/test/LoopbackPeer.h
+++ b/src/overlay/test/LoopbackPeer.h
@@ -116,32 +116,27 @@ class LoopbackPeer : public Peer
 
     void clearInAndOutQueues();
 
-    virtual bool
-    useBackgroundThread() const override
+    virtual bool useBackgroundThread() const override
     {
         return false;
     }
 
-    size_t
-    getTxQueueByteCount() const
+    size_t getTxQueueByteCount() const
     {
         return mFlowControl->getTxQueueByteCountForTesting();
     }
 
-    std::array<std::deque<FlowControl::QueuedOutboundMessage>, 4>&
-    getQueues()
+    std::array<std::deque<FlowControl::QueuedOutboundMessage>, 4>& getQueues()
     {
         return getFlowControl()->getQueuesForTesting();
     }
 
-    uint64_t
-    getOutboundCapacity()
+    uint64_t getOutboundCapacity()
     {
         return getFlowControl()->getCapacity().getOutboundCapacity();
     }
 
-    Config const&
-    getConfig()
+    Config const& getConfig()
     {
         return mAppConnector.getConfig();
     }

--- a/src/overlay/test/OverlayManagerTests.cpp
+++ b/src/overlay/test/OverlayManagerTests.cpp
@@ -42,27 +42,23 @@ class PeerStub : public Peer
         mAddress = address;
         mRemoteOverlayVersion = app.getConfig().OVERLAY_PROTOCOL_VERSION;
     }
-    virtual void
-    drop(std::string const&, DropDirection) override
+    virtual void drop(std::string const&, DropDirection) override
     {
     }
-    virtual void
-    sendMessage(xdr::msg_ptr&& xdrBytes, ConstStellarMessagePtr msgPtr) override
+    virtual void sendMessage(xdr::msg_ptr&& xdrBytes,
+                             ConstStellarMessagePtr msgPtr) override
     {
     }
-    virtual void
-    sendMessage(std::shared_ptr<StellarMessage const> msg,
-                bool log = true) override
+    virtual void sendMessage(std::shared_ptr<StellarMessage const> msg,
+                             bool log = true) override
     {
         mSent += static_cast<int>(OverlayManager::isFloodMessage(*msg));
     }
-    virtual void
-    scheduleRead() override
+    virtual void scheduleRead() override
     {
     }
 
-    void
-    setPullMode()
+    void setPullMode()
     {
         auto weakSelf = std::weak_ptr<Peer>(shared_from_this());
         mTxAdverts->start(
@@ -83,8 +79,7 @@ class OverlayManagerStub : public OverlayManagerImpl
     {
     }
 
-    virtual bool
-    connectToImpl(PeerBareAddress const& address, bool) override
+    virtual bool connectToImpl(PeerBareAddress const& address, bool) override
     {
         if (getConnectedPeer(address))
         {
@@ -110,16 +105,14 @@ class OverlayManagerTests
         {
         }
 
-        virtual OverlayManagerStub&
-        getOverlayManager() override
+        virtual OverlayManagerStub& getOverlayManager() override
         {
             auto& overlay = ApplicationImpl::getOverlayManager();
             return static_cast<OverlayManagerStub&>(overlay);
         }
 
       private:
-        virtual std::unique_ptr<OverlayManager>
-        createOverlayManager() override
+        virtual std::unique_ptr<OverlayManager> createOverlayManager() override
         {
             return std::make_unique<OverlayManagerStub>(*this);
         }
@@ -146,8 +139,7 @@ class OverlayManagerTests
         app = createTestApplication<ApplicationStub>(clock, cfg);
     }
 
-    void
-    testAddPeerList(bool async = false)
+    void testAddPeerList(bool async = false)
     {
         OverlayManagerStub& pm = app->getOverlayManager();
 
@@ -172,7 +164,6 @@ class OverlayManagerTests
         size_t i = 0;
         for (auto it = rs.begin(); it != rs.end(); ++it, ++i)
         {
-
             PeerBareAddress pba{it->get<std::string>(0),
                                 static_cast<unsigned short>(it->get<int>(1))};
             auto type = it->get<int>(2);
@@ -191,8 +182,7 @@ class OverlayManagerTests
         REQUIRE(i == (threePeers.size() + fourPeers.size()));
     }
 
-    void
-    testAddPeerListUpdateType()
+    void testAddPeerListUpdateType()
     {
         // This test case assumes peer was discovered prior to
         // resolution, and makes sure peer type is properly updated
@@ -237,8 +227,7 @@ class OverlayManagerTests
         REQUIRE(found == 2);
     }
 
-    std::vector<int>
-    sentCounts(OverlayManagerImpl& pm)
+    std::vector<int> sentCounts(OverlayManagerImpl& pm)
     {
         auto getSent = [](Peer::pointer p) {
             auto peer = static_pointer_cast<PeerStub>(p);
@@ -252,8 +241,7 @@ class OverlayManagerTests
         return result;
     }
 
-    void
-    crank(size_t n)
+    void crank(size_t n)
     {
         while (n != 0)
         {
@@ -262,8 +250,7 @@ class OverlayManagerTests
         }
     }
 
-    void
-    testBroadcast()
+    void testBroadcast()
     {
         OverlayManagerStub& pm = app->getOverlayManager();
 

--- a/src/overlay/test/OverlayTestUtils.cpp
+++ b/src/overlay/test/OverlayTestUtils.cpp
@@ -20,50 +20,43 @@ namespace stellar
 namespace overlaytestutils
 {
 
-uint64_t
-getOverlayFloodMessageCount(std::shared_ptr<Application> app,
-                            std::string const& name)
+uint64_t getOverlayFloodMessageCount(std::shared_ptr<Application> app,
+                                     std::string const& name)
 {
     return app->getMetrics()
         .NewMeter({"overlay", "flood", name}, "message")
         .count();
 }
 
-uint64_t
-getAdvertisedHashCount(std::shared_ptr<Application> app)
+uint64_t getAdvertisedHashCount(std::shared_ptr<Application> app)
 {
     return getOverlayFloodMessageCount(app, "advertised");
 }
 
-uint64_t
-getFulfilledDemandCount(std::shared_ptr<Application> app)
+uint64_t getFulfilledDemandCount(std::shared_ptr<Application> app)
 {
     return getOverlayFloodMessageCount(app, "fulfilled");
 }
 
-uint64_t
-getUnfulfilledDemandCount(std::shared_ptr<Application> app)
+uint64_t getUnfulfilledDemandCount(std::shared_ptr<Application> app)
 {
     return getOverlayFloodMessageCount(app, "unfulfilled-unknown") +
            getOverlayFloodMessageCount(app, "unfulfilled-banned");
 }
 
-uint64_t
-getUnknownDemandCount(std::shared_ptr<Application> app)
+uint64_t getUnknownDemandCount(std::shared_ptr<Application> app)
 {
     return getOverlayFloodMessageCount(app, "unfulfilled-unknown");
 }
 
-uint64_t
-getSentDemandCount(std::shared_ptr<Application> app)
+uint64_t getSentDemandCount(std::shared_ptr<Application> app)
 {
     return app->getOverlayManager()
         .getOverlayMetrics()
         .mSendFloodDemandMeter.count();
 }
 
-bool
-knowsAs(Application& knowingApp, Application& knownApp, PeerType peerType)
+bool knowsAs(Application& knowingApp, Application& knownApp, PeerType peerType)
 {
     auto data = knowingApp.getOverlayManager().getPeerManager().load(
         PeerBareAddress{"127.0.0.1", knownApp.getConfig().PEER_PORT});
@@ -75,8 +68,7 @@ knowsAs(Application& knowingApp, Application& knownApp, PeerType peerType)
     return data.first.mType == static_cast<int>(peerType);
 }
 
-bool
-doesNotKnow(Application& knowingApp, Application& knownApp)
+bool doesNotKnow(Application& knowingApp, Application& knownApp)
 {
     return !knowingApp.getOverlayManager()
                 .getPeerManager()
@@ -85,32 +77,27 @@ doesNotKnow(Application& knowingApp, Application& knownApp)
                 .second;
 }
 
-bool
-knowsAsInbound(Application& knowingApp, Application& knownApp)
+bool knowsAsInbound(Application& knowingApp, Application& knownApp)
 {
     return knowsAs(knowingApp, knownApp, PeerType::INBOUND);
 }
 
-bool
-knowsAsOutbound(Application& knowingApp, Application& knownApp)
+bool knowsAsOutbound(Application& knowingApp, Application& knownApp)
 {
     return knowsAs(knowingApp, knownApp, PeerType::OUTBOUND);
 }
 
-bool
-knowsAsPreferred(Application& knowingApp, Application& knownApp)
+bool knowsAsPreferred(Application& knowingApp, Application& knownApp)
 {
     return knowsAs(knowingApp, knownApp, PeerType::PREFERRED);
 }
 
-int
-numberOfAppConnections(Application& app)
+int numberOfAppConnections(Application& app)
 {
     return app.getOverlayManager().getAuthenticatedPeersCount();
 }
 
-int
-numberOfSimulationConnections(std::shared_ptr<Simulation> simulation)
+int numberOfSimulationConnections(std::shared_ptr<Simulation> simulation)
 {
     auto nodes = simulation->getNodes();
     auto num = std::accumulate(std::begin(nodes), std::end(nodes), 0,
@@ -120,8 +107,7 @@ numberOfSimulationConnections(std::shared_ptr<Simulation> simulation)
     return num;
 }
 
-std::shared_ptr<StellarMessage>
-makeStellarMessage(uint32_t wasmSize)
+std::shared_ptr<StellarMessage> makeStellarMessage(uint32_t wasmSize)
 {
     Operation uploadOp;
     uploadOp.body.type(INVOKE_HOST_FUNCTION);

--- a/src/overlay/test/OverlayTests.cpp
+++ b/src/overlay/test/OverlayTests.cpp
@@ -37,8 +37,7 @@ using namespace stellar::overlaytestutils;
 namespace
 {
 
-ClaimPredicate
-recursivePredicate(uint32_t counter)
+ClaimPredicate recursivePredicate(uint32_t counter)
 {
     if (counter == 10)
     {
@@ -55,8 +54,7 @@ recursivePredicate(uint32_t counter)
     return andPred;
 }
 
-Operation
-getOperationGreaterThanMinMaxSizeBytes()
+Operation getOperationGreaterThanMinMaxSizeBytes()
 {
     Claimant c;
     c.v0().destination = txtest::getAccount("acc").getPublicKey();
@@ -2239,8 +2237,7 @@ TEST_CASE("overlay flow control", "[overlay][flowcontrol][acceptance]")
                 .count() == 0);
 }
 
-PeerBareAddress
-localhost(unsigned short port)
+PeerBareAddress localhost(unsigned short port)
 {
     return PeerBareAddress{"127.0.0.1", port};
 }

--- a/src/overlay/test/OverlayTopologyTests.cpp
+++ b/src/overlay/test/OverlayTopologyTests.cpp
@@ -26,8 +26,7 @@ using TraverseFunc =
     std::function<void(Application& app, Application& otherApp)>;
 
 // A basic DFS algorithm to traverse the topology
-void
-dfs(Application& app, std::unordered_set<NodeID>& visited, TraverseFunc f)
+void dfs(Application& app, std::unordered_set<NodeID>& visited, TraverseFunc f)
 {
     visited.emplace(app.getConfig().NODE_SEED.getPublicKey());
     for (auto const& node : app.getOverlayManager().getAuthenticatedPeers())
@@ -46,8 +45,7 @@ dfs(Application& app, std::unordered_set<NodeID>& visited, TraverseFunc f)
     }
 }
 
-bool
-isConnected(int numNodes, int numWatchers, Simulation::pointer simulation)
+bool isConnected(int numNodes, int numWatchers, Simulation::pointer simulation)
 {
     // Check if a graph is fully connected
     std::unordered_set<NodeID> visited;
@@ -56,8 +54,7 @@ isConnected(int numNodes, int numWatchers, Simulation::pointer simulation)
 }
 
 // Log basic information about each node in the topology
-void
-logTopologyInfo(Simulation::pointer simulation)
+void logTopologyInfo(Simulation::pointer simulation)
 {
     for (auto const& node : simulation->getNodes())
     {
@@ -76,9 +73,8 @@ logTopologyInfo(Simulation::pointer simulation)
               numberOfSimulationConnections(simulation));
 }
 
-void
-populateGraphJson(Application& app, std::unordered_set<NodeID>& visited,
-                  Json::Value& res)
+void populateGraphJson(Application& app, std::unordered_set<NodeID>& visited,
+                       Json::Value& res)
 {
     auto func = [&](Application& app, Application& otherApp) {
         auto id = KeyUtils::toStrKey(app.getConfig().NODE_SEED.getPublicKey());
@@ -91,8 +87,7 @@ populateGraphJson(Application& app, std::unordered_set<NodeID>& visited,
     dfs(app, visited, func);
 }
 
-void
-exportGraphJson(Json::Value graphJson, std::string prefix, int testID)
+void exportGraphJson(Json::Value graphJson, std::string prefix, int testID)
 {
     std::string refJsonPath =
         fmt::format("src/testdata/test-{}-topology-{}-{}.json", testID, prefix,

--- a/src/overlay/test/PeerManagerTests.cpp
+++ b/src/overlay/test/PeerManagerTests.cpp
@@ -18,8 +18,7 @@ namespace stellar
 
 using namespace std;
 
-PeerBareAddress
-localhost(unsigned short port)
+PeerBareAddress localhost(unsigned short port)
 {
     return PeerBareAddress{"127.0.0.1", port};
 }

--- a/src/overlay/test/SurveyManagerTests.cpp
+++ b/src/overlay/test/SurveyManagerTests.cpp
@@ -20,8 +20,7 @@ using namespace stellar;
 namespace
 {
 // Begin survey collecting from `node`
-void
-startSurveyCollecting(Application& node, uint32_t nonce)
+void startSurveyCollecting(Application& node, uint32_t nonce)
 {
     std::string const cmd =
         "startsurveycollecting?nonce=" + std::to_string(nonce);
@@ -29,8 +28,7 @@ startSurveyCollecting(Application& node, uint32_t nonce)
 }
 
 // Stop survey collecting from `node`
-void
-stopSurveyCollecting(Application& node, uint32_t nonce)
+void stopSurveyCollecting(Application& node, uint32_t nonce)
 {
     std::string const cmd = "stopsurveycollecting";
     node.getCommandHandler().manualCmd(cmd);
@@ -38,9 +36,9 @@ stopSurveyCollecting(Application& node, uint32_t nonce)
 
 // Request survey data from `surveyed`. Returns `true` iff the request succeeded
 // in adding `surveyed` to the backlog.
-bool
-surveyTopologyTimeSliced(Application& surveyor, PublicKey const& surveyed,
-                         uint32_t inboundPeerIndex, uint32_t outboundPeerIndex)
+bool surveyTopologyTimeSliced(Application& surveyor, PublicKey const& surveyed,
+                              uint32_t inboundPeerIndex,
+                              uint32_t outboundPeerIndex)
 {
     std::string const cmd =
         "surveytopologytimesliced?node=" + KeyUtils::toStrKey(surveyed) +
@@ -53,8 +51,8 @@ surveyTopologyTimeSliced(Application& surveyor, PublicKey const& surveyed,
 }
 
 // Crank the simulation for a short time to allow survey messages to propagate
-void
-crankForSurveyPropagation(Simulation::pointer simulation, Config const& cfg)
+void crankForSurveyPropagation(Simulation::pointer simulation,
+                               Config const& cfg)
 {
     simulation->crankForAtLeast(
         simulation->getExpectedLedgerCloseTime() *
@@ -63,8 +61,8 @@ crankForSurveyPropagation(Simulation::pointer simulation, Config const& cfg)
 }
 
 // Get survey into reporting mode
-void
-startSurveyReportingFrom(Simulation::pointer simulation, PublicKey const& node)
+void startSurveyReportingFrom(Simulation::pointer simulation,
+                              PublicKey const& node)
 {
     constexpr uint32_t nonce = 0xCAFE;
     auto& surveyor = *simulation->getNode(node);
@@ -76,8 +74,7 @@ startSurveyReportingFrom(Simulation::pointer simulation, PublicKey const& node)
 }
 
 // Get survey results from `node`
-Json::Value
-getSurveyResult(Application& node)
+Json::Value getSurveyResult(Application& node)
 {
     auto const strResult =
         node.getCommandHandler().manualCmd("getsurveyresult");

--- a/src/overlay/test/TrackerTests.cpp
+++ b/src/overlay/test/TrackerTests.cpp
@@ -16,8 +16,7 @@ namespace stellar
 namespace
 {
 
-SCPEnvelope
-makeEnvelope(int slotIndex)
+SCPEnvelope makeEnvelope(int slotIndex)
 {
     auto result = SCPEnvelope{};
     result.statement.slotIndex = slotIndex;

--- a/src/process/PosixSpawnFileActions.cpp
+++ b/src/process/PosixSpawnFileActions.cpp
@@ -26,8 +26,7 @@ PosixSpawnFileActions::~PosixSpawnFileActions()
     }
 }
 
-void
-PosixSpawnFileActions::initialize()
+void PosixSpawnFileActions::initialize()
 {
     if (mInitialized)
     {
@@ -43,9 +42,8 @@ PosixSpawnFileActions::initialize()
     mInitialized = true;
 }
 
-void
-PosixSpawnFileActions::addOpen(int fildes, std::string const& fileName,
-                               int oflag, mode_t mode)
+void PosixSpawnFileActions::addOpen(int fildes, std::string const& fileName,
+                                    int oflag, mode_t mode)
 {
     assert(!fileName.empty());
     initialize();
@@ -59,8 +57,7 @@ PosixSpawnFileActions::addOpen(int fildes, std::string const& fileName,
     }
 }
 
-PosixSpawnFileActions::
-operator posix_spawn_file_actions_t*()
+PosixSpawnFileActions::operator posix_spawn_file_actions_t*()
 {
     return mInitialized ? &mFileActions : nullptr;
 }

--- a/src/process/ProcessManagerImpl.cpp
+++ b/src/process/ProcessManagerImpl.cpp
@@ -60,8 +60,8 @@ namespace stellar
 static const asio::error_code ABORT_ERROR_CODE(asio::error::operation_aborted,
                                                asio::system_category());
 
-static asio::error_code
-mapExitStatusToErrorCode(std::string const& cmdLine, int pid, int status)
+static asio::error_code mapExitStatusToErrorCode(std::string const& cmdLine,
+                                                 int pid, int status)
 {
 // On windows, an exit status is just an exit status. On unix it's
 // got some flags incorporated into it.
@@ -119,8 +119,7 @@ mapExitStatusToErrorCode(std::string const& cmdLine, int pid, int status)
 #endif
 }
 
-std::shared_ptr<ProcessManager>
-ProcessManager::create(Application& app)
+std::shared_ptr<ProcessManager> ProcessManager::create(Application& app)
 {
     return std::make_shared<ProcessManagerImpl>(app);
 }
@@ -157,8 +156,7 @@ class ProcessExitEvent::Impl
     {
     }
 
-    bool
-    finish()
+    bool finish()
     {
         ZoneScoped;
         releaseAssertOrThrow(mLifecycle == ProcessLifecycle::TERMINATED);
@@ -180,22 +178,19 @@ class ProcessExitEvent::Impl
     }
 
     void run();
-    void
-    cancel(asio::error_code const& ec)
+    void cancel(asio::error_code const& ec)
     {
         *mOuterEc = ec;
         mOuterTimer->cancel();
     }
 
-    int
-    getProcessId() const
+    int getProcessId() const
     {
         return mProcessId;
     }
 };
 
-size_t
-ProcessManagerImpl::getNumRunningProcesses()
+size_t ProcessManagerImpl::getNumRunningProcesses()
 {
     std::lock_guard<std::recursive_mutex> guard(mProcessesMutex);
     size_t n = 0;
@@ -209,8 +204,7 @@ ProcessManagerImpl::getNumRunningProcesses()
     return n;
 }
 
-size_t
-ProcessManagerImpl::getNumRunningOrShuttingDownProcesses()
+size_t ProcessManagerImpl::getNumRunningOrShuttingDownProcesses()
 {
     std::lock_guard<std::recursive_mutex> guard(mProcessesMutex);
     return mProcesses.size();
@@ -253,14 +247,12 @@ ProcessManagerImpl::~ProcessManagerImpl()
     }
 }
 
-bool
-ProcessManagerImpl::isShutdown() const
+bool ProcessManagerImpl::isShutdown() const
 {
     return mIsShutdown;
 }
 
-void
-ProcessManagerImpl::shutdown()
+void ProcessManagerImpl::shutdown()
 {
     std::lock_guard<std::recursive_mutex> guard(mProcessesMutex);
     if (!mIsShutdown)
@@ -278,8 +270,7 @@ ProcessManagerImpl::shutdown()
     }
 }
 
-void
-ProcessManagerImpl::tryProcessShutdownAll()
+void ProcessManagerImpl::tryProcessShutdownAll()
 {
     std::lock_guard<std::recursive_mutex> guard(mProcessesMutex);
     for (auto const& pe : mProcesses)
@@ -288,8 +279,8 @@ ProcessManagerImpl::tryProcessShutdownAll()
     }
 }
 
-bool
-ProcessManagerImpl::tryProcessShutdown(std::shared_ptr<ProcessExitEvent> pe)
+bool ProcessManagerImpl::tryProcessShutdown(
+    std::shared_ptr<ProcessExitEvent> pe)
 {
     ZoneScoped;
     std::lock_guard<std::recursive_mutex> guard(mProcessesMutex);
@@ -360,8 +351,8 @@ ProcessManagerImpl::tryProcessShutdown(std::shared_ptr<ProcessExitEvent> pe)
     return true;
 }
 
-asio::error_code
-ProcessManagerImpl::handleProcessTermination(int pid, int status)
+asio::error_code ProcessManagerImpl::handleProcessTermination(int pid,
+                                                              int status)
 {
     ZoneScoped;
     std::lock_guard<std::recursive_mutex> guard(mProcessesMutex);
@@ -414,20 +405,17 @@ ProcessManagerImpl::ProcessManagerImpl(Application& app)
 {
 }
 
-void
-ProcessManagerImpl::startWaitingForSignalChild()
+void ProcessManagerImpl::startWaitingForSignalChild()
 {
     // No-op on windows, uses waitable object handles
 }
 
-void
-ProcessManagerImpl::handleSignalChild()
+void ProcessManagerImpl::handleSignalChild()
 {
     // No-op on windows, uses waitable object handles
 }
 
-void
-ProcessManagerImpl::reapChildren()
+void ProcessManagerImpl::reapChildren()
 {
     // No-op on windows, uses waitable object handles
 }
@@ -445,8 +433,7 @@ struct InfoHelper
         ZeroMemory(&mStartupInfo, sizeof(mStartupInfo));
         mStartupInfo.StartupInfo.cb = sizeof(mStartupInfo);
     }
-    void
-    prepare()
+    void prepare()
     {
         ZoneScoped;
         if (mInitialized)
@@ -488,8 +475,7 @@ struct InfoHelper
 };
 }
 
-void
-ProcessExitEvent::Impl::run()
+void ProcessExitEvent::Impl::run()
 {
     ZoneScoped;
     auto manager = mProcManagerImpl.lock();
@@ -610,8 +596,7 @@ ProcessExitEvent::Impl::run()
     mLifecycle = ProcessLifecycle::RUNNING;
 }
 
-bool
-ProcessManagerImpl::politeShutdown(std::shared_ptr<ProcessExitEvent> pe)
+bool ProcessManagerImpl::politeShutdown(std::shared_ptr<ProcessExitEvent> pe)
 {
     ZoneScoped;
     checkInvariants();
@@ -632,8 +617,7 @@ ProcessManagerImpl::politeShutdown(std::shared_ptr<ProcessExitEvent> pe)
     return true;
 }
 
-bool
-ProcessManagerImpl::forcedShutdown(std::shared_ptr<ProcessExitEvent> pe)
+bool ProcessManagerImpl::forcedShutdown(std::shared_ptr<ProcessExitEvent> pe)
 {
     ZoneScoped;
     checkInvariants();
@@ -672,16 +656,14 @@ ProcessManagerImpl::ProcessManagerImpl(Application& app)
     startWaitingForSignalChild();
 }
 
-void
-ProcessManagerImpl::startWaitingForSignalChild()
+void ProcessManagerImpl::startWaitingForSignalChild()
 {
     std::lock_guard<std::recursive_mutex> guard(mProcessesMutex);
     mSigChild.async_wait(
         std::bind(&ProcessManagerImpl::handleSignalChild, this));
 }
 
-void
-ProcessManagerImpl::handleSignalChild()
+void ProcessManagerImpl::handleSignalChild()
 {
     if (isShutdown())
     {
@@ -691,8 +673,7 @@ ProcessManagerImpl::handleSignalChild()
     reapChildren();
 }
 
-void
-ProcessManagerImpl::reapChildren()
+void ProcessManagerImpl::reapChildren()
 {
     // Store tuples (pid, status)
     std::vector<std::tuple<int, int>> signaledChildren;
@@ -723,8 +704,7 @@ ProcessManagerImpl::reapChildren()
     }
 }
 
-bool
-ProcessManagerImpl::politeShutdown(std::shared_ptr<ProcessExitEvent> pe)
+bool ProcessManagerImpl::politeShutdown(std::shared_ptr<ProcessExitEvent> pe)
 {
     ZoneScoped;
     checkInvariants();
@@ -745,8 +725,7 @@ ProcessManagerImpl::politeShutdown(std::shared_ptr<ProcessExitEvent> pe)
     return true;
 }
 
-bool
-ProcessManagerImpl::forcedShutdown(std::shared_ptr<ProcessExitEvent> pe)
+bool ProcessManagerImpl::forcedShutdown(std::shared_ptr<ProcessExitEvent> pe)
 {
     ZoneScoped;
     checkInvariants();
@@ -766,8 +745,7 @@ ProcessManagerImpl::forcedShutdown(std::shared_ptr<ProcessExitEvent> pe)
     return true;
 }
 
-static std::vector<std::string>
-split(std::string const& s)
+static std::vector<std::string> split(std::string const& s)
 {
     std::vector<std::string> parts;
     std::regex ws_re("\\s+");
@@ -776,8 +754,7 @@ split(std::string const& s)
     return parts;
 }
 
-void
-ProcessExitEvent::Impl::run()
+void ProcessExitEvent::Impl::run()
 {
     ZoneScoped;
     auto manager = mProcManagerImpl.lock();
@@ -858,8 +835,7 @@ ProcessManagerImpl::runProcess(std::string const& cmdLine, std::string outFile)
     return std::weak_ptr<ProcessExitEvent>(pe);
 }
 
-void
-ProcessManagerImpl::maybeRunPendingProcesses()
+void ProcessManagerImpl::maybeRunPendingProcesses()
 {
     ZoneScoped;
     checkInvariants();
@@ -902,8 +878,7 @@ ProcessManagerImpl::maybeRunPendingProcesses()
     }
 }
 
-void
-ProcessManagerImpl::checkInvariants()
+void ProcessManagerImpl::checkInvariants()
 {
     std::lock_guard<std::recursive_mutex> guard(mProcessesMutex);
     if (mIsShutdown)
@@ -935,8 +910,7 @@ ProcessExitEvent::~ProcessExitEvent()
 {
 }
 
-void
-ProcessExitEvent::async_wait(
+void ProcessExitEvent::async_wait(
     std::function<void(asio::error_code)> const& handler)
 {
     // Unfortunately when you cancel a timer, asio delivers

--- a/src/rust/CppShims.h
+++ b/src/rust/CppShims.h
@@ -24,15 +24,13 @@ namespace stellar
 {
 class Application;
 
-inline bool
-shim_isLogLevelAtLeast(std::string const& partition, LogLevel level)
+inline bool shim_isLogLevelAtLeast(std::string const& partition, LogLevel level)
 {
     return Logging::isLogLevelAtLeast(partition, level);
 }
 
-inline void
-shim_logAtPartitionAndLevel(std::string const& partition, LogLevel level,
-                            std::string const& msg)
+inline void shim_logAtPartitionAndLevel(std::string const& partition,
+                                        LogLevel level, std::string const& msg)
 {
     Logging::logAtPartitionAndLevel(partition, level, msg);
 }

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -34,8 +34,8 @@ BallotProtocol::BallotProtocol(Slot& slot)
 {
 }
 
-bool
-BallotProtocol::isNewerStatement(NodeID const& nodeID, SCPStatement const& st)
+bool BallotProtocol::isNewerStatement(NodeID const& nodeID,
+                                      SCPStatement const& st)
 {
     auto oldp = mLatestEnvelopes.find(nodeID);
     bool res = false;
@@ -51,9 +51,8 @@ BallotProtocol::isNewerStatement(NodeID const& nodeID, SCPStatement const& st)
     return res;
 }
 
-bool
-BallotProtocol::isNewerStatement(SCPStatement const& oldst,
-                                 SCPStatement const& st)
+bool BallotProtocol::isNewerStatement(SCPStatement const& oldst,
+                                      SCPStatement const& st)
 {
     bool res = false;
 
@@ -133,8 +132,7 @@ BallotProtocol::isNewerStatement(SCPStatement const& oldst,
     return res;
 }
 
-void
-BallotProtocol::recordEnvelope(SCPEnvelopeWrapperPtr env)
+void BallotProtocol::recordEnvelope(SCPEnvelopeWrapperPtr env)
 {
     auto const& st = env->getStatement();
     auto oldp = mLatestEnvelopes.find(st.nodeID);
@@ -235,8 +233,7 @@ BallotProtocol::processEnvelope(SCPEnvelopeWrapperPtr envelope, bool self)
     return SCP::EnvelopeState::INVALID;
 }
 
-bool
-BallotProtocol::isStatementSane(SCPStatement const& st, bool self)
+bool BallotProtocol::isStatementSane(SCPStatement const& st, bool self)
 {
     auto qSet = mSlot.getQuorumSetFromStatement(st);
     const char* errString = nullptr;
@@ -308,8 +305,7 @@ BallotProtocol::isStatementSane(SCPStatement const& st, bool self)
     return res;
 }
 
-bool
-BallotProtocol::abandonBallot(uint32 n)
+bool BallotProtocol::abandonBallot(uint32 n)
 {
     ZoneScoped;
     CLOG_TRACE(SCP, "BallotProtocol::abandonBallot");
@@ -337,8 +333,7 @@ BallotProtocol::abandonBallot(uint32 n)
     return res;
 }
 
-bool
-BallotProtocol::bumpState(Value const& value, bool force)
+bool BallotProtocol::bumpState(Value const& value, bool force)
 {
     uint32 n;
     if (!force && mCurrentBallot)
@@ -351,8 +346,7 @@ BallotProtocol::bumpState(Value const& value, bool force)
     return bumpState(value, n);
 }
 
-bool
-BallotProtocol::bumpState(Value const& value, uint32 n)
+bool BallotProtocol::bumpState(Value const& value, uint32 n)
 {
     ZoneScoped;
     if (mPhase != SCP_PHASE_PREPARE && mPhase != SCP_PHASE_CONFIRM)
@@ -391,8 +385,7 @@ BallotProtocol::bumpState(Value const& value, uint32 n)
 
 // updates the local state based to the specified ballot
 // (that could be a prepared ballot) enforcing invariants
-bool
-BallotProtocol::updateCurrentValue(SCPBallot const& ballot)
+bool BallotProtocol::updateCurrentValue(SCPBallot const& ballot)
 {
     ZoneScoped;
     if (mPhase != SCP_PHASE_PREPARE && mPhase != SCP_PHASE_CONFIRM)
@@ -444,8 +437,7 @@ BallotProtocol::updateCurrentValue(SCPBallot const& ballot)
     return updated;
 }
 
-void
-BallotProtocol::bumpToBallot(SCPBallot const& ballot, bool check)
+void BallotProtocol::bumpToBallot(SCPBallot const& ballot, bool check)
 {
     ZoneScoped;
     ZoneValue(static_cast<int64_t>(mSlot.getSlotIndex()));
@@ -492,8 +484,7 @@ BallotProtocol::bumpToBallot(SCPBallot const& ballot, bool check)
     }
 }
 
-void
-BallotProtocol::startBallotProtocolTimer()
+void BallotProtocol::startBallotProtocolTimer()
 {
     std::chrono::milliseconds timeout = mSlot.getSCPDriver().computeTimeout(
         mCurrentBallot->getBallot().counter, /*isNomination=*/false);
@@ -504,8 +495,7 @@ BallotProtocol::startBallotProtocolTimer()
         [slot]() { slot->getBallotProtocol().ballotProtocolTimerExpired(); });
 }
 
-void
-BallotProtocol::stopBallotProtocolTimer()
+void BallotProtocol::stopBallotProtocolTimer()
 {
     std::shared_ptr<Slot> slot = mSlot.shared_from_this();
     mSlot.getSCPDriver().setupTimer(mSlot.getSlotIndex(),
@@ -513,15 +503,13 @@ BallotProtocol::stopBallotProtocolTimer()
                                     std::chrono::seconds::zero(), nullptr);
 }
 
-void
-BallotProtocol::ballotProtocolTimerExpired()
+void BallotProtocol::ballotProtocolTimerExpired()
 {
     mTimerExpCount++;
     abandonBallot(0);
 }
 
-SCPStatement
-BallotProtocol::createStatement(SCPStatementType const& type)
+SCPStatement BallotProtocol::createStatement(SCPStatementType const& type)
 {
     ZoneScoped;
     SCPStatement statement;
@@ -582,8 +570,7 @@ BallotProtocol::createStatement(SCPStatementType const& type)
     return statement;
 }
 
-void
-BallotProtocol::emitCurrentStateStatement()
+void BallotProtocol::emitCurrentStateStatement()
 {
     ZoneScoped;
     SCPStatementType t;
@@ -638,8 +625,7 @@ BallotProtocol::emitCurrentStateStatement()
     }
 }
 
-void
-BallotProtocol::checkInvariants()
+void BallotProtocol::checkInvariants()
 {
     switch (mPhase)
     {
@@ -786,8 +772,7 @@ BallotProtocol::getPrepareCandidates(SCPStatement const& hint)
     return candidates;
 }
 
-bool
-BallotProtocol::updateCurrentIfNeeded(SCPBallot const& h)
+bool BallotProtocol::updateCurrentIfNeeded(SCPBallot const& h)
 {
     bool didWork = false;
     if (!mCurrentBallot || compareBallots(mCurrentBallot->getBallot(), h) < 0)
@@ -798,8 +783,7 @@ BallotProtocol::updateCurrentIfNeeded(SCPBallot const& h)
     return didWork;
 }
 
-bool
-BallotProtocol::attemptAcceptPrepared(SCPStatement const& hint)
+bool BallotProtocol::attemptAcceptPrepared(SCPStatement const& hint)
 {
     ZoneScoped;
     if (mPhase != SCP_PHASE_PREPARE && mPhase != SCP_PHASE_CONFIRM)
@@ -886,8 +870,7 @@ BallotProtocol::attemptAcceptPrepared(SCPStatement const& hint)
     return false;
 }
 
-bool
-BallotProtocol::setAcceptPrepared(SCPBallot const& ballot)
+bool BallotProtocol::setAcceptPrepared(SCPBallot const& ballot)
 {
     ZoneScoped;
     CLOG_TRACE(SCP, "BallotProtocol::setAcceptPrepared i: {} b: {}",
@@ -922,8 +905,7 @@ BallotProtocol::setAcceptPrepared(SCPBallot const& ballot)
     return didWork;
 }
 
-bool
-BallotProtocol::attemptConfirmPrepared(SCPStatement const& hint)
+bool BallotProtocol::attemptConfirmPrepared(SCPStatement const& hint)
 {
     ZoneScoped;
     if (mPhase != SCP_PHASE_PREPARE)
@@ -1009,9 +991,9 @@ BallotProtocol::attemptConfirmPrepared(SCPStatement const& hint)
     return res;
 }
 
-bool
-BallotProtocol::commitPredicate(SCPBallot const& ballot, Interval const& check,
-                                SCPStatement const& st)
+bool BallotProtocol::commitPredicate(SCPBallot const& ballot,
+                                     Interval const& check,
+                                     SCPStatement const& st)
 {
     bool res = false;
     auto const& pl = st.pledges;
@@ -1043,8 +1025,8 @@ BallotProtocol::commitPredicate(SCPBallot const& ballot, Interval const& check,
     return res;
 }
 
-bool
-BallotProtocol::setConfirmPrepared(SCPBallot const& newC, SCPBallot const& newH)
+bool BallotProtocol::setConfirmPrepared(SCPBallot const& newC,
+                                        SCPBallot const& newH)
 {
     ZoneScoped;
     CLOG_TRACE(SCP, "BallotProtocol::setConfirmPrepared i: {} h: {}",
@@ -1090,10 +1072,9 @@ BallotProtocol::setConfirmPrepared(SCPBallot const& newC, SCPBallot const& newH)
     return didWork;
 }
 
-void
-BallotProtocol::findExtendedInterval(Interval& candidate,
-                                     std::set<uint32> const& boundaries,
-                                     std::function<bool(Interval const&)> pred)
+void BallotProtocol::findExtendedInterval(
+    Interval& candidate, std::set<uint32> const& boundaries,
+    std::function<bool(Interval const&)> pred)
 {
     // iterate through interesting boundaries, starting from the top
     for (auto it = boundaries.rbegin(); it != boundaries.rend(); it++)
@@ -1178,8 +1159,7 @@ BallotProtocol::getCommitBoundariesFromStatements(SCPBallot const& ballot)
     return res;
 }
 
-bool
-BallotProtocol::attemptAcceptCommit(SCPStatement const& hint)
+bool BallotProtocol::attemptAcceptCommit(SCPStatement const& hint)
 {
     ZoneScoped;
     if (mPhase != SCP_PHASE_PREPARE && mPhase != SCP_PHASE_CONFIRM)
@@ -1304,8 +1284,7 @@ BallotProtocol::attemptAcceptCommit(SCPStatement const& hint)
     return res;
 }
 
-bool
-BallotProtocol::setAcceptCommit(SCPBallot const& c, SCPBallot const& h)
+bool BallotProtocol::setAcceptCommit(SCPBallot const& c, SCPBallot const& h)
 {
     ZoneScoped;
     CLOG_TRACE(SCP, "BallotProtocol::setAcceptCommit i: {} new c: {} new h: {}",
@@ -1351,8 +1330,7 @@ BallotProtocol::setAcceptCommit(SCPBallot const& c, SCPBallot const& h)
     return didWork;
 }
 
-static uint32
-statementBallotCounter(SCPStatement const& st)
+static uint32 statementBallotCounter(SCPStatement const& st)
 {
     switch (st.pledges.type())
     {
@@ -1368,8 +1346,7 @@ statementBallotCounter(SCPStatement const& st)
     }
 }
 
-static bool
-hasVBlockingSubsetStrictlyAheadOf(
+static bool hasVBlockingSubsetStrictlyAheadOf(
     std::shared_ptr<LocalNode> localNode,
     std::map<NodeID, SCPEnvelopeWrapperPtr> const& map, uint32_t n)
 {
@@ -1395,13 +1372,11 @@ hasVBlockingSubsetStrictlyAheadOf(
 //   SCPExternalize messages, which implicitly have an infinite ballot
 //   counter.
 
-bool
-BallotProtocol::attemptBump()
+bool BallotProtocol::attemptBump()
 {
     ZoneScoped;
     if (mPhase == SCP_PHASE_PREPARE || mPhase == SCP_PHASE_CONFIRM)
     {
-
         // First check to see if this condition applies at all. If there
         // is no v-blocking set ahead of the local node, there's nothing
         // to do, return early.
@@ -1440,8 +1415,7 @@ BallotProtocol::attemptBump()
     return false;
 }
 
-bool
-BallotProtocol::attemptConfirmCommit(SCPStatement const& hint)
+bool BallotProtocol::attemptConfirmCommit(SCPStatement const& hint)
 {
     ZoneScoped;
     if (mPhase != SCP_PHASE_CONFIRM)
@@ -1505,8 +1479,7 @@ BallotProtocol::attemptConfirmCommit(SCPStatement const& hint)
     return res;
 }
 
-bool
-BallotProtocol::setConfirmCommit(SCPBallot const& c, SCPBallot const& h)
+bool BallotProtocol::setConfirmCommit(SCPBallot const& c, SCPBallot const& h)
 {
     ZoneScoped;
     CLOG_TRACE(SCP,
@@ -1530,9 +1503,8 @@ BallotProtocol::setConfirmCommit(SCPBallot const& c, SCPBallot const& h)
     return true;
 }
 
-bool
-BallotProtocol::hasPreparedBallot(SCPBallot const& ballot,
-                                  SCPStatement const& st)
+bool BallotProtocol::hasPreparedBallot(SCPBallot const& ballot,
+                                       SCPStatement const& st)
 {
     bool res;
 
@@ -1568,8 +1540,8 @@ BallotProtocol::hasPreparedBallot(SCPBallot const& ballot,
     return res;
 }
 
-Hash
-BallotProtocol::getCompanionQuorumSetHashFromStatement(SCPStatement const& st)
+Hash BallotProtocol::getCompanionQuorumSetHashFromStatement(
+    SCPStatement const& st)
 {
     Hash h;
     switch (st.pledges.type())
@@ -1589,8 +1561,7 @@ BallotProtocol::getCompanionQuorumSetHashFromStatement(SCPStatement const& st)
     return h;
 }
 
-SCPBallot
-BallotProtocol::getWorkingBallot(SCPStatement const& st)
+SCPBallot BallotProtocol::getWorkingBallot(SCPStatement const& st)
 {
     SCPBallot res;
     switch (st.pledges.type())
@@ -1613,8 +1584,7 @@ BallotProtocol::getWorkingBallot(SCPStatement const& st)
     return res;
 }
 
-bool
-BallotProtocol::setPrepared(SCPBallot const& ballot)
+bool BallotProtocol::setPrepared(SCPBallot const& ballot)
 {
     bool didWork = false;
 
@@ -1658,9 +1628,8 @@ BallotProtocol::setPrepared(SCPBallot const& ballot)
     return didWork;
 }
 
-int
-BallotProtocol::compareBallots(std::unique_ptr<SCPBallot> const& b1,
-                               std::unique_ptr<SCPBallot> const& b2)
+int BallotProtocol::compareBallots(std::unique_ptr<SCPBallot> const& b1,
+                                   std::unique_ptr<SCPBallot> const& b2)
 {
     int res;
     if (b1 && b2)
@@ -1682,8 +1651,7 @@ BallotProtocol::compareBallots(std::unique_ptr<SCPBallot> const& b1,
     return res;
 }
 
-int
-BallotProtocol::compareBallots(SCPBallot const& b1, SCPBallot const& b2)
+int BallotProtocol::compareBallots(SCPBallot const& b1, SCPBallot const& b2)
 {
     if (b1.counter < b2.counter)
     {
@@ -1708,28 +1676,25 @@ BallotProtocol::compareBallots(SCPBallot const& b1, SCPBallot const& b2)
     }
 }
 
-bool
-BallotProtocol::areBallotsCompatible(SCPBallot const& b1, SCPBallot const& b2)
+bool BallotProtocol::areBallotsCompatible(SCPBallot const& b1,
+                                          SCPBallot const& b2)
 {
     return b1.value == b2.value;
 }
 
-bool
-BallotProtocol::areBallotsLessAndIncompatible(SCPBallot const& b1,
-                                              SCPBallot const& b2)
+bool BallotProtocol::areBallotsLessAndIncompatible(SCPBallot const& b1,
+                                                   SCPBallot const& b2)
 {
     return (compareBallots(b1, b2) <= 0) && !areBallotsCompatible(b1, b2);
 }
 
-bool
-BallotProtocol::areBallotsLessAndCompatible(SCPBallot const& b1,
-                                            SCPBallot const& b2)
+bool BallotProtocol::areBallotsLessAndCompatible(SCPBallot const& b1,
+                                                 SCPBallot const& b2)
 {
     return (compareBallots(b1, b2) <= 0) && areBallotsCompatible(b1, b2);
 }
 
-void
-BallotProtocol::setStateFromEnvelope(SCPEnvelopeWrapperPtr e)
+void BallotProtocol::setStateFromEnvelope(SCPEnvelopeWrapperPtr e)
 {
     ZoneScoped;
     if (mCurrentBallot)
@@ -1798,8 +1763,7 @@ BallotProtocol::setStateFromEnvelope(SCPEnvelopeWrapperPtr e)
     }
 }
 
-bool
-BallotProtocol::processCurrentState(
+bool BallotProtocol::processCurrentState(
     std::function<bool(SCPEnvelope const&)> const& f, bool forceSelf) const
 {
     for (auto const& n : mLatestEnvelopes)
@@ -1817,8 +1781,7 @@ BallotProtocol::processCurrentState(
     return true;
 }
 
-SCPEnvelope const*
-BallotProtocol::getLatestMessage(NodeID const& id) const
+SCPEnvelope const* BallotProtocol::getLatestMessage(NodeID const& id) const
 {
     auto it = mLatestEnvelopes.find(id);
     if (it != mLatestEnvelopes.end())
@@ -1828,8 +1791,7 @@ BallotProtocol::getLatestMessage(NodeID const& id) const
     return nullptr;
 }
 
-std::vector<SCPEnvelope>
-BallotProtocol::getExternalizingState() const
+std::vector<SCPEnvelope> BallotProtocol::getExternalizingState() const
 {
     std::vector<SCPEnvelope> res;
     if (mPhase == SCP_PHASE_EXTERNALIZE)
@@ -1859,8 +1821,7 @@ BallotProtocol::getExternalizingState() const
     return res;
 }
 
-void
-BallotProtocol::advanceSlot(SCPStatement const& hint)
+void BallotProtocol::advanceSlot(SCPStatement const& hint)
 {
     ZoneScoped;
     mCurrentMessageLevel++;
@@ -1915,8 +1876,7 @@ BallotProtocol::advanceSlot(SCPStatement const& hint)
     }
 }
 
-std::set<Value>
-BallotProtocol::getStatementValues(SCPStatement const& st)
+std::set<Value> BallotProtocol::getStatementValues(SCPStatement const& st)
 {
     std::set<Value> values;
 
@@ -1981,8 +1941,7 @@ BallotProtocol::validateValues(SCPStatement const& st)
     return res;
 }
 
-void
-BallotProtocol::sendLatestEnvelope()
+void BallotProtocol::sendLatestEnvelope()
 {
     ZoneScoped;
     // emit current envelope if needed
@@ -1999,8 +1958,7 @@ BallotProtocol::sendLatestEnvelope()
 std::array<const char*, BallotProtocol::SCP_PHASE_NUM>
     BallotProtocol::phaseNames = std::array{"PREPARE", "FINISH", "EXTERNALIZE"};
 
-Json::Value
-BallotProtocol::getJsonInfo()
+Json::Value BallotProtocol::getJsonInfo()
 {
     Json::Value ret;
     ret["heard"] = mHeardFromQuorum;
@@ -2011,8 +1969,8 @@ BallotProtocol::getJsonInfo()
     return ret;
 }
 
-SCP::QuorumInfoNodeState
-BallotProtocol::getState(NodeID const& n, bool selfAlreadyMovedOn)
+SCP::QuorumInfoNodeState BallotProtocol::getState(NodeID const& n,
+                                                  bool selfAlreadyMovedOn)
 {
     auto state = SCP::QuorumInfoNodeState::AGREE;
     if (n == mSlot.getLocalNode()->getNodeID())
@@ -2072,8 +2030,8 @@ BallotProtocol::getState(NodeID const& n, bool selfAlreadyMovedOn)
     return state;
 }
 
-Json::Value
-BallotProtocol::getJsonQuorumInfo(NodeID const& id, bool summary, bool fullKeys)
+Json::Value BallotProtocol::getJsonQuorumInfo(NodeID const& id, bool summary,
+                                              bool fullKeys)
 {
     Json::Value ret;
     auto& phase = ret["phase"];
@@ -2147,8 +2105,7 @@ BallotProtocol::getJsonQuorumInfo(NodeID const& id, bool summary, bool fullKeys)
     return ret;
 }
 
-std::string
-BallotProtocol::getLocalState() const
+std::string BallotProtocol::getLocalState() const
 {
     std::ostringstream oss;
 
@@ -2162,29 +2119,25 @@ BallotProtocol::getLocalState() const
     return oss.str();
 }
 
-std::shared_ptr<LocalNode>
-BallotProtocol::getLocalNode()
+std::shared_ptr<LocalNode> BallotProtocol::getLocalNode()
 {
     return mSlot.getSCP().getLocalNode();
 }
 
-bool
-BallotProtocol::federatedAccept(StatementPredicate voted,
-                                StatementPredicate accepted)
+bool BallotProtocol::federatedAccept(StatementPredicate voted,
+                                     StatementPredicate accepted)
 {
     ZoneScoped;
     return mSlot.federatedAccept(voted, accepted, mLatestEnvelopes);
 }
 
-bool
-BallotProtocol::federatedRatify(StatementPredicate voted)
+bool BallotProtocol::federatedRatify(StatementPredicate voted)
 {
     ZoneScoped;
     return mSlot.federatedRatify(voted, mLatestEnvelopes);
 }
 
-void
-BallotProtocol::checkHeardFromQuorum()
+void BallotProtocol::checkHeardFromQuorum()
 {
     // this method is safe to call regardless of the transitions of the other
     // nodes on the network:
@@ -2251,8 +2204,7 @@ BallotProtocol::makeBallot(uint32 c, Value const& v) const
     return makeBallot(SCPBallot(c, v));
 }
 
-std::string
-BallotProtocol::ballotToStr(
+std::string BallotProtocol::ballotToStr(
     BallotProtocol::SCPBallotWrapperUPtr const& ballot) const
 {
     std::string res;

--- a/src/scp/BallotProtocol.h
+++ b/src/scp/BallotProtocol.h
@@ -60,14 +60,12 @@ class BallotProtocol
             releaseAssert(o.mWvalue);
         }
 
-        SCPBallot const&
-        getBallot() const
+        SCPBallot const& getBallot() const
         {
             return mBallot;
         }
 
-        ValueWrapperPtr const&
-        getWValue() const
+        ValueWrapperPtr const& getWValue() const
         {
             return mWvalue;
         }
@@ -145,8 +143,7 @@ class BallotProtocol
     // c for EXTERNALIZE messages
     static SCPBallot getWorkingBallot(SCPStatement const& st);
 
-    SCPEnvelope const*
-    getLastMessageSend() const
+    SCPEnvelope const* getLastMessageSend() const
     {
         return mLastEnvelopeEmit ? &mLastEnvelopeEmit->getEnvelope() : nullptr;
     }

--- a/src/scp/LocalNode.cpp
+++ b/src/scp/LocalNode.cpp
@@ -33,8 +33,7 @@ LocalNode::LocalNode(NodeID const& nodeID, bool isValidator,
     gSingleQSetHash = driver.getHashOf({xdr::xdr_to_opaque(*mSingleQSet)});
 }
 
-SCPQuorumSet
-LocalNode::buildSingletonQSet(NodeID const& nodeID)
+SCPQuorumSet LocalNode::buildSingletonQSet(NodeID const& nodeID)
 {
     SCPQuorumSet qSet;
     qSet.threshold = 1;
@@ -42,35 +41,30 @@ LocalNode::buildSingletonQSet(NodeID const& nodeID)
     return qSet;
 }
 
-void
-LocalNode::updateQuorumSet(SCPQuorumSet const& qSet)
+void LocalNode::updateQuorumSet(SCPQuorumSet const& qSet)
 {
     ZoneScoped;
     mQSetHash = mDriver.getHashOf({xdr::xdr_to_opaque(qSet)});
     mQSet = qSet;
 }
 
-SCPQuorumSet const&
-LocalNode::getQuorumSet()
+SCPQuorumSet const& LocalNode::getQuorumSet()
 {
     return mQSet;
 }
 
-Hash const&
-LocalNode::getQuorumSetHash()
+Hash const& LocalNode::getQuorumSetHash()
 {
     return mQSetHash;
 }
 
-SCPQuorumSetPtr
-LocalNode::getSingletonQSet(NodeID const& nodeID)
+SCPQuorumSetPtr LocalNode::getSingletonQSet(NodeID const& nodeID)
 {
     return std::make_shared<SCPQuorumSet>(buildSingletonQSet(nodeID));
 }
 
-bool
-LocalNode::forAllNodes(SCPQuorumSet const& qset,
-                       std::function<bool(NodeID const&)> proc)
+bool LocalNode::forAllNodes(SCPQuorumSet const& qset,
+                            std::function<bool(NodeID const&)> proc)
 {
     for (auto const& n : qset.validators)
     {
@@ -89,9 +83,8 @@ LocalNode::forAllNodes(SCPQuorumSet const& qset,
     return true;
 }
 
-bool
-LocalNode::isQuorumSliceInternal(SCPQuorumSet const& qset,
-                                 std::vector<NodeID> const& nodeSet)
+bool LocalNode::isQuorumSliceInternal(SCPQuorumSet const& qset,
+                                      std::vector<NodeID> const& nodeSet)
 {
     uint32 thresholdLeft = qset.threshold;
     for (auto const& validator : qset.validators)
@@ -121,17 +114,15 @@ LocalNode::isQuorumSliceInternal(SCPQuorumSet const& qset,
     return false;
 }
 
-bool
-LocalNode::isQuorumSlice(SCPQuorumSet const& qSet,
-                         std::vector<NodeID> const& nodeSet)
+bool LocalNode::isQuorumSlice(SCPQuorumSet const& qSet,
+                              std::vector<NodeID> const& nodeSet)
 {
     return isQuorumSliceInternal(qSet, nodeSet);
 }
 
 // called recursively
-bool
-LocalNode::isVBlockingInternal(SCPQuorumSet const& qset,
-                               std::vector<NodeID> const& nodeSet)
+bool LocalNode::isVBlockingInternal(SCPQuorumSet const& qset,
+                                    std::vector<NodeID> const& nodeSet)
 {
     // There is no v-blocking set for {\empty}
     if (qset.threshold == 0)
@@ -170,17 +161,16 @@ LocalNode::isVBlockingInternal(SCPQuorumSet const& qset,
     return false;
 }
 
-bool
-LocalNode::isVBlocking(SCPQuorumSet const& qSet,
-                       std::vector<NodeID> const& nodeSet)
+bool LocalNode::isVBlocking(SCPQuorumSet const& qSet,
+                            std::vector<NodeID> const& nodeSet)
 {
     return isVBlockingInternal(qSet, nodeSet);
 }
 
-bool
-LocalNode::isVBlocking(SCPQuorumSet const& qSet,
-                       std::map<NodeID, SCPEnvelopeWrapperPtr> const& map,
-                       std::function<bool(SCPStatement const&)> const& filter)
+bool LocalNode::isVBlocking(
+    SCPQuorumSet const& qSet,
+    std::map<NodeID, SCPEnvelopeWrapperPtr> const& map,
+    std::function<bool(SCPStatement const&)> const& filter)
 {
     ZoneScoped;
     std::vector<NodeID> pNodes;
@@ -195,8 +185,7 @@ LocalNode::isVBlocking(SCPQuorumSet const& qSet,
     return isVBlocking(qSet, pNodes);
 }
 
-bool
-LocalNode::isQuorum(
+bool LocalNode::isQuorum(
     SCPQuorumSet const& qSet,
     std::map<NodeID, SCPEnvelopeWrapperPtr> const& map,
     std::function<SCPQuorumSetPtr(SCPStatement const&)> const& qfun,
@@ -237,8 +226,7 @@ LocalNode::isQuorum(
     return isQuorumSlice(qSet, pNodes);
 }
 
-std::vector<NodeID>
-LocalNode::findClosestVBlocking(
+std::vector<NodeID> LocalNode::findClosestVBlocking(
     SCPQuorumSet const& qset,
     std::map<NodeID, SCPEnvelopeWrapperPtr> const& map,
     std::function<bool(SCPStatement const&)> const& filter,
@@ -291,9 +279,8 @@ LocalNode::findClosestVBlocking(SCPQuorumSet const& qset,
 
     struct orderBySize
     {
-        bool
-        operator()(std::vector<NodeID> const& v1,
-                   std::vector<NodeID> const& v2) const
+        bool operator()(std::vector<NodeID> const& v1,
+                        std::vector<NodeID> const& v2) const
         {
             return v1.size() < v2.size();
         }
@@ -338,16 +325,14 @@ LocalNode::findClosestVBlocking(SCPQuorumSet const& qset,
     return res;
 }
 
-Json::Value
-LocalNode::toJson(SCPQuorumSet const& qSet, bool fullKeys) const
+Json::Value LocalNode::toJson(SCPQuorumSet const& qSet, bool fullKeys) const
 {
     return toJson(
         qSet, [&](NodeID const& k) { return mDriver.toStrKey(k, fullKeys); });
 }
 
-Json::Value
-LocalNode::toJson(SCPQuorumSet const& qSet,
-                  std::function<std::string(NodeID const&)> r)
+Json::Value LocalNode::toJson(SCPQuorumSet const& qSet,
+                              std::function<std::string(NodeID const&)> r)
 {
     Json::Value ret;
     ret["t"] = qSet.threshold;
@@ -378,8 +363,7 @@ LocalNode::toJson(SCPQuorumSet const& qSet,
     return ret;
 }
 
-SCPQuorumSet
-LocalNode::fromJson(Json::Value const& qSetJson)
+SCPQuorumSet LocalNode::fromJson(Json::Value const& qSetJson)
 {
     if (!qSetJson.isObject())
     {
@@ -433,21 +417,18 @@ LocalNode::fromJson(Json::Value const& qSetJson)
     return ret;
 }
 
-std::string
-LocalNode::to_string(SCPQuorumSet const& qSet) const
+std::string LocalNode::to_string(SCPQuorumSet const& qSet) const
 {
     Json::FastWriter fw;
     return fw.write(toJson(qSet, false));
 }
 
-NodeID const&
-LocalNode::getNodeID()
+NodeID const& LocalNode::getNodeID()
 {
     return mNodeID;
 }
 
-bool
-LocalNode::isValidator()
+bool LocalNode::isValidator()
 {
     return mIsValidator;
 }

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -26,9 +26,8 @@ NominationProtocol::NominationProtocol(Slot& slot)
 {
 }
 
-bool
-NominationProtocol::isNewerStatement(NodeID const& nodeID,
-                                     SCPNomination const& st)
+bool NominationProtocol::isNewerStatement(NodeID const& nodeID,
+                                          SCPNomination const& st)
 {
     auto oldp = mLatestNominations.find(nodeID);
     bool res = false;
@@ -45,9 +44,9 @@ NominationProtocol::isNewerStatement(NodeID const& nodeID,
     return res;
 }
 
-bool
-NominationProtocol::isSubsetHelper(xdr::xvector<Value> const& p,
-                                   xdr::xvector<Value> const& v, bool& notEqual)
+bool NominationProtocol::isSubsetHelper(xdr::xvector<Value> const& p,
+                                        xdr::xvector<Value> const& v,
+                                        bool& notEqual)
 {
     bool res;
     if (p.size() <= v.size())
@@ -70,23 +69,20 @@ NominationProtocol::isSubsetHelper(xdr::xvector<Value> const& p,
     return res;
 }
 
-SCPDriver::ValidationLevel
-NominationProtocol::validateValue(Value const& v)
+SCPDriver::ValidationLevel NominationProtocol::validateValue(Value const& v)
 {
     ZoneScoped;
     return mSlot.getSCPDriver().validateValue(mSlot.getSlotIndex(), v, true);
 }
 
-ValueWrapperPtr
-NominationProtocol::extractValidValue(Value const& value)
+ValueWrapperPtr NominationProtocol::extractValidValue(Value const& value)
 {
     ZoneScoped;
     return mSlot.getSCPDriver().extractValidValue(mSlot.getSlotIndex(), value);
 }
 
-bool
-NominationProtocol::isNewerStatement(SCPNomination const& oldst,
-                                     SCPNomination const& st)
+bool NominationProtocol::isNewerStatement(SCPNomination const& oldst,
+                                          SCPNomination const& st)
 {
     bool res = false;
     bool grows;
@@ -105,8 +101,7 @@ NominationProtocol::isNewerStatement(SCPNomination const& oldst,
     return res;
 }
 
-bool
-NominationProtocol::isSane(SCPStatement const& st)
+bool NominationProtocol::isSane(SCPStatement const& st)
 {
     auto const& nom = st.pledges.nominate();
     bool res = (nom.votes.size() + nom.accepted.size()) != 0;
@@ -127,8 +122,7 @@ NominationProtocol::isSane(SCPStatement const& st)
 
 // only called after a call to isNewerStatement so safe to replace the
 // mLatestNomination
-void
-NominationProtocol::recordEnvelope(SCPEnvelopeWrapperPtr env)
+void NominationProtocol::recordEnvelope(SCPEnvelopeWrapperPtr env)
 {
     auto const& st = env->getStatement();
     auto oldp = mLatestNominations.find(st.nodeID);
@@ -143,8 +137,7 @@ NominationProtocol::recordEnvelope(SCPEnvelopeWrapperPtr env)
     mSlot.recordStatement(env->getStatement());
 }
 
-void
-NominationProtocol::emitNomination()
+void NominationProtocol::emitNomination()
 {
     ZoneScoped;
     SCPStatement st;
@@ -188,8 +181,7 @@ NominationProtocol::emitNomination()
     }
 }
 
-bool
-NominationProtocol::acceptPredicate(Value const& v, SCPStatement const& st)
+bool NominationProtocol::acceptPredicate(Value const& v, SCPStatement const& st)
 {
     auto const& nom = st.pledges.nominate();
     bool res;
@@ -198,9 +190,8 @@ NominationProtocol::acceptPredicate(Value const& v, SCPStatement const& st)
     return res;
 }
 
-void
-NominationProtocol::applyAll(SCPNomination const& nom,
-                             std::function<void(Value const&)> processor)
+void NominationProtocol::applyAll(SCPNomination const& nom,
+                                  std::function<void(Value const&)> processor)
 {
     for (auto const& v : nom.votes)
     {
@@ -216,8 +207,7 @@ NominationProtocol::applyAll(SCPNomination const& nom,
     }
 }
 
-void
-NominationProtocol::updateRoundLeaders()
+void NominationProtocol::updateRoundLeaders()
 {
     ZoneScoped;
     SCPQuorumSet myQSet = mSlot.getLocalNode()->getQuorumSet();
@@ -291,8 +281,7 @@ NominationProtocol::updateRoundLeaders()
     CLOG_DEBUG(SCP, "updateRoundLeaders: nothing to do");
 }
 
-uint64
-NominationProtocol::hashNode(bool isPriority, NodeID const& nodeID)
+uint64 NominationProtocol::hashNode(bool isPriority, NodeID const& nodeID)
 {
     ZoneScoped;
     dbgAssert(!mPreviousValue.empty());
@@ -300,8 +289,7 @@ NominationProtocol::hashNode(bool isPriority, NodeID const& nodeID)
         mSlot.getSlotIndex(), mPreviousValue, isPriority, mRoundNumber, nodeID);
 }
 
-uint64
-NominationProtocol::hashValue(Value const& value)
+uint64 NominationProtocol::hashValue(Value const& value)
 {
     ZoneScoped;
     dbgAssert(!mPreviousValue.empty());
@@ -309,9 +297,8 @@ NominationProtocol::hashValue(Value const& value)
         mSlot.getSlotIndex(), mPreviousValue, mRoundNumber, value);
 }
 
-uint64
-NominationProtocol::getNodePriority(NodeID const& nodeID,
-                                    SCPQuorumSet const& qset)
+uint64 NominationProtocol::getNodePriority(NodeID const& nodeID,
+                                           SCPQuorumSet const& qset)
 {
     ZoneScoped;
     uint64 res;
@@ -517,9 +504,8 @@ NominationProtocol::getStatementValues(SCPStatement const& st)
 }
 
 // attempts to nominate a value for consensus
-bool
-NominationProtocol::nominate(ValueWrapperPtr value, Value const& previousValue,
-                             bool timedout)
+bool NominationProtocol::nominate(ValueWrapperPtr value,
+                                  Value const& previousValue, bool timedout)
 {
     ZoneScoped;
 
@@ -610,20 +596,17 @@ NominationProtocol::nominate(ValueWrapperPtr value, Value const& previousValue,
     return updated;
 }
 
-void
-NominationProtocol::stopNomination()
+void NominationProtocol::stopNomination()
 {
     mNominationStarted = false;
 }
 
-std::set<NodeID> const&
-NominationProtocol::getLeaders() const
+std::set<NodeID> const& NominationProtocol::getLeaders() const
 {
     return mRoundLeaders;
 }
 
-Json::Value
-NominationProtocol::getJsonInfo()
+Json::Value NominationProtocol::getJsonInfo()
 {
     Json::Value ret;
     ret["roundnumber"] = mRoundNumber;
@@ -653,8 +636,8 @@ NominationProtocol::getJsonInfo()
     return ret;
 }
 
-SCP::QuorumInfoNodeState
-NominationProtocol::getState(NodeID const& n, bool selfAlreadyMovedOn)
+SCP::QuorumInfoNodeState NominationProtocol::getState(NodeID const& n,
+                                                      bool selfAlreadyMovedOn)
 {
     auto state = SCP::QuorumInfoNodeState::AGREE;
     if (n == mSlot.getLocalNode()->getNodeID())
@@ -714,8 +697,7 @@ NominationProtocol::getState(NodeID const& n, bool selfAlreadyMovedOn)
     return state;
 }
 
-void
-NominationProtocol::setStateFromEnvelope(SCPEnvelopeWrapperPtr e)
+void NominationProtocol::setStateFromEnvelope(SCPEnvelopeWrapperPtr e)
 {
     if (mNominationStarted)
     {
@@ -736,8 +718,7 @@ NominationProtocol::setStateFromEnvelope(SCPEnvelopeWrapperPtr e)
     mLastEnvelope = e;
 }
 
-bool
-NominationProtocol::processCurrentState(
+bool NominationProtocol::processCurrentState(
     std::function<bool(SCPEnvelope const&)> const& f, bool forceSelf) const
 {
     for (auto const& n : mLatestNominations)
@@ -755,8 +736,7 @@ NominationProtocol::processCurrentState(
     return true;
 }
 
-SCPEnvelope const*
-NominationProtocol::getLatestMessage(NodeID const& id) const
+SCPEnvelope const* NominationProtocol::getLatestMessage(NodeID const& id) const
 {
     auto it = mLatestNominations.find(id);
     if (it != mLatestNominations.end())

--- a/src/scp/NominationProtocol.h
+++ b/src/scp/NominationProtocol.h
@@ -101,8 +101,7 @@ class NominationProtocol
     // return the current leaders
     std::set<NodeID> const& getLeaders() const;
 
-    ValueWrapperPtr const&
-    getLatestCompositeCandidate() const
+    ValueWrapperPtr const& getLatestCompositeCandidate() const
     {
         return mLatestCompositeCandidate;
     }
@@ -112,8 +111,7 @@ class NominationProtocol
     SCP::QuorumInfoNodeState getState(NodeID const& node,
                                       bool selfAlreadyMovedOn);
 
-    SCPEnvelope const*
-    getLastMessageSend() const
+    SCPEnvelope const* getLastMessageSend() const
     {
         return mLastEnvelope ? &mLastEnvelope->getEnvelope() : nullptr;
     }

--- a/src/scp/QuorumSetUtils.cpp
+++ b/src/scp/QuorumSetUtils.cpp
@@ -23,8 +23,7 @@ class QuorumSetSanityChecker
   public:
     explicit QuorumSetSanityChecker(SCPQuorumSet const& qSet, bool extraChecks,
                                     char const*& errString);
-    bool
-    isSane() const
+    bool isSane() const
     {
         return mIsSane;
     }
@@ -53,9 +52,8 @@ QuorumSetSanityChecker::QuorumSetSanityChecker(SCPQuorumSet const& qSet,
     }
 }
 
-bool
-QuorumSetSanityChecker::checkSanity(SCPQuorumSet const& qSet, uint32 depth,
-                                    char const*& errString)
+bool QuorumSetSanityChecker::checkSanity(SCPQuorumSet const& qSet, uint32 depth,
+                                         char const*& errString)
 {
     if (depth > MAXIMUM_QUORUM_NESTING_LEVEL)
     {
@@ -112,9 +110,8 @@ QuorumSetSanityChecker::checkSanity(SCPQuorumSet const& qSet, uint32 depth,
 }
 }
 
-bool
-isQuorumSetSane(SCPQuorumSet const& qSet, bool extraChecks,
-                char const*& errString)
+bool isQuorumSetSane(SCPQuorumSet const& qSet, bool extraChecks,
+                     char const*& errString)
 {
     QuorumSetSanityChecker checker{qSet, extraChecks, errString};
     return checker.isSane();
@@ -133,8 +130,7 @@ namespace
 //  * simplifies singleton innersets
 //      { t:1, { innerSet } } into innerSet
 
-void
-normalizeQSetSimplify(SCPQuorumSet& qSet, NodeID const* idToRemove)
+void normalizeQSetSimplify(SCPQuorumSet& qSet, NodeID const* idToRemove)
 {
     using xdr::operator==;
     auto& v = qSet.validators;
@@ -174,9 +170,8 @@ normalizeQSetSimplify(SCPQuorumSet& qSet, NodeID const* idToRemove)
 }
 
 template <typename InputIt1, typename InputIt2, class Compare>
-int
-intLexicographicalCompare(InputIt1 first1, InputIt1 last1, InputIt2 first2,
-                          InputIt2 last2, Compare comp)
+int intLexicographicalCompare(InputIt1 first1, InputIt1 last1, InputIt2 first2,
+                              InputIt2 last2, Compare comp)
 {
     for (; first1 != last1 && first2 != last2; first1++, first2++)
     {
@@ -200,8 +195,7 @@ intLexicographicalCompare(InputIt1 first1, InputIt1 last1, InputIt2 first2,
 // returns -1 if l < r ; 0 if l == r ; 1 if l > r
 // lexicographical sort
 // looking at, in order: validators, innerSets, threshold
-int
-qSetCompareInt(SCPQuorumSet const& l, SCPQuorumSet const& r)
+int qSetCompareInt(SCPQuorumSet const& l, SCPQuorumSet const& r)
 {
     auto& lvals = l.validators;
     auto& rvals = r.validators;
@@ -242,8 +236,7 @@ qSetCompareInt(SCPQuorumSet const& l, SCPQuorumSet const& r)
 
 // helper function that reorders validators and inner sets
 // in a standard way
-void
-normalizeQuorumSetReorder(SCPQuorumSet& qset)
+void normalizeQuorumSetReorder(SCPQuorumSet& qset)
 {
     std::sort(qset.validators.begin(), qset.validators.end());
     for (auto& qs : qset.innerSets)
@@ -257,8 +250,7 @@ normalizeQuorumSetReorder(SCPQuorumSet& qset)
               });
 }
 }
-void
-normalizeQSet(SCPQuorumSet& qSet, NodeID const* idToRemove)
+void normalizeQSet(SCPQuorumSet& qSet, NodeID const* idToRemove)
 {
     normalizeQSetSimplify(qSet, idToRemove);
     normalizeQuorumSetReorder(qSet);

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -26,23 +26,20 @@ SCP::SCP(SCPDriver& driver, NodeID const& nodeID, bool isValidator,
         std::make_shared<LocalNode>(nodeID, isValidator, qSetLocal, driver);
 }
 
-SCP::EnvelopeState
-SCP::receiveEnvelope(SCPEnvelopeWrapperPtr envelope)
+SCP::EnvelopeState SCP::receiveEnvelope(SCPEnvelopeWrapperPtr envelope)
 {
     uint64 slotIndex = envelope->getStatement().slotIndex;
     return getSlot(slotIndex, true)->processEnvelope(envelope, false);
 }
 
-bool
-SCP::nominate(uint64 slotIndex, ValueWrapperPtr value,
-              Value const& previousValue)
+bool SCP::nominate(uint64 slotIndex, ValueWrapperPtr value,
+                   Value const& previousValue)
 {
     dbgAssert(isValidator());
     return getSlot(slotIndex, true)->nominate(value, previousValue, false);
 }
 
-void
-SCP::stopNomination(uint64 slotIndex)
+void SCP::stopNomination(uint64 slotIndex)
 {
     auto s = getSlot(slotIndex, false);
     if (s)
@@ -51,26 +48,22 @@ SCP::stopNomination(uint64 slotIndex)
     }
 }
 
-void
-SCP::updateLocalQuorumSet(SCPQuorumSet const& qSet)
+void SCP::updateLocalQuorumSet(SCPQuorumSet const& qSet)
 {
     mLocalNode->updateQuorumSet(qSet);
 }
 
-SCPQuorumSet const&
-SCP::getLocalQuorumSet()
+SCPQuorumSet const& SCP::getLocalQuorumSet()
 {
     return mLocalNode->getQuorumSet();
 }
 
-NodeID const&
-SCP::getLocalNodeID()
+NodeID const& SCP::getLocalNodeID()
 {
     return mLocalNode->getNodeID();
 }
 
-void
-SCP::purgeSlots(uint64 maxSlotIndex, uint64 slotToKeep)
+void SCP::purgeSlots(uint64 maxSlotIndex, uint64 slotToKeep)
 {
     auto it = mKnownSlots.begin();
     while (it != mKnownSlots.end() && it->first < maxSlotIndex)
@@ -86,14 +79,12 @@ SCP::purgeSlots(uint64 maxSlotIndex, uint64 slotToKeep)
     }
 }
 
-std::shared_ptr<LocalNode>
-SCP::getLocalNode()
+std::shared_ptr<LocalNode> SCP::getLocalNode()
 {
     return mLocalNode;
 }
 
-std::shared_ptr<Slot>
-SCP::getSlot(uint64 slotIndex, bool create)
+std::shared_ptr<Slot> SCP::getSlot(uint64 slotIndex, bool create)
 {
     std::shared_ptr<Slot> res;
     auto it = mKnownSlots.find(slotIndex);
@@ -112,8 +103,7 @@ SCP::getSlot(uint64 slotIndex, bool create)
     return res;
 }
 
-Json::Value
-SCP::getJsonInfo(size_t limit, bool fullKeys)
+Json::Value SCP::getJsonInfo(size_t limit, bool fullKeys)
 {
     Json::Value ret;
     auto it = mKnownSlots.rbegin();
@@ -127,8 +117,7 @@ SCP::getJsonInfo(size_t limit, bool fullKeys)
     return ret;
 }
 
-SCP::QuorumInfoNodeState
-SCP::getState(NodeID const& node, uint64 slotIndex)
+SCP::QuorumInfoNodeState SCP::getState(NodeID const& node, uint64 slotIndex)
 {
     for (int k = 0; k < NUM_SLOTS_TO_CHECK_FOR_REPORTING; k++)
     {
@@ -152,9 +141,8 @@ SCP::getState(NodeID const& node, uint64 slotIndex)
     return SCP::QuorumInfoNodeState::MISSING;
 }
 
-Json::Value
-SCP::getJsonQuorumInfo(NodeID const& id, bool summary, bool fullKeys,
-                       uint64 index)
+Json::Value SCP::getJsonQuorumInfo(NodeID const& id, bool summary,
+                                   bool fullKeys, uint64 index)
 {
     Json::Value ret;
     if (mKnownSlots.empty())
@@ -238,8 +226,7 @@ SCP::getJsonQuorumInfo(NodeID const& id, bool summary, bool fullKeys,
     return ret;
 }
 
-std::set<NodeID>
-SCP::getMissingNodes(NodeID const& id, uint64 index)
+std::set<NodeID> SCP::getMissingNodes(NodeID const& id, uint64 index)
 {
     std::set<NodeID> ret;
     if (index == 0)
@@ -261,14 +248,12 @@ SCP::getMissingNodes(NodeID const& id, uint64 index)
     return ret;
 }
 
-bool
-SCP::isValidator()
+bool SCP::isValidator()
 {
     return mLocalNode->isValidator();
 }
 
-bool
-SCP::isSlotFullyValidated(uint64 slotIndex)
+bool SCP::isSlotFullyValidated(uint64 slotIndex)
 {
     auto slot = getSlot(slotIndex, false);
     if (slot)
@@ -281,8 +266,7 @@ SCP::isSlotFullyValidated(uint64 slotIndex)
     }
 }
 
-bool
-SCP::gotVBlocking(uint64 slotIndex)
+bool SCP::gotVBlocking(uint64 slotIndex)
 {
     auto slot = getSlot(slotIndex, false);
     if (slot)
@@ -295,14 +279,12 @@ SCP::gotVBlocking(uint64 slotIndex)
     }
 }
 
-size_t
-SCP::getKnownSlotsCount() const
+size_t SCP::getKnownSlotsCount() const
 {
     return mKnownSlots.size();
 }
 
-size_t
-SCP::getCumulativeStatemtCount() const
+size_t SCP::getCumulativeStatemtCount() const
 {
     size_t c = 0;
     for (auto const& s : mKnownSlots)
@@ -312,8 +294,7 @@ SCP::getCumulativeStatemtCount() const
     return c;
 }
 
-std::vector<SCPEnvelope>
-SCP::getLatestMessagesSend(uint64 slotIndex)
+std::vector<SCPEnvelope> SCP::getLatestMessagesSend(uint64 slotIndex)
 {
     auto slot = getSlot(slotIndex, false);
     if (slot)
@@ -326,23 +307,20 @@ SCP::getLatestMessagesSend(uint64 slotIndex)
     }
 }
 
-void
-SCP::setStateFromEnvelope(uint64 slotIndex, SCPEnvelopeWrapperPtr e)
+void SCP::setStateFromEnvelope(uint64 slotIndex, SCPEnvelopeWrapperPtr e)
 {
     auto slot = getSlot(slotIndex, true);
     slot->setStateFromEnvelope(e);
 }
 
-bool
-SCP::empty() const
+bool SCP::empty() const
 {
     return mKnownSlots.empty();
 }
 
-void
-SCP::processCurrentState(uint64 slotIndex,
-                         std::function<bool(SCPEnvelope const&)> const& f,
-                         bool forceSelf)
+void SCP::processCurrentState(uint64 slotIndex,
+                              std::function<bool(SCPEnvelope const&)> const& f,
+                              bool forceSelf)
 {
     auto slot = getSlot(slotIndex, false);
     if (slot)
@@ -351,9 +329,8 @@ SCP::processCurrentState(uint64 slotIndex,
     }
 }
 
-void
-SCP::processSlotsAscendingFrom(uint64 startingSlot,
-                               std::function<bool(uint64)> const& f)
+void SCP::processSlotsAscendingFrom(uint64 startingSlot,
+                                    std::function<bool(uint64)> const& f)
 {
     for (auto iter = mKnownSlots.lower_bound(startingSlot);
          iter != mKnownSlots.end(); ++iter)
@@ -365,9 +342,8 @@ SCP::processSlotsAscendingFrom(uint64 startingSlot,
     }
 }
 
-void
-SCP::processSlotsDescendingFrom(uint64 startingSlot,
-                                std::function<bool(uint64)> const& f)
+void SCP::processSlotsDescendingFrom(uint64 startingSlot,
+                                     std::function<bool(uint64)> const& f)
 {
     auto iter = mKnownSlots.upper_bound(startingSlot);
     while (iter != mKnownSlots.begin())
@@ -380,8 +356,7 @@ SCP::processSlotsDescendingFrom(uint64 startingSlot,
     }
 }
 
-SCPEnvelope const*
-SCP::getLatestMessage(NodeID const& id)
+SCPEnvelope const* SCP::getLatestMessage(NodeID const& id)
 {
     for (auto it = mKnownSlots.rbegin(); it != mKnownSlots.rend(); it++)
     {
@@ -395,9 +370,8 @@ SCP::getLatestMessage(NodeID const& id)
     return nullptr;
 }
 
-bool
-SCP::isNewerNominationOrBallotSt(SCPStatement const& oldSt,
-                                 SCPStatement const& newSt)
+bool SCP::isNewerNominationOrBallotSt(SCPStatement const& oldSt,
+                                      SCPStatement const& newSt)
 {
     if (oldSt.slotIndex != newSt.slotIndex || !(oldSt.nodeID == newSt.nodeID))
     {
@@ -413,8 +387,7 @@ SCP::isNewerNominationOrBallotSt(SCPStatement const& oldSt,
     return false;
 }
 
-std::vector<SCPEnvelope>
-SCP::getExternalizingState(uint64 slotIndex)
+std::vector<SCPEnvelope> SCP::getExternalizingState(uint64 slotIndex)
 {
     auto slot = getSlot(slotIndex, false);
     if (slot)
@@ -427,14 +400,12 @@ SCP::getExternalizingState(uint64 slotIndex)
     }
 }
 
-std::string
-SCP::getValueString(Value const& v) const
+std::string SCP::getValueString(Value const& v) const
 {
     return mDriver.getValueString(v);
 }
 
-std::string
-SCP::ballotToStr(SCPBallot const& ballot) const
+std::string SCP::ballotToStr(SCPBallot const& ballot) const
 {
     std::ostringstream oss;
 
@@ -442,8 +413,7 @@ SCP::ballotToStr(SCPBallot const& ballot) const
     return oss.str();
 }
 
-std::string
-SCP::ballotToStr(std::unique_ptr<SCPBallot> const& ballot) const
+std::string SCP::ballotToStr(std::unique_ptr<SCPBallot> const& ballot) const
 {
     std::string res;
     if (ballot)
@@ -457,14 +427,12 @@ SCP::ballotToStr(std::unique_ptr<SCPBallot> const& ballot) const
     return res;
 }
 
-std::string
-SCP::envToStr(SCPEnvelope const& envelope, bool fullKeys) const
+std::string SCP::envToStr(SCPEnvelope const& envelope, bool fullKeys) const
 {
     return envToStr(envelope.statement, fullKeys);
 }
 
-std::string
-SCP::envToStr(SCPStatement const& st, bool fullKeys) const
+std::string SCP::envToStr(SCPStatement const& st, bool fullKeys) const
 {
     std::ostringstream oss;
 

--- a/src/scp/SCP.h
+++ b/src/scp/SCP.h
@@ -28,13 +28,11 @@ class SCP
     SCP(SCPDriver& driver, NodeID const& nodeID, bool isValidator,
         SCPQuorumSet const& qSetLocal);
 
-    SCPDriver&
-    getDriver()
+    SCPDriver& getDriver()
     {
         return mDriver;
     }
-    SCPDriver const&
-    getDriver() const
+    SCPDriver const& getDriver() const
     {
         return mDriver;
     }
@@ -151,8 +149,7 @@ class SCP
                          bool fullKeys = false) const;
     std::string envToStr(SCPStatement const& st, bool fullKeys = false) const;
 
-    uint64
-    getHighestKnownSlotIndex()
+    uint64 getHighestKnownSlotIndex()
     {
         return mKnownSlots.empty() ? 0 : mKnownSlots.rbegin()->first;
     }

--- a/src/scp/SCPDriver.cpp
+++ b/src/scp/SCPDriver.cpp
@@ -18,8 +18,7 @@ namespace stellar
 
 namespace
 {
-uint64
-computeWeight(uint64 m, uint64 total, uint64 threshold)
+uint64 computeWeight(uint64 m, uint64 total, uint64 threshold)
 {
     uint64 res;
     releaseAssert(threshold <= total);
@@ -32,9 +31,8 @@ computeWeight(uint64 m, uint64 total, uint64 threshold)
 }
 } // namespace
 
-bool
-WrappedValuePtrComparator::operator()(ValueWrapperPtr const& l,
-                                      ValueWrapperPtr const& r) const
+bool WrappedValuePtrComparator::operator()(ValueWrapperPtr const& l,
+                                           ValueWrapperPtr const& r) const
 {
     releaseAssert(l && r);
     return l->getValue() < r->getValue();
@@ -56,36 +54,31 @@ ValueWrapper::~ValueWrapper()
 {
 }
 
-SCPEnvelopeWrapperPtr
-SCPDriver::wrapEnvelope(SCPEnvelope const& envelope)
+SCPEnvelopeWrapperPtr SCPDriver::wrapEnvelope(SCPEnvelope const& envelope)
 {
     auto res = std::make_shared<SCPEnvelopeWrapper>(envelope);
     return res;
 }
 
-ValueWrapperPtr
-SCPDriver::wrapValue(Value const& value)
+ValueWrapperPtr SCPDriver::wrapValue(Value const& value)
 {
     auto res = std::make_shared<ValueWrapper>(value);
     return res;
 }
 
-std::string
-SCPDriver::getValueString(Value const& v) const
+std::string SCPDriver::getValueString(Value const& v) const
 {
     Hash valueHash = getHashOf({xdr::xdr_to_opaque(v)});
 
     return hexAbbrev(valueHash);
 }
 
-std::string
-SCPDriver::toStrKey(NodeID const& pk, bool fullKey) const
+std::string SCPDriver::toStrKey(NodeID const& pk, bool fullKey) const
 {
     return fullKey ? KeyUtils::toStrKey(pk) : toShortString(pk);
 }
 
-std::string
-SCPDriver::toShortString(NodeID const& pk) const
+std::string SCPDriver::toShortString(NodeID const& pk) const
 {
     return KeyUtils::toShortString(pk);
 }
@@ -95,8 +88,7 @@ static const uint32 hash_N = 1;
 static const uint32 hash_P = 2;
 static const uint32 hash_K = 3;
 
-uint64
-SCPDriver::hashHelper(
+uint64 SCPDriver::hashHelper(
     uint64 slotIndex, Value const& prev,
     std::function<void(std::vector<xdr::opaque_vec<>>&)> extra)
 {
@@ -113,9 +105,9 @@ SCPDriver::hashHelper(
     return res;
 }
 
-uint64
-SCPDriver::computeHashNode(uint64 slotIndex, Value const& prev, bool isPriority,
-                           int32_t roundNumber, NodeID const& nodeID)
+uint64 SCPDriver::computeHashNode(uint64 slotIndex, Value const& prev,
+                                  bool isPriority, int32_t roundNumber,
+                                  NodeID const& nodeID)
 {
 #ifdef BUILD_TESTS
     if (mPriorityLookupForTesting)
@@ -131,9 +123,8 @@ SCPDriver::computeHashNode(uint64 slotIndex, Value const& prev, bool isPriority,
         });
 }
 
-uint64
-SCPDriver::computeValueHash(uint64 slotIndex, Value const& prev,
-                            int32_t roundNumber, Value const& value)
+uint64 SCPDriver::computeValueHash(uint64 slotIndex, Value const& prev,
+                                   int32_t roundNumber, Value const& value)
 {
     return hashHelper(slotIndex, prev,
                       [&](std::vector<xdr::opaque_vec<>>& vals) {
@@ -145,9 +136,8 @@ SCPDriver::computeValueHash(uint64 slotIndex, Value const& prev,
 
 // if a validator is repeated multiple times its weight is only the
 // weight of the first occurrence
-uint64
-SCPDriver::getNodeWeight(NodeID const& nodeID, SCPQuorumSet const& qset,
-                         bool isLocalNode) const
+uint64 SCPDriver::getNodeWeight(NodeID const& nodeID, SCPQuorumSet const& qset,
+                                bool isLocalNode) const
 {
     if (isLocalNode)
     {

--- a/src/scp/SCPDriver.h
+++ b/src/scp/SCPDriver.h
@@ -23,8 +23,7 @@ class ValueWrapper : public NonMovableOrCopyable
     explicit ValueWrapper(Value const& value);
     virtual ~ValueWrapper();
 
-    Value const&
-    getValue() const
+    Value const& getValue() const
     {
         return mValue;
     }
@@ -49,13 +48,11 @@ class SCPEnvelopeWrapper : public NonMovableOrCopyable
     explicit SCPEnvelopeWrapper(SCPEnvelope const& e);
     virtual ~SCPEnvelopeWrapper();
 
-    SCPEnvelope const&
-    getEnvelope() const
+    SCPEnvelope const& getEnvelope() const
     {
         return mEnvelope;
     }
-    SCPStatement const&
-    getStatement() const
+    SCPStatement const& getStatement() const
     {
         return mEnvelope.statement;
     }
@@ -119,8 +116,8 @@ class SCPDriver
         kMaybeValidValue = 1,    // value may be valid
         kFullyValidatedValue = 2 // value is valid for sure
     };
-    virtual ValidationLevel
-    validateValue(uint64 slotIndex, Value const& value, bool nomination)
+    virtual ValidationLevel validateValue(uint64 slotIndex, Value const& value,
+                                          bool nomination)
     {
         return kMaybeValidValue;
     }
@@ -130,8 +127,8 @@ class SCPDriver
     // This is used during nomination when encountering an invalid value (ie
     // validateValue did not return `kFullyValidatedValue` for this value).
     // returning nullptr means no valid value could be extracted
-    virtual ValueWrapperPtr
-    extractValidValue(uint64 slotIndex, Value const& value)
+    virtual ValueWrapperPtr extractValidValue(uint64 slotIndex,
+                                              Value const& value)
     {
         return nullptr;
     }
@@ -190,15 +187,13 @@ class SCPDriver
 
     // `valueExternalized` is called at most once per slot when the slot
     // externalize its value.
-    virtual void
-    valueExternalized(uint64 slotIndex, Value const& value)
+    virtual void valueExternalized(uint64 slotIndex, Value const& value)
     {
     }
 
     // ``nominatingValue`` is called every time the local instance nominates
     // a new value.
-    virtual void
-    nominatingValue(uint64 slotIndex, Value const& value)
+    virtual void nominatingValue(uint64 slotIndex, Value const& value)
     {
     }
 
@@ -208,48 +203,45 @@ class SCPDriver
     // `updatedCandidateValue` is called every time a new candidate value
     // is included in the candidate set, the value passed in is
     // a composite value
-    virtual void
-    updatedCandidateValue(uint64 slotIndex, Value const& value)
+    virtual void updatedCandidateValue(uint64 slotIndex, Value const& value)
     {
     }
 
     // `startedBallotProtocol` is called when the ballot protocol is started
     // (ie attempts to prepare a new ballot)
-    virtual void
-    startedBallotProtocol(uint64 slotIndex, SCPBallot const& ballot)
+    virtual void startedBallotProtocol(uint64 slotIndex,
+                                       SCPBallot const& ballot)
     {
     }
 
     // `acceptedBallotPrepared` every time a ballot is accepted as prepared
-    virtual void
-    acceptedBallotPrepared(uint64 slotIndex, SCPBallot const& ballot)
+    virtual void acceptedBallotPrepared(uint64 slotIndex,
+                                        SCPBallot const& ballot)
     {
     }
 
     // `confirmedBallotPrepared` every time a ballot is confirmed prepared
-    virtual void
-    confirmedBallotPrepared(uint64 slotIndex, SCPBallot const& ballot)
+    virtual void confirmedBallotPrepared(uint64 slotIndex,
+                                         SCPBallot const& ballot)
     {
     }
 
     // `acceptedCommit` every time a ballot is accepted commit
-    virtual void
-    acceptedCommit(uint64 slotIndex, SCPBallot const& ballot)
+    virtual void acceptedCommit(uint64 slotIndex, SCPBallot const& ballot)
     {
     }
 
     // `ballotDidHearFromQuorum` is called when we received messages related to
     // the current `mBallot` from a set of node that is a transitive quorum for
     // the local node.
-    virtual void
-    ballotDidHearFromQuorum(uint64 slotIndex, SCPBallot const& ballot)
+    virtual void ballotDidHearFromQuorum(uint64 slotIndex,
+                                         SCPBallot const& ballot)
     {
     }
 
 #ifdef BUILD_TESTS
     std::function<uint64(NodeID const&)> mPriorityLookupForTesting;
-    void
-    setPriorityLookup(std::function<uint64(NodeID const&)> const& f)
+    void setPriorityLookup(std::function<uint64(NodeID const&)> const& f)
     {
         mPriorityLookupForTesting = f;
     }

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -30,14 +30,12 @@ Slot::Slot(uint64 slotIndex, SCP& scp)
 {
 }
 
-ValueWrapperPtr const&
-Slot::getLatestCompositeCandidate()
+ValueWrapperPtr const& Slot::getLatestCompositeCandidate()
 {
     return mNominationProtocol.getLatestCompositeCandidate();
 }
 
-std::vector<SCPEnvelope>
-Slot::getLatestMessagesSend() const
+std::vector<SCPEnvelope> Slot::getLatestMessagesSend() const
 {
     std::vector<SCPEnvelope> res;
     if (mFullyValidated)
@@ -57,8 +55,7 @@ Slot::getLatestMessagesSend() const
     return res;
 }
 
-void
-Slot::setStateFromEnvelope(SCPEnvelopeWrapperPtr env)
+void Slot::setStateFromEnvelope(SCPEnvelopeWrapperPtr env)
 {
     auto& e = env->getEnvelope();
     if (e.statement.nodeID == getSCP().getLocalNodeID() &&
@@ -87,16 +84,14 @@ Slot::setStateFromEnvelope(SCPEnvelopeWrapperPtr env)
     }
 }
 
-void
-Slot::processCurrentState(std::function<bool(SCPEnvelope const&)> const& f,
-                          bool forceSelf) const
+void Slot::processCurrentState(std::function<bool(SCPEnvelope const&)> const& f,
+                               bool forceSelf) const
 {
     mNominationProtocol.processCurrentState(f, forceSelf) &&
         mBallotProtocol.processCurrentState(f, forceSelf);
 }
 
-SCPEnvelope const*
-Slot::getLatestMessage(NodeID const& id) const
+SCPEnvelope const* Slot::getLatestMessage(NodeID const& id) const
 {
     auto m = mBallotProtocol.getLatestMessage(id);
     if (m == nullptr)
@@ -106,9 +101,8 @@ Slot::getLatestMessage(NodeID const& id) const
     return m;
 }
 
-bool
-Slot::isNewerNominationOrBallotSt(SCPStatement const& oldSt,
-                                  SCPStatement const& newSt)
+bool Slot::isNewerNominationOrBallotSt(SCPStatement const& oldSt,
+                                       SCPStatement const& newSt)
 {
     bool oldNomination =
         oldSt.pledges.type() == SCPStatementType::SCP_ST_NOMINATE;
@@ -140,14 +134,12 @@ Slot::isNewerNominationOrBallotSt(SCPStatement const& oldSt,
     return replace;
 }
 
-std::vector<SCPEnvelope>
-Slot::getExternalizingState() const
+std::vector<SCPEnvelope> Slot::getExternalizingState() const
 {
     return mBallotProtocol.getExternalizingState();
 }
 
-void
-Slot::recordStatement(SCPStatement const& st)
+void Slot::recordStatement(SCPStatement const& st)
 {
     mStatementsHistory.emplace_back(
         HistoricalStatement{std::time(nullptr), st, mFullyValidated});
@@ -156,8 +148,8 @@ Slot::recordStatement(SCPStatement const& st)
                (mFullyValidated ? "true" : "false"));
 }
 
-SCP::EnvelopeState
-Slot::processEnvelope(SCPEnvelopeWrapperPtr envelope, bool self)
+SCP::EnvelopeState Slot::processEnvelope(SCPEnvelopeWrapperPtr envelope,
+                                         bool self)
 {
     dbgAssert(envelope->getStatement().slotIndex == mSlotIndex);
 
@@ -199,51 +191,43 @@ Slot::processEnvelope(SCPEnvelopeWrapperPtr envelope, bool self)
     return res;
 }
 
-bool
-Slot::abandonBallot()
+bool Slot::abandonBallot()
 {
     return mBallotProtocol.abandonBallot(0);
 }
 
-bool
-Slot::bumpState(Value const& value, bool force)
+bool Slot::bumpState(Value const& value, bool force)
 {
-
     return mBallotProtocol.bumpState(value, force);
 }
 
-bool
-Slot::nominate(ValueWrapperPtr value, Value const& previousValue, bool timedout)
+bool Slot::nominate(ValueWrapperPtr value, Value const& previousValue,
+                    bool timedout)
 {
     return mNominationProtocol.nominate(value, previousValue, timedout);
 }
 
-void
-Slot::stopNomination()
+void Slot::stopNomination()
 {
     mNominationProtocol.stopNomination();
 }
 
-std::set<NodeID>
-Slot::getNominationLeaders() const
+std::set<NodeID> Slot::getNominationLeaders() const
 {
     return mNominationProtocol.getLeaders();
 }
 
-bool
-Slot::isFullyValidated() const
+bool Slot::isFullyValidated() const
 {
     return mFullyValidated;
 }
 
-void
-Slot::setFullyValidated(bool fullyValidated)
+void Slot::setFullyValidated(bool fullyValidated)
 {
     mFullyValidated = fullyValidated;
 }
 
-SCPEnvelope
-Slot::createEnvelope(SCPStatement const& statement)
+SCPEnvelope Slot::createEnvelope(SCPStatement const& statement)
 {
     SCPEnvelope envelope;
 
@@ -257,8 +241,7 @@ Slot::createEnvelope(SCPStatement const& statement)
     return envelope;
 }
 
-Hash
-Slot::getCompanionQuorumSetHashFromStatement(SCPStatement const& st)
+Hash Slot::getCompanionQuorumSetHashFromStatement(SCPStatement const& st)
 {
     Hash h;
     switch (st.pledges.type())
@@ -281,8 +264,7 @@ Slot::getCompanionQuorumSetHashFromStatement(SCPStatement const& st)
     return h;
 }
 
-std::vector<Value>
-Slot::getStatementValues(SCPStatement const& st)
+std::vector<Value> Slot::getStatementValues(SCPStatement const& st)
 {
     std::vector<Value> res;
     if (st.pledges.type() == SCP_ST_NOMINATE)
@@ -301,8 +283,7 @@ Slot::getStatementValues(SCPStatement const& st)
     return res;
 }
 
-SCPQuorumSetPtr
-Slot::getQuorumSetFromStatement(SCPStatement const& st)
+SCPQuorumSetPtr Slot::getQuorumSetFromStatement(SCPStatement const& st)
 {
     SCPQuorumSetPtr res;
     SCPStatementType t = st.pledges.type();
@@ -335,8 +316,7 @@ Slot::getQuorumSetFromStatement(SCPStatement const& st)
     return res;
 }
 
-Json::Value
-Slot::getJsonInfo(bool fullKeys)
+Json::Value Slot::getJsonInfo(bool fullKeys)
 {
     Json::Value ret;
     std::map<Hash, SCPQuorumSetPtr> qSetsUsed;
@@ -371,8 +351,8 @@ Slot::getJsonInfo(bool fullKeys)
     return ret;
 }
 
-SCP::QuorumInfoNodeState
-Slot::getState(NodeID const& node, bool selfAlreadyMovedOn)
+SCP::QuorumInfoNodeState Slot::getState(NodeID const& node,
+                                        bool selfAlreadyMovedOn)
 {
     auto b = mBallotProtocol.getState(node, selfAlreadyMovedOn);
     if (b != SCP::QuorumInfoNodeState::NO_INFO)
@@ -382,8 +362,8 @@ Slot::getState(NodeID const& node, bool selfAlreadyMovedOn)
     return mNominationProtocol.getState(node, selfAlreadyMovedOn);
 }
 
-Json::Value
-Slot::getJsonQuorumInfo(NodeID const& id, bool summary, bool fullKeys)
+Json::Value Slot::getJsonQuorumInfo(NodeID const& id, bool summary,
+                                    bool fullKeys)
 {
     Json::Value ret = mBallotProtocol.getJsonQuorumInfo(id, summary, fullKeys);
     if (getLocalNode()->isValidator())
@@ -393,9 +373,9 @@ Slot::getJsonQuorumInfo(NodeID const& id, bool summary, bool fullKeys)
     return ret;
 }
 
-bool
-Slot::federatedAccept(StatementPredicate voted, StatementPredicate accepted,
-                      std::map<NodeID, SCPEnvelopeWrapperPtr> const& envs)
+bool Slot::federatedAccept(StatementPredicate voted,
+                           StatementPredicate accepted,
+                           std::map<NodeID, SCPEnvelopeWrapperPtr> const& envs)
 {
     // Checks if the nodes that claimed to accept the statement form a
     // v-blocking set
@@ -423,23 +403,20 @@ Slot::federatedAccept(StatementPredicate voted, StatementPredicate accepted,
     return false;
 }
 
-bool
-Slot::federatedRatify(StatementPredicate voted,
-                      std::map<NodeID, SCPEnvelopeWrapperPtr> const& envs)
+bool Slot::federatedRatify(StatementPredicate voted,
+                           std::map<NodeID, SCPEnvelopeWrapperPtr> const& envs)
 {
     return LocalNode::isQuorum(
         getLocalNode()->getQuorumSet(), envs,
         std::bind(&Slot::getQuorumSetFromStatement, this, _1), voted);
 }
 
-std::shared_ptr<LocalNode>
-Slot::getLocalNode()
+std::shared_ptr<LocalNode> Slot::getLocalNode()
 {
     return mSCP.getLocalNode();
 }
 
-std::vector<SCPEnvelope>
-Slot::getEntireCurrentState()
+std::vector<SCPEnvelope> Slot::getEntireCurrentState()
 {
     std::vector<SCPEnvelope> res;
     processCurrentState(
@@ -451,8 +428,7 @@ Slot::getEntireCurrentState()
     return res;
 }
 
-void
-Slot::maybeSetGotVBlocking()
+void Slot::maybeSetGotVBlocking()
 {
     if (mGotVBlocking)
     {

--- a/src/scp/Slot.h
+++ b/src/scp/Slot.h
@@ -51,32 +51,27 @@ class Slot : public std::enable_shared_from_this<Slot>
   public:
     Slot(uint64 slotIndex, SCP& SCP);
 
-    uint64
-    getSlotIndex() const
+    uint64 getSlotIndex() const
     {
         return mSlotIndex;
     }
 
-    SCP&
-    getSCP()
+    SCP& getSCP()
     {
         return mSCP;
     }
 
-    SCPDriver&
-    getSCPDriver()
+    SCPDriver& getSCPDriver()
     {
         return mSCP.getDriver();
     }
 
-    SCPDriver const&
-    getSCPDriver() const
+    SCPDriver const& getSCPDriver() const
     {
         return mSCP.getDriver();
     }
 
-    BallotProtocol&
-    getBallotProtocol()
+    BallotProtocol& getBallotProtocol()
     {
         return mBallotProtocol;
     }
@@ -138,14 +133,12 @@ class Slot : public std::enable_shared_from_this<Slot>
 
     // ** status methods
 
-    size_t
-    getStatementCount() const
+    size_t getStatementCount() const
     {
         return mStatementsHistory.size();
     }
 
-    bool
-    gotVBlocking() const
+    bool gotVBlocking() const
     {
         return mGotVBlocking;
     }

--- a/src/scp/test/SCPTests.cpp
+++ b/src/scp/test/SCPTests.cpp
@@ -31,8 +31,7 @@ namespace stellar
 // k can be anything
 static Value xValue, yValue, zValue, zzValue, kValue;
 
-static void
-setupValues()
+static void setupValues()
 {
     std::vector<Value> v;
     std::string d =
@@ -77,33 +76,30 @@ class TestSCP : public SCPDriver
         storeQuorumSet(localQSet);
     }
 
-    void
-    signEnvelope(SCPEnvelope&) override
+    void signEnvelope(SCPEnvelope&) override
     {
     }
 
-    void
-    storeQuorumSet(SCPQuorumSetPtr qSet)
+    void storeQuorumSet(SCPQuorumSetPtr qSet)
     {
         Hash qSetHash = sha256(xdr::xdr_to_opaque(*qSet.get()));
         mQuorumSets[qSetHash] = qSet;
     }
 
-    SCPDriver::ValidationLevel
-    validateValue(uint64 slotIndex, Value const& value,
-                  bool nomination) override
+    SCPDriver::ValidationLevel validateValue(uint64 slotIndex,
+                                             Value const& value,
+                                             bool nomination) override
     {
         return SCPDriver::kFullyValidatedValue;
     }
 
-    void
-    ballotDidHearFromQuorum(uint64 slotIndex, SCPBallot const& ballot) override
+    void ballotDidHearFromQuorum(uint64 slotIndex,
+                                 SCPBallot const& ballot) override
     {
         mHeardFromQuorums[slotIndex].push_back(ballot);
     }
 
-    void
-    valueExternalized(uint64 slotIndex, Value const& value) override
+    void valueExternalized(uint64 slotIndex, Value const& value) override
     {
         if (mExternalizedValues.find(slotIndex) != mExternalizedValues.end())
         {
@@ -112,32 +108,27 @@ class TestSCP : public SCPDriver
         mExternalizedValues[slotIndex] = value;
     }
 
-    SCPQuorumSetPtr
-    getQSet(Hash const& qSetHash) override
+    SCPQuorumSetPtr getQSet(Hash const& qSetHash) override
     {
         if (mQuorumSets.find(qSetHash) != mQuorumSets.end())
         {
-
             return mQuorumSets[qSetHash];
         }
         return SCPQuorumSetPtr();
     }
 
-    void
-    emitEnvelope(SCPEnvelope const& envelope) override
+    void emitEnvelope(SCPEnvelope const& envelope) override
     {
         mEnvs.push_back(envelope);
     }
 
     // used to test BallotProtocol and bypass nomination
-    bool
-    bumpState(uint64 slotIndex, Value const& v)
+    bool bumpState(uint64 slotIndex, Value const& v)
     {
         return mSCP.getSlot(slotIndex, true)->bumpState(v, true);
     }
 
-    bool
-    nominate(uint64 slotIndex, Value const& value, bool timedout)
+    bool nominate(uint64 slotIndex, Value const& value, bool timedout)
     {
         auto wv = wrapValue(value);
         return mSCP.getSlot(slotIndex, true)->nominate(wv, value, timedout);
@@ -165,8 +156,7 @@ class TestSCP : public SCPDriver
     std::set<Value> mExpectedCandidates;
     Value mCompositeValue;
 
-    Hash
-    getHashOf(std::vector<xdr::opaque_vec<>> const& vals) const override
+    Hash getHashOf(std::vector<xdr::opaque_vec<>> const& vals) const override
     {
         SHA256 hasher;
         for (auto const& v : vals)
@@ -178,9 +168,8 @@ class TestSCP : public SCPDriver
 
     // override the internal hashing scheme in order to make tests
     // more predictable.
-    uint64
-    computeHashNode(uint64 slotIndex, Value const& prev, bool isPriority,
-                    int32_t roundNumber, NodeID const& nodeID) override
+    uint64 computeHashNode(uint64 slotIndex, Value const& prev, bool isPriority,
+                           int32_t roundNumber, NodeID const& nodeID) override
     {
         uint64 res;
         if (isPriority)
@@ -195,9 +184,8 @@ class TestSCP : public SCPDriver
     }
 
     // override the value hashing, to make tests more predictable.
-    uint64
-    computeValueHash(uint64 slotIndex, Value const& prev, int32_t roundNumber,
-                     Value const& value) override
+    uint64 computeValueHash(uint64 slotIndex, Value const& prev,
+                            int32_t roundNumber, Value const& value) override
     {
         return mHashValueCalculator(value);
     }
@@ -218,9 +206,9 @@ class TestSCP : public SCPDriver
     std::map<int, TimerData> mTimers;
     std::chrono::milliseconds mCurrentTimerOffset{0};
 
-    void
-    setupTimer(uint64 slotIndex, int timerID, std::chrono::milliseconds timeout,
-               std::function<void()> cb) override
+    void setupTimer(uint64 slotIndex, int timerID,
+                    std::chrono::milliseconds timeout,
+                    std::function<void()> cb) override
     {
         mTimers[timerID] =
             TimerData{mCurrentTimerOffset +
@@ -228,21 +216,18 @@ class TestSCP : public SCPDriver
                       cb};
     }
 
-    void
-    stopTimer(uint64 slotIndex, int timerID) override
+    void stopTimer(uint64 slotIndex, int timerID) override
     {
         mTimers.erase(timerID);
     }
 
-    TimerData
-    getBallotProtocolTimer()
+    TimerData getBallotProtocolTimer()
     {
         return mTimers[Slot::BALLOT_PROTOCOL_TIMER];
     }
 
     // pretends the time moved forward
-    std::chrono::milliseconds
-    bumpTimerOffset()
+    std::chrono::milliseconds bumpTimerOffset()
     {
         // increase by more than the maximum timeout
         mCurrentTimerOffset += std::chrono::hours(5);
@@ -250,8 +235,7 @@ class TestSCP : public SCPDriver
     }
 
     // returns true if a ballot protocol timer exists (in the past or future)
-    bool
-    hasBallotTimer()
+    bool hasBallotTimer()
     {
         return !!getBallotProtocolTimer().mCallback;
     }
@@ -259,44 +243,38 @@ class TestSCP : public SCPDriver
     // returns true if the ballot protocol timer is scheduled in the future
     // false if scheduled in the past
     // this method is mostly used to verify that the timer *would* have fired
-    bool
-    hasBallotTimerUpcoming()
+    bool hasBallotTimerUpcoming()
     {
         // timer must be scheduled in the past or future
         REQUIRE(hasBallotTimer());
         return mCurrentTimerOffset < getBallotProtocolTimer().mAbsoluteTimeout;
     }
 
-    Value const&
-    getLatestCompositeCandidate(uint64 slotIndex)
+    Value const& getLatestCompositeCandidate(uint64 slotIndex)
     {
         return mSCP.getSlot(slotIndex, true)
             ->getLatestCompositeCandidate()
             ->getValue();
     }
 
-    void
-    receiveEnvelope(SCPEnvelope const& envelope)
+    void receiveEnvelope(SCPEnvelope const& envelope)
     {
         auto envW = mSCP.getDriver().wrapEnvelope(envelope);
         mSCP.receiveEnvelope(envW);
     }
 
-    Slot&
-    getSlot(uint64 index)
+    Slot& getSlot(uint64 index)
     {
         return *mSCP.getSlot(index, false);
     }
 
-    std::vector<SCPEnvelope>
-    getEntireState(uint64 index)
+    std::vector<SCPEnvelope> getEntireState(uint64 index)
     {
         auto v = mSCP.getSlot(index, false)->getEntireCurrentState();
         return v;
     }
 
-    SCPEnvelope
-    getCurrentEnvelope(uint64 index, NodeID const& id)
+    SCPEnvelope getCurrentEnvelope(uint64 index, NodeID const& id)
     {
         auto r = getEntireState(index);
         auto it = std::find_if(r.begin(), r.end(), [&](SCPEnvelope const& e) {
@@ -309,8 +287,7 @@ class TestSCP : public SCPDriver
         throw std::runtime_error("not found");
     }
 
-    std::set<NodeID>
-    getNominationLeaders(uint64 slotIndex)
+    std::set<NodeID> getNominationLeaders(uint64 slotIndex)
     {
         return mSCP.getSlot(slotIndex, false)->getNominationLeaders();
     }
@@ -318,8 +295,8 @@ class TestSCP : public SCPDriver
     // Copied from HerderSCPDriver.cpp
     static const uint32_t MAX_TIMEOUT_MS = (30 * 60) * 1000;
 
-    std::chrono::milliseconds
-    computeTimeout(uint32 roundNumber, bool isNomination) override
+    std::chrono::milliseconds computeTimeout(uint32 roundNumber,
+                                             bool isNomination) override
     {
         int initialTimeoutMS;
         int incrementMS;
@@ -344,9 +321,8 @@ class TestSCP : public SCPDriver
     }
 };
 
-static SCPEnvelope
-makeEnvelope(SecretKey const& secretKey, uint64 slotIndex,
-             SCPStatement const& statement)
+static SCPEnvelope makeEnvelope(SecretKey const& secretKey, uint64 slotIndex,
+                                SCPStatement const& statement)
 {
     SCPEnvelope envelope;
     envelope.statement = statement;
@@ -358,9 +334,9 @@ makeEnvelope(SecretKey const& secretKey, uint64 slotIndex,
     return envelope;
 }
 
-static SCPEnvelope
-makeExternalize(SecretKey const& secretKey, Hash const& qSetHash,
-                uint64 slotIndex, SCPBallot const& commitBallot, uint32 nH)
+static SCPEnvelope makeExternalize(SecretKey const& secretKey,
+                                   Hash const& qSetHash, uint64 slotIndex,
+                                   SCPBallot const& commitBallot, uint32 nH)
 {
     SCPStatement st;
     st.pledges.type(SCP_ST_EXTERNALIZE);
@@ -372,9 +348,9 @@ makeExternalize(SecretKey const& secretKey, Hash const& qSetHash,
     return makeEnvelope(secretKey, slotIndex, st);
 }
 
-static SCPEnvelope
-makeConfirm(SecretKey const& secretKey, Hash const& qSetHash, uint64 slotIndex,
-            uint32 prepareCounter, SCPBallot const& b, uint32 nC, uint32 nH)
+static SCPEnvelope makeConfirm(SecretKey const& secretKey, Hash const& qSetHash,
+                               uint64 slotIndex, uint32 prepareCounter,
+                               SCPBallot const& b, uint32 nC, uint32 nH)
 {
     SCPStatement st;
     st.pledges.type(SCP_ST_CONFIRM);
@@ -388,10 +364,11 @@ makeConfirm(SecretKey const& secretKey, Hash const& qSetHash, uint64 slotIndex,
     return makeEnvelope(secretKey, slotIndex, st);
 }
 
-static SCPEnvelope
-makePrepare(SecretKey const& secretKey, Hash const& qSetHash, uint64 slotIndex,
-            SCPBallot const& ballot, SCPBallot* prepared = nullptr,
-            uint32 nC = 0, uint32 nH = 0, SCPBallot* preparedPrime = nullptr)
+static SCPEnvelope makePrepare(SecretKey const& secretKey, Hash const& qSetHash,
+                               uint64 slotIndex, SCPBallot const& ballot,
+                               SCPBallot* prepared = nullptr, uint32 nC = 0,
+                               uint32 nH = 0,
+                               SCPBallot* preparedPrime = nullptr)
 {
     SCPStatement st;
     st.pledges.type(SCP_ST_PREPARE);
@@ -414,9 +391,10 @@ makePrepare(SecretKey const& secretKey, Hash const& qSetHash, uint64 slotIndex,
     return makeEnvelope(secretKey, slotIndex, st);
 }
 
-static SCPEnvelope
-makeNominate(SecretKey const& secretKey, Hash const& qSetHash, uint64 slotIndex,
-             std::vector<Value> votes, std::vector<Value> accepted)
+static SCPEnvelope makeNominate(SecretKey const& secretKey,
+                                Hash const& qSetHash, uint64 slotIndex,
+                                std::vector<Value> votes,
+                                std::vector<Value> accepted)
 {
     std::sort(votes.begin(), votes.end());
     std::sort(accepted.begin(), accepted.end());
@@ -436,40 +414,37 @@ makeNominate(SecretKey const& secretKey, Hash const& qSetHash, uint64 slotIndex,
     return makeEnvelope(secretKey, slotIndex, st);
 }
 
-void
-verifyPrepare(SCPEnvelope const& actual, SecretKey const& secretKey,
-              Hash const& qSetHash, uint64 slotIndex, SCPBallot const& ballot,
-              SCPBallot* prepared = nullptr, uint32 nC = 0, uint32 nH = 0,
-              SCPBallot* preparedPrime = nullptr)
+void verifyPrepare(SCPEnvelope const& actual, SecretKey const& secretKey,
+                   Hash const& qSetHash, uint64 slotIndex,
+                   SCPBallot const& ballot, SCPBallot* prepared = nullptr,
+                   uint32 nC = 0, uint32 nH = 0,
+                   SCPBallot* preparedPrime = nullptr)
 {
     auto exp = makePrepare(secretKey, qSetHash, slotIndex, ballot, prepared, nC,
                            nH, preparedPrime);
     REQUIRE(exp.statement == actual.statement);
 }
 
-void
-verifyConfirm(SCPEnvelope const& actual, SecretKey const& secretKey,
-              Hash const& qSetHash, uint64 slotIndex, uint32 nPrepared,
-              SCPBallot const& b, uint32 nC, uint32 nH)
+void verifyConfirm(SCPEnvelope const& actual, SecretKey const& secretKey,
+                   Hash const& qSetHash, uint64 slotIndex, uint32 nPrepared,
+                   SCPBallot const& b, uint32 nC, uint32 nH)
 {
     auto exp =
         makeConfirm(secretKey, qSetHash, slotIndex, nPrepared, b, nC, nH);
     REQUIRE(exp.statement == actual.statement);
 }
 
-void
-verifyExternalize(SCPEnvelope const& actual, SecretKey const& secretKey,
-                  Hash const& qSetHash, uint64 slotIndex,
-                  SCPBallot const& commit, uint32 nH)
+void verifyExternalize(SCPEnvelope const& actual, SecretKey const& secretKey,
+                       Hash const& qSetHash, uint64 slotIndex,
+                       SCPBallot const& commit, uint32 nH)
 {
     auto exp = makeExternalize(secretKey, qSetHash, slotIndex, commit, nH);
     REQUIRE(exp.statement == actual.statement);
 }
 
-void
-verifyNominate(SCPEnvelope const& actual, SecretKey const& secretKey,
-               Hash const& qSetHash, uint64 slotIndex, std::vector<Value> votes,
-               std::vector<Value> accepted)
+void verifyNominate(SCPEnvelope const& actual, SecretKey const& secretKey,
+                    Hash const& qSetHash, uint64 slotIndex,
+                    std::vector<Value> votes, std::vector<Value> accepted)
 {
     auto exp = makeNominate(secretKey, qSetHash, slotIndex, votes, accepted);
     REQUIRE(exp.statement == actual.statement);
@@ -605,26 +580,24 @@ typedef std::function<SCPEnvelope(SecretKey const& sk)> genEnvelope;
 
 using namespace std::placeholders;
 
-static genEnvelope
-makePrepareGen(Hash const& qSetHash, SCPBallot const& ballot,
-               SCPBallot* prepared = nullptr, uint32 nC = 0, uint32 nH = 0,
-               SCPBallot* preparedPrime = nullptr)
+static genEnvelope makePrepareGen(Hash const& qSetHash, SCPBallot const& ballot,
+                                  SCPBallot* prepared = nullptr, uint32 nC = 0,
+                                  uint32 nH = 0,
+                                  SCPBallot* preparedPrime = nullptr)
 {
     return std::bind(makePrepare, _1, std::cref(qSetHash), 0, std::cref(ballot),
                      prepared, nC, nH, preparedPrime);
 }
 
-static genEnvelope
-makeConfirmGen(Hash const& qSetHash, uint32 prepareCounter, SCPBallot const& b,
-               uint32 nC, uint32 nH)
+static genEnvelope makeConfirmGen(Hash const& qSetHash, uint32 prepareCounter,
+                                  SCPBallot const& b, uint32 nC, uint32 nH)
 {
     return std::bind(makeConfirm, _1, std::cref(qSetHash), 0, prepareCounter,
                      std::cref(b), nC, nH);
 }
 
-static genEnvelope
-makeExternalizeGen(Hash const& qSetHash, SCPBallot const& commitBallot,
-                   uint32 nH)
+static genEnvelope makeExternalizeGen(Hash const& qSetHash,
+                                      SCPBallot const& commitBallot, uint32 nH)
 {
     return std::bind(makeExternalize, _1, std::cref(qSetHash), 0,
                      std::cref(commitBallot), nH);
@@ -632,8 +605,7 @@ makeExternalizeGen(Hash const& qSetHash, SCPBallot const& commitBallot,
 
 // Testing matrix that covers interesting min/max values for each timeout
 // parameter
-static void
-testTimeouts(TestSCP& scp, std::function<void(TestSCP&)> f)
+static void testTimeouts(TestSCP& scp, std::function<void(TestSCP&)> f)
 {
     SECTION("minimum values")
     {

--- a/src/scp/test/SCPUnitTests.cpp
+++ b/src/scp/test/SCPUnitTests.cpp
@@ -8,8 +8,7 @@
 
 namespace stellar
 {
-bool
-isNear(uint64 r, double target)
+bool isNear(uint64 r, double target)
 {
     double v = (double)r / (double)UINT64_MAX;
     return (std::abs(v - target) < .01);
@@ -32,38 +31,33 @@ class TestNominationSCP : public SCPDriver
         storeQuorumSet(localQSet);
     }
 
-    void
-    signEnvelope(SCPEnvelope&) override
+    void signEnvelope(SCPEnvelope&) override
     {
     }
 
-    void
-    storeQuorumSet(SCPQuorumSetPtr qSet)
+    void storeQuorumSet(SCPQuorumSetPtr qSet)
     {
         Hash qSetHash = sha256(xdr::xdr_to_opaque(*qSet.get()));
         mQuorumSets[qSetHash] = qSet;
     }
 
-    SCPDriver::ValidationLevel
-    validateValue(uint64 slotIndex, Value const& value,
-                  bool nomination) override
+    SCPDriver::ValidationLevel validateValue(uint64 slotIndex,
+                                             Value const& value,
+                                             bool nomination) override
     {
         return SCPDriver::kFullyValidatedValue;
     }
 
-    SCPQuorumSetPtr
-    getQSet(Hash const& qSetHash) override
+    SCPQuorumSetPtr getQSet(Hash const& qSetHash) override
     {
         if (mQuorumSets.find(qSetHash) != mQuorumSets.end())
         {
-
             return mQuorumSets[qSetHash];
         }
         return SCPQuorumSetPtr();
     }
 
-    void
-    emitEnvelope(SCPEnvelope const& envelope) override
+    void emitEnvelope(SCPEnvelope const& envelope) override
     {
     }
 
@@ -74,28 +68,25 @@ class TestNominationSCP : public SCPDriver
         return nullptr;
     }
 
-    void
-    setupTimer(uint64 slotIndex, int timerID, std::chrono::milliseconds timeout,
-               std::function<void()> cb) override
+    void setupTimer(uint64 slotIndex, int timerID,
+                    std::chrono::milliseconds timeout,
+                    std::function<void()> cb) override
     {
     }
 
-    void
-    stopTimer(uint64 slotIndex, int timerID) override
+    void stopTimer(uint64 slotIndex, int timerID) override
     {
     }
 
     std::map<Hash, SCPQuorumSetPtr> mQuorumSets;
 
-    Value const&
-    getLatestCompositeCandidate(uint64 slotIndex)
+    Value const& getLatestCompositeCandidate(uint64 slotIndex)
     {
         static Value const emptyValue{};
         return emptyValue;
     }
 
-    Hash
-    getHashOf(std::vector<xdr::opaque_vec<>> const& vals) const override
+    Hash getHashOf(std::vector<xdr::opaque_vec<>> const& vals) const override
     {
         SHA256 hasher;
         for (auto const& v : vals)
@@ -108,8 +99,8 @@ class TestNominationSCP : public SCPDriver
     // Copied from HerderSCPDriver.cpp
     static const uint32_t MAX_TIMEOUT_MS = (30 * 60) * 1000;
 
-    std::chrono::milliseconds
-    computeTimeout(uint32 roundNumber, bool isNomination) override
+    std::chrono::milliseconds computeTimeout(uint32 roundNumber,
+                                             bool isNomination) override
     {
         int initialTimeoutMS;
         int incrementMS;
@@ -177,40 +168,34 @@ class NominationTestHandler : public NominationProtocol
     {
     }
 
-    void
-    setPreviousValue(Value const& v)
+    void setPreviousValue(Value const& v)
     {
         mPreviousValue = v;
     }
 
-    void
-    setRoundNumber(int32 n)
+    void setRoundNumber(int32 n)
     {
         mRoundNumber = n;
     }
 
-    void
-    updateRoundLeaders()
+    void updateRoundLeaders()
     {
         NominationProtocol::updateRoundLeaders();
     }
 
-    std::set<NodeID>&
-    getRoundLeaders()
+    std::set<NodeID>& getRoundLeaders()
     {
         return mRoundLeaders;
     }
 
-    uint64
-    getNodePriority(NodeID const& nodeID, SCPQuorumSet const& qset)
+    uint64 getNodePriority(NodeID const& nodeID, SCPQuorumSet const& qset)
     {
         return NominationProtocol::getNodePriority(nodeID, qset);
     }
 };
 
-static SCPQuorumSet
-makeQSet(std::vector<NodeID> const& nodeIDs, int threshold, int total,
-         int offset)
+static SCPQuorumSet makeQSet(std::vector<NodeID> const& nodeIDs, int threshold,
+                             int total, int offset)
 {
     SCPQuorumSet qSet;
     qSet.threshold = threshold;

--- a/src/simulation/ApplyLoad.cpp
+++ b/src/simulation/ApplyLoad.cpp
@@ -32,8 +32,7 @@ namespace stellar
 {
 namespace
 {
-SorobanUpgradeConfig
-getUpgradeConfig(Config const& cfg)
+SorobanUpgradeConfig getUpgradeConfig(Config const& cfg)
 {
     SorobanUpgradeConfig upgradeConfig;
     upgradeConfig.maxContractSizeBytes = 65536;
@@ -98,9 +97,9 @@ getUpgradeConfig(Config const& cfg)
     return upgradeConfig;
 }
 
-SorobanUpgradeConfig
-getUpgradeConfigForMaxTPS(Config const& cfg, uint64_t instructionsPerCluster,
-                          uint32_t totalTxs)
+SorobanUpgradeConfig getUpgradeConfigForMaxTPS(Config const& cfg,
+                                               uint64_t instructionsPerCluster,
+                                               uint32_t totalTxs)
 {
     SorobanUpgradeConfig upgradeConfig;
     upgradeConfig.ledgerMaxDependentTxClusters =
@@ -160,8 +159,7 @@ getUpgradeConfigForMaxTPS(Config const& cfg, uint64_t instructionsPerCluster,
 }
 }
 
-uint64_t
-ApplyLoad::calculateInstructionsPerTx() const
+uint64_t ApplyLoad::calculateInstructionsPerTx() const
 {
     uint32_t batchSize = mApp.getConfig().APPLY_LOAD_BATCH_SAC_COUNT;
     if (batchSize > 1)
@@ -172,8 +170,7 @@ ApplyLoad::calculateInstructionsPerTx() const
     return TxGenerator::SAC_TX_INSTRUCTIONS;
 }
 
-void
-ApplyLoad::upgradeSettingsForMaxTPS(uint32_t txsToGenerate)
+void ApplyLoad::upgradeSettingsForMaxTPS(uint32_t txsToGenerate)
 {
     // Calculate the actual instructions needed for all transactions. The
     // ledger max instructions is the total instruction count per cluster. In
@@ -200,10 +197,8 @@ ApplyLoad::upgradeSettingsForMaxTPS(uint32_t txsToGenerate)
 
 // Given an index, returns the LedgerKey for an archived entry that is
 // pre-populated in the Hot Archive.
-LedgerKey
-ApplyLoad::getKeyForArchivedEntry(uint64_t index)
+LedgerKey ApplyLoad::getKeyForArchivedEntry(uint64_t index)
 {
-
     static const SCAddress hotArchiveContractID = [] {
         SCAddress addr;
         addr.type(SC_ADDRESS_TYPE_CONTRACT);
@@ -220,8 +215,7 @@ ApplyLoad::getKeyForArchivedEntry(uint64_t index)
     return lk;
 }
 
-uint32_t
-ApplyLoad::calculateRequiredHotArchiveEntries(Config const& cfg)
+uint32_t ApplyLoad::calculateRequiredHotArchiveEntries(Config const& cfg)
 {
     // If no RO entries are configured, return 0
     if (cfg.APPLY_LOAD_NUM_DISK_READ_ENTRIES.empty())
@@ -301,8 +295,7 @@ ApplyLoad::ApplyLoad(Application& app, ApplyLoadMode mode)
     setup();
 }
 
-void
-ApplyLoad::setup()
+void ApplyLoad::setup()
 {
     releaseAssert(mTxGenerator.loadAccount(mRoot));
 
@@ -350,10 +343,9 @@ ApplyLoad::setup()
     }
 }
 
-void
-ApplyLoad::closeLedger(std::vector<TransactionFrameBasePtr> const& txs,
-                       xdr::xvector<UpgradeType, 6> const& upgrades,
-                       bool recordSorobanUtilization)
+void ApplyLoad::closeLedger(std::vector<TransactionFrameBasePtr> const& txs,
+                            xdr::xvector<UpgradeType, 6> const& upgrades,
+                            bool recordSorobanUtilization)
 {
     auto txSet = makeTxSetFromTransactions(txs, mApp, 0, 0);
 
@@ -401,8 +393,7 @@ ApplyLoad::closeLedger(std::vector<TransactionFrameBasePtr> const& txs,
     stellar::txtest::closeLedger(mApp, txs, /* strictOrder */ false, upgrades);
 }
 
-void
-ApplyLoad::setupAccounts()
+void ApplyLoad::setupAccounts()
 {
     auto const& lm = mApp.getLedgerManager();
     // pass in false for initialAccounts so we fund new account with a lower
@@ -424,8 +415,7 @@ ApplyLoad::setupAccounts()
     }
 }
 
-void
-ApplyLoad::setupUpgradeContract()
+void ApplyLoad::setupUpgradeContract()
 {
     auto wasm = rust_bridge::get_write_bytes();
     xdr::opaque_vec<> wasmBytes;
@@ -464,8 +454,7 @@ ApplyLoad::setupUpgradeContract()
 
 // To upgrade settings, just modify mUpgradeConfig and then call
 // upgradeSettings()
-void
-ApplyLoad::applyConfigUpgrade(SorobanUpgradeConfig const& upgradeConfig)
+void ApplyLoad::applyConfigUpgrade(SorobanUpgradeConfig const& upgradeConfig)
 {
     int64_t currApplySorobanSuccess =
         mTxGenerator.getApplySorobanSuccess().count();
@@ -499,8 +488,7 @@ ApplyLoad::applyConfigUpgrade(SorobanUpgradeConfig const& upgradeConfig)
                   1);
 }
 
-void
-ApplyLoad::upgradeSettings()
+void ApplyLoad::upgradeSettings()
 {
     releaseAssertOrThrow(mMode != ApplyLoadMode::MAX_SAC_TPS);
 
@@ -508,8 +496,7 @@ ApplyLoad::upgradeSettings()
     applyConfigUpgrade(upgradeConfig);
 }
 
-void
-ApplyLoad::setupLoadContract()
+void ApplyLoad::setupLoadContract()
 {
     auto wasm = rust_bridge::get_test_wasm_loadgen();
     xdr::opaque_vec<> wasmBytes;
@@ -553,8 +540,7 @@ ApplyLoad::setupLoadContract()
         footprintSize(mApp, mLoadInstance.readOnlyKeys);
 }
 
-void
-ApplyLoad::setupXLMContract()
+void ApplyLoad::setupXLMContract()
 {
     int64_t currApplySorobanSuccess =
         mTxGenerator.getApplySorobanSuccess().count();
@@ -578,8 +564,7 @@ ApplyLoad::setupXLMContract()
         footprintSize(mApp, mSACInstanceXLM.readOnlyKeys);
 }
 
-void
-ApplyLoad::setupBatchTransferContracts()
+void ApplyLoad::setupBatchTransferContracts()
 {
     auto const& lm = mApp.getLedgerManager();
 
@@ -658,8 +643,7 @@ ApplyLoad::setupBatchTransferContracts()
     releaseAssertOrThrow(mBatchTransferInstances.size() == numClusters);
 }
 
-void
-ApplyLoad::setupBucketList()
+void ApplyLoad::setupBucketList()
 {
     auto lh = mApp.getLedgerManager().getLastClosedLedgerHeader().header;
     auto& bl = mApp.getBucketManager().getLiveBucketList();
@@ -838,8 +822,7 @@ ApplyLoad::setupBucketList()
     closeLedger({}, {});
 }
 
-void
-ApplyLoad::benchmark()
+void ApplyLoad::benchmark()
 {
     releaseAssertOrThrow(mMode != ApplyLoadMode::MAX_SAC_TPS);
 
@@ -943,8 +926,7 @@ ApplyLoad::benchmark()
     closeLedger(txs, {}, /* recordSorobanUtilization */ true);
 }
 
-double
-ApplyLoad::successRate()
+double ApplyLoad::successRate()
 {
     auto& success =
         mApp.getMetrics().NewCounter({"ledger", "apply", "success"});
@@ -953,44 +935,36 @@ ApplyLoad::successRate()
     return success.count() * 1.0 / (success.count() + failure.count());
 }
 
-medida::Histogram const&
-ApplyLoad::getTxCountUtilization()
+medida::Histogram const& ApplyLoad::getTxCountUtilization()
 {
     return mTxCountUtilization;
 }
-medida::Histogram const&
-ApplyLoad::getInstructionUtilization()
+medida::Histogram const& ApplyLoad::getInstructionUtilization()
 {
     return mInstructionUtilization;
 }
-medida::Histogram const&
-ApplyLoad::getTxSizeUtilization()
+medida::Histogram const& ApplyLoad::getTxSizeUtilization()
 {
     return mTxSizeUtilization;
 }
-medida::Histogram const&
-ApplyLoad::getDiskReadByteUtilization()
+medida::Histogram const& ApplyLoad::getDiskReadByteUtilization()
 {
     return mDiskReadByteUtilization;
 }
-medida::Histogram const&
-ApplyLoad::getDiskWriteByteUtilization()
+medida::Histogram const& ApplyLoad::getDiskWriteByteUtilization()
 {
     return mWriteByteUtilization;
 }
-medida::Histogram const&
-ApplyLoad::getDiskReadEntryUtilization()
+medida::Histogram const& ApplyLoad::getDiskReadEntryUtilization()
 {
     return mDiskReadEntryUtilization;
 }
-medida::Histogram const&
-ApplyLoad::getWriteEntryUtilization()
+medida::Histogram const& ApplyLoad::getWriteEntryUtilization()
 {
     return mWriteEntryUtilization;
 }
 
-void
-ApplyLoad::warmAccountCache()
+void ApplyLoad::warmAccountCache()
 {
     auto const& accounts = mTxGenerator.getAccounts();
     CLOG_INFO(Perf, "Warming account cache with {} accounts.", accounts.size());
@@ -1003,8 +977,7 @@ ApplyLoad::warmAccountCache()
     }
 }
 
-void
-ApplyLoad::findMaxSacTps()
+void ApplyLoad::findMaxSacTps()
 {
     releaseAssertOrThrow(mMode == ApplyLoadMode::MAX_SAC_TPS);
 
@@ -1070,8 +1043,7 @@ ApplyLoad::findMaxSacTps()
     CLOG_WARNING(Perf, "================================================");
 }
 
-double
-ApplyLoad::benchmarkSacTps(uint32_t txsPerLedger)
+double ApplyLoad::benchmarkSacTps(uint32_t txsPerLedger)
 {
     // For timing, we just want to track the TX application itself. This
     // includes charging fees, applying transactions, and post apply work (like
@@ -1141,9 +1113,8 @@ ApplyLoad::benchmarkSacTps(uint32_t txsPerLedger)
     return avgTime;
 }
 
-void
-ApplyLoad::generateSacPayments(std::vector<TransactionFrameBasePtr>& txs,
-                               uint32_t count)
+void ApplyLoad::generateSacPayments(std::vector<TransactionFrameBasePtr>& txs,
+                                    uint32_t count)
 {
     auto const& accounts = mTxGenerator.getAccounts();
     auto& lm = mApp.getLedgerManager();

--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -30,9 +30,8 @@ using namespace stellar;
 //     --test [simulation]~[long]
 //
 
-void
-printStats(int& nLedgers, std::chrono::system_clock::time_point tBegin,
-           Simulation::pointer sim)
+void printStats(int& nLedgers, std::chrono::system_clock::time_point tBegin,
+                Simulation::pointer sim)
 {
     auto t = std::chrono::duration_cast<std::chrono::seconds>(
         std::chrono::system_clock::now() - tBegin);
@@ -160,8 +159,7 @@ TEST_CASE("core topology 4 ledgers at scales 2 to 4",
     }
 }
 
-static void
-resilienceTest(Simulation::pointer sim)
+static void resilienceTest(Simulation::pointer sim)
 {
     auto nodes = sim->getNodeIDs();
     auto nbNodes = nodes.size();
@@ -275,9 +273,8 @@ TEST_CASE("resilience tests", "[resilience][simulation][!hide]")
     }
 }
 
-static void
-hierarchicalTopoTest(int nLedgers, int nBranches, Simulation::Mode mode,
-                     Hash const& networkID)
+static void hierarchicalTopoTest(int nLedgers, int nBranches,
+                                 Simulation::Mode mode, Hash const& networkID)
 {
     LOG_DEBUG(DEFAULT_LOG, "starting topo test {} : {}", nLedgers, nBranches);
 
@@ -319,9 +316,9 @@ TEST_CASE("hierarchical topology scales 1 to 3", "[simulation][acceptance]")
     }
 }
 
-static void
-hierarchicalSimplifiedTest(int nLedgers, int nbCore, int nbOuterNodes,
-                           Simulation::Mode mode, Hash const& networkID)
+static void hierarchicalSimplifiedTest(int nLedgers, int nbCore,
+                                       int nbOuterNodes, Simulation::Mode mode,
+                                       Hash const& networkID)
 {
     LOG_DEBUG(DEFAULT_LOG, "starting simplified test {} : {}", nLedgers,
               nbCore);
@@ -422,8 +419,8 @@ TEST_CASE(
     LOG_INFO(DEFAULT_LOG, "{}", simulation->metricsSummary("database"));
 }
 
-Application::pointer
-newLoadTestApp(VirtualClock& clock, uint32_t accountCount = 0)
+Application::pointer newLoadTestApp(VirtualClock& clock,
+                                    uint32_t accountCount = 0)
 {
     Config cfg =
 #ifdef USE_POSTGRES
@@ -450,8 +447,8 @@ class ScaleReporter
     std::string mFilename;
     std::ofstream mOut;
     size_t mNumWritten{0};
-    static std::string
-    join(std::vector<std::string> const& parts, std::string const& sep)
+    static std::string join(std::vector<std::string> const& parts,
+                            std::string const& sep)
     {
         std::string sum;
         bool first = true;
@@ -487,8 +484,7 @@ class ScaleReporter
         LOG_INFO(DEFAULT_LOG, "Wrote {} rows to {}", mNumWritten, mFilename);
     }
 
-    void
-    write(std::vector<double> const& vals)
+    void write(std::vector<double> const& vals)
     {
         assert(vals.size() == mColumns.size());
         std::ostringstream oss;

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -47,9 +47,8 @@ namespace
 // Sample from a discrete distribution of `values` with weights `weights`.
 // Returns `defaultValue` if `values` is empty.
 template <typename T>
-T
-sampleDiscrete(std::vector<T> const& values,
-               std::vector<uint32_t> const& weights, T defaultValue)
+T sampleDiscrete(std::vector<T> const& values,
+                 std::vector<uint32_t> const& weights, T defaultValue)
 {
     if (values.empty())
     {
@@ -82,8 +81,7 @@ const uint32_t LoadGenerator::COMPLETION_TIMEOUT_WITHOUT_CHECKS = 4;
 // buffer in case loadgen is unstable and needs more accounts)
 const uint32_t LoadGenerator::MIN_UNIQUE_ACCOUNT_MULTIPLIER = 3;
 
-uint32_t
-getTxCount(Application& app, bool isSoroban)
+uint32_t getTxCount(Application& app, bool isSoroban)
 {
     if (isSoroban)
     {
@@ -120,8 +118,7 @@ LoadGenerator::LoadGenerator(Application& app)
 {
 }
 
-LoadGenMode
-LoadGenerator::getMode(std::string const& mode)
+LoadGenMode LoadGenerator::getMode(std::string const& mode)
 {
     if (mode == "pay")
     {
@@ -166,8 +163,7 @@ LoadGenerator::getMode(std::string const& mode)
     }
 }
 
-std::optional<uint32_t>
-LoadGenerator::chooseByteCount(Config const& cfg) const
+std::optional<uint32_t> LoadGenerator::chooseByteCount(Config const& cfg) const
 {
     if (cfg.LOADGEN_BYTE_COUNT_FOR_TESTING.size() == 0)
     {
@@ -177,9 +173,9 @@ LoadGenerator::chooseByteCount(Config const& cfg) const
                           cfg.LOADGEN_BYTE_COUNT_DISTRIBUTION_FOR_TESTING, 0u);
 }
 
-int64_t
-LoadGenerator::getTxPerStep(uint32_t txRate, std::chrono::seconds spikeInterval,
-                            uint32_t spikeSize)
+int64_t LoadGenerator::getTxPerStep(uint32_t txRate,
+                                    std::chrono::seconds spikeInterval,
+                                    uint32_t spikeSize)
 {
     if (!mStartTime)
     {
@@ -210,8 +206,7 @@ LoadGenerator::getTxPerStep(uint32_t txRate, std::chrono::seconds spikeInterval,
     return txs - mTotalSubmitted;
 }
 
-void
-LoadGenerator::cleanupAccounts()
+void LoadGenerator::cleanupAccounts()
 {
     ZoneScoped;
 
@@ -236,8 +231,7 @@ LoadGenerator::cleanupAccounts()
 
 // Reset everything except Soroban persistent state
 // Do not reset pregenerated transaction file position either
-void
-LoadGenerator::reset()
+void LoadGenerator::reset()
 {
     mTxGenerator.reset();
     mAccountsInUse.clear();
@@ -257,16 +251,14 @@ LoadGenerator::reset()
 }
 
 // Reset Soroban persistent state
-void
-LoadGenerator::resetSorobanState()
+void LoadGenerator::resetSorobanState()
 {
     mContractInstanceKeys.clear();
     mCodeKey.reset();
     mContactOverheadBytes = 0;
 }
 
-void
-LoadGenerator::stop()
+void LoadGenerator::stop()
 {
     ZoneScoped;
     if (mStarted)
@@ -282,8 +274,7 @@ LoadGenerator::stop()
     }
 }
 
-void
-LoadGenerator::start(GeneratedLoadConfig& cfg)
+void LoadGenerator::start(GeneratedLoadConfig& cfg)
 {
     if (mStarted)
     {
@@ -442,8 +433,7 @@ LoadGenerator::start(GeneratedLoadConfig& cfg)
     mStarted = true;
 }
 
-ConfigUpgradeSetKey
-LoadGenerator::getConfigUpgradeSetKey(
+ConfigUpgradeSetKey LoadGenerator::getConfigUpgradeSetKey(
     SorobanUpgradeConfig const& upgradeCfg) const
 {
     auto testingKeys = getContractInstanceKeysForTesting();
@@ -454,8 +444,7 @@ LoadGenerator::getConfigUpgradeSetKey(
 }
 
 // Schedule a callback to generateLoad() STEP_MSECS milliseconds from now.
-void
-LoadGenerator::scheduleLoadGeneration(GeneratedLoadConfig cfg)
+void LoadGenerator::scheduleLoadGeneration(GeneratedLoadConfig cfg)
 {
     std::optional<std::string> errorMsg;
     // If previously scheduled step of load did not succeed, fail this loadgen
@@ -560,21 +549,18 @@ LoadGenerator::scheduleLoadGeneration(GeneratedLoadConfig cfg)
     }
 }
 
-bool
-GeneratedLoadConfig::isDone() const
+bool GeneratedLoadConfig::isDone() const
 {
     return (isLoad() && nTxs == 0) ||
            (isSorobanSetup() && getSorobanConfig().nInstances == 0);
 }
 
-bool
-GeneratedLoadConfig::areTxsRemaining() const
+bool GeneratedLoadConfig::areTxsRemaining() const
 {
     return nTxs != 0;
 }
 
-Json::Value
-GeneratedLoadConfig::getStatus() const
+Json::Value GeneratedLoadConfig::getStatus() const
 {
     Json::Value ret;
     std::string modeStr;
@@ -648,8 +634,7 @@ GeneratedLoadConfig::getStatus() const
 // given target number of accounts and txs, and a given target tx/s rate.
 // If work remains after the current step, call scheduleLoadGeneration()
 // with the remainder.
-void
-LoadGenerator::generateLoad(GeneratedLoadConfig cfg)
+void LoadGenerator::generateLoad(GeneratedLoadConfig cfg)
 {
     ZoneScoped;
 
@@ -842,11 +827,11 @@ LoadGenerator::generateLoad(GeneratedLoadConfig cfg)
     scheduleLoadGeneration(cfg);
 }
 
-bool
-LoadGenerator::submitTx(GeneratedLoadConfig const& cfg,
-                        std::function<std::pair<TxGenerator::TestAccountPtr,
-                                                TransactionFrameBaseConstPtr>()>
-                            generateTx)
+bool LoadGenerator::submitTx(
+    GeneratedLoadConfig const& cfg,
+    std::function<
+        std::pair<TxGenerator::TestAccountPtr, TransactionFrameBaseConstPtr>()>
+        generateTx)
 {
     auto [from, tx] = generateTx();
 
@@ -857,7 +842,6 @@ LoadGenerator::submitTx(GeneratedLoadConfig const& cfg,
     while ((status = execute(tx, cfg.mode, code)) !=
            TransactionQueue::AddResultCode::ADD_STATUS_PENDING)
     {
-
         if (cfg.mode != LoadGenMode::PAY_PREGENERATED && cfg.skipLowFeeTxs &&
             (status ==
                  TransactionQueue::AddResultCode::ADD_STATUS_TRY_AGAIN_LATER ||
@@ -895,8 +879,7 @@ LoadGenerator::submitTx(GeneratedLoadConfig const& cfg,
     return true;
 }
 
-uint64_t
-LoadGenerator::getNextAvailableAccount(uint32_t ledgerNum)
+uint64_t LoadGenerator::getNextAvailableAccount(uint32_t ledgerNum)
 {
     uint64_t sourceAccountId;
     do
@@ -938,9 +921,8 @@ LoadGenerator::getNextAvailableAccount(uint32_t ledgerNum)
     return sourceAccountId;
 }
 
-void
-LoadGenerator::logProgress(std::chrono::nanoseconds submitTimer,
-                           GeneratedLoadConfig const& cfg) const
+void LoadGenerator::logProgress(std::chrono::nanoseconds submitTimer,
+                                GeneratedLoadConfig const& cfg) const
 {
     using namespace std::chrono;
 
@@ -1078,11 +1060,9 @@ LoadGenerator::createInstanceTransaction(GeneratedLoadConfig const& cfg,
     return txPair;
 }
 
-void
-LoadGenerator::maybeHandleFailedTx(TransactionFrameBaseConstPtr tx,
-                                   TxGenerator::TestAccountPtr sourceAccount,
-                                   TransactionQueue::AddResultCode status,
-                                   TransactionResultCode code)
+void LoadGenerator::maybeHandleFailedTx(
+    TransactionFrameBaseConstPtr tx, TxGenerator::TestAccountPtr sourceAccount,
+    TransactionQueue::AddResultCode status, TransactionResultCode code)
 {
     // Note that if transaction is a DUPLICATE, its sequence number is
     // incremented on the next call to execute.
@@ -1171,8 +1151,7 @@ LoadGenerator::checkAccountSynced(Application& app)
     return result;
 }
 
-bool
-LoadGenerator::checkMinimumSorobanSuccess(GeneratedLoadConfig const& cfg)
+bool LoadGenerator::checkMinimumSorobanSuccess(GeneratedLoadConfig const& cfg)
 {
     if (!cfg.isSoroban())
     {
@@ -1196,8 +1175,7 @@ LoadGenerator::checkMinimumSorobanSuccess(GeneratedLoadConfig const& cfg)
     return (nSuccessful * 100) / nTxns >= cfg.getMinSorobanPercentSuccess();
 }
 
-void
-LoadGenerator::waitTillComplete(GeneratedLoadConfig cfg)
+void LoadGenerator::waitTillComplete(GeneratedLoadConfig cfg)
 {
     if (!mLoadTimer)
     {
@@ -1275,8 +1253,7 @@ LoadGenerator::waitTillComplete(GeneratedLoadConfig cfg)
     }
 }
 
-void
-LoadGenerator::emitFailure(bool resetSoroban)
+void LoadGenerator::emitFailure(bool resetSoroban)
 {
     CLOG_INFO(LoadGen, "Load generation failed.");
     mLoadgenFail.Mark();
@@ -1287,8 +1264,7 @@ LoadGenerator::emitFailure(bool resetSoroban)
     }
 }
 
-void
-LoadGenerator::waitTillCompleteWithoutChecks()
+void LoadGenerator::waitTillCompleteWithoutChecks()
 {
     if (!mLoadTimer)
     {
@@ -1333,8 +1309,7 @@ LoadGenerator::TxMetrics::TxMetrics(medida::MetricsRegistry& m)
 {
 }
 
-void
-LoadGenerator::TxMetrics::report()
+void LoadGenerator::TxMetrics::report()
 {
     CLOG_DEBUG(LoadGen,
                "Counts: {} tx, {} rj, {} by, {} na, {} "
@@ -1422,7 +1397,6 @@ LoadGenerator::execute(TransactionFrameBasePtr txf, LoadGenMode mode,
         mApp.getHerder().recvTransaction(txf, true, isPregeneratedTx);
     if (addResult.code != TransactionQueue::AddResultCode::ADD_STATUS_PENDING)
     {
-
         auto resultStr = addResult.txResult
                              ? xdrToCerealString(addResult.txResult->getXDR(),
                                                  "TransactionResult")
@@ -1448,8 +1422,7 @@ LoadGenerator::execute(TransactionFrameBasePtr txf, LoadGenMode mode,
     return addResult.code;
 }
 
-void
-GeneratedLoadConfig::copySorobanNetworkConfigToUpgradeConfig(
+void GeneratedLoadConfig::copySorobanNetworkConfigToUpgradeConfig(
     SorobanNetworkConfig const& baseConfig,
     SorobanNetworkConfig const& updatedConfig)
 {
@@ -1554,10 +1527,8 @@ GeneratedLoadConfig::copySorobanNetworkConfigToUpgradeConfig(
         updatedConfig.nominationTimeoutIncrementMilliseconds();
 }
 
-GeneratedLoadConfig
-GeneratedLoadConfig::createSorobanInvokeSetupLoad(uint32_t nAccounts,
-                                                  uint32_t nInstances,
-                                                  uint32_t txRate)
+GeneratedLoadConfig GeneratedLoadConfig::createSorobanInvokeSetupLoad(
+    uint32_t nAccounts, uint32_t nInstances, uint32_t txRate)
 {
     GeneratedLoadConfig cfg;
     cfg.mode = LoadGenMode::SOROBAN_INVOKE_SETUP;
@@ -1567,8 +1538,7 @@ GeneratedLoadConfig::createSorobanInvokeSetupLoad(uint32_t nAccounts,
     return cfg;
 }
 
-GeneratedLoadConfig
-GeneratedLoadConfig::createSorobanUpgradeSetupLoad()
+GeneratedLoadConfig GeneratedLoadConfig::createSorobanUpgradeSetupLoad()
 {
     GeneratedLoadConfig cfg;
     cfg.mode = LoadGenMode::SOROBAN_UPGRADE_SETUP;
@@ -1578,10 +1548,11 @@ GeneratedLoadConfig::createSorobanUpgradeSetupLoad()
     return cfg;
 }
 
-GeneratedLoadConfig
-GeneratedLoadConfig::txLoad(LoadGenMode mode, uint32_t nAccounts, uint32_t nTxs,
-                            uint32_t txRate, uint32_t offset,
-                            std::optional<uint32_t> maxFee)
+GeneratedLoadConfig GeneratedLoadConfig::txLoad(LoadGenMode mode,
+                                                uint32_t nAccounts,
+                                                uint32_t nTxs, uint32_t txRate,
+                                                uint32_t offset,
+                                                std::optional<uint32_t> maxFee)
 {
     GeneratedLoadConfig cfg;
     cfg.mode = mode;
@@ -1609,8 +1580,7 @@ GeneratedLoadConfig::pregeneratedTxLoad(uint32_t nAccounts, uint32_t nTxs,
     return cfg;
 }
 
-GeneratedLoadConfig::SorobanConfig&
-GeneratedLoadConfig::getMutSorobanConfig()
+GeneratedLoadConfig::SorobanConfig& GeneratedLoadConfig::getMutSorobanConfig()
 {
     releaseAssert(isSoroban() && mode != LoadGenMode::SOROBAN_UPLOAD);
     return sorobanConfig;
@@ -1623,15 +1593,13 @@ GeneratedLoadConfig::getSorobanConfig() const
     return sorobanConfig;
 }
 
-SorobanUpgradeConfig&
-GeneratedLoadConfig::getMutSorobanUpgradeConfig()
+SorobanUpgradeConfig& GeneratedLoadConfig::getMutSorobanUpgradeConfig()
 {
     releaseAssert(mode == LoadGenMode::SOROBAN_CREATE_UPGRADE);
     return sorobanUpgradeConfig;
 }
 
-SorobanUpgradeConfig const&
-GeneratedLoadConfig::getSorobanUpgradeConfig() const
+SorobanUpgradeConfig const& GeneratedLoadConfig::getSorobanUpgradeConfig() const
 {
     releaseAssert(mode == LoadGenMode::SOROBAN_CREATE_UPGRADE);
     return sorobanUpgradeConfig;
@@ -1651,15 +1619,13 @@ GeneratedLoadConfig::getMixClassicSorobanConfig() const
     return mixClassicSorobanConfig;
 }
 
-uint32_t
-GeneratedLoadConfig::getMinSorobanPercentSuccess() const
+uint32_t GeneratedLoadConfig::getMinSorobanPercentSuccess() const
 {
     releaseAssert(isSoroban());
     return mMinSorobanPercentSuccess;
 }
 
-void
-GeneratedLoadConfig::setMinSorobanPercentSuccess(uint32_t percent)
+void GeneratedLoadConfig::setMinSorobanPercentSuccess(uint32_t percent)
 {
     releaseAssert(isSoroban());
     if (percent > 100)
@@ -1669,8 +1635,7 @@ GeneratedLoadConfig::setMinSorobanPercentSuccess(uint32_t percent)
     mMinSorobanPercentSuccess = percent;
 }
 
-bool
-GeneratedLoadConfig::isSoroban() const
+bool GeneratedLoadConfig::isSoroban() const
 {
     return mode == LoadGenMode::SOROBAN_INVOKE ||
            mode == LoadGenMode::SOROBAN_INVOKE_SETUP ||
@@ -1681,15 +1646,13 @@ GeneratedLoadConfig::isSoroban() const
            mode == LoadGenMode::SOROBAN_INVOKE_APPLY_LOAD;
 }
 
-bool
-GeneratedLoadConfig::isSorobanSetup() const
+bool GeneratedLoadConfig::isSorobanSetup() const
 {
     return mode == LoadGenMode::SOROBAN_INVOKE_SETUP ||
            mode == LoadGenMode::SOROBAN_UPGRADE_SETUP;
 }
 
-bool
-GeneratedLoadConfig::isLoad() const
+bool GeneratedLoadConfig::isLoad() const
 {
     return mode == LoadGenMode::PAY || mode == LoadGenMode::SOROBAN_UPLOAD ||
            mode == LoadGenMode::SOROBAN_INVOKE ||
@@ -1699,22 +1662,19 @@ GeneratedLoadConfig::isLoad() const
            mode == LoadGenMode::SOROBAN_INVOKE_APPLY_LOAD;
 }
 
-bool
-GeneratedLoadConfig::modeInvokes() const
+bool GeneratedLoadConfig::modeInvokes() const
 {
     return mode == LoadGenMode::SOROBAN_INVOKE ||
            mode == LoadGenMode::MIXED_CLASSIC_SOROBAN ||
            mode == LoadGenMode::SOROBAN_INVOKE_APPLY_LOAD;
 }
 
-bool
-GeneratedLoadConfig::modeSetsUpInvoke() const
+bool GeneratedLoadConfig::modeSetsUpInvoke() const
 {
     return mode == LoadGenMode::SOROBAN_INVOKE_SETUP;
 }
 
-bool
-GeneratedLoadConfig::modeUploads() const
+bool GeneratedLoadConfig::modeUploads() const
 {
     return mode == LoadGenMode::SOROBAN_UPLOAD ||
            mode == LoadGenMode::MIXED_CLASSIC_SOROBAN;

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -183,20 +183,17 @@ class LoadGenerator
     std::vector<LedgerKey>
     checkSorobanStateSynced(Application& app, GeneratedLoadConfig const& cfg);
 
-    UnorderedSet<LedgerKey> const&
-    getContractInstanceKeysForTesting() const
+    UnorderedSet<LedgerKey> const& getContractInstanceKeysForTesting() const
     {
         return mContractInstanceKeys;
     }
 
-    std::optional<LedgerKey> const&
-    getCodeKeyForTesting() const
+    std::optional<LedgerKey> const& getCodeKeyForTesting() const
     {
         return mCodeKey;
     }
 
-    uint64_t
-    getContactOverheadBytesForTesting() const
+    uint64_t getContactOverheadBytesForTesting() const
     {
         return mContactOverheadBytes;
     }

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -67,8 +67,7 @@ Simulation::~Simulation()
                std::chrono::seconds(20), false);
 }
 
-void
-Simulation::setCurrentVirtualTime(VirtualClock::time_point t)
+void Simulation::setCurrentVirtualTime(VirtualClock::time_point t)
 {
     mClock.setCurrentVirtualTime(t);
     for (auto& p : mNodes)
@@ -77,8 +76,7 @@ Simulation::setCurrentVirtualTime(VirtualClock::time_point t)
     }
 }
 
-void
-Simulation::setCurrentVirtualTime(VirtualClock::system_time_point t)
+void Simulation::setCurrentVirtualTime(VirtualClock::system_time_point t)
 {
     mClock.setCurrentVirtualTime(t);
     for (auto& p : mNodes)
@@ -87,9 +85,8 @@ Simulation::setCurrentVirtualTime(VirtualClock::system_time_point t)
     }
 }
 
-Application::pointer
-Simulation::addNode(SecretKey nodeKey, SCPQuorumSet qSet, Config const* cfg2,
-                    bool newDB)
+Application::pointer Simulation::addNode(SecretKey nodeKey, SCPQuorumSet qSet,
+                                         Config const* cfg2, bool newDB)
 {
     auto cfg = cfg2 ? std::make_shared<Config>(*cfg2)
                     : std::make_shared<Config>(newConfig());
@@ -139,21 +136,18 @@ Simulation::addNode(SecretKey nodeKey, SCPQuorumSet qSet, Config const* cfg2,
     return app;
 }
 
-Application::pointer
-Simulation::getNode(NodeID nodeID)
+Application::pointer Simulation::getNode(NodeID nodeID)
 {
     return mNodes[nodeID].mApp;
 }
-vector<Application::pointer>
-Simulation::getNodes()
+vector<Application::pointer> Simulation::getNodes()
 {
     vector<Application::pointer> result;
     for (auto const& p : mNodes)
         result.push_back(p.second.mApp);
     return result;
 }
-vector<NodeID>
-Simulation::getNodeIDs()
+vector<NodeID> Simulation::getNodeIDs()
 {
     vector<NodeID> result;
     for (auto const& p : mNodes)
@@ -161,8 +155,7 @@ Simulation::getNodeIDs()
     return result;
 }
 
-void
-Simulation::removeNode(NodeID const& id)
+void Simulation::removeNode(NodeID const& id)
 {
     auto it = mNodes.find(id);
     if (it != mNodes.end())
@@ -180,8 +173,7 @@ Simulation::removeNode(NodeID const& id)
     }
 }
 
-Application::pointer
-Simulation::getAppFromPeerMap(unsigned short peerPort)
+Application::pointer Simulation::getAppFromPeerMap(unsigned short peerPort)
 {
     releaseAssert(mMode == OVER_LOOPBACK);
     auto it = mPeerMap.find(peerPort);
@@ -199,8 +191,7 @@ Simulation::getAppFromPeerMap(unsigned short peerPort)
     return nullptr;
 }
 
-void
-Simulation::dropAllConnections(NodeID const& id)
+void Simulation::dropAllConnections(NodeID const& id)
 {
     if (mMode == OVER_LOOPBACK)
     {
@@ -226,15 +217,13 @@ Simulation::dropAllConnections(NodeID const& id)
     }
 }
 
-void
-Simulation::addPendingConnection(NodeID const& initiator,
-                                 NodeID const& acceptor)
+void Simulation::addPendingConnection(NodeID const& initiator,
+                                      NodeID const& acceptor)
 {
     mPendingConnections.push_back(std::make_pair(initiator, acceptor));
 }
 
-void
-Simulation::addConnection(NodeID initiator, NodeID acceptor)
+void Simulation::addConnection(NodeID initiator, NodeID acceptor)
 {
     if (mMode == OVER_LOOPBACK)
         addLoopbackConnection(initiator, acceptor);
@@ -242,8 +231,7 @@ Simulation::addConnection(NodeID initiator, NodeID acceptor)
         addTCPConnection(initiator, acceptor);
 }
 
-void
-Simulation::dropConnection(NodeID initiator, NodeID acceptor)
+void Simulation::dropConnection(NodeID initiator, NodeID acceptor)
 {
     if (mMode == OVER_LOOPBACK)
         dropLoopbackConnection(initiator, acceptor);
@@ -264,8 +252,7 @@ Simulation::dropConnection(NodeID initiator, NodeID acceptor)
     }
 }
 
-void
-Simulation::addLoopbackConnection(NodeID initiator, NodeID acceptor)
+void Simulation::addLoopbackConnection(NodeID initiator, NodeID acceptor)
 {
     if (mNodes[initiator].mApp && mNodes[acceptor].mApp)
     {
@@ -291,8 +278,7 @@ Simulation::getLoopbackConnection(NodeID const& initiator,
     return it == std::end(mLoopbackConnections) ? nullptr : *it;
 }
 
-void
-Simulation::dropLoopbackConnection(NodeID initiator, NodeID acceptor)
+void Simulation::dropLoopbackConnection(NodeID initiator, NodeID acceptor)
 {
     auto it = std::find_if(
         std::begin(mLoopbackConnections), std::end(mLoopbackConnections),
@@ -308,8 +294,7 @@ Simulation::dropLoopbackConnection(NodeID initiator, NodeID acceptor)
     }
 }
 
-void
-Simulation::addTCPConnection(NodeID initiator, NodeID acceptor)
+void Simulation::addTCPConnection(NodeID initiator, NodeID acceptor)
 {
     if (mMode != OVER_TCP)
     {
@@ -325,8 +310,7 @@ Simulation::addTCPConnection(NodeID initiator, NodeID acceptor)
     from->getOverlayManager().connectTo(address);
 }
 
-void
-Simulation::stopOverlayTick()
+void Simulation::stopOverlayTick()
 {
     auto cancel = [](Application::pointer app) {
         auto& ov = static_cast<OverlayManagerImpl&>(app->getOverlayManager());
@@ -339,8 +323,7 @@ Simulation::stopOverlayTick()
     }
 }
 
-std::chrono::milliseconds
-Simulation::getExpectedLedgerCloseTime() const
+std::chrono::milliseconds Simulation::getExpectedLedgerCloseTime() const
 {
     if (mNodes.empty())
     {
@@ -352,8 +335,7 @@ Simulation::getExpectedLedgerCloseTime() const
     return node->getLedgerManager().getExpectedLedgerCloseTime();
 }
 
-void
-Simulation::startAllNodes()
+void Simulation::startAllNodes()
 {
     for (auto const& it : mNodes)
     {
@@ -371,8 +353,7 @@ Simulation::startAllNodes()
     mPendingConnections.clear();
 }
 
-void
-Simulation::stopAllNodes()
+void Simulation::stopAllNodes()
 {
     for (auto& n : mNodes)
     {
@@ -384,8 +365,7 @@ Simulation::stopAllNodes()
         ;
 }
 
-size_t
-Simulation::crankNode(NodeID const& id, VirtualClock::time_point timeout)
+size_t Simulation::crankNode(NodeID const& id, VirtualClock::time_point timeout)
 {
     auto p = mNodes[id];
     auto clock = p.mClock;
@@ -436,10 +416,8 @@ Simulation::crankNode(NodeID const& id, VirtualClock::time_point timeout)
     return count - quantumClicks;
 }
 
-std::size_t
-Simulation::crankAllNodes(int nbTicks)
+std::size_t Simulation::crankAllNodes(int nbTicks)
 {
-
     std::size_t count = 0;
 
     VirtualTimer mainQuantumTimer(*mIdleApp);
@@ -536,9 +514,8 @@ Simulation::crankAllNodes(int nbTicks)
     return count;
 }
 
-bool
-Simulation::haveAllExternalized(uint32 num, uint32 maxSpread,
-                                bool validatorsOnly)
+bool Simulation::haveAllExternalized(uint32 num, uint32 maxSpread,
+                                     bool validatorsOnly)
 {
     uint32_t min = UINT32_MAX, max = 0;
     for (auto it = mNodes.begin(); it != mNodes.end(); ++it)
@@ -563,8 +540,7 @@ Simulation::haveAllExternalized(uint32 num, uint32 maxSpread,
     return num <= min;
 }
 
-void
-Simulation::crankForAtMost(VirtualClock::duration seconds, bool finalCrank)
+void Simulation::crankForAtMost(VirtualClock::duration seconds, bool finalCrank)
 {
     bool stop = false;
     auto stopIt = [&](asio::error_code const& error) {
@@ -591,8 +567,8 @@ Simulation::crankForAtMost(VirtualClock::duration seconds, bool finalCrank)
     }
 }
 
-void
-Simulation::crankForAtLeast(VirtualClock::duration seconds, bool finalCrank)
+void Simulation::crankForAtLeast(VirtualClock::duration seconds,
+                                 bool finalCrank)
 {
     bool stop = false;
     auto stopIt = [&](asio::error_code const& error) {
@@ -620,9 +596,8 @@ Simulation::crankForAtLeast(VirtualClock::duration seconds, bool finalCrank)
     }
 }
 
-void
-Simulation::crankUntil(function<bool()> const& predicate,
-                       VirtualClock::duration timeout, bool finalCrank)
+void Simulation::crankUntil(function<bool()> const& predicate,
+                            VirtualClock::duration timeout, bool finalCrank)
 {
     bool timedOut = false;
     VirtualTimer timeoutTimer(*mIdleApp);
@@ -675,8 +650,7 @@ Simulation::crankUntil(function<bool()> const& predicate,
     }
 }
 
-void
-Simulation::crankUntil(VirtualClock::time_point timePoint, bool finalCrank)
+void Simulation::crankUntil(VirtualClock::time_point timePoint, bool finalCrank)
 {
     bool stop = false;
     auto stopIt = [&](asio::error_code const& error) {
@@ -701,16 +675,14 @@ Simulation::crankUntil(VirtualClock::time_point timePoint, bool finalCrank)
     }
 }
 
-void
-Simulation::crankUntil(VirtualClock::system_time_point timePoint,
-                       bool finalCrank)
+void Simulation::crankUntil(VirtualClock::system_time_point timePoint,
+                            bool finalCrank)
 {
     crankUntil(VirtualClock::time_point(timePoint.time_since_epoch()),
                finalCrank);
 }
 
-Config
-Simulation::newConfig()
+Config Simulation::newConfig()
 {
     Config cfg;
     if (mConfigGen)
@@ -739,8 +711,7 @@ class ConsoleReporterWithSum : public medida::reporting::ConsoleReporter
     {
     }
 
-    void
-    Process(medida::Timer& timer) override
+    void Process(medida::Timer& timer) override
     {
         auto snapshot = timer.GetSnapshot();
         auto unit = "ms";
@@ -754,8 +725,7 @@ class ConsoleReporterWithSum : public medida::reporting::ConsoleReporter
     }
 };
 
-string
-Simulation::metricsSummary(string domain)
+string Simulation::metricsSummary(string domain)
 {
     auto& registry = getNodes().front()->getMetrics();
     auto const& metrics = registry.GetAllMetrics();
@@ -775,9 +745,8 @@ Simulation::metricsSummary(string domain)
     return out.str();
 }
 
-bool
-LoopbackOverlayManager::connectToImpl(PeerBareAddress const& address,
-                                      bool forceoutbound)
+bool LoopbackOverlayManager::connectToImpl(PeerBareAddress const& address,
+                                           bool forceoutbound)
 {
     CLOG_TRACE(Overlay, "Connect to {}", address.toString());
     auto currentConnection = getConnectedPeer(address);

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 // Copyright 2014 Stellar Development Foundation and contributors. Licensed
@@ -94,14 +93,12 @@ class Simulation
 
     std::chrono::milliseconds getExpectedLedgerCloseTime() const;
 
-    bool
-    isSetUpForSorobanUpgrade() const
+    bool isSetUpForSorobanUpgrade() const
     {
         return mSetupForSorobanUpgrade;
     }
 
-    void
-    markReadyForSorobanUpgrade()
+    void markReadyForSorobanUpgrade()
     {
         mSetupForSorobanUpgrade = true;
     }
@@ -166,22 +163,19 @@ class ApplicationLoopbackOverlay : public TestApplication
     {
     }
 
-    virtual LoopbackOverlayManager&
-    getOverlayManager() override
+    virtual LoopbackOverlayManager& getOverlayManager() override
     {
         auto& overlay = ApplicationImpl::getOverlayManager();
         return static_cast<LoopbackOverlayManager&>(overlay);
     }
 
-    Simulation&
-    getSim()
+    Simulation& getSim()
     {
         return mSim;
     }
 
   private:
-    virtual std::unique_ptr<OverlayManager>
-    createOverlayManager() override
+    virtual std::unique_ptr<OverlayManager> createOverlayManager() override
     {
         return std::make_unique<LoopbackOverlayManager>(*this);
     }

--- a/src/simulation/Topologies.cpp
+++ b/src/simulation/Topologies.cpp
@@ -9,10 +9,10 @@ namespace stellar
 {
 using namespace std;
 
-Simulation::pointer
-Topologies::pair(Simulation::Mode mode, Hash const& networkID,
-                 Simulation::ConfigGen confGen,
-                 Simulation::QuorumSetAdjuster qSetAdjust)
+Simulation::pointer Topologies::pair(Simulation::Mode mode,
+                                     Hash const& networkID,
+                                     Simulation::ConfigGen confGen,
+                                     Simulation::QuorumSetAdjuster qSetAdjust)
 {
     Simulation::pointer simulation =
         make_shared<Simulation>(mode, networkID, confGen, qSetAdjust);
@@ -33,9 +33,9 @@ Topologies::pair(Simulation::Mode mode, Hash const& networkID,
     return simulation;
 }
 
-Simulation::pointer
-Topologies::cycle4(Hash const& networkID, Simulation::ConfigGen confGen,
-                   Simulation::QuorumSetAdjuster qSetAdjust)
+Simulation::pointer Topologies::cycle4(Hash const& networkID,
+                                       Simulation::ConfigGen confGen,
+                                       Simulation::QuorumSetAdjuster qSetAdjust)
 {
     Simulation::pointer simulation = make_shared<Simulation>(
         Simulation::OVER_LOOPBACK, networkID, confGen, qSetAdjust);
@@ -123,11 +123,11 @@ Topologies::separate(int nNodes, double quorumThresoldFraction,
     return simulation;
 }
 
-Simulation::pointer
-Topologies::core(int nNodes, double quorumThresoldFraction,
-                 Simulation::Mode mode, Hash const& networkID,
-                 Simulation::ConfigGen confGen,
-                 Simulation::QuorumSetAdjuster qSetAdjust)
+Simulation::pointer Topologies::core(int nNodes, double quorumThresoldFraction,
+                                     Simulation::Mode mode,
+                                     Hash const& networkID,
+                                     Simulation::ConfigGen confGen,
+                                     Simulation::QuorumSetAdjuster qSetAdjust)
 {
     auto simulation = Topologies::separate(nNodes, quorumThresoldFraction, mode,
                                            networkID, 0, confGen, qSetAdjust);
@@ -146,11 +146,11 @@ Topologies::core(int nNodes, double quorumThresoldFraction,
     return simulation;
 }
 
-Simulation::pointer
-Topologies::cycle(int nNodes, double quorumThresoldFraction,
-                  Simulation::Mode mode, Hash const& networkID,
-                  Simulation::ConfigGen confGen,
-                  Simulation::QuorumSetAdjuster qSetAdjust)
+Simulation::pointer Topologies::cycle(int nNodes, double quorumThresoldFraction,
+                                      Simulation::Mode mode,
+                                      Hash const& networkID,
+                                      Simulation::ConfigGen confGen,
+                                      Simulation::QuorumSetAdjuster qSetAdjust)
 {
     auto simulation = Topologies::separate(nNodes, quorumThresoldFraction, mode,
                                            networkID, 0, confGen, qSetAdjust);
@@ -191,8 +191,7 @@ Topologies::branchedcycle(int nNodes, double quorumThresoldFraction,
     return simulation;
 }
 
-Simulation::pointer
-Topologies::hierarchicalQuorum(
+Simulation::pointer Topologies::hierarchicalQuorum(
     int nBranches, Simulation::Mode mode, Hash const& networkID,
     Simulation::ConfigGen confGen, int connectionsToCore,
     Simulation::QuorumSetAdjuster qSetAdjust) // Figure 3 from the paper
@@ -257,8 +256,7 @@ Topologies::hierarchicalQuorum(
     return sim;
 }
 
-Simulation::pointer
-Topologies::hierarchicalQuorumSimplified(
+Simulation::pointer Topologies::hierarchicalQuorumSimplified(
     int coreSize, int nbOuterNodes, Simulation::Mode mode,
     Hash const& networkID, Simulation::ConfigGen confGen, int connectionsToCore,
     Simulation::QuorumSetAdjuster qSetAdjust)
@@ -384,7 +382,6 @@ Topologies::asymmetric(Simulation::Mode mode, Hash const& networkID,
                        Simulation::ConfigGen confGen, int connections,
                        Simulation::QuorumSetAdjuster qSetAdjust)
 {
-
     Simulation::pointer s =
         Topologies::core(10, 0.7, mode, networkID, confGen, qSetAdjust);
     auto node = s->getNodes()[0];

--- a/src/simulation/TxGenerator.cpp
+++ b/src/simulation/TxGenerator.cpp
@@ -29,9 +29,8 @@ constexpr uint32_t DEFAULT_INSTRUCTIONS = 28'000'000;
 // Sample from a discrete distribution of `values` with weights `weights`.
 // Returns `defaultValue` if `values` is empty.
 template <typename T>
-T
-sampleDiscrete(std::vector<T> const& values,
-               std::vector<uint32_t> const& weights, T defaultValue)
+T sampleDiscrete(std::vector<T> const& values,
+                 std::vector<uint32_t> const& weights, T defaultValue)
 {
     if (values.empty())
     {
@@ -44,8 +43,8 @@ sampleDiscrete(std::vector<T> const& values,
 }
 } // namespace
 
-uint64_t
-footprintSize(Application& app, xdr::xvector<stellar::LedgerKey> const& keys)
+uint64_t footprintSize(Application& app,
+                       xdr::xvector<stellar::LedgerKey> const& keys)
 {
     LedgerSnapshot lsg(app);
     uint64_t total = 0;
@@ -72,8 +71,7 @@ TxGenerator::TxGenerator(Application& app, uint32_t prePopulatedArchivedEntries)
     updateMinBalance();
 }
 
-void
-TxGenerator::updateMinBalance()
+void TxGenerator::updateMinBalance()
 {
     auto b = mApp.getLedgerManager().getLastMinBalance(0);
     if (b > mMinBalance)
@@ -82,8 +80,7 @@ TxGenerator::updateMinBalance()
     }
 }
 
-bool
-TxGenerator::isLive(LedgerKey const& lk, uint32_t ledgerNum) const
+bool TxGenerator::isLive(LedgerKey const& lk, uint32_t ledgerNum) const
 {
     LedgerSnapshot lsg(mApp);
     auto ttlEntryPtr = lsg.load(getTTLKey(lk));
@@ -91,9 +88,8 @@ TxGenerator::isLive(LedgerKey const& lk, uint32_t ledgerNum) const
     return ttlEntryPtr && stellar::isLive(ttlEntryPtr.current(), ledgerNum);
 }
 
-int
-TxGenerator::generateFee(std::optional<uint32_t> maxGeneratedFeeRate,
-                         size_t opsCnt)
+int TxGenerator::generateFee(std::optional<uint32_t> maxGeneratedFeeRate,
+                             size_t opsCnt)
 {
     int fee = 0;
     auto baseFee = mApp.getLedgerManager().getLastTxFee();
@@ -123,8 +119,7 @@ TxGenerator::generateFee(std::optional<uint32_t> maxGeneratedFeeRate,
     return fee;
 }
 
-bool
-TxGenerator::loadAccount(TestAccount& account)
+bool TxGenerator::loadAccount(TestAccount& account)
 {
     LedgerSnapshot lsg(mApp);
     auto const entry = lsg.getAccount(account.getPublicKey());
@@ -136,8 +131,7 @@ TxGenerator::loadAccount(TestAccount& account)
     return true;
 }
 
-bool
-TxGenerator::loadAccount(TxGenerator::TestAccountPtr acc)
+bool TxGenerator::loadAccount(TxGenerator::TestAccountPtr acc)
 {
     if (acc)
     {
@@ -164,8 +158,8 @@ TxGenerator::pickAccountPair(uint32_t numAccounts, uint32_t offset,
         sourceAccount, destAccount);
 }
 
-TxGenerator::TestAccountPtr
-TxGenerator::findAccount(uint64_t accountId, uint32_t ledgerNum)
+TxGenerator::TestAccountPtr TxGenerator::findAccount(uint64_t accountId,
+                                                     uint32_t ledgerNum)
 {
     // Load account and cache it.
     TxGenerator::TestAccountPtr newAccountPtr;
@@ -202,9 +196,10 @@ TxGenerator::findAccount(uint64_t accountId, uint32_t ledgerNum)
     return newAccountPtr;
 }
 
-std::vector<Operation>
-TxGenerator::createAccounts(uint64_t start, uint64_t count, uint32_t ledgerNum,
-                            bool initialAccounts)
+std::vector<Operation> TxGenerator::createAccounts(uint64_t start,
+                                                   uint64_t count,
+                                                   uint32_t ledgerNum,
+                                                   bool initialAccounts)
 {
     vector<Operation> ops;
     SequenceNumber sn = static_cast<SequenceNumber>(ledgerNum) << 32;
@@ -222,8 +217,7 @@ TxGenerator::createAccounts(uint64_t start, uint64_t count, uint32_t ledgerNum,
     return ops;
 }
 
-TransactionFrameBasePtr
-TxGenerator::createTransactionFramePtr(
+TransactionFrameBasePtr TxGenerator::createTransactionFramePtr(
     TxGenerator::TestAccountPtr from, std::vector<Operation> ops,
     std::optional<uint32_t> maxGeneratedFeeRate)
 {
@@ -234,8 +228,7 @@ TxGenerator::createTransactionFramePtr(
     return txf;
 }
 
-TransactionFrameBasePtr
-TxGenerator::createTransactionFramePtr(
+TransactionFrameBasePtr TxGenerator::createTransactionFramePtr(
     TxGenerator::TestAccountPtr from, std::vector<Operation> ops,
     std::optional<uint32_t> maxGeneratedFeeRate,
     std::optional<uint32_t> byteCount)
@@ -356,8 +349,7 @@ TxGenerator::createSACTransaction(uint32_t ledgerNum,
     return std::make_pair(account, tx);
 }
 
-static void
-increaseOpSize(Operation& op, uint32_t increaseUpToBytes)
+static void increaseOpSize(Operation& op, uint32_t increaseUpToBytes)
 {
     if (increaseUpToBytes == 0)
     {
@@ -820,26 +812,22 @@ TxGenerator::getAccounts()
     return mAccounts;
 }
 
-medida::Counter const&
-TxGenerator::getApplySorobanSuccess()
+medida::Counter const& TxGenerator::getApplySorobanSuccess()
 {
     return mApplySorobanSuccess;
 }
 
-medida::Counter const&
-TxGenerator::getApplySorobanFailure()
+medida::Counter const& TxGenerator::getApplySorobanFailure()
 {
     return mApplySorobanFailure;
 }
 
-void
-TxGenerator::reset()
+void TxGenerator::reset()
 {
     mAccounts.clear();
 }
 
-TxGenerator::TestAccountPtr
-TxGenerator::getAccount(uint64_t accountId) const
+TxGenerator::TestAccountPtr TxGenerator::getAccount(uint64_t accountId) const
 {
     auto res = mAccounts.find(accountId);
     if (res == mAccounts.end())
@@ -849,8 +837,8 @@ TxGenerator::getAccount(uint64_t accountId) const
     return res->second;
 }
 
-void
-TxGenerator::addAccount(uint64_t accountId, TxGenerator::TestAccountPtr account)
+void TxGenerator::addAccount(uint64_t accountId,
+                             TxGenerator::TestAccountPtr account)
 {
     mAccounts.emplace(accountId, account);
 }
@@ -868,8 +856,7 @@ TxGenerator::getConfigUpgradeSetKey(SorobanUpgradeConfig const& upgradeCfg,
     return upgradeSetKey;
 }
 
-SCBytes
-TxGenerator::getConfigUpgradeSetFromLoadConfig(
+SCBytes TxGenerator::getConfigUpgradeSetFromLoadConfig(
     SorobanUpgradeConfig const& upgradeCfg) const
 {
     xdr::xvector<ConfigSettingEntry> updatedEntries;

--- a/src/test/Catch2.h
+++ b/src/test/Catch2.h
@@ -46,8 +46,7 @@ namespace Catch
 template <typename T>
 struct StringMaker<T, std::enable_if_t<xdr::xdr_traits<T>::valid>>
 {
-    static std::string
-    convert(T const& val)
+    static std::string convert(T const& val)
     {
         return xdr::xdr_to_string(val, "value");
     }

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -50,26 +50,22 @@ auto constexpr MIN_ACCOUNT_BALANCE =
 // must be strictly less than 255
 uint8_t constexpr NUMBER_OF_PREGENERATED_ACCOUNTS = 5U;
 
-void
-setShortKey(uint256& ed25519, int i)
+void setShortKey(uint256& ed25519, int i)
 {
     ed25519[0] = static_cast<uint8_t>(i);
 }
 
-void
-setShortKey(PublicKey& pk, int i)
+void setShortKey(PublicKey& pk, int i)
 {
     setShortKey(pk.ed25519(), i);
 }
 
-uint8_t
-getShortKey(uint256 const& ed25519)
+uint8_t getShortKey(uint256 const& ed25519)
 {
     return ed25519[0];
 }
 
-uint8_t
-getShortKey(PublicKey const& pk)
+uint8_t getShortKey(PublicKey const& pk)
 {
     return getShortKey(pk.ed25519());
 }
@@ -79,32 +75,27 @@ uint8_t constexpr NUMBER_OF_ASSET_CODE_BITS = 8 - NUMBER_OF_ASSET_ISSUER_BITS;
 uint8_t constexpr NUMBER_OF_ASSETS_TO_USE = 1 << NUMBER_OF_ASSET_CODE_BITS;
 uint8_t constexpr ENCODE_ASSET_CODE_MASK = NUMBER_OF_ASSETS_TO_USE - 1;
 
-uint8_t
-getShortKey(AssetCode4 const& code)
+uint8_t getShortKey(AssetCode4 const& code)
 {
     return code.data()[0] & ENCODE_ASSET_CODE_MASK;
 }
 
-uint8_t
-getShortKey(AssetCode12 const& code)
+uint8_t getShortKey(AssetCode12 const& code)
 {
     return code.data()[0] & ENCODE_ASSET_CODE_MASK;
 }
 
-uint8_t
-decodeAssetIssuer(uint8_t byte)
+uint8_t decodeAssetIssuer(uint8_t byte)
 {
     return byte >> NUMBER_OF_ASSET_CODE_BITS;
 }
 
-uint8_t
-decodeAssetCodeDigit(uint8_t byte)
+uint8_t decodeAssetCodeDigit(uint8_t byte)
 {
     return byte & ENCODE_ASSET_CODE_MASK;
 }
 
-uint8_t
-getShortKey(Asset const& asset)
+uint8_t getShortKey(Asset const& asset)
 {
     // This encoding does _not_ make compacting a left-inverse of unpack.  We
     // could make it so, but it's not necessary -- compacting, which alone uses
@@ -122,8 +113,7 @@ getShortKey(Asset const& asset)
     }
 }
 
-uint8_t
-getShortKey(AssetCode const& code)
+uint8_t getShortKey(AssetCode const& code)
 {
     switch (code.type())
     {
@@ -138,14 +128,12 @@ getShortKey(AssetCode const& code)
     }
 }
 
-uint8_t
-getShortKey(ClaimableBalanceID const& balanceID)
+uint8_t getShortKey(ClaimableBalanceID const& balanceID)
 {
     return balanceID.v0()[0];
 }
 
-uint8_t
-getShortKey(LedgerKey const& key)
+uint8_t getShortKey(LedgerKey const& key)
 {
     switch (key.type())
     {
@@ -188,8 +176,7 @@ getShortKey(LedgerKey const& key)
 }
 
 // Sets "code" to a 4-byte alphanumeric AssetCode "Ast<digit>".
-void
-setAssetCode4(AssetCode4& code, int digit)
+void setAssetCode4(AssetCode4& code, int digit)
 {
     static_assert(
         FuzzUtils::NUMBER_OF_ASSETS_TO_USE <= 10,
@@ -201,8 +188,7 @@ setAssetCode4(AssetCode4& code, int digit)
 // For digit == 0, returns native Asset.
 // For digit != 0, returns an Asset with a 4-byte alphanumeric code "Ast<digit>"
 // and an issuer with the given public key.
-Asset
-makeAsset(int issuer, int digit)
+Asset makeAsset(int issuer, int digit)
 {
     Asset asset;
     if (digit == 0)
@@ -218,14 +204,12 @@ makeAsset(int issuer, int digit)
     return asset;
 }
 
-Asset
-makeAsset(uint8_t byte)
+Asset makeAsset(uint8_t byte)
 {
     return makeAsset(decodeAssetIssuer(byte), decodeAssetCodeDigit(byte));
 }
 
-AssetCode
-makeAssetCode(uint8_t byte)
+AssetCode makeAssetCode(uint8_t byte)
 {
     AssetCode code;
     auto digit = decodeAssetCodeDigit(byte);
@@ -241,9 +225,8 @@ makeAssetCode(uint8_t byte)
     return code;
 }
 
-void
-generateStoredLedgerKeys(StoredLedgerKeys::iterator begin,
-                         StoredLedgerKeys::iterator end)
+void generateStoredLedgerKeys(StoredLedgerKeys::iterator begin,
+                              StoredLedgerKeys::iterator end)
 {
     if (std::distance(begin, end) <= NUM_UNVALIDATED_LEDGER_KEYS)
     {
@@ -264,22 +247,21 @@ generateStoredLedgerKeys(StoredLedgerKeys::iterator begin,
     });
 }
 
-void
-setShortKey(std::array<LedgerKey, NUM_STORED_LEDGER_KEYS> const& storedKeys,
-            LedgerKey& key, uint8_t byte)
+void setShortKey(
+    std::array<LedgerKey, NUM_STORED_LEDGER_KEYS> const& storedKeys,
+    LedgerKey& key, uint8_t byte)
 {
     key = storedKeys[byte % NUM_STORED_LEDGER_KEYS];
 }
 
-void
-setShortKey(FuzzUtils::StoredPoolIDs const& storedPoolIDs, PoolID& key,
-            uint8_t byte)
+void setShortKey(FuzzUtils::StoredPoolIDs const& storedPoolIDs, PoolID& key,
+                 uint8_t byte)
 {
     key = storedPoolIDs[byte % NUM_STORED_POOL_IDS];
 }
 
-SequenceNumber
-getSequenceNumber(AbstractLedgerTxn& ltx, PublicKey const& sourceAccountID)
+SequenceNumber getSequenceNumber(AbstractLedgerTxn& ltx,
+                                 PublicKey const& sourceAccountID)
 {
     auto account = loadAccount(ltx, sourceAccountID);
     return account.current().data.account().seqNum;
@@ -287,11 +269,10 @@ getSequenceNumber(AbstractLedgerTxn& ltx, PublicKey const& sourceAccountID)
 
 // Append "newOp" to "ops", optionally after enclosing it in a sandwich of
 // begin/end-sponsoring-future-reserves.
-void
-emplaceConditionallySponsored(xdr::xvector<Operation>& ops,
-                              Operation const& newOp, bool isSponsored,
-                              int sponsorShortKey,
-                              PublicKey const& sponsoredKey)
+void emplaceConditionallySponsored(xdr::xvector<Operation>& ops,
+                                   Operation const& newOp, bool isSponsored,
+                                   int sponsorShortKey,
+                                   PublicKey const& sponsoredKey)
 {
     if (isSponsored)
     {
@@ -354,8 +335,7 @@ struct xdr_fuzzer_compactor
     {
     }
 
-    void
-    put_bytes(void const* buf, size_t len)
+    void put_bytes(void const* buf, size_t len)
     {
         if (len != 0)
         {
@@ -364,8 +344,7 @@ struct xdr_fuzzer_compactor
         }
     }
 
-    void
-    check(std::size_t n) const
+    void check(std::size_t n) const
     {
         if (n > std::size_t(reinterpret_cast<char*>(mEnd) -
                             reinterpret_cast<char*>(mCur)))
@@ -373,8 +352,7 @@ struct xdr_fuzzer_compactor
                 "insufficient buffer space in xdr_fuzzer_compactor");
     }
 
-    uint32_t
-    size() const
+    uint32_t size() const
     {
         auto s = std::size_t(reinterpret_cast<char*>(mCur) -
                              reinterpret_cast<char*>(mStart));
@@ -503,8 +481,7 @@ struct xdr_fuzzer_compactor
 };
 
 template <typename... Args>
-opaque_vec<>
-xdr_to_fuzzer_opaque(Args const&... args)
+opaque_vec<> xdr_to_fuzzer_opaque(Args const&... args)
 {
     opaque_vec<> m(opaque_vec<>::size_type{xdr_argpack_size(args...)});
     xdr_fuzzer_compactor p(m.data(), m.data() + m.size());
@@ -540,8 +517,7 @@ struct xdr_fuzzer_unpacker
     {
     }
 
-    void
-    get_bytes(void* buf, size_t len)
+    void get_bytes(void* buf, size_t len)
     {
         if (len != 0)
         {
@@ -550,16 +526,14 @@ struct xdr_fuzzer_unpacker
         }
     }
 
-    uint8_t
-    get_byte()
+    uint8_t get_byte()
     {
         uint8_t b;
         get_bytes(&b, 1);
         return b;
     }
 
-    void
-    check(std::size_t n) const
+    void check(std::size_t n) const
     {
         if (n > std::size_t(reinterpret_cast<char const*>(mCur) -
                             reinterpret_cast<char const*>(mEnd)))
@@ -567,9 +541,7 @@ struct xdr_fuzzer_unpacker
                 "insufficient buffer space in xdr_fuzzer_unpacker");
     }
 
-    template <typename T>
-    T
-    get32()
+    template <typename T> T get32()
     {
         // 1 byte --> uint32
         check(1);
@@ -587,9 +559,7 @@ struct xdr_fuzzer_unpacker
         return xdr_traits<T>::from_uint(w);
     }
 
-    template <typename T>
-    T
-    get64()
+    template <typename T> T get64()
     {
         // 2 bytes --> uint64 **with** "sign extension"
         check(2);
@@ -627,8 +597,7 @@ struct xdr_fuzzer_unpacker
     }
 
     template <typename T>
-    typename std::enable_if<xdr_traits<T>::is_bytes>::type
-    operator()(T& t)
+    typename std::enable_if<xdr_traits<T>::is_bytes>::type operator()(T& t)
     {
         std::uint32_t s2 = 0;
         if (xdr_traits<T>::variable_nelem)
@@ -779,8 +748,7 @@ struct xdr_fuzzer_unpacker
         stellar::FuzzUtils::setShortKey(mStoredLedgerKeys, key, v);
     }
 
-    void
-    done()
+    void done()
     {
         if (mCur != mEnd)
         {
@@ -790,8 +758,7 @@ struct xdr_fuzzer_unpacker
 };
 
 template <typename Bytes, typename... Args>
-auto
-xdr_from_fuzzer_opaque(
+auto xdr_from_fuzzer_opaque(
     stellar::FuzzUtils::StoredLedgerKeys const& storedLedgerKeys,
     stellar::FuzzUtils::StoredPoolIDs const& storedPoolIDs, Bytes const& m,
     Args&... args) -> decltype(detail::bytes_to_void(m))
@@ -803,9 +770,7 @@ xdr_from_fuzzer_opaque(
 }
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-template <>
-void
-generator_t::operator()(stellar::PublicKey& t) const
+template <> void generator_t::operator()(stellar::PublicKey& t) const
 {
     // Generate account IDs in a somewhat larger range than the number of
     // accounts created during setup, so that the fuzzer can generate some
@@ -824,8 +789,7 @@ static int RECURSION_COUNT = 0;
 static const int RECURSION_LIMIT = 50;
 
 template <>
-void
-generator_t::operator()<stellar::SCVal>(stellar::SCVal& val) const
+void generator_t::operator()<stellar::SCVal>(stellar::SCVal& val) const
 {
     if (++RECURSION_COUNT > RECURSION_LIMIT)
     {
@@ -845,8 +809,7 @@ generator_t::operator()<stellar::SCVal>(stellar::SCVal& val) const
 }
 
 template <>
-void
-generator_t::operator()<stellar::SorobanAuthorizedInvocation>(
+void generator_t::operator()<stellar::SorobanAuthorizedInvocation>(
     stellar::SorobanAuthorizedInvocation& auth) const
 {
     if (++RECURSION_COUNT > RECURSION_LIMIT)
@@ -866,8 +829,7 @@ namespace stellar
 {
 // creates a generic configuration with settings rigged to maximize
 // determinism
-static Config
-getFuzzConfig(int instanceNumber)
+static Config getFuzzConfig(int instanceNumber)
 {
     Config cfg = getTestConfig(instanceNumber);
     cfg.MANUAL_CLOSE = true;
@@ -886,8 +848,7 @@ getFuzzConfig(int instanceNumber)
     return cfg;
 }
 
-static void
-resetTxInternalState(Application& app)
+static void resetTxInternalState(Application& app)
 {
     reinitializeAllGlobalStateWithSeed(1);
 // reset caches to clear persistent state
@@ -913,8 +874,7 @@ class FuzzTransactionFrame : public TransactionFrame
         : TransactionFrame(networkID, envelope)
         , mTxResult(MutableTransactionResult::createSuccess(*this, 0)) {};
 
-    void
-    attemptApplication(Application& app, AbstractLedgerTxn& ltx)
+    void attemptApplication(Application& app, AbstractLedgerTxn& ltx)
     {
         // No soroban ops allowed
         if (std::any_of(getOperations().begin(), getOperations().end(),
@@ -976,25 +936,21 @@ class FuzzTransactionFrame : public TransactionFrame
         }
     }
 
-    TransactionResult const&
-    getResult() const
+    TransactionResult const& getResult() const
     {
         return mTxResult->getXDR();
     }
 
-    TransactionResultCode
-    getResultCode() const
+    TransactionResultCode getResultCode() const
     {
         return mTxResult->getResultCode();
     }
 };
 
-std::shared_ptr<FuzzTransactionFrame>
-createFuzzTransactionFrame(AbstractLedgerTxn& ltx,
-                           PublicKey const& sourceAccountID,
-                           std::vector<Operation>::const_iterator begin,
-                           std::vector<Operation>::const_iterator end,
-                           Hash const& networkID)
+std::shared_ptr<FuzzTransactionFrame> createFuzzTransactionFrame(
+    AbstractLedgerTxn& ltx, PublicKey const& sourceAccountID,
+    std::vector<Operation>::const_iterator begin,
+    std::vector<Operation>::const_iterator end, Hash const& networkID)
 {
     // construct a transaction envelope, which, for each transaction
     // application in the fuzzer, is the exact same, except for the inner
@@ -1012,8 +968,7 @@ createFuzzTransactionFrame(AbstractLedgerTxn& ltx,
     return res;
 }
 
-bool
-isBadOverlayFuzzerInput(StellarMessage const& m)
+bool isBadOverlayFuzzerInput(StellarMessage const& m)
 {
     // HELLO, AUTH and ERROR_MSG messages cause the connection between
     // the peers to drop. Since peer connections are only established
@@ -1029,11 +984,10 @@ isBadOverlayFuzzerInput(StellarMessage const& m)
 // Empties "ops" as operations are applied.  Throws if any operations fail.
 // Handles breaking up the list of operations into multiple transactions, if the
 // caller provides more operations than fit in a single transaction.
-static void
-applySetupOperations(LedgerTxn& ltx, PublicKey const& sourceAccount,
-                     xdr::xvector<Operation>::const_iterator begin,
-                     xdr::xvector<Operation>::const_iterator end,
-                     Application& app)
+static void applySetupOperations(LedgerTxn& ltx, PublicKey const& sourceAccount,
+                                 xdr::xvector<Operation>::const_iterator begin,
+                                 xdr::xvector<Operation>::const_iterator end,
+                                 Application& app)
 {
     while (begin != end)
     {
@@ -1091,11 +1045,10 @@ applySetupOperations(LedgerTxn& ltx, PublicKey const& sourceAccount,
 
 // Requires a set of operations small enough to fit in a single transaction.
 // Tolerates the failure of transaction application.
-static void
-applyFuzzOperations(LedgerTxn& ltx, PublicKey const& sourceAccount,
-                    xdr::xvector<Operation>::const_iterator begin,
-                    xdr::xvector<Operation>::const_iterator end,
-                    Application& app)
+static void applyFuzzOperations(LedgerTxn& ltx, PublicKey const& sourceAccount,
+                                xdr::xvector<Operation>::const_iterator begin,
+                                xdr::xvector<Operation>::const_iterator end,
+                                Application& app)
 {
     auto txFramePtr = createFuzzTransactionFrame(ltx, sourceAccount, begin, end,
                                                  app.getNetworkID());
@@ -1120,8 +1073,7 @@ struct AssetID
         assert(mSuffixDigit < FuzzUtils::NUMBER_OF_ASSETS_TO_USE);
     }
 
-    Asset
-    toAsset() const
+    Asset toAsset() const
     {
         return mIsNative ? txtest::makeNativeAsset()
                          : FuzzUtils::makeAsset(mIssuer, mSuffixDigit);
@@ -1528,8 +1480,7 @@ std::array<PoolSetupParameters,
      {3, AssetID(3), AssetID(4), INT64_MAX - 50, INT64_MAX - 50, 1, 1, 1, 1,
       INT64_MAX}}};
 
-void
-TransactionFuzzer::initialize()
+void TransactionFuzzer::initialize()
 {
     reinitializeAllGlobalStateWithSeed(1);
     mApp = createTestApplication(mClock, getFuzzConfig(0));
@@ -1567,9 +1518,8 @@ TransactionFuzzer::initialize()
 #endif // BUILD_TESTS
 }
 
-void
-TransactionFuzzer::storeSetupPoolIDs(AbstractLedgerTxn& ltx,
-                                     std::vector<LedgerEntry> const& entries)
+void TransactionFuzzer::storeSetupPoolIDs(
+    AbstractLedgerTxn& ltx, std::vector<LedgerEntry> const& entries)
 {
     std::vector<PoolID> poolIDs;
     for (auto const& entry : entries)
@@ -1588,8 +1538,7 @@ TransactionFuzzer::storeSetupPoolIDs(AbstractLedgerTxn& ltx,
                   []() { return PoolID{}; });
 }
 
-void
-TransactionFuzzer::storeSetupLedgerKeysAndPoolIDs(AbstractLedgerTxn& ltx)
+void TransactionFuzzer::storeSetupLedgerKeysAndPoolIDs(AbstractLedgerTxn& ltx)
 {
     // Get the list of ledger entries created during setup to place into
     // mStoredLedgerKeys.
@@ -1630,8 +1579,7 @@ TransactionFuzzer::storeSetupLedgerKeysAndPoolIDs(AbstractLedgerTxn& ltx)
     storeSetupPoolIDs(ltx, init);
 }
 
-void
-TransactionFuzzer::initializeAccounts(AbstractLedgerTxn& ltxOuter)
+void TransactionFuzzer::initializeAccounts(AbstractLedgerTxn& ltxOuter)
 {
     LedgerTxn ltx(ltxOuter);
     xdr::xvector<Operation> ops;
@@ -1664,8 +1612,7 @@ TransactionFuzzer::initializeAccounts(AbstractLedgerTxn& ltxOuter)
     ltx.commit();
 }
 
-void
-TransactionFuzzer::initializeTrustLines(AbstractLedgerTxn& ltxOuter)
+void TransactionFuzzer::initializeTrustLines(AbstractLedgerTxn& ltxOuter)
 {
     LedgerTxn ltx(ltxOuter);
 
@@ -1720,8 +1667,7 @@ TransactionFuzzer::initializeTrustLines(AbstractLedgerTxn& ltxOuter)
     ltx.commit();
 }
 
-void
-TransactionFuzzer::initializeClaimableBalances(AbstractLedgerTxn& ltxOuter)
+void TransactionFuzzer::initializeClaimableBalances(AbstractLedgerTxn& ltxOuter)
 {
     LedgerTxn ltx(ltxOuter);
 
@@ -1750,8 +1696,7 @@ TransactionFuzzer::initializeClaimableBalances(AbstractLedgerTxn& ltxOuter)
     ltx.commit();
 }
 
-void
-TransactionFuzzer::initializeOffers(AbstractLedgerTxn& ltxOuter)
+void TransactionFuzzer::initializeOffers(AbstractLedgerTxn& ltxOuter)
 {
     LedgerTxn ltx(ltxOuter);
 
@@ -1780,8 +1725,7 @@ TransactionFuzzer::initializeOffers(AbstractLedgerTxn& ltxOuter)
     ltx.commit();
 }
 
-void
-TransactionFuzzer::initializeLiquidityPools(AbstractLedgerTxn& ltxOuter)
+void TransactionFuzzer::initializeLiquidityPools(AbstractLedgerTxn& ltxOuter)
 {
     LedgerTxn ltx(ltxOuter);
 
@@ -1830,8 +1774,8 @@ TransactionFuzzer::initializeLiquidityPools(AbstractLedgerTxn& ltxOuter)
     ltx.commit();
 }
 
-void
-TransactionFuzzer::reduceNativeBalancesAfterSetup(AbstractLedgerTxn& ltxOuter)
+void TransactionFuzzer::reduceNativeBalancesAfterSetup(
+    AbstractLedgerTxn& ltxOuter)
 {
     LedgerTxn ltx(ltxOuter);
 
@@ -1863,8 +1807,7 @@ TransactionFuzzer::reduceNativeBalancesAfterSetup(AbstractLedgerTxn& ltxOuter)
     ltx.commit();
 }
 
-void
-TransactionFuzzer::adjustTrustLineBalancesAfterSetup(
+void TransactionFuzzer::adjustTrustLineBalancesAfterSetup(
     AbstractLedgerTxn& ltxOuter)
 {
     LedgerTxn ltx(ltxOuter);
@@ -1934,8 +1877,8 @@ TransactionFuzzer::adjustTrustLineBalancesAfterSetup(
     ltx.commit();
 }
 
-void
-TransactionFuzzer::reduceTrustLineLimitsAfterSetup(AbstractLedgerTxn& ltxOuter)
+void TransactionFuzzer::reduceTrustLineLimitsAfterSetup(
+    AbstractLedgerTxn& ltxOuter)
 {
     LedgerTxn ltx(ltxOuter);
 
@@ -1973,14 +1916,12 @@ TransactionFuzzer::reduceTrustLineLimitsAfterSetup(AbstractLedgerTxn& ltxOuter)
     ltx.commit();
 }
 
-void
-TransactionFuzzer::shutdown()
+void TransactionFuzzer::shutdown()
 {
     exit(1);
 }
 
-void
-TransactionFuzzer::inject(std::string const& filename)
+void TransactionFuzzer::inject(std::string const& filename)
 {
     std::ifstream in;
     in.exceptions(std::ios::badbit);
@@ -2027,16 +1968,14 @@ TransactionFuzzer::inject(std::string const& filename)
     applyFuzzOperations(ltx, mSourceAccountID, ops.begin(), ops.end(), *mApp);
 }
 
-int
-TransactionFuzzer::xdrSizeLimit()
+int TransactionFuzzer::xdrSizeLimit()
 {
     // 50 bytes in compact mode seems to hold large operations
     return 50 * FuzzUtils::FUZZER_MAX_OPERATIONS;
 }
 
 #define FUZZER_INITIAL_CORPUS_OPERATION_GEN_UPPERBOUND 128
-void
-TransactionFuzzer::genFuzz(std::string const& filename)
+void TransactionFuzzer::genFuzz(std::string const& filename)
 {
     reinitializeAllGlobalStateWithSeed(std::random_device()());
     std::ofstream out;
@@ -2072,14 +2011,12 @@ TransactionFuzzer::genFuzz(std::string const& filename)
     out.write(reinterpret_cast<char const*>(bins.data()), bins.size());
 }
 
-void
-OverlayFuzzer::shutdown()
+void OverlayFuzzer::shutdown()
 {
     mSimulation->stopAllNodes();
 }
 
-void
-OverlayFuzzer::initialize()
+void OverlayFuzzer::initialize()
 {
     reinitializeAllGlobalStateWithSeed(1);
     stellar::FuzzUtils::generateStoredLedgerKeys(mStoredLedgerKeys.begin(),
@@ -2120,8 +2057,7 @@ OverlayFuzzer::initialize()
         std::chrono::milliseconds{500}, false);
 }
 
-void
-OverlayFuzzer::inject(std::string const& filename)
+void OverlayFuzzer::inject(std::string const& filename)
 {
     std::ifstream in;
     in.exceptions(std::ios::badbit);
@@ -2187,15 +2123,13 @@ OverlayFuzzer::inject(std::string const& filename)
         ;
 }
 
-int
-OverlayFuzzer::xdrSizeLimit()
+int OverlayFuzzer::xdrSizeLimit()
 {
     return MAX_MESSAGE_SIZE;
 }
 
 #define FUZZER_INITIAL_CORPUS_MESSAGE_GEN_UPPERBOUND 16
-void
-OverlayFuzzer::genFuzz(std::string const& filename)
+void OverlayFuzzer::genFuzz(std::string const& filename)
 {
     reinitializeAllGlobalStateWithSeed(std::random_device()());
     std::ofstream out;

--- a/src/test/SimpleTestReporter.h
+++ b/src/test/SimpleTestReporter.h
@@ -19,29 +19,25 @@ struct SimpleTestReporter : public ConsoleReporter
 
     ~SimpleTestReporter();
 
-    static std::string
-    getDescription()
+    static std::string getDescription()
     {
         return "Reports minimal information on tests";
     }
 
-    ReporterPreferences
-    getPreferences() const override
+    ReporterPreferences getPreferences() const override
     {
         ReporterPreferences prefs;
         prefs.shouldRedirectStdOut = false;
         return prefs;
     }
 
-    void
-    testCaseStarting(TestCaseInfo const& ti) override
+    void testCaseStarting(TestCaseInfo const& ti) override
     {
         ConsoleReporter::testCaseStarting(ti);
         stream << "\"" << ti.name << "\" " << ti.lineInfo << std::endl;
     }
 
-    void
-    sectionStarting(SectionInfo const& _sectionInfo) override
+    void sectionStarting(SectionInfo const& _sectionInfo) override
     {
         if (!gDisableDots)
         {
@@ -50,14 +46,12 @@ struct SimpleTestReporter : public ConsoleReporter
         ConsoleReporter::sectionStarting(_sectionInfo);
     }
 
-    void
-    assertionStarting(AssertionInfo const& ai) override
+    void assertionStarting(AssertionInfo const& ai) override
     {
         mLastAssertInfo = std::make_unique<AssertionInfo>(ai);
     }
 
-    bool
-    assertionEnded(AssertionStats const& _assertionStats) override
+    bool assertionEnded(AssertionStats const& _assertionStats) override
     {
         bool res = _assertionStats.assertionResult.isOk();
         if (!res)
@@ -72,8 +66,7 @@ struct SimpleTestReporter : public ConsoleReporter
         return res;
     }
 
-    void
-    testCaseEnded(TestCaseStats const&) override
+    void testCaseEnded(TestCaseStats const&) override
     {
         stream << "<done>";
         printNewLine();
@@ -84,8 +77,7 @@ struct SimpleTestReporter : public ConsoleReporter
 
     std::unique_ptr<AssertionInfo> mLastAssertInfo;
 
-    void
-    printDot()
+    void printDot()
     {
         stream << '.' << std::flush;
         mDots++;
@@ -95,8 +87,7 @@ struct SimpleTestReporter : public ConsoleReporter
         }
     }
 
-    void
-    printNewLine()
+    void printNewLine()
     {
         stream << '\n';
         mDots = 0;

--- a/src/test/TestAccount.cpp
+++ b/src/test/TestAccount.cpp
@@ -21,15 +21,13 @@ namespace stellar
 
 using namespace txtest;
 
-SequenceNumber
-TestAccount::loadSequenceNumber()
+SequenceNumber TestAccount::loadSequenceNumber()
 {
     mSn = 0;
     return getLastSequenceNumber();
 }
 
-void
-TestAccount::updateSequenceNumber()
+void TestAccount::updateSequenceNumber()
 {
     if (mSn == 0)
     {
@@ -42,8 +40,7 @@ TestAccount::updateSequenceNumber()
     }
 }
 
-uint32_t
-TestAccount::getTrustlineFlags(Asset const& asset) const
+uint32_t TestAccount::getTrustlineFlags(Asset const& asset) const
 {
     LedgerSnapshot lsg(mApp);
     auto const trust = lsg.load(trustlineKey(getPublicKey(), asset));
@@ -51,8 +48,7 @@ TestAccount::getTrustlineFlags(Asset const& asset) const
     return trust.current().data.trustLine().flags;
 }
 
-int64_t
-TestAccount::getTrustlineBalance(Asset const& asset) const
+int64_t TestAccount::getTrustlineBalance(Asset const& asset) const
 {
     LedgerTxn ltx(mApp.getLedgerTxnRoot());
     auto trustLine = stellar::loadTrustLine(ltx, getPublicKey(), asset);
@@ -60,8 +56,7 @@ TestAccount::getTrustlineBalance(Asset const& asset) const
     return trustLine.getBalance();
 }
 
-int64_t
-TestAccount::getTrustlineBalance(PoolID const& poolID) const
+int64_t TestAccount::getTrustlineBalance(PoolID const& poolID) const
 {
     LedgerSnapshot lsg(mApp);
     TrustLineAsset asset(ASSET_TYPE_POOL_SHARE);
@@ -71,16 +66,14 @@ TestAccount::getTrustlineBalance(PoolID const& poolID) const
     return trustLine.current().data.trustLine().balance;
 }
 
-int64_t
-TestAccount::getBalance() const
+int64_t TestAccount::getBalance() const
 {
     LedgerSnapshot lsg(mApp);
     auto const entry = lsg.getAccount(getPublicKey());
     return entry.current().data.account().balance;
 }
 
-int64_t
-TestAccount::getAvailableBalance() const
+int64_t TestAccount::getAvailableBalance() const
 {
     LedgerSnapshot lsg(mApp);
     auto const entry = lsg.getAccount(getPublicKey());
@@ -88,24 +81,20 @@ TestAccount::getAvailableBalance() const
                                         entry.current());
 }
 
-uint32_t
-TestAccount::getNumSubEntries() const
+uint32_t TestAccount::getNumSubEntries() const
 {
     LedgerSnapshot lsg(mApp);
     auto const entry = lsg.getAccount(getPublicKey());
     return entry.current().data.account().numSubEntries;
 }
 
-bool
-TestAccount::exists() const
+bool TestAccount::exists() const
 {
     return doesAccountExist(mApp, getPublicKey());
 }
 
-void
-TestAccount::applyOpsBatch(std::vector<Operation> const& ops)
+void TestAccount::applyOpsBatch(std::vector<Operation> const& ops)
 {
-
     for (int i = 0; i < ops.size(); i += MAX_OPS_PER_TX)
     {
         std::vector<Operation> txOps(
@@ -121,8 +110,8 @@ TestAccount::applyOpsBatch(std::vector<Operation> const& ops)
     }
 }
 
-TransactionTestFramePtr
-TestAccount::tx(std::vector<Operation> const& ops, SequenceNumber sn)
+TransactionTestFramePtr TestAccount::tx(std::vector<Operation> const& ops,
+                                        SequenceNumber sn)
 {
     if (sn == 0)
     {
@@ -132,15 +121,14 @@ TestAccount::tx(std::vector<Operation> const& ops, SequenceNumber sn)
     return transactionFromOperations(mApp, getSecretKey(), sn, ops);
 }
 
-Operation
-TestAccount::op(Operation operation)
+Operation TestAccount::op(Operation operation)
 {
     operation.sourceAccount.activate() = toMuxedAccount(getPublicKey());
     return operation;
 }
 
-TestAccount
-TestAccount::create(SecretKey const& secretKey, uint64_t initialBalance)
+TestAccount TestAccount::create(SecretKey const& secretKey,
+                                uint64_t initialBalance)
 {
     auto publicKey = secretKey.getPublicKey();
 
@@ -199,8 +187,8 @@ TestAccount::createBatch(std::vector<SecretKey> const& secretKeys,
     return accounts;
 }
 
-TestAccount
-TestAccount::create(std::string const& name, uint64_t initialBalance)
+TestAccount TestAccount::create(std::string const& name,
+                                uint64_t initialBalance)
 {
     return create(getAccount(name.c_str()), initialBalance);
 }
@@ -217,8 +205,7 @@ TestAccount::createBatch(std::vector<std::string> const& names,
     return createBatch(keys, initialBalance);
 }
 
-void
-TestAccount::merge(PublicKey const& into)
+void TestAccount::merge(PublicKey const& into)
 {
     applyTx(tx({accountMerge(into)}), mApp);
 
@@ -227,40 +214,34 @@ TestAccount::merge(PublicKey const& into)
     REQUIRE(!lsg.getAccount(getPublicKey()));
 }
 
-void
-TestAccount::inflation()
+void TestAccount::inflation()
 {
     applyTx(tx({txtest::inflation()}), mApp);
 }
 
-Asset
-TestAccount::asset(std::string const& name)
+Asset TestAccount::asset(std::string const& name)
 {
     return txtest::makeAsset(*this, name);
 }
 
-void
-TestAccount::changeTrust(Asset const& asset, int64_t limit)
+void TestAccount::changeTrust(Asset const& asset, int64_t limit)
 {
     applyTx(tx({txtest::changeTrust(asset, limit)}), mApp);
 }
 
-void
-TestAccount::changeTrust(ChangeTrustAsset const& asset, int64_t limit)
+void TestAccount::changeTrust(ChangeTrustAsset const& asset, int64_t limit)
 {
     applyTx(tx({txtest::changeTrust(asset, limit)}), mApp);
 }
 
-void
-TestAccount::allowTrust(Asset const& asset, PublicKey const& trustor,
-                        uint32_t flag)
+void TestAccount::allowTrust(Asset const& asset, PublicKey const& trustor,
+                             uint32_t flag)
 {
     applyTx(tx({txtest::allowTrust(trustor, asset, flag)}), mApp);
 }
 
-void
-TestAccount::allowTrust(Asset const& asset, PublicKey const& trustor,
-                        TrustFlagOp op)
+void TestAccount::allowTrust(Asset const& asset, PublicKey const& trustor,
+                             TrustFlagOp op)
 {
     if (op == TrustFlagOp::ALLOW_TRUST)
     {
@@ -280,9 +261,8 @@ TestAccount::allowTrust(Asset const& asset, PublicKey const& trustor,
     }
 }
 
-void
-TestAccount::denyTrust(Asset const& asset, PublicKey const& trustor,
-                       TrustFlagOp op)
+void TestAccount::denyTrust(Asset const& asset, PublicKey const& trustor,
+                            TrustFlagOp op)
 {
     if (op == TrustFlagOp::ALLOW_TRUST)
     {
@@ -299,9 +279,9 @@ TestAccount::denyTrust(Asset const& asset, PublicKey const& trustor,
     }
 }
 
-void
-TestAccount::allowMaintainLiabilities(Asset const& asset,
-                                      PublicKey const& trustor, TrustFlagOp op)
+void TestAccount::allowMaintainLiabilities(Asset const& asset,
+                                           PublicKey const& trustor,
+                                           TrustFlagOp op)
 {
     if (op == TrustFlagOp::ALLOW_TRUST)
     {
@@ -322,22 +302,19 @@ TestAccount::allowMaintainLiabilities(Asset const& asset,
     }
 }
 
-void
-TestAccount::setTrustLineFlags(
+void TestAccount::setTrustLineFlags(
     Asset const& asset, PublicKey const& trustor,
     txtest::SetTrustLineFlagsArguments const& arguments)
 {
     applyTx(tx({txtest::setTrustLineFlags(trustor, asset, arguments)}), mApp);
 }
 
-TrustLineEntry
-TestAccount::loadTrustLine(Asset const& asset) const
+TrustLineEntry TestAccount::loadTrustLine(Asset const& asset) const
 {
     return loadTrustLine(assetToTrustLineAsset(asset));
 }
 
-TrustLineEntry
-TestAccount::loadTrustLine(TrustLineAsset const& asset) const
+TrustLineEntry TestAccount::loadTrustLine(TrustLineAsset const& asset) const
 {
     LedgerSnapshot lsg(mApp);
     LedgerKey key(TRUSTLINE);
@@ -346,14 +323,12 @@ TestAccount::loadTrustLine(TrustLineAsset const& asset) const
     return lsg.load(key).current().data.trustLine();
 }
 
-bool
-TestAccount::hasTrustLine(Asset const& asset) const
+bool TestAccount::hasTrustLine(Asset const& asset) const
 {
     return hasTrustLine(assetToTrustLineAsset(asset));
 }
 
-bool
-TestAccount::hasTrustLine(TrustLineAsset const& asset) const
+bool TestAccount::hasTrustLine(TrustLineAsset const& asset) const
 {
     LedgerSnapshot lsg(mApp);
     LedgerKey key(TRUSTLINE);
@@ -362,14 +337,12 @@ TestAccount::hasTrustLine(TrustLineAsset const& asset) const
     return static_cast<bool>(lsg.load(key));
 }
 
-void
-TestAccount::setOptions(SetOptionsArguments const& arguments)
+void TestAccount::setOptions(SetOptionsArguments const& arguments)
 {
     applyTx(tx({txtest::setOptions(arguments)}), mApp);
 }
 
-void
-TestAccount::manageData(std::string const& name, DataValue* value)
+void TestAccount::manageData(std::string const& name, DataValue* value)
 {
     applyTx(tx({txtest::manageData(name, value)}), mApp);
 
@@ -386,8 +359,7 @@ TestAccount::manageData(std::string const& name, DataValue* value)
     }
 }
 
-void
-TestAccount::bumpSequence(SequenceNumber to)
+void TestAccount::bumpSequence(SequenceNumber to)
 {
     applyTx(tx({txtest::bumpSequence(to)}), mApp, false);
 
@@ -438,8 +410,7 @@ TestAccount::createClaimableBalance(Asset const& asset, int64_t amount,
     return returnedBalanceID;
 }
 
-void
-TestAccount::claimClaimableBalance(ClaimableBalanceID const& balanceID)
+void TestAccount::claimClaimableBalance(ClaimableBalanceID const& balanceID)
 {
     applyTx(tx({txtest::claimClaimableBalance(balanceID)}), mApp);
 
@@ -447,8 +418,8 @@ TestAccount::claimClaimableBalance(ClaimableBalanceID const& balanceID)
     REQUIRE(!stellar::loadClaimableBalance(ltx, balanceID));
 }
 
-ClaimableBalanceID
-TestAccount::getBalanceID(uint32_t opIndex, SequenceNumber sn)
+ClaimableBalanceID TestAccount::getBalanceID(uint32_t opIndex,
+                                             SequenceNumber sn)
 {
     if (sn == 0)
     {
@@ -467,38 +438,37 @@ TestAccount::getBalanceID(uint32_t opIndex, SequenceNumber sn)
     return balanceID;
 }
 
-int64_t
-TestAccount::manageOffer(int64_t offerID, Asset const& selling,
-                         Asset const& buying, Price const& price,
-                         int64_t amount, ManageOfferEffect expectedEffect)
+int64_t TestAccount::manageOffer(int64_t offerID, Asset const& selling,
+                                 Asset const& buying, Price const& price,
+                                 int64_t amount,
+                                 ManageOfferEffect expectedEffect)
 {
     return applyManageOffer(mApp, offerID, getSecretKey(), selling, buying,
                             price, amount, nextSequenceNumber(),
                             expectedEffect);
 }
 
-int64_t
-TestAccount::manageBuyOffer(int64_t offerID, Asset const& selling,
-                            Asset const& buying, Price const& price,
-                            int64_t amount, ManageOfferEffect expectedEffect)
+int64_t TestAccount::manageBuyOffer(int64_t offerID, Asset const& selling,
+                                    Asset const& buying, Price const& price,
+                                    int64_t amount,
+                                    ManageOfferEffect expectedEffect)
 {
     return applyManageBuyOffer(mApp, offerID, getSecretKey(), selling, buying,
                                price, amount, nextSequenceNumber(),
                                expectedEffect);
 }
 
-int64_t
-TestAccount::createPassiveOffer(Asset const& selling, Asset const& buying,
-                                Price const& price, int64_t amount,
-                                ManageOfferEffect expectedEffect)
+int64_t TestAccount::createPassiveOffer(Asset const& selling,
+                                        Asset const& buying, Price const& price,
+                                        int64_t amount,
+                                        ManageOfferEffect expectedEffect)
 {
     return applyCreatePassiveOffer(mApp, getSecretKey(), selling, buying, price,
                                    amount, nextSequenceNumber(),
                                    expectedEffect);
 }
 
-void
-TestAccount::pay(PublicKey const& destination, int64_t amount)
+void TestAccount::pay(PublicKey const& destination, int64_t amount)
 {
     std::unique_ptr<LedgerEntry> toAccount;
     {
@@ -545,9 +515,8 @@ TestAccount::pay(PublicKey const& destination, int64_t amount)
     REQUIRE(toAccountAfter);
 }
 
-void
-TestAccount::pay(PublicKey const& destination, Asset const& asset,
-                 int64_t amount)
+void TestAccount::pay(PublicKey const& destination, Asset const& asset,
+                      int64_t amount)
 {
     applyTx(tx({payment(destination, asset, amount)}), mApp);
 }
@@ -579,12 +548,10 @@ TestAccount::pay(PublicKey const& destination, Asset const& sendCur,
     return getFirstResult(transaction).tr().pathPaymentStrictReceiveResult();
 }
 
-PathPaymentStrictSendResult
-TestAccount::pathPaymentStrictSend(PublicKey const& destination,
-                                   Asset const& sendCur, int64_t sendAmount,
-                                   Asset const& destCur, int64_t destMin,
-                                   std::vector<Asset> const& path,
-                                   Asset* noIssuer)
+PathPaymentStrictSendResult TestAccount::pathPaymentStrictSend(
+    PublicKey const& destination, Asset const& sendCur, int64_t sendAmount,
+    Asset const& destCur, int64_t destMin, std::vector<Asset> const& path,
+    Asset* noIssuer)
 {
     auto transaction = tx({txtest::pathPaymentStrictSend(
         destination, sendCur, sendAmount, destCur, destMin, path)});
@@ -609,14 +576,13 @@ TestAccount::pathPaymentStrictSend(PublicKey const& destination,
     return getFirstResult(transaction).tr().pathPaymentStrictSendResult();
 }
 
-void
-TestAccount::clawback(PublicKey const& from, Asset const& asset, int64_t amount)
+void TestAccount::clawback(PublicKey const& from, Asset const& asset,
+                           int64_t amount)
 {
     applyTx(tx({txtest::clawback(from, asset, amount)}), mApp);
 }
 
-void
-TestAccount::clawbackClaimableBalance(ClaimableBalanceID const& balanceID)
+void TestAccount::clawbackClaimableBalance(ClaimableBalanceID const& balanceID)
 {
     applyTx(tx({txtest::clawbackClaimableBalance(balanceID)}), mApp);
 
@@ -624,19 +590,18 @@ TestAccount::clawbackClaimableBalance(ClaimableBalanceID const& balanceID)
     REQUIRE(!stellar::loadClaimableBalance(ltx, balanceID));
 }
 
-void
-TestAccount::liquidityPoolDeposit(PoolID const& poolID, int64_t maxAmountA,
-                                  int64_t maxAmountB, Price const& minPrice,
-                                  Price const& maxPrice)
+void TestAccount::liquidityPoolDeposit(PoolID const& poolID, int64_t maxAmountA,
+                                       int64_t maxAmountB,
+                                       Price const& minPrice,
+                                       Price const& maxPrice)
 {
     applyTx(tx({txtest::liquidityPoolDeposit(poolID, maxAmountA, maxAmountB,
                                              minPrice, maxPrice)}),
             mApp);
 }
 
-void
-TestAccount::liquidityPoolWithdraw(PoolID const& poolID, int64_t amount,
-                                   int64_t minAmountA, int64_t minAmountB)
+void TestAccount::liquidityPoolWithdraw(PoolID const& poolID, int64_t amount,
+                                        int64_t minAmountA, int64_t minAmountB)
 {
     applyTx(tx({txtest::liquidityPoolWithdraw(poolID, amount, minAmountA,
                                               minAmountB)}),

--- a/src/test/TestAccount.h
+++ b/src/test/TestAccount.h
@@ -133,32 +133,27 @@ class TestAccount
         return getPublicKey();
     }
 
-    SecretKey const&
-    getSecretKey() const
+    SecretKey const& getSecretKey() const
     {
         return mSk;
     }
-    PublicKey const&
-    getPublicKey() const
+    PublicKey const& getPublicKey() const
     {
         return mSk.getPublicKey();
     }
 
-    void
-    setSequenceNumber(SequenceNumber sn)
+    void setSequenceNumber(SequenceNumber sn)
     {
         mSn = sn;
     }
 
-    SequenceNumber
-    getLastSequenceNumber()
+    SequenceNumber getLastSequenceNumber()
     {
         updateSequenceNumber();
         return mSn;
     }
 
-    SequenceNumber
-    nextSequenceNumber()
+    SequenceNumber nextSequenceNumber()
     {
         updateSequenceNumber();
         if (mSn == std::numeric_limits<SequenceNumber>::max())
@@ -170,8 +165,7 @@ class TestAccount
     }
     SequenceNumber loadSequenceNumber();
 
-    std::string
-    getAccountId()
+    std::string getAccountId()
     {
         return mAccountID;
     }

--- a/src/test/TestExceptions.cpp
+++ b/src/test/TestExceptions.cpp
@@ -11,8 +11,7 @@ namespace stellar
 namespace txtest
 {
 
-void
-throwIf(CreateAccountResult const& result)
+void throwIf(CreateAccountResult const& result)
 {
     switch (result.code())
     {
@@ -31,8 +30,7 @@ throwIf(CreateAccountResult const& result)
     }
 }
 
-void
-throwIf(PaymentResult const& result)
+void throwIf(PaymentResult const& result)
 {
     switch (result.code())
     {
@@ -61,8 +59,7 @@ throwIf(PaymentResult const& result)
     }
 }
 
-void
-throwIf(PathPaymentStrictReceiveResult const& result)
+void throwIf(PathPaymentStrictReceiveResult const& result)
 {
     switch (result.code())
     {
@@ -97,8 +94,7 @@ throwIf(PathPaymentStrictReceiveResult const& result)
     }
 }
 
-void
-throwIf(PathPaymentStrictSendResult const& result)
+void throwIf(PathPaymentStrictSendResult const& result)
 {
     switch (result.code())
     {
@@ -133,8 +129,7 @@ throwIf(PathPaymentStrictSendResult const& result)
     }
 }
 
-void
-throwIf(ManageSellOfferResult const& result)
+void throwIf(ManageSellOfferResult const& result)
 {
     switch (result.code())
     {
@@ -169,8 +164,7 @@ throwIf(ManageSellOfferResult const& result)
     }
 }
 
-void
-throwIf(ManageBuyOfferResult const& result)
+void throwIf(ManageBuyOfferResult const& result)
 {
     switch (result.code())
     {
@@ -205,8 +199,7 @@ throwIf(ManageBuyOfferResult const& result)
     }
 }
 
-void
-throwIf(SetOptionsResult const& result)
+void throwIf(SetOptionsResult const& result)
 {
     switch (result.code())
     {
@@ -237,8 +230,7 @@ throwIf(SetOptionsResult const& result)
     }
 }
 
-void
-throwIf(ChangeTrustResult const& result)
+void throwIf(ChangeTrustResult const& result)
 {
     switch (result.code())
     {
@@ -265,8 +257,7 @@ throwIf(ChangeTrustResult const& result)
     }
 }
 
-void
-throwIf(AllowTrustResult const& result)
+void throwIf(AllowTrustResult const& result)
 {
     switch (result.code())
     {
@@ -287,8 +278,7 @@ throwIf(AllowTrustResult const& result)
     }
 }
 
-void
-throwIf(AccountMergeResult const& result)
+void throwIf(AccountMergeResult const& result)
 {
     switch (result.code())
     {
@@ -313,8 +303,7 @@ throwIf(AccountMergeResult const& result)
     }
 }
 
-void
-throwIf(InflationResult const& result)
+void throwIf(InflationResult const& result)
 {
     switch (result.code())
     {
@@ -327,8 +316,7 @@ throwIf(InflationResult const& result)
     }
 }
 
-void
-throwIf(ManageDataResult const& result)
+void throwIf(ManageDataResult const& result)
 {
     switch (result.code())
     {
@@ -347,8 +335,7 @@ throwIf(ManageDataResult const& result)
     }
 }
 
-void
-throwIf(BumpSequenceResult const& result)
+void throwIf(BumpSequenceResult const& result)
 {
     switch (result.code())
     {
@@ -361,8 +348,7 @@ throwIf(BumpSequenceResult const& result)
     }
 }
 
-void
-throwIf(CreateClaimableBalanceResult const& result)
+void throwIf(CreateClaimableBalanceResult const& result)
 {
     switch (result.code())
     {
@@ -383,8 +369,7 @@ throwIf(CreateClaimableBalanceResult const& result)
     }
 }
 
-void
-throwIf(ClaimClaimableBalanceResult const& result)
+void throwIf(ClaimClaimableBalanceResult const& result)
 {
     switch (result.code())
     {
@@ -405,8 +390,7 @@ throwIf(ClaimClaimableBalanceResult const& result)
     }
 }
 
-void
-throwIf(ClawbackResult const& result)
+void throwIf(ClawbackResult const& result)
 {
     switch (result.code())
     {
@@ -425,8 +409,7 @@ throwIf(ClawbackResult const& result)
     }
 }
 
-void
-throwIf(ClawbackClaimableBalanceResult const& result)
+void throwIf(ClawbackClaimableBalanceResult const& result)
 {
     switch (result.code())
     {
@@ -443,8 +426,7 @@ throwIf(ClawbackClaimableBalanceResult const& result)
     }
 }
 
-void
-throwIf(SetTrustLineFlagsResult const& result)
+void throwIf(SetTrustLineFlagsResult const& result)
 {
     switch (result.code())
     {
@@ -463,8 +445,7 @@ throwIf(SetTrustLineFlagsResult const& result)
     }
 }
 
-void
-throwIf(LiquidityPoolDepositResult const& result)
+void throwIf(LiquidityPoolDepositResult const& result)
 {
     switch (result.code())
     {
@@ -489,8 +470,7 @@ throwIf(LiquidityPoolDepositResult const& result)
     }
 }
 
-void
-throwIf(LiquidityPoolWithdrawResult const& result)
+void throwIf(LiquidityPoolWithdrawResult const& result)
 {
     switch (result.code())
     {
@@ -511,8 +491,7 @@ throwIf(LiquidityPoolWithdrawResult const& result)
     }
 }
 
-void
-throwIf(InvokeHostFunctionResult const& result)
+void throwIf(InvokeHostFunctionResult const& result)
 {
     switch (result.code())
     {
@@ -529,8 +508,7 @@ throwIf(InvokeHostFunctionResult const& result)
     }
 }
 
-void
-throwIf(ExtendFootprintTTLResult const& result)
+void throwIf(ExtendFootprintTTLResult const& result)
 {
     switch (result.code())
     {
@@ -545,8 +523,7 @@ throwIf(ExtendFootprintTTLResult const& result)
     }
 }
 
-void
-throwIf(RestoreFootprintResult const& result)
+void throwIf(RestoreFootprintResult const& result)
 {
     switch (result.code())
     {
@@ -561,8 +538,7 @@ throwIf(RestoreFootprintResult const& result)
     }
 }
 
-void
-throwIf(TransactionResult const& result)
+void throwIf(TransactionResult const& result)
 {
     switch (result.result.code())
     {

--- a/src/test/TestMarket.cpp
+++ b/src/test/TestMarket.cpp
@@ -18,8 +18,7 @@ namespace stellar
 
 using namespace txtest;
 
-bool
-operator<(OfferKey const& x, OfferKey const& y)
+bool operator<(OfferKey const& x, OfferKey const& y)
 {
     if (x.sellerID < y.sellerID)
     {
@@ -46,8 +45,7 @@ OfferState::OfferState(OfferEntry const& entry)
 {
 }
 
-bool
-operator==(OfferState const& x, OfferState const& y)
+bool operator==(OfferState const& x, OfferState const& y)
 {
     if (!(x.selling == y.selling))
     {
@@ -72,9 +70,8 @@ operator==(OfferState const& x, OfferState const& y)
     return true;
 }
 
-ClaimAtom
-TestMarketOffer::exchanged(uint32_t ledgerVersion, int64_t sold,
-                           int64_t bought) const
+ClaimAtom TestMarketOffer::exchanged(uint32_t ledgerVersion, int64_t sold,
+                                     int64_t bought) const
 {
     return makeClaimAtom(ledgerVersion, key.sellerID, key.offerID,
                          state.selling, sold, state.buying, bought);
@@ -84,9 +81,9 @@ TestMarket::TestMarket(Application& app) : mApp{app}
 {
 }
 
-TestMarketOffer
-TestMarket::addOffer(TestAccount& account, OfferState const& state,
-                     OfferState const& finishedState)
+TestMarketOffer TestMarket::addOffer(TestAccount& account,
+                                     OfferState const& state,
+                                     OfferState const& finishedState)
 {
     auto newOffersState = mOffers;
     auto deleted = finishedState == OfferState::DELETED;
@@ -108,7 +105,6 @@ TestMarket::addOffer(TestAccount& account, OfferState const& state,
     {
         if (mLastAddedID != 0)
         {
-
             REQUIRE(offerId == mLastAddedID + 1);
         }
         mLastAddedID = offerId;
@@ -118,10 +114,9 @@ TestMarket::addOffer(TestAccount& account, OfferState const& state,
             finishedState == OfferState::SAME ? state : finishedState};
 }
 
-TestMarketOffer
-TestMarket::updateOffer(TestAccount& account, int64_t id,
-                        OfferState const& state,
-                        OfferState const& finishedState)
+TestMarketOffer TestMarket::updateOffer(TestAccount& account, int64_t id,
+                                        OfferState const& state,
+                                        OfferState const& finishedState)
 {
     auto newOffersState = mOffers;
     auto deleted = finishedState == OfferState::DELETED;
@@ -143,9 +138,8 @@ TestMarket::updateOffer(TestAccount& account, int64_t id,
             finishedState == OfferState::SAME ? state : finishedState};
 }
 
-void
-TestMarket::requireChanges(std::vector<TestMarketOffer> const& changes,
-                           std::function<void()> const& f)
+void TestMarket::requireChanges(std::vector<TestMarketOffer> const& changes,
+                                std::function<void()> const& f)
 {
     auto newOffersState = mOffers;
     try
@@ -213,8 +207,8 @@ TestMarket::requireChangesWithOffer(std::vector<TestMarketOffer> changes,
     return o;
 }
 
-void
-TestMarket::requireBalances(std::vector<TestMarketBalances> const& balances)
+void TestMarket::requireBalances(
+    std::vector<TestMarketBalances> const& balances)
 {
     for (auto const& accountBalances : balances)
     {
@@ -240,15 +234,13 @@ TestMarket::requireBalances(std::vector<TestMarketBalances> const& balances)
     }
 }
 
-void
-TestMarket::checkCurrentOffers()
+void TestMarket::checkCurrentOffers()
 {
     checkState(mOffers, {});
 }
 
-void
-TestMarket::checkState(std::map<OfferKey, OfferState> const& offers,
-                       std::vector<OfferKey> const& deletedOffers)
+void TestMarket::checkState(std::map<OfferKey, OfferState> const& offers,
+                            std::vector<OfferKey> const& deletedOffers)
 {
     LedgerTxn ltx(mApp.getLedgerTxnRoot());
     for (auto const& o : offers)

--- a/src/test/TestUtils.cpp
+++ b/src/test/TestUtils.cpp
@@ -22,8 +22,7 @@ namespace stellar
 namespace testutil
 {
 
-void
-crankSome(VirtualClock& clock)
+void crankSome(VirtualClock& clock)
 {
     auto start = clock.now();
     for (size_t i = 0;
@@ -33,24 +32,22 @@ crankSome(VirtualClock& clock)
         ;
 }
 
-void
-crankFor(VirtualClock& clock, VirtualClock::duration duration)
+void crankFor(VirtualClock& clock, VirtualClock::duration duration)
 {
     auto start = clock.now();
     while (clock.now() < (start + duration) && clock.crank(false) > 0)
         ;
 }
 
-void
-crankUntil(Application::pointer app, std::function<bool()> const& predicate,
-           VirtualClock::duration timeout)
+void crankUntil(Application::pointer app,
+                std::function<bool()> const& predicate,
+                VirtualClock::duration timeout)
 {
     crankUntil(*app, predicate, timeout);
 }
 
-void
-crankUntil(Application& app, std::function<bool()> const& predicate,
-           VirtualClock::duration timeout)
+void crankUntil(Application& app, std::function<bool()> const& predicate,
+                VirtualClock::duration timeout)
 {
     auto start = std::chrono::system_clock::now();
     while (!predicate())
@@ -65,8 +62,7 @@ crankUntil(Application& app, std::function<bool()> const& predicate,
     }
 }
 
-void
-shutdownWorkScheduler(Application& app)
+void shutdownWorkScheduler(Application& app)
 {
     if (app.getClock().getIOContext().stopped())
     {
@@ -80,8 +76,7 @@ shutdownWorkScheduler(Application& app)
     }
 }
 
-std::vector<Asset>
-getInvalidAssets(SecretKey const& issuer)
+std::vector<Asset> getInvalidAssets(SecretKey const& issuer)
 {
     std::vector<Asset> assets;
 
@@ -116,8 +111,7 @@ getInvalidAssets(SecretKey const& issuer)
     return assets;
 }
 
-int32_t
-computeMultiplier(LedgerEntry const& le)
+int32_t computeMultiplier(LedgerEntry const& le)
 {
     switch (le.data.type())
     {
@@ -163,9 +157,8 @@ TestInvariantManager::TestInvariantManager(Application& app)
 {
 }
 
-void
-TestInvariantManager::handleInvariantFailure(bool isStrict,
-                                             std::string const& message) const
+void TestInvariantManager::handleInvariantFailure(
+    bool isStrict, std::string const& message) const
 {
     CLOG_DEBUG(Invariant, "{}", message);
     throw InvariantDoesNotHold{message};
@@ -176,14 +169,12 @@ TestApplication::TestApplication(VirtualClock& clock, Config const& cfg)
 {
 }
 
-std::unique_ptr<InvariantManager>
-TestApplication::createInvariantManager()
+std::unique_ptr<InvariantManager> TestApplication::createInvariantManager()
 {
     return std::make_unique<TestInvariantManager>(*this);
 }
 
-TimePoint
-getTestDate(int day, int month, int year)
+TimePoint getTestDate(int day, int month, int year)
 {
     auto tm = getTestDateTime(day, month, year, 0, 0, 0);
 
@@ -193,8 +184,8 @@ getTestDate(int day, int month, int year)
     return t;
 }
 
-std::tm
-getTestDateTime(int day, int month, int year, int hour, int minute, int second)
+std::tm getTestDateTime(int day, int month, int year, int hour, int minute,
+                        int second)
 {
     std::tm tm = {0};
     tm.tm_hour = hour;
@@ -206,17 +197,15 @@ getTestDateTime(int day, int month, int year, int hour, int minute, int second)
     return tm;
 }
 
-VirtualClock::system_time_point
-genesis(int minute, int second)
+VirtualClock::system_time_point genesis(int minute, int second)
 {
     return VirtualClock::tmToSystemPoint(
         getTestDateTime(1, 7, 2014, 0, minute, second));
 }
 
-void
-upgradeSorobanNetworkConfig(std::function<void(SorobanNetworkConfig&)> modifyFn,
-                            std::shared_ptr<Simulation> simulation,
-                            bool applyUpgrade)
+void upgradeSorobanNetworkConfig(
+    std::function<void(SorobanNetworkConfig&)> modifyFn,
+    std::shared_ptr<Simulation> simulation, bool applyUpgrade)
 {
     auto nodes = simulation->getNodes();
     auto& lg = nodes[0]->getLoadGenerator();
@@ -291,8 +280,7 @@ upgradeSorobanNetworkConfig(std::function<void(SorobanNetworkConfig&)> modifyFn,
 // 3. Creating the upgrade ContractData entry
 // 4. Arming for the upgrade
 // Note that the armed ledger will not be closed.
-std::pair<SorobanNetworkConfig, UpgradeType>
-prepareSorobanNetworkConfigUpgrade(
+std::pair<SorobanNetworkConfig, UpgradeType> prepareSorobanNetworkConfigUpgrade(
     Application& app, std::function<void(SorobanNetworkConfig&)> modifyFn)
 {
     releaseAssertOrThrow(modifyFn);
@@ -397,9 +385,8 @@ prepareSorobanNetworkConfigUpgrade(
 // 3. Creating the upgrade ContractData entry
 // 4. Arming for the upgrade
 // 5. Closing the ledger for which the upgrade is armed
-void
-modifySorobanNetworkConfig(Application& app,
-                           std::function<void(SorobanNetworkConfig&)> modifyFn)
+void modifySorobanNetworkConfig(
+    Application& app, std::function<void(SorobanNetworkConfig&)> modifyFn)
 {
     if (!modifyFn)
     {
@@ -423,9 +410,8 @@ modifySorobanNetworkConfig(Application& app,
     releaseAssertOrThrow(postUpgradeCfg == upgradeCfg);
 }
 
-void
-setSorobanNetworkConfigForTest(SorobanNetworkConfig& cfg,
-                               std::optional<uint32_t> ledgerVersion)
+void setSorobanNetworkConfigForTest(SorobanNetworkConfig& cfg,
+                                    std::optional<uint32_t> ledgerVersion)
 {
     cfg.mMaxContractSizeBytes = 64 * 1024;
     cfg.mMaxContractDataEntrySizeBytes = 64 * 1024;
@@ -461,8 +447,7 @@ setSorobanNetworkConfigForTest(SorobanNetworkConfig& cfg,
     }
 }
 
-void
-overrideSorobanNetworkConfigForTest(Application& app)
+void overrideSorobanNetworkConfigForTest(Application& app)
 {
     modifySorobanNetworkConfig(app, [&app](SorobanNetworkConfig& cfg) {
         setSorobanNetworkConfigForTest(cfg, app.getLedgerManager()
@@ -471,8 +456,7 @@ overrideSorobanNetworkConfigForTest(Application& app)
     });
 }
 
-bool
-appProtocolVersionStartsFrom(Application& app, ProtocolVersion fromVersion)
+bool appProtocolVersionStartsFrom(Application& app, ProtocolVersion fromVersion)
 {
     LedgerTxn ltx(app.getLedgerTxnRoot());
     auto ledgerVersion = ltx.loadHeader().current().ledgerVersion;
@@ -480,10 +464,10 @@ appProtocolVersionStartsFrom(Application& app, ProtocolVersion fromVersion)
     return protocolVersionStartsFrom(ledgerVersion, fromVersion);
 }
 
-void
-generateTransactions(Application& app, std::filesystem::path const& outputFile,
-                     uint32_t numTransactions, uint32_t accounts,
-                     uint32_t offset)
+void generateTransactions(Application& app,
+                          std::filesystem::path const& outputFile,
+                          uint32_t numTransactions, uint32_t accounts,
+                          uint32_t offset)
 {
     // Create a TxGenerator for generating payment transactions
     TxGenerator txgen(app);

--- a/src/test/TestUtils.h
+++ b/src/test/TestUtils.h
@@ -46,8 +46,7 @@ template <class BucketT> class BucketListDepthModifier
     ~BucketListDepthModifier();
 };
 
-inline BucketMetadata
-testBucketMetadata(uint32_t protocolVersion)
+inline BucketMetadata testBucketMetadata(uint32_t protocolVersion)
 {
     BucketMetadata meta;
     meta.ledgerVersion = protocolVersion;
@@ -86,9 +85,9 @@ class TestApplication : public ApplicationImpl
 template <typename T = TestApplication, typename... Args,
           typename = typename std::enable_if<
               std::is_base_of<TestApplication, T>::value>::type>
-std::shared_ptr<T>
-createTestApplication(VirtualClock& clock, Config const& cfg, Args&&... args,
-                      bool newDB = true, bool startApp = true)
+std::shared_ptr<T> createTestApplication(VirtualClock& clock, Config const& cfg,
+                                         Args&&... args, bool newDB = true,
+                                         bool startApp = true)
 {
     Config c2(cfg);
     c2.adjust();
@@ -122,15 +121,13 @@ void overrideSorobanNetworkConfigForTest(Application& app);
 // applyUpgrade == true, close ledgers until the upgrade has been applied.
 // Otherwise just arm the nodes without closing the ledger containing the
 // upgrade.
-void
-upgradeSorobanNetworkConfig(std::function<void(SorobanNetworkConfig&)> modifyFn,
-                            std::shared_ptr<Simulation> simulation,
-                            bool applyUpgrade = true);
+void upgradeSorobanNetworkConfig(
+    std::function<void(SorobanNetworkConfig&)> modifyFn,
+    std::shared_ptr<Simulation> simulation, bool applyUpgrade = true);
 std::pair<SorobanNetworkConfig, UpgradeType> prepareSorobanNetworkConfigUpgrade(
     Application& app, std::function<void(SorobanNetworkConfig&)> modifyFn);
-void
-modifySorobanNetworkConfig(Application& app,
-                           std::function<void(SorobanNetworkConfig&)> modifyFn);
+void modifySorobanNetworkConfig(
+    Application& app, std::function<void(SorobanNetworkConfig&)> modifyFn);
 
 bool appProtocolVersionStartsFrom(Application& app,
                                   ProtocolVersion fromVersion);

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -93,9 +93,9 @@ ExpectedOpResult::ExpectedOpResult(SetOptionsResultCode setOptionsResultCode)
     mOperationResult.tr().setOptionsResult().code(setOptionsResultCode);
 }
 
-TransactionResult
-expectedResult(int64_t fee, size_t opsCount, TransactionResultCode code,
-               std::vector<ExpectedOpResult> ops)
+TransactionResult expectedResult(int64_t fee, size_t opsCount,
+                                 TransactionResultCode code,
+                                 std::vector<ExpectedOpResult> ops)
 {
     auto result = TransactionResult{};
     result.feeCharged = fee;
@@ -119,8 +119,7 @@ expectedResult(int64_t fee, size_t opsCount, TransactionResultCode code,
     return result;
 }
 
-bool
-applyCheck(TransactionTestFramePtr tx, Application& app, bool checkSeqNum)
+bool applyCheck(TransactionTestFramePtr tx, Application& app, bool checkSeqNum)
 {
     // Close the ledger here to advance ledgerSeq
     closeLedger(app);
@@ -387,8 +386,7 @@ applyCheck(TransactionTestFramePtr tx, Application& app, bool checkSeqNum)
     return res;
 }
 
-void
-checkTransaction(TransactionTestFrame& txFrame, Application& app)
+void checkTransaction(TransactionTestFrame& txFrame, Application& app)
 {
     REQUIRE(txFrame.getResult().feeCharged ==
             app.getLedgerManager().getLastTxFee());
@@ -396,8 +394,8 @@ checkTransaction(TransactionTestFrame& txFrame, Application& app)
              txFrame.getResultCode() == txFAILED));
 }
 
-void
-applyTx(TransactionTestFramePtr const& tx, Application& app, bool checkSeqNum)
+void applyTx(TransactionTestFramePtr const& tx, Application& app,
+             bool checkSeqNum)
 {
     if (app.getConfig().MODE_USES_IN_MEMORY_LEDGER)
     {
@@ -437,10 +435,9 @@ applyTx(TransactionTestFramePtr const& tx, Application& app, bool checkSeqNum)
     }
 }
 
-void
-validateTxResults(TransactionTestFramePtr const& tx, Application& app,
-                  ValidationResult validationResult,
-                  TransactionResult const& applyResult)
+void validateTxResults(TransactionTestFramePtr const& tx, Application& app,
+                       ValidationResult validationResult,
+                       TransactionResult const& applyResult)
 {
     auto shouldValidateOk = validationResult.code == txSUCCESS;
 
@@ -477,10 +474,10 @@ validateTxResults(TransactionTestFramePtr const& tx, Application& app,
     REQUIRE(applyOk == shouldApplyOk);
 };
 
-void
-checkLiquidityPool(Application& app, PoolID const& poolID, int64_t reserveA,
-                   int64_t reserveB, int64_t totalPoolShares,
-                   int64_t poolSharesTrustLineCount)
+void checkLiquidityPool(Application& app, PoolID const& poolID,
+                        int64_t reserveA, int64_t reserveB,
+                        int64_t totalPoolShares,
+                        int64_t poolSharesTrustLineCount)
 {
     LedgerTxn ltx(app.getLedgerTxnRoot());
     auto lp = loadLiquidityPool(ltx, poolID);
@@ -603,8 +600,7 @@ closeLedgerOn(Application& app, uint32 ledgerSeq, TimePoint closeTime,
     return lm.mLatestTxResultSet;
 }
 
-TransactionResultSet
-closeLedger(Application& app, TxSetXDRFrameConstPtr txSet)
+TransactionResultSet closeLedger(Application& app, TxSetXDRFrameConstPtr txSet)
 {
     auto lastCloseTime = app.getLedgerManager()
                              .getLastClosedLedgerHeader()
@@ -613,9 +609,9 @@ closeLedger(Application& app, TxSetXDRFrameConstPtr txSet)
     return closeLedgerOn(app, nextLedgerSeq, lastCloseTime, txSet);
 }
 
-TransactionResultSet
-closeLedgerOn(Application& app, uint32 ledgerSeq, time_t closeTime,
-              TxSetXDRFrameConstPtr txSet)
+TransactionResultSet closeLedgerOn(Application& app, uint32 ledgerSeq,
+                                   time_t closeTime,
+                                   TxSetXDRFrameConstPtr txSet)
 {
     app.getHerder().externalizeValue(txSet, ledgerSeq, closeTime,
                                      emptyUpgradeSteps);
@@ -628,14 +624,12 @@ closeLedgerOn(Application& app, uint32 ledgerSeq, time_t closeTime,
     return z1;
 }
 
-SecretKey
-getRoot(Hash const& networkID)
+SecretKey getRoot(Hash const& networkID)
 {
     return SecretKey::fromSeed(networkID);
 }
 
-SecretKey
-getAccount(std::string const& n)
+SecretKey getAccount(std::string const& n)
 {
     // stretch seed to 32 bytes
     std::string seed(n);
@@ -644,14 +638,13 @@ getAccount(std::string const& n)
     return SecretKey::fromSeed(seed);
 }
 
-Signer
-makeSigner(SecretKey key, int weight)
+Signer makeSigner(SecretKey key, int weight)
 {
     return Signer{KeyUtils::convertKey<SignerKey>(key.getPublicKey()), weight};
 }
 
-ConstLedgerTxnEntry
-loadAccount(AbstractLedgerTxn& ltx, PublicKey const& k, bool mustExist)
+ConstLedgerTxnEntry loadAccount(AbstractLedgerTxn& ltx, PublicKey const& k,
+                                bool mustExist)
 {
     auto res = stellar::loadAccountWithoutRecord(ltx, k);
     if (mustExist)
@@ -661,26 +654,22 @@ loadAccount(AbstractLedgerTxn& ltx, PublicKey const& k, bool mustExist)
     return res;
 }
 
-bool
-doesAccountExist(Application& app, PublicKey const& k)
+bool doesAccountExist(Application& app, PublicKey const& k)
 {
     LedgerSnapshot lss(app);
     return (bool)lss.getAccount(k);
 }
 
-xdr::xvector<Signer, 20>
-getAccountSigners(PublicKey const& k, Application& app)
+xdr::xvector<Signer, 20> getAccountSigners(PublicKey const& k, Application& app)
 {
     LedgerSnapshot lss(app);
     auto account = lss.getAccount(k);
     return account.current().data.account().signers;
 }
 
-TransactionTestFramePtr
-transactionFromOperationsV0(Application& app, SecretKey const& from,
-                            SequenceNumber seq,
-                            const std::vector<Operation>& ops, uint32_t fee,
-                            std::optional<Memo> memo)
+TransactionTestFramePtr transactionFromOperationsV0(
+    Application& app, SecretKey const& from, SequenceNumber seq,
+    const std::vector<Operation>& ops, uint32_t fee, std::optional<Memo> memo)
 {
     TransactionEnvelope e(ENVELOPE_TYPE_TX_V0);
     e.v0().tx.sourceAccountEd25519 = from.getPublicKey().ed25519();
@@ -724,11 +713,9 @@ makeEnvelopeV1(Application& app, SecretKey const& from, SequenceNumber seq,
     return e;
 }
 
-TransactionTestFramePtr
-paddedTransactionFromOperationsV1(Application& app, SecretKey const& from,
-                                  SequenceNumber seq,
-                                  std::vector<Operation> const& ops,
-                                  uint32_t fee, uint32_t desiredSize)
+TransactionTestFramePtr paddedTransactionFromOperationsV1(
+    Application& app, SecretKey const& from, SequenceNumber seq,
+    std::vector<Operation> const& ops, uint32_t fee, uint32_t desiredSize)
 {
     TransactionEnvelope e =
         makeEnvelopeV1(app, from, seq, ops, fee, std::nullopt);
@@ -776,13 +763,11 @@ paddedTransactionFromOperationsV1(Application& app, SecretKey const& from,
     return res;
 }
 
-TransactionTestFramePtr
-transactionFromOperationsV1(Application& app, SecretKey const& from,
-                            SequenceNumber seq,
-                            std::vector<Operation> const& ops, uint32_t fee,
-                            std::optional<PreconditionsV2> cond,
-                            std::optional<uint64_t> sourceMux,
-                            std::optional<Memo> memo)
+TransactionTestFramePtr transactionFromOperationsV1(
+    Application& app, SecretKey const& from, SequenceNumber seq,
+    std::vector<Operation> const& ops, uint32_t fee,
+    std::optional<PreconditionsV2> cond, std::optional<uint64_t> sourceMux,
+    std::optional<Memo> memo)
 {
     TransactionEnvelope e =
         makeEnvelopeV1(app, from, seq, ops, fee, std::nullopt);
@@ -804,11 +789,9 @@ transactionFromOperationsV1(Application& app, SecretKey const& from,
     return res;
 }
 
-TransactionTestFramePtr
-paddedTransactionFromOperations(Application& app, SecretKey const& from,
-                                SequenceNumber seq,
-                                const std::vector<Operation>& ops, uint32_t fee,
-                                uint32_t desiredSize)
+TransactionTestFramePtr paddedTransactionFromOperations(
+    Application& app, SecretKey const& from, SequenceNumber seq,
+    const std::vector<Operation>& ops, uint32_t fee, uint32_t desiredSize)
 {
     auto ledgerVersion =
         app.getLedgerManager().getLastClosedLedgerHeader().header.ledgerVersion;
@@ -846,10 +829,9 @@ transactionWithV2Precondition(Application& app, TestAccount& account,
         {payment(account.getPublicKey(), 1)}, fee, cond);
 }
 
-TransactionTestFramePtr
-feeBump(Application& app, TestAccount& feeSource,
-        TransactionFrameBaseConstPtr tx, int64_t fee,
-        bool useInclusionAsFullFee)
+TransactionTestFramePtr feeBump(Application& app, TestAccount& feeSource,
+                                TransactionFrameBaseConstPtr tx, int64_t fee,
+                                bool useInclusionAsFullFee)
 {
     REQUIRE(tx->getEnvelope().type() == ENVELOPE_TYPE_TX);
     TransactionEnvelope fb(ENVELOPE_TYPE_TX_FEE_BUMP);
@@ -873,14 +855,12 @@ feeBump(Application& app, TestAccount& feeSource,
     return TransactionTestFrame::fromTxFrame(ret);
 }
 
-Operation
-changeTrust(Asset const& asset, int64_t limit)
+Operation changeTrust(Asset const& asset, int64_t limit)
 {
     return changeTrust(assetToChangeTrustAsset(asset), limit);
 }
 
-Operation
-changeTrust(ChangeTrustAsset const& asset, int64_t limit)
+Operation changeTrust(ChangeTrustAsset const& asset, int64_t limit)
 {
     Operation op;
 
@@ -891,8 +871,8 @@ changeTrust(ChangeTrustAsset const& asset, int64_t limit)
     return op;
 }
 
-Operation
-allowTrust(PublicKey const& trustor, Asset const& asset, uint32_t authorize)
+Operation allowTrust(PublicKey const& trustor, Asset const& asset,
+                     uint32_t authorize)
 {
     Operation op;
 
@@ -915,8 +895,7 @@ allowTrust(PublicKey const& trustor, Asset const& asset, uint32_t authorize)
     return op;
 }
 
-Operation
-createAccount(PublicKey const& dest, int64_t amount)
+Operation createAccount(PublicKey const& dest, int64_t amount)
 {
     Operation op;
     op.body.type(CREATE_ACCOUNT);
@@ -925,8 +904,7 @@ createAccount(PublicKey const& dest, int64_t amount)
     return op;
 }
 
-Operation
-payment(PublicKey const& to, int64_t amount)
+Operation payment(PublicKey const& to, int64_t amount)
 {
     Operation op;
     op.body.type(PAYMENT);
@@ -936,8 +914,7 @@ payment(PublicKey const& to, int64_t amount)
     return op;
 }
 
-Operation
-payment(PublicKey const& to, Asset const& asset, int64_t amount)
+Operation payment(PublicKey const& to, Asset const& asset, int64_t amount)
 {
     Operation op;
     op.body.type(PAYMENT);
@@ -947,9 +924,9 @@ payment(PublicKey const& to, Asset const& asset, int64_t amount)
     return op;
 }
 
-TransactionTestFramePtr
-createPaymentTx(Application& app, SecretKey const& from, PublicKey const& to,
-                SequenceNumber seq, int64_t amount)
+TransactionTestFramePtr createPaymentTx(Application& app, SecretKey const& from,
+                                        PublicKey const& to, SequenceNumber seq,
+                                        int64_t amount)
 {
     return transactionFromOperations(app, from, seq, {payment(to, amount)});
 }
@@ -963,9 +940,9 @@ createCreditPaymentTx(Application& app, SecretKey const& from,
     return transactionFromOperations(app, from, seq, {op});
 }
 
-TransactionTestFramePtr
-createSimpleDexTx(Application& app, TestAccount& account, uint32 nbOps,
-                  uint32_t fee)
+TransactionTestFramePtr createSimpleDexTx(Application& app,
+                                          TestAccount& account, uint32 nbOps,
+                                          uint32_t fee)
 {
     std::vector<Operation> ops;
     Asset asset1(ASSET_TYPE_NATIVE);
@@ -987,9 +964,8 @@ createSimpleDexTx(Application& app, TestAccount& account, uint32 nbOps,
                                      ops, fee);
 }
 
-Operation
-createUploadWasmOperation(uint32_t generatedWasmSize,
-                          std::optional<uint64_t> wasmSeed)
+Operation createUploadWasmOperation(uint32_t generatedWasmSize,
+                                    std::optional<uint64_t> wasmSeed)
 {
     uint32_t const WASM_HEADER_SIZE = 100;
 
@@ -1048,11 +1024,10 @@ createUploadWasmTx(Application& app, TestAccount& account,
                                           memo, seq);
 }
 
-int64_t
-sorobanResourceFee(Application& app, SorobanResources const& resources,
-                   size_t txSize, uint32_t eventsSize,
-                   std::optional<std::vector<uint32_t>> archivedIndexes,
-                   bool isRestoreFootprintOp)
+int64_t sorobanResourceFee(Application& app, SorobanResources const& resources,
+                           size_t txSize, uint32_t eventsSize,
+                           std::optional<std::vector<uint32_t>> archivedIndexes,
+                           bool isRestoreFootprintOp)
 {
     releaseAssert(txSize <= INT32_MAX);
     SorobanTransactionData::_ext_t ext;
@@ -1071,24 +1046,21 @@ sorobanResourceFee(Application& app, SorobanResources const& resources,
     return feePair.non_refundable_fee + feePair.refundable_fee;
 }
 
-Asset
-makeNativeAsset()
+Asset makeNativeAsset()
 {
     Asset asset;
     asset.type(ASSET_TYPE_NATIVE);
     return asset;
 }
 
-Asset
-makeInvalidAsset()
+Asset makeInvalidAsset()
 {
     Asset asset;
     asset.type(ASSET_TYPE_CREDIT_ALPHANUM4);
     return asset;
 }
 
-Asset
-makeAsset(SecretKey const& issuer, std::string const& code)
+Asset makeAsset(SecretKey const& issuer, std::string const& code)
 {
     Asset asset;
     asset.type(ASSET_TYPE_CREDIT_ALPHANUM4);
@@ -1097,8 +1069,7 @@ makeAsset(SecretKey const& issuer, std::string const& code)
     return asset;
 }
 
-Asset
-makeAssetAlphanum12(SecretKey const& issuer, std::string const& code)
+Asset makeAssetAlphanum12(SecretKey const& issuer, std::string const& code)
 {
     Asset asset;
     asset.type(ASSET_TYPE_CREDIT_ALPHANUM12);
@@ -1107,9 +1078,8 @@ makeAssetAlphanum12(SecretKey const& issuer, std::string const& code)
     return asset;
 }
 
-ChangeTrustAsset
-makeChangeTrustAssetPoolShare(Asset const& assetA, Asset const& assetB,
-                              int32_t fee)
+ChangeTrustAsset makeChangeTrustAssetPoolShare(Asset const& assetA,
+                                               Asset const& assetB, int32_t fee)
 {
     REQUIRE(assetA < assetB);
     ChangeTrustAsset poolAsset;
@@ -1120,10 +1090,9 @@ makeChangeTrustAssetPoolShare(Asset const& assetA, Asset const& assetB,
     return poolAsset;
 }
 
-Operation
-pathPayment(PublicKey const& to, Asset const& sendCur, int64_t sendMax,
-            Asset const& destCur, int64_t destAmount,
-            std::vector<Asset> const& path)
+Operation pathPayment(PublicKey const& to, Asset const& sendCur,
+                      int64_t sendMax, Asset const& destCur, int64_t destAmount,
+                      std::vector<Asset> const& path)
 {
     Operation op;
     op.body.type(PATH_PAYMENT_STRICT_RECEIVE);
@@ -1138,10 +1107,9 @@ pathPayment(PublicKey const& to, Asset const& sendCur, int64_t sendMax,
     return op;
 }
 
-Operation
-pathPaymentStrictSend(PublicKey const& to, Asset const& sendCur,
-                      int64_t sendAmount, Asset const& destCur, int64_t destMin,
-                      std::vector<Asset> const& path)
+Operation pathPaymentStrictSend(PublicKey const& to, Asset const& sendCur,
+                                int64_t sendAmount, Asset const& destCur,
+                                int64_t destMin, std::vector<Asset> const& path)
 {
     Operation op;
     op.body.type(PATH_PAYMENT_STRICT_SEND);
@@ -1156,9 +1124,8 @@ pathPaymentStrictSend(PublicKey const& to, Asset const& sendCur,
     return op;
 }
 
-Operation
-createPassiveOffer(Asset const& selling, Asset const& buying,
-                   Price const& price, int64_t amount)
+Operation createPassiveOffer(Asset const& selling, Asset const& buying,
+                             Price const& price, int64_t amount)
 {
     Operation op;
     op.body.type(CREATE_PASSIVE_SELL_OFFER);
@@ -1170,9 +1137,8 @@ createPassiveOffer(Asset const& selling, Asset const& buying,
     return op;
 }
 
-Operation
-manageOffer(int64 offerId, Asset const& selling, Asset const& buying,
-            Price const& price, int64_t amount)
+Operation manageOffer(int64 offerId, Asset const& selling, Asset const& buying,
+                      Price const& price, int64_t amount)
 {
     Operation op;
     op.body.type(MANAGE_SELL_OFFER);
@@ -1185,9 +1151,9 @@ manageOffer(int64 offerId, Asset const& selling, Asset const& buying,
     return op;
 }
 
-Operation
-manageBuyOffer(int64 offerId, Asset const& selling, Asset const& buying,
-               Price const& price, int64_t amount)
+Operation manageBuyOffer(int64 offerId, Asset const& selling,
+                         Asset const& buying, Price const& price,
+                         int64_t amount)
 {
     Operation op;
     op.body.type(MANAGE_BUY_OFFER);
@@ -1267,11 +1233,11 @@ applyCreateOfferHelper(Application& app, int64 offerId, SecretKey const& source,
     return manageSellOfferResult;
 }
 
-int64_t
-applyManageOffer(Application& app, int64 offerId, SecretKey const& source,
-                 Asset const& selling, Asset const& buying, Price const& price,
-                 int64_t amount, SequenceNumber seq,
-                 ManageOfferEffect expectedEffect)
+int64_t applyManageOffer(Application& app, int64 offerId,
+                         SecretKey const& source, Asset const& selling,
+                         Asset const& buying, Price const& price,
+                         int64_t amount, SequenceNumber seq,
+                         ManageOfferEffect expectedEffect)
 {
     ManageSellOfferResult const& createOfferRes = applyCreateOfferHelper(
         app, offerId, source, selling, buying, price, amount, seq);
@@ -1282,11 +1248,11 @@ applyManageOffer(Application& app, int64 offerId, SecretKey const& source,
                                                     : 0;
 }
 
-int64_t
-applyManageBuyOffer(Application& app, int64 offerId, SecretKey const& source,
-                    Asset const& selling, Asset const& buying,
-                    Price const& price, int64_t amount, SequenceNumber seq,
-                    ManageOfferEffect expectedEffect)
+int64_t applyManageBuyOffer(Application& app, int64 offerId,
+                            SecretKey const& source, Asset const& selling,
+                            Asset const& buying, Price const& price,
+                            int64_t amount, SequenceNumber seq,
+                            ManageOfferEffect expectedEffect)
 {
     auto getIdPool = [&]() {
         LedgerTxn ltx(app.getLedgerTxnRoot());
@@ -1349,11 +1315,11 @@ applyManageBuyOffer(Application& app, int64 offerId, SecretKey const& source,
                                                     : 0;
 }
 
-int64_t
-applyCreatePassiveOffer(Application& app, SecretKey const& source,
-                        Asset const& selling, Asset const& buying,
-                        Price const& price, int64_t amount, SequenceNumber seq,
-                        ManageOfferEffect expectedEffect)
+int64_t applyCreatePassiveOffer(Application& app, SecretKey const& source,
+                                Asset const& selling, Asset const& buying,
+                                Price const& price, int64_t amount,
+                                SequenceNumber seq,
+                                ManageOfferEffect expectedEffect)
 {
     auto getIdPool = [&]() {
         LedgerTxn ltx(app.getLedgerTxnRoot());
@@ -1423,8 +1389,8 @@ applyCreatePassiveOffer(Application& app, SecretKey const& source,
                                                     : 0;
 }
 
-SetOptionsArguments
-operator|(SetOptionsArguments const& x, SetOptionsArguments const& y)
+SetOptionsArguments operator|(SetOptionsArguments const& x,
+                              SetOptionsArguments const& y)
 {
     auto result = SetOptionsArguments{};
     result.masterWeight = y.masterWeight ? y.masterWeight : x.masterWeight;
@@ -1439,8 +1405,7 @@ operator|(SetOptionsArguments const& x, SetOptionsArguments const& y)
     return result;
 }
 
-Operation
-setOptions(SetOptionsArguments const& arguments)
+Operation setOptions(SetOptionsArguments const& arguments)
 {
     Operation op;
     op.body.type(SET_OPTIONS);
@@ -1492,81 +1457,71 @@ setOptions(SetOptionsArguments const& arguments)
     return op;
 }
 
-SetOptionsArguments
-setMasterWeight(int master)
+SetOptionsArguments setMasterWeight(int master)
 {
     SetOptionsArguments result;
     result.masterWeight = std::make_optional<int>(master);
     return result;
 }
 
-SetOptionsArguments
-setLowThreshold(int low)
+SetOptionsArguments setLowThreshold(int low)
 {
     SetOptionsArguments result;
     result.lowThreshold = std::make_optional<int>(low);
     return result;
 }
 
-SetOptionsArguments
-setMedThreshold(int med)
+SetOptionsArguments setMedThreshold(int med)
 {
     SetOptionsArguments result;
     result.medThreshold = std::make_optional<int>(med);
     return result;
 }
 
-SetOptionsArguments
-setHighThreshold(int high)
+SetOptionsArguments setHighThreshold(int high)
 {
     SetOptionsArguments result;
     result.highThreshold = std::make_optional<int>(high);
     return result;
 }
 
-SetOptionsArguments
-setSigner(Signer signer)
+SetOptionsArguments setSigner(Signer signer)
 {
     SetOptionsArguments result;
     result.signer = std::make_optional<Signer>(signer);
     return result;
 }
 
-SetOptionsArguments
-setFlags(uint32_t setFlags)
+SetOptionsArguments setFlags(uint32_t setFlags)
 {
     SetOptionsArguments result;
     result.setFlags = std::make_optional<uint32_t>(setFlags);
     return result;
 }
 
-SetOptionsArguments
-clearFlags(uint32_t clearFlags)
+SetOptionsArguments clearFlags(uint32_t clearFlags)
 {
     SetOptionsArguments result;
     result.clearFlags = std::make_optional<uint32_t>(clearFlags);
     return result;
 }
 
-SetOptionsArguments
-setInflationDestination(AccountID inflationDest)
+SetOptionsArguments setInflationDestination(AccountID inflationDest)
 {
     SetOptionsArguments result;
     result.inflationDest = std::make_optional<AccountID>(inflationDest);
     return result;
 }
 
-SetOptionsArguments
-setHomeDomain(std::string const& homeDomain)
+SetOptionsArguments setHomeDomain(std::string const& homeDomain)
 {
     SetOptionsArguments result;
     result.homeDomain = std::make_optional<std::string>(homeDomain);
     return result;
 }
 
-SetTrustLineFlagsArguments
-operator|(SetTrustLineFlagsArguments const& x,
-          SetTrustLineFlagsArguments const& y)
+SetTrustLineFlagsArguments operator|(SetTrustLineFlagsArguments const& x,
+                                     SetTrustLineFlagsArguments const& y)
 {
     auto result = SetTrustLineFlagsArguments{};
     result.setFlags = y.setFlags | x.setFlags;
@@ -1574,9 +1529,8 @@ operator|(SetTrustLineFlagsArguments const& x,
     return result;
 }
 
-Operation
-setTrustLineFlags(PublicKey const& trustor, Asset const& asset,
-                  SetTrustLineFlagsArguments const& arguments)
+Operation setTrustLineFlags(PublicKey const& trustor, Asset const& asset,
+                            SetTrustLineFlagsArguments const& arguments)
 {
     Operation op;
     op.body.type(SET_TRUST_LINE_FLAGS);
@@ -1590,24 +1544,21 @@ setTrustLineFlags(PublicKey const& trustor, Asset const& asset,
     return op;
 }
 
-SetTrustLineFlagsArguments
-setTrustLineFlags(uint32_t setFlags)
+SetTrustLineFlagsArguments setTrustLineFlags(uint32_t setFlags)
 {
     SetTrustLineFlagsArguments result;
     result.setFlags = setFlags;
     return result;
 }
 
-SetTrustLineFlagsArguments
-clearTrustLineFlags(uint32_t clearFlags)
+SetTrustLineFlagsArguments clearTrustLineFlags(uint32_t clearFlags)
 {
     SetTrustLineFlagsArguments result;
     result.clearFlags = clearFlags;
     return result;
 }
 
-Operation
-inflation()
+Operation inflation()
 {
     Operation op;
     op.body.type(INFLATION);
@@ -1615,8 +1566,7 @@ inflation()
     return op;
 }
 
-Operation
-accountMerge(PublicKey const& dest)
+Operation accountMerge(PublicKey const& dest)
 {
     Operation op;
     op.body.type(ACCOUNT_MERGE);
@@ -1624,8 +1574,7 @@ accountMerge(PublicKey const& dest)
     return op;
 }
 
-Operation
-manageData(std::string const& name, DataValue* value)
+Operation manageData(std::string const& name, DataValue* value)
 {
     Operation op;
     op.body.type(MANAGE_DATA);
@@ -1636,8 +1585,7 @@ manageData(std::string const& name, DataValue* value)
     return op;
 }
 
-Operation
-bumpSequence(SequenceNumber to)
+Operation bumpSequence(SequenceNumber to)
 {
     Operation op;
     op.body.type(BUMP_SEQUENCE);
@@ -1645,9 +1593,8 @@ bumpSequence(SequenceNumber to)
     return op;
 }
 
-Operation
-createClaimableBalance(Asset const& asset, int64_t amount,
-                       xdr::xvector<Claimant, 10> const& claimants)
+Operation createClaimableBalance(Asset const& asset, int64_t amount,
+                                 xdr::xvector<Claimant, 10> const& claimants)
 {
     Operation op;
     op.body.type(CREATE_CLAIMABLE_BALANCE);
@@ -1657,8 +1604,7 @@ createClaimableBalance(Asset const& asset, int64_t amount,
     return op;
 }
 
-Operation
-claimClaimableBalance(ClaimableBalanceID const& balanceID)
+Operation claimClaimableBalance(ClaimableBalanceID const& balanceID)
 {
     Operation op;
     op.body.type(CLAIM_CLAIMABLE_BALANCE);
@@ -1666,8 +1612,7 @@ claimClaimableBalance(ClaimableBalanceID const& balanceID)
     return op;
 }
 
-Operation
-beginSponsoringFutureReserves(PublicKey const& sponsoredID)
+Operation beginSponsoringFutureReserves(PublicKey const& sponsoredID)
 {
     Operation op;
     op.body.type(BEGIN_SPONSORING_FUTURE_RESERVES);
@@ -1675,16 +1620,14 @@ beginSponsoringFutureReserves(PublicKey const& sponsoredID)
     return op;
 }
 
-Operation
-endSponsoringFutureReserves()
+Operation endSponsoringFutureReserves()
 {
     Operation op;
     op.body.type(END_SPONSORING_FUTURE_RESERVES);
     return op;
 }
 
-Operation
-revokeSponsorship(LedgerKey const& key)
+Operation revokeSponsorship(LedgerKey const& key)
 {
     Operation op;
     op.body.type(REVOKE_SPONSORSHIP);
@@ -1693,8 +1636,7 @@ revokeSponsorship(LedgerKey const& key)
     return op;
 }
 
-Operation
-revokeSponsorship(AccountID const& accID, SignerKey const& key)
+Operation revokeSponsorship(AccountID const& accID, SignerKey const& key)
 {
     Operation op;
     op.body.type(REVOKE_SPONSORSHIP);
@@ -1704,8 +1646,7 @@ revokeSponsorship(AccountID const& accID, SignerKey const& key)
     return op;
 }
 
-Operation
-clawback(AccountID const& from, Asset const& asset, int64_t amount)
+Operation clawback(AccountID const& from, Asset const& asset, int64_t amount)
 {
     Operation op;
     op.body.type(CLAWBACK);
@@ -1716,8 +1657,7 @@ clawback(AccountID const& from, Asset const& asset, int64_t amount)
     return op;
 }
 
-Operation
-clawbackClaimableBalance(ClaimableBalanceID const& balanceID)
+Operation clawbackClaimableBalance(ClaimableBalanceID const& balanceID)
 {
     Operation op;
     op.body.type(CLAWBACK_CLAIMABLE_BALANCE);
@@ -1725,10 +1665,9 @@ clawbackClaimableBalance(ClaimableBalanceID const& balanceID)
     return op;
 }
 
-Operation
-liquidityPoolDeposit(PoolID const& poolID, int64_t maxAmountA,
-                     int64_t maxAmountB, Price const& minPrice,
-                     Price const& maxPrice)
+Operation liquidityPoolDeposit(PoolID const& poolID, int64_t maxAmountA,
+                               int64_t maxAmountB, Price const& minPrice,
+                               Price const& maxPrice)
 {
     Operation op;
     op.body.type(LIQUIDITY_POOL_DEPOSIT);
@@ -1740,9 +1679,8 @@ liquidityPoolDeposit(PoolID const& poolID, int64_t maxAmountA,
     return op;
 }
 
-Operation
-liquidityPoolWithdraw(PoolID const& poolID, int64_t amount, int64_t minAmountA,
-                      int64_t minAmountB)
+Operation liquidityPoolWithdraw(PoolID const& poolID, int64_t amount,
+                                int64_t minAmountA, int64_t minAmountB)
 {
     Operation op;
     op.body.type(LIQUIDITY_POOL_WITHDRAW);
@@ -1753,34 +1691,29 @@ liquidityPoolWithdraw(PoolID const& poolID, int64_t amount, int64_t minAmountA,
     return op;
 }
 
-OperationResult const&
-getFirstResult(TransactionTestFramePtr tx)
+OperationResult const& getFirstResult(TransactionTestFramePtr tx)
 {
     return tx->getOperationResultAt(0);
 }
 
-OperationResultCode
-getFirstResultCode(TransactionTestFramePtr tx)
+OperationResultCode getFirstResultCode(TransactionTestFramePtr tx)
 {
     return tx->getOperationResultAt(0).code();
 }
 
-void
-checkTx(int index, TransactionResultSet& r, TransactionResultCode expected)
+void checkTx(int index, TransactionResultSet& r, TransactionResultCode expected)
 {
     REQUIRE(r.results[index].result.result.code() == expected);
 };
 
-void
-checkTx(int index, TransactionResultSet& r, TransactionResultCode expected,
-        OperationResultCode code)
+void checkTx(int index, TransactionResultSet& r, TransactionResultCode expected,
+             OperationResultCode code)
 {
     checkTx(index, r, expected);
     REQUIRE(r.results[index].result.result.results()[0].code() == code);
 };
 
-void
-sign(Hash const& networkID, SecretKey key, TransactionV1Envelope& env)
+void sign(Hash const& networkID, SecretKey key, TransactionV1Envelope& env)
 {
     env.signatures.emplace_back(SignatureUtils::sign(
         key, sha256(xdr::xdr_to_opaque(networkID, ENVELOPE_TYPE_TX, env.tx))));
@@ -1812,15 +1745,13 @@ envelopeFromOps(Hash const& networkID, TestAccount& source,
     return tx;
 }
 
-static TransactionEnvelope
-sorobanEnvelopeFromOps(Hash const& networkID, TestAccount& source,
-                       std::vector<Operation> const& ops,
-                       std::vector<SecretKey> const& opKeys,
-                       SorobanResources const& resources, uint32_t totalFee,
-                       int64_t resourceFee, std::optional<std::string> memo,
-                       std::optional<SequenceNumber> seq,
-                       std::optional<uint64_t> muxedData,
-                       std::optional<std::vector<uint32_t>> archivedIndexes)
+static TransactionEnvelope sorobanEnvelopeFromOps(
+    Hash const& networkID, TestAccount& source,
+    std::vector<Operation> const& ops, std::vector<SecretKey> const& opKeys,
+    SorobanResources const& resources, uint32_t totalFee, int64_t resourceFee,
+    std::optional<std::string> memo, std::optional<SequenceNumber> seq,
+    std::optional<uint64_t> muxedData,
+    std::optional<std::vector<uint32_t>> archivedIndexes)
 {
     TransactionEnvelope tx(ENVELOPE_TYPE_TX);
     if (muxedData)
@@ -1880,8 +1811,7 @@ transactionFrameFromOps(Hash const& networkID, TestAccount& source,
     return TransactionTestFrame::fromTxFrame(tx);
 }
 
-TransactionTestFramePtr
-sorobanTransactionFrameFromOps(
+TransactionTestFramePtr sorobanTransactionFrameFromOps(
     Hash const& networkID, TestAccount& source,
     std::vector<Operation> const& ops, std::vector<SecretKey> const& opKeys,
     SorobanResources const& resources, uint32_t inclusionFee,
@@ -1902,8 +1832,7 @@ sorobanTransactionFrameFromOps(
     return TransactionTestFrame::fromTxFrame(tx);
 }
 
-TransactionTestFramePtr
-sorobanTransactionFrameFromOpsWithTotalFee(
+TransactionTestFramePtr sorobanTransactionFrameFromOpsWithTotalFee(
     Hash const& networkID, TestAccount& source,
     std::vector<Operation> const& ops, std::vector<SecretKey> const& opKeys,
     SorobanResources const& resources, uint32_t totalFee, int64_t resourceFee,
@@ -1918,17 +1847,16 @@ sorobanTransactionFrameFromOpsWithTotalFee(
     return TransactionTestFrame::fromTxFrame(tx);
 }
 
-LedgerUpgrade
-makeBaseReserveUpgrade(int baseReserve)
+LedgerUpgrade makeBaseReserveUpgrade(int baseReserve)
 {
     auto result = LedgerUpgrade{LEDGER_UPGRADE_BASE_RESERVE};
     result.newBaseReserve() = baseReserve;
     return result;
 }
 
-LedgerHeader
-executeUpgrades(Application& app, xdr::xvector<UpgradeType, 6> const& upgrades,
-                bool upgradesIgnored)
+LedgerHeader executeUpgrades(Application& app,
+                             xdr::xvector<UpgradeType, 6> const& upgrades,
+                             bool upgradesIgnored)
 {
     auto& lm = app.getLedgerManager();
     auto currLh = app.getLedgerManager().getLastClosedLedgerHeader().header;
@@ -1954,9 +1882,8 @@ executeUpgrades(Application& app, xdr::xvector<UpgradeType, 6> const& upgrades,
     return lm.getLastClosedLedgerHeader().header;
 };
 
-LedgerHeader
-executeUpgrade(Application& app, LedgerUpgrade const& lupgrade,
-               bool upgradeIgnored)
+LedgerHeader executeUpgrade(Application& app, LedgerUpgrade const& lupgrade,
+                            bool upgradeIgnored)
 {
     return executeUpgrades(app, {LedgerTestUtils::toUpgradeType(lupgrade)},
                            upgradeIgnored);
@@ -2002,8 +1929,7 @@ makeConfigUpgradeSet(AbstractLedgerTxn& ltx, ConfigUpgradeSet configUpgradeSet,
     return ConfigUpgradeSetFrame::makeFromKey(lsg, upgradeKey);
 }
 
-LedgerUpgrade
-makeConfigUpgrade(ConfigUpgradeSetFrame const& configUpgradeSet)
+LedgerUpgrade makeConfigUpgrade(ConfigUpgradeSetFrame const& configUpgradeSet)
 {
     auto result = LedgerUpgrade{LEDGER_UPGRADE_CONFIG};
     result.newConfig() = configUpgradeSet.getKey();
@@ -2012,9 +1938,9 @@ makeConfigUpgrade(ConfigUpgradeSetFrame const& configUpgradeSet)
 
 // trades is a vector of pairs, where the bool indicates if assetA or assetB is
 // sent in the payment, and the int64_t is the amount
-void
-depositTradeWithdrawTest(Application& app, TestAccount& root, int depositSize,
-                         std::vector<std::pair<bool, int64_t>> const& trades)
+void depositTradeWithdrawTest(
+    Application& app, TestAccount& root, int depositSize,
+    std::vector<std::pair<bool, int64_t>> const& trades)
 {
     struct Deposit
     {
@@ -2089,8 +2015,8 @@ depositTradeWithdrawTest(Application& app, TestAccount& root, int depositSize,
     REQUIRE(!loadLiquidityPool(ltx, pool12));
 }
 
-int64_t
-getBalance(Application& app, AccountID const& accountID, Asset const& asset)
+int64_t getBalance(Application& app, AccountID const& accountID,
+                   Asset const& asset)
 {
     LedgerTxn ltx(app.getLedgerTxnRoot());
     if (asset.type() == ASSET_TYPE_NATIVE)
@@ -2105,22 +2031,19 @@ getBalance(Application& app, AccountID const& accountID, Asset const& asset)
     }
 }
 
-uint32_t
-getLclProtocolVersion(Application& app)
+uint32_t getLclProtocolVersion(Application& app)
 {
     auto const& lcl = app.getLedgerManager().getLastClosedLedgerHeader();
     return lcl.header.ledgerVersion;
 }
 
-bool
-isSuccessResult(TransactionResult const& res)
+bool isSuccessResult(TransactionResult const& res)
 {
     return res.result.code() == txSUCCESS ||
            res.result.code() == txFEE_BUMP_INNER_SUCCESS;
 }
 
-TestAccount
-getGenesisAccount(Application& app, uint32_t accountIndex)
+TestAccount getGenesisAccount(Application& app, uint32_t accountIndex)
 {
     REQUIRE(accountIndex < app.getConfig().GENESIS_TEST_ACCOUNT_COUNT);
     return TestAccount(

--- a/src/test/TxTests.h
+++ b/src/test/TxTests.h
@@ -367,9 +367,9 @@ LedgerHeader executeUpgrades(Application& app,
 LedgerHeader executeUpgrade(Application& app, LedgerUpgrade const& lupgrade,
                             bool upgradeIgnored = false);
 
-void
-depositTradeWithdrawTest(Application& app, TestAccount& root, int depositSize,
-                         std::vector<std::pair<bool, int64_t>> const& trades);
+void depositTradeWithdrawTest(
+    Application& app, TestAccount& root, int depositSize,
+    std::vector<std::pair<bool, int64_t>> const& trades);
 
 int64_t getBalance(Application& app, AccountID const& accountID,
                    Asset const& asset);

--- a/src/test/fuzz.cpp
+++ b/src/test/fuzz.cpp
@@ -31,8 +31,7 @@ namespace stellar
 {
 namespace FuzzUtils
 {
-std::unique_ptr<Fuzzer>
-createFuzzer(int processID, FuzzerMode fuzzerMode)
+std::unique_ptr<Fuzzer> createFuzzer(int processID, FuzzerMode fuzzerMode)
 {
     gBaseInstance = processID;
     switch (fuzzerMode)
@@ -48,9 +47,8 @@ createFuzzer(int processID, FuzzerMode fuzzerMode)
 }
 
 #define PERSIST_MAX 1000000
-void
-fuzz(std::string const& filename, std::vector<std::string> const& metrics,
-     int processID, FuzzerMode fuzzerMode)
+void fuzz(std::string const& filename, std::vector<std::string> const& metrics,
+          int processID, FuzzerMode fuzzerMode)
 {
     auto fuzzer = FuzzUtils::createFuzzer(processID, fuzzerMode);
     fuzzer->initialize();

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -61,8 +61,7 @@ struct ReseedPRNGListener : Catch::TestEventListenerBase
 {
     using TestEventListenerBase::TestEventListenerBase;
     static unsigned int sCommandLineSeed;
-    virtual void
-    testCaseStarting(Catch::TestCaseInfo const& testInfo) override
+    virtual void testCaseStarting(Catch::TestCaseInfo const& testInfo) override
     {
         reinitializeAllGlobalStateWithSeed(sCommandLineSeed);
     }
@@ -92,8 +91,7 @@ struct TestContextListener : Catch::TestEventListenerBase
     static std::optional<Catch::TestCaseInfo> sTestCtx;
     static std::vector<Catch::SectionInfo> sSectCtx;
 
-    void
-    testCaseStarting(Catch::TestCaseInfo const& testInfo) override
+    void testCaseStarting(Catch::TestCaseInfo const& testInfo) override
     {
         if (gTestTxMetaMode != TestTxMetaMode::META_TEST_IGNORE)
         {
@@ -102,8 +100,7 @@ struct TestContextListener : Catch::TestEventListenerBase
             sTestCtx.emplace(testInfo);
         }
     }
-    void
-    testCaseEnded(Catch::TestCaseStats const& testCaseStats) override
+    void testCaseEnded(Catch::TestCaseStats const& testCaseStats) override
     {
         if (gTestTxMetaMode != TestTxMetaMode::META_TEST_IGNORE)
         {
@@ -113,8 +110,7 @@ struct TestContextListener : Catch::TestEventListenerBase
             sTestCtx.reset();
         }
     }
-    void
-    sectionStarting(Catch::SectionInfo const& sectionInfo) override
+    void sectionStarting(Catch::SectionInfo const& sectionInfo) override
     {
         if (gTestTxMetaMode != TestTxMetaMode::META_TEST_IGNORE)
         {
@@ -122,8 +118,7 @@ struct TestContextListener : Catch::TestEventListenerBase
             sSectCtx.emplace_back(sectionInfo);
         }
     }
-    void
-    sectionEnded(Catch::SectionStats const& sectionStats) override
+    void sectionEnded(Catch::SectionStats const& sectionStats) override
     {
         if (gTestTxMetaMode != TestTxMetaMode::META_TEST_IGNORE)
         {
@@ -152,8 +147,7 @@ int gBaseInstance{0};
 static bool gMustUseTestVersionsWrapper{false};
 static uint32_t gTestingVersion{Config::CURRENT_LEDGER_PROTOCOL_VERSION};
 
-static void
-clearConfigs()
+static void clearConfigs()
 {
     for (auto& a : gTestCfg)
     {
@@ -161,8 +155,7 @@ clearConfigs()
     }
 }
 
-void
-test_versions_wrapper(std::function<void(void)> f)
+void test_versions_wrapper(std::function<void(void)> f)
 {
     gMustUseTestVersionsWrapper = true;
     for (auto v : gVersionsToTest)
@@ -189,8 +182,7 @@ static void reportTestTxMeta();
 // be manually cleared using cleanupTmpDirs. If this isn't done, gTestRoots will
 // try to use the logger when it is destructed, which is an issue because the
 // logger will have been destroyed.
-Config const&
-getTestConfig(int instanceNumber, Config::TestDbMode mode)
+Config const& getTestConfig(int instanceNumber, Config::TestDbMode mode)
 {
     instanceNumber += gBaseInstance;
     if (mode == Config::TESTDB_DEFAULT)
@@ -341,8 +333,7 @@ getTestConfig(int instanceNumber, Config::TestDbMode mode)
     return *cfgs[instanceNumber];
 }
 
-std::filesystem::path
-getSrcTestDataPath(std::filesystem::path rel)
+std::filesystem::path getSrcTestDataPath(std::filesystem::path rel)
 {
     namespace fs = std::filesystem;
     fs::path testdata("testdata");
@@ -354,8 +345,7 @@ getSrcTestDataPath(std::filesystem::path rel)
     return testdata / rel;
 }
 
-std::filesystem::path
-getBuildTestDataPath(std::filesystem::path rel)
+std::filesystem::path getBuildTestDataPath(std::filesystem::path rel)
 {
     namespace fs = std::filesystem;
     fs::path testdata("testdata");
@@ -367,8 +357,7 @@ getBuildTestDataPath(std::filesystem::path rel)
     return testdata / rel;
 }
 
-int
-runTest(CommandLineArgs const& args)
+int runTest(CommandLineArgs const& args)
 {
     LogLevel logLevel{LogLevel::LVL_INFO};
 
@@ -512,55 +501,49 @@ runTest(CommandLineArgs const& args)
     return r;
 }
 
-void
-cleanupTmpDirs()
+void cleanupTmpDirs()
 {
     gTestRoots.clear();
 }
 
-void
-for_versions_to(uint32 to, Application& app, std::function<void(void)> const& f)
+void for_versions_to(uint32 to, Application& app,
+                     std::function<void(void)> const& f)
 {
     for_versions(1, to, app, f);
 }
 
-void
-for_versions_from(uint32 from, Application& app,
-                  std::function<void(void)> const& f)
+void for_versions_from(uint32 from, Application& app,
+                       std::function<void(void)> const& f)
 {
     for_versions(from, Config::CURRENT_LEDGER_PROTOCOL_VERSION, app, f);
 }
 
-void
-for_versions_from(std::vector<uint32> const& versions, Application& app,
-                  std::function<void(void)> const& f)
+void for_versions_from(std::vector<uint32> const& versions, Application& app,
+                       std::function<void(void)> const& f)
 {
     for_versions(versions, app, f);
     for_versions_from(versions.back() + 1, app, f);
 }
 
-void
-for_versions_from(uint32 from, Config const& cfg,
-                  std::function<void(Config const&)> const& f)
+void for_versions_from(uint32 from, Config const& cfg,
+                       std::function<void(Config const&)> const& f)
 {
     for_versions(from, Config::CURRENT_LEDGER_PROTOCOL_VERSION, cfg, f);
 }
 
-void
-for_all_versions(Application& app, std::function<void(void)> const& f)
+void for_all_versions(Application& app, std::function<void(void)> const& f)
 {
     for_versions(1, Config::CURRENT_LEDGER_PROTOCOL_VERSION, app, f);
 }
 
-void
-for_all_versions(Config const& cfg, std::function<void(Config const&)> const& f)
+void for_all_versions(Config const& cfg,
+                      std::function<void(Config const&)> const& f)
 {
     for_versions(1, Config::CURRENT_LEDGER_PROTOCOL_VERSION, cfg, f);
 }
 
-void
-for_versions(uint32 from, uint32 to, Application& app,
-             std::function<void(void)> const& f)
+void for_versions(uint32 from, uint32 to, Application& app,
+                  std::function<void(void)> const& f)
 {
     if (from > to)
     {
@@ -573,9 +556,8 @@ for_versions(uint32 from, uint32 to, Application& app,
     for_versions(versions, app, f);
 }
 
-void
-for_versions(uint32 from, uint32 to, Config const& cfg,
-             std::function<void(Config const&)> const& f)
+void for_versions(uint32 from, uint32 to, Config const& cfg,
+                  std::function<void(Config const&)> const& f)
 {
     if (from > to)
     {
@@ -588,9 +570,8 @@ for_versions(uint32 from, uint32 to, Config const& cfg,
     for_versions(versions, cfg, f);
 }
 
-void
-for_versions(uint32 from, uint32 to, Config const& cfg,
-             std::function<void(Config&)> const& f)
+void for_versions(uint32 from, uint32 to, Config const& cfg,
+                  std::function<void(Config&)> const& f)
 {
     if (from > to)
     {
@@ -603,9 +584,8 @@ for_versions(uint32 from, uint32 to, Config const& cfg,
     for_versions(versions, cfg, f);
 }
 
-void
-for_versions(std::vector<uint32> const& versions, Application& app,
-             std::function<void(void)> const& f)
+void for_versions(std::vector<uint32> const& versions, Application& app,
+                  std::function<void(void)> const& f)
 {
     REQUIRE(gMustUseTestVersionsWrapper);
 
@@ -621,9 +601,8 @@ for_versions(std::vector<uint32> const& versions, Application& app,
     }
 }
 
-void
-for_versions(std::vector<uint32> const& versions, Config const& cfg,
-             std::function<void(Config const&)> const& f)
+void for_versions(std::vector<uint32> const& versions, Config const& cfg,
+                  std::function<void(Config const&)> const& f)
 {
     REQUIRE(gMustUseTestVersionsWrapper);
 
@@ -637,9 +616,8 @@ for_versions(std::vector<uint32> const& versions, Config const& cfg,
     }
 }
 
-void
-for_versions(std::vector<uint32> const& versions, Config const& cfg,
-             std::function<void(Config&)> const& f)
+void for_versions(std::vector<uint32> const& versions, Config const& cfg,
+                  std::function<void(Config&)> const& f)
 {
     REQUIRE(gMustUseTestVersionsWrapper);
 
@@ -653,9 +631,9 @@ for_versions(std::vector<uint32> const& versions, Config const& cfg,
     }
 }
 
-void
-for_all_versions_except(std::vector<uint32> const& versions, Application& app,
-                        std::function<void(void)> const& f)
+void for_all_versions_except(std::vector<uint32> const& versions,
+                             Application& app,
+                             std::function<void(void)> const& f)
 {
     uint32 lastExcept = 0;
     for (uint32 except : versions)
@@ -666,15 +644,13 @@ for_all_versions_except(std::vector<uint32> const& versions, Application& app,
     for_versions_from(lastExcept + 1, app, f);
 }
 
-static void
-logFatalAndThrow(std::string const& msg)
+static void logFatalAndThrow(std::string const& msg)
 {
     LOG_FATAL(DEFAULT_LOG, "{}", msg);
     throw std::runtime_error(msg);
 }
 
-static std::pair<stdfs::path, std::string>
-getCurrentTestContext()
+static std::pair<stdfs::path, std::string> getCurrentTestContext()
 {
     releaseAssert(threadIsMain());
 
@@ -701,8 +677,7 @@ getCurrentTestContext()
     return std::make_pair(file, oss.str());
 }
 
-void
-recordOrCheckGlobalTestTxMetadata(TransactionMeta const& txMetaIn)
+void recordOrCheckGlobalTestTxMetadata(TransactionMeta const& txMetaIn)
 {
     if (gTestTxMetaMode == TestTxMetaMode::META_TEST_IGNORE)
     {
@@ -761,9 +736,8 @@ static char const* TESTKEY_ALL_VERSIONS = "!test all versions";
 static char const* TESTKEY_VERSIONS_TO_TEST = "!versions to test";
 
 template <typename T>
-void
-checkTestKeyVal(std::string const& k, T const& expected, T const& got,
-                stdfs::path const& path)
+void checkTestKeyVal(std::string const& k, T const& expected, T const& got,
+                     stdfs::path const& path)
 {
     if (expected != got)
     {
@@ -773,9 +747,8 @@ checkTestKeyVal(std::string const& k, T const& expected, T const& got,
 }
 
 template <typename T>
-void
-checkTestKeyVals(std::string const& k, T const& expected, T const& got,
-                 stdfs::path const& path)
+void checkTestKeyVals(std::string const& k, T const& expected, T const& got,
+                      stdfs::path const& path)
 {
     if (expected != got)
     {
@@ -785,8 +758,7 @@ checkTestKeyVals(std::string const& k, T const& expected, T const& got,
     }
 }
 
-static void
-loadTestTxMeta(stdfs::path const& dir)
+static void loadTestTxMeta(stdfs::path const& dir)
 {
     if (!stdfs::is_directory(dir))
     {
@@ -872,8 +844,7 @@ loadTestTxMeta(stdfs::path const& dir)
     LOG_INFO(DEFAULT_LOG, "Loaded {} TxMetas to check during replay", n);
 }
 
-static void
-saveTestTxMeta(stdfs::path const& dir)
+static void saveTestTxMeta(stdfs::path const& dir)
 {
     for (auto const& filePair : gTestTxMetadata)
     {
@@ -916,8 +887,7 @@ saveTestTxMeta(stdfs::path const& dir)
     }
 }
 
-static void
-reportTestTxMeta()
+static void reportTestTxMeta()
 {
     size_t contexts = 0, nonempty = 0, hashes = 0;
     for (auto const& filePair : gTestTxMetadata)

--- a/src/transactions/AllowTrustOpFrame.cpp
+++ b/src/transactions/AllowTrustOpFrame.cpp
@@ -27,52 +27,44 @@ AllowTrustOpFrame::AllowTrustOpFrame(Operation const& op,
 {
 }
 
-void
-AllowTrustOpFrame::setResultSelfNotAllowed(OperationResult& res) const
+void AllowTrustOpFrame::setResultSelfNotAllowed(OperationResult& res) const
 {
     innerResult(res).code(ALLOW_TRUST_SELF_NOT_ALLOWED);
 }
 
-void
-AllowTrustOpFrame::setResultNoTrustLine(OperationResult& res) const
+void AllowTrustOpFrame::setResultNoTrustLine(OperationResult& res) const
 {
     innerResult(res).code(ALLOW_TRUST_NO_TRUST_LINE);
 }
 
-void
-AllowTrustOpFrame::setResultLowReserve(OperationResult& res) const
+void AllowTrustOpFrame::setResultLowReserve(OperationResult& res) const
 {
     innerResult(res).code(ALLOW_TRUST_LOW_RESERVE);
 }
 
-void
-AllowTrustOpFrame::setResultSuccess(OperationResult& res) const
+void AllowTrustOpFrame::setResultSuccess(OperationResult& res) const
 {
     innerResult(res).code(ALLOW_TRUST_SUCCESS);
 }
 
-AccountID const&
-AllowTrustOpFrame::getOpTrustor() const
+AccountID const& AllowTrustOpFrame::getOpTrustor() const
 {
     return mAllowTrust.trustor;
 }
 
-Asset const&
-AllowTrustOpFrame::getOpAsset() const
+Asset const& AllowTrustOpFrame::getOpAsset() const
 {
     return mAsset;
 }
 
-uint32_t
-AllowTrustOpFrame::getOpIndex() const
+uint32_t AllowTrustOpFrame::getOpIndex() const
 {
     return mOpIndex;
 }
 
-bool
-AllowTrustOpFrame::calcExpectedFlagValue(LedgerTxnEntry const& trust,
-                                         uint32_t& expectedVal,
-                                         OperationResult& res) const
+bool AllowTrustOpFrame::calcExpectedFlagValue(LedgerTxnEntry const& trust,
+                                              uint32_t& expectedVal,
+                                              OperationResult& res) const
 {
     expectedVal = trust.current().data.trustLine().flags;
     expectedVal &= ~TRUSTLINE_AUTH_FLAGS;
@@ -80,9 +72,9 @@ AllowTrustOpFrame::calcExpectedFlagValue(LedgerTxnEntry const& trust,
     return true;
 }
 
-void
-AllowTrustOpFrame::setFlagValue(AbstractLedgerTxn& ltx, LedgerKey const& key,
-                                uint32_t flagVal) const
+void AllowTrustOpFrame::setFlagValue(AbstractLedgerTxn& ltx,
+                                     LedgerKey const& key,
+                                     uint32_t flagVal) const
 {
     if (!trustLineFlagIsValid(mAllowTrust.authorize, ltx.loadHeader()))
     {
@@ -99,10 +91,9 @@ AllowTrustOpFrame::setFlagValue(AbstractLedgerTxn& ltx, LedgerKey const& key,
     trust.current().data.trustLine().flags = flagVal;
 }
 
-bool
-AllowTrustOpFrame::isAuthRevocationValid(AbstractLedgerTxn& ltx,
-                                         bool& authRevocable,
-                                         OperationResult& res) const
+bool AllowTrustOpFrame::isAuthRevocationValid(AbstractLedgerTxn& ltx,
+                                              bool& authRevocable,
+                                              OperationResult& res) const
 {
     // Load the source account
     LedgerTxn ltxSource(ltx); // ltxSource will be rolled back
@@ -131,8 +122,7 @@ AllowTrustOpFrame::isAuthRevocationValid(AbstractLedgerTxn& ltx,
     return true;
 }
 
-bool
-AllowTrustOpFrame::isRevocationToMaintainLiabilitiesValid(
+bool AllowTrustOpFrame::isRevocationToMaintainLiabilitiesValid(
     bool authRevocable, LedgerTxnEntry const& trust, uint32_t flags,
     OperationResult& res) const
 {
@@ -152,9 +142,8 @@ AllowTrustOpFrame::isRevocationToMaintainLiabilitiesValid(
     return true;
 }
 
-bool
-AllowTrustOpFrame::doCheckValid(uint32_t ledgerVersion,
-                                OperationResult& res) const
+bool AllowTrustOpFrame::doCheckValid(uint32_t ledgerVersion,
+                                     OperationResult& res) const
 {
     if (mAllowTrust.asset.type() == ASSET_TYPE_NATIVE)
     {

--- a/src/transactions/AllowTrustOpFrame.h
+++ b/src/transactions/AllowTrustOpFrame.h
@@ -10,8 +10,7 @@ namespace stellar
 {
 class AllowTrustOpFrame : public TrustFlagsOpFrameBase
 {
-    AllowTrustResult&
-    innerResult(OperationResult& res) const
+    AllowTrustResult& innerResult(OperationResult& res) const
     {
         return res.tr().allowTrustResult();
     }
@@ -49,8 +48,7 @@ class AllowTrustOpFrame : public TrustFlagsOpFrameBase
     bool doCheckValid(uint32_t ledgerVersion,
                       OperationResult& res) const override;
 
-    static AllowTrustResultCode
-    getInnerCode(OperationResult const& res)
+    static AllowTrustResultCode getInnerCode(OperationResult const& res)
     {
         return res.tr().allowTrustResult().code();
     }

--- a/src/transactions/BeginSponsoringFutureReservesOpFrame.cpp
+++ b/src/transactions/BeginSponsoringFutureReservesOpFrame.cpp
@@ -21,16 +21,14 @@ BeginSponsoringFutureReservesOpFrame::BeginSponsoringFutureReservesOpFrame(
 {
 }
 
-bool
-BeginSponsoringFutureReservesOpFrame::isOpSupported(
+bool BeginSponsoringFutureReservesOpFrame::isOpSupported(
     LedgerHeader const& header) const
 {
     return protocolVersionStartsFrom(header.ledgerVersion,
                                      ProtocolVersion::V_14);
 }
 
-void
-BeginSponsoringFutureReservesOpFrame::createSponsorship(
+void BeginSponsoringFutureReservesOpFrame::createSponsorship(
     AbstractLedgerTxn& ltx) const
 {
     InternalLedgerEntry gle(InternalLedgerEntryType::SPONSORSHIP);
@@ -45,8 +43,7 @@ BeginSponsoringFutureReservesOpFrame::createSponsorship(
     }
 }
 
-void
-BeginSponsoringFutureReservesOpFrame::createSponsorshipCounter(
+void BeginSponsoringFutureReservesOpFrame::createSponsorshipCounter(
     AbstractLedgerTxn& ltx) const
 {
     InternalLedgerEntry gle(InternalLedgerEntryType::SPONSORSHIP_COUNTER);
@@ -61,8 +58,7 @@ BeginSponsoringFutureReservesOpFrame::createSponsorshipCounter(
     }
 }
 
-bool
-BeginSponsoringFutureReservesOpFrame::doApply(
+bool BeginSponsoringFutureReservesOpFrame::doApply(
     AppConnector& app, AbstractLedgerTxn& ltx, OperationResult& res,
     OperationMetaBuilder& opMeta) const
 {
@@ -102,9 +98,8 @@ BeginSponsoringFutureReservesOpFrame::doApply(
     return true;
 }
 
-bool
-BeginSponsoringFutureReservesOpFrame::doCheckValid(uint32_t ledgerVersion,
-                                                   OperationResult& res) const
+bool BeginSponsoringFutureReservesOpFrame::doCheckValid(
+    uint32_t ledgerVersion, OperationResult& res) const
 {
     if (mBeginSponsoringFutureReservesOp.sponsoredID == getSourceID())
     {

--- a/src/transactions/BeginSponsoringFutureReservesOpFrame.h
+++ b/src/transactions/BeginSponsoringFutureReservesOpFrame.h
@@ -13,8 +13,7 @@ class BeginSponsoringFutureReservesOpFrame : public OperationFrame
 {
     bool isOpSupported(LedgerHeader const& header) const override;
 
-    BeginSponsoringFutureReservesResult&
-    innerResult(OperationResult& res) const
+    BeginSponsoringFutureReservesResult& innerResult(OperationResult& res) const
     {
         return res.tr().beginSponsoringFutureReservesResult();
     }

--- a/src/transactions/BumpSequenceOpFrame.cpp
+++ b/src/transactions/BumpSequenceOpFrame.cpp
@@ -21,24 +21,21 @@ BumpSequenceOpFrame::BumpSequenceOpFrame(Operation const& op,
 {
 }
 
-ThresholdLevel
-BumpSequenceOpFrame::getThresholdLevel() const
+ThresholdLevel BumpSequenceOpFrame::getThresholdLevel() const
 {
     // bumping sequence is low threshold
     return ThresholdLevel::LOW;
 }
 
-bool
-BumpSequenceOpFrame::isOpSupported(LedgerHeader const& header) const
+bool BumpSequenceOpFrame::isOpSupported(LedgerHeader const& header) const
 {
     return protocolVersionStartsFrom(header.ledgerVersion,
                                      ProtocolVersion::V_10);
 }
 
-bool
-BumpSequenceOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
-                             OperationResult& res,
-                             OperationMetaBuilder& opMeta) const
+bool BumpSequenceOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
+                                  OperationResult& res,
+                                  OperationMetaBuilder& opMeta) const
 {
     ZoneNamedN(applyZone, "BumpSequenceOp apply", true);
     LedgerTxn ltxInner(ltx);
@@ -68,9 +65,8 @@ BumpSequenceOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
     return true;
 }
 
-bool
-BumpSequenceOpFrame::doCheckValid(uint32_t ledgerVersion,
-                                  OperationResult& res) const
+bool BumpSequenceOpFrame::doCheckValid(uint32_t ledgerVersion,
+                                       OperationResult& res) const
 {
     if (mBumpSequenceOp.bumpTo < 0)
     {

--- a/src/transactions/BumpSequenceOpFrame.h
+++ b/src/transactions/BumpSequenceOpFrame.h
@@ -16,8 +16,7 @@ class BumpSequenceOpFrame : public OperationFrame
     ThresholdLevel getThresholdLevel() const override;
     bool isOpSupported(LedgerHeader const& header) const override;
 
-    BumpSequenceResult&
-    innerResult(OperationResult& res) const
+    BumpSequenceResult& innerResult(OperationResult& res) const
     {
         return res.tr().bumpSeqResult();
     }
@@ -32,8 +31,7 @@ class BumpSequenceOpFrame : public OperationFrame
     bool doCheckValid(uint32_t ledgerVersion,
                       OperationResult& res) const override;
 
-    static BumpSequenceResultCode
-    getInnerCode(OperationResult const& res)
+    static BumpSequenceResultCode getInnerCode(OperationResult const& res)
     {
         return res.tr().bumpSeqResult().code();
     }

--- a/src/transactions/ChangeTrustOpFrame.cpp
+++ b/src/transactions/ChangeTrustOpFrame.cpp
@@ -18,8 +18,7 @@
 namespace stellar
 {
 
-void
-ChangeTrustOpFrame::managePoolOnDeletedTrustLine(
+void ChangeTrustOpFrame::managePoolOnDeletedTrustLine(
     AbstractLedgerTxn& ltx, TrustLineAsset const& tlAsset) const
 {
     LedgerTxn ltxInner(ltx);
@@ -45,10 +44,9 @@ ChangeTrustOpFrame::managePoolOnDeletedTrustLine(
     ltxInner.commit();
 }
 
-bool
-ChangeTrustOpFrame::tryIncrementPoolUseCount(AbstractLedgerTxn& ltx,
-                                             Asset const& asset,
-                                             OperationResult& res) const
+bool ChangeTrustOpFrame::tryIncrementPoolUseCount(AbstractLedgerTxn& ltx,
+                                                  Asset const& asset,
+                                                  OperationResult& res) const
 {
     if (!isIssuer(getSourceID(), asset) && asset.type() != ASSET_TYPE_NATIVE)
     {
@@ -80,10 +78,9 @@ ChangeTrustOpFrame::tryIncrementPoolUseCount(AbstractLedgerTxn& ltx,
     return true;
 }
 
-bool
-ChangeTrustOpFrame::tryManagePoolOnNewTrustLine(AbstractLedgerTxn& ltx,
-                                                TrustLineAsset const& tlAsset,
-                                                OperationResult& res) const
+bool ChangeTrustOpFrame::tryManagePoolOnNewTrustLine(
+    AbstractLedgerTxn& ltx, TrustLineAsset const& tlAsset,
+    OperationResult& res) const
 {
     LedgerTxn ltxInner(ltx);
 
@@ -140,10 +137,9 @@ ChangeTrustOpFrame::ChangeTrustOpFrame(Operation const& op,
 {
 }
 
-bool
-ChangeTrustOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
-                            OperationResult& res,
-                            OperationMetaBuilder& opMeta) const
+bool ChangeTrustOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
+                                 OperationResult& res,
+                                 OperationMetaBuilder& opMeta) const
 {
     ZoneNamedN(applyZone, "ChangeTrustOp apply", true);
 
@@ -307,9 +303,8 @@ ChangeTrustOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
     }
 }
 
-bool
-ChangeTrustOpFrame::doCheckValid(uint32_t ledgerVersion,
-                                 OperationResult& res) const
+bool ChangeTrustOpFrame::doCheckValid(uint32_t ledgerVersion,
+                                      OperationResult& res) const
 {
     if (mChangeTrust.limit < 0)
     {

--- a/src/transactions/ChangeTrustOpFrame.h
+++ b/src/transactions/ChangeTrustOpFrame.h
@@ -10,8 +10,7 @@ namespace stellar
 {
 class ChangeTrustOpFrame : public OperationFrame
 {
-    ChangeTrustResult&
-    innerResult(OperationResult& res) const
+    ChangeTrustResult& innerResult(OperationResult& res) const
     {
         return res.tr().changeTrustResult();
     }
@@ -36,8 +35,7 @@ class ChangeTrustOpFrame : public OperationFrame
     bool doCheckValid(uint32_t ledgerVersion,
                       OperationResult& res) const override;
 
-    static ChangeTrustResultCode
-    getInnerCode(OperationResult const& res)
+    static ChangeTrustResultCode getInnerCode(OperationResult const& res)
     {
         return res.tr().changeTrustResult().code();
     }

--- a/src/transactions/ClaimClaimableBalanceOpFrame.cpp
+++ b/src/transactions/ClaimClaimableBalanceOpFrame.cpp
@@ -23,21 +23,19 @@ ClaimClaimableBalanceOpFrame::ClaimClaimableBalanceOpFrame(
 {
 }
 
-ThresholdLevel
-ClaimClaimableBalanceOpFrame::getThresholdLevel() const
+ThresholdLevel ClaimClaimableBalanceOpFrame::getThresholdLevel() const
 {
     return ThresholdLevel::LOW;
 }
 
-bool
-ClaimClaimableBalanceOpFrame::isOpSupported(LedgerHeader const& header) const
+bool ClaimClaimableBalanceOpFrame::isOpSupported(
+    LedgerHeader const& header) const
 {
     return protocolVersionStartsFrom(header.ledgerVersion,
                                      ProtocolVersion::V_14);
 }
 
-bool
-validatePredicate(ClaimPredicate const& pred, TimePoint closeTime)
+bool validatePredicate(ClaimPredicate const& pred, TimePoint closeTime)
 {
     switch (pred.type())
     {
@@ -69,10 +67,10 @@ validatePredicate(ClaimPredicate const& pred, TimePoint closeTime)
     return true;
 }
 
-bool
-ClaimClaimableBalanceOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
-                                      OperationResult& res,
-                                      OperationMetaBuilder& opMeta) const
+bool ClaimClaimableBalanceOpFrame::doApply(AppConnector& app,
+                                           AbstractLedgerTxn& ltx,
+                                           OperationResult& res,
+                                           OperationMetaBuilder& opMeta) const
 {
     ZoneNamedN(applyZone, "ClaimClaimableBalanceOpFrame apply", true);
 
@@ -148,15 +146,13 @@ ClaimClaimableBalanceOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
     return true;
 }
 
-bool
-ClaimClaimableBalanceOpFrame::doCheckValid(uint32_t ledgerVersion,
-                                           OperationResult& res) const
+bool ClaimClaimableBalanceOpFrame::doCheckValid(uint32_t ledgerVersion,
+                                                OperationResult& res) const
 {
     return true;
 }
 
-void
-ClaimClaimableBalanceOpFrame::insertLedgerKeysToPrefetch(
+void ClaimClaimableBalanceOpFrame::insertLedgerKeysToPrefetch(
     UnorderedSet<LedgerKey>& keys) const
 {
     keys.emplace(claimableBalanceKey(mClaimClaimableBalance.balanceID));

--- a/src/transactions/ClaimClaimableBalanceOpFrame.h
+++ b/src/transactions/ClaimClaimableBalanceOpFrame.h
@@ -14,8 +14,7 @@ class AbstractLedgerTxn;
 class ClaimClaimableBalanceOpFrame : public OperationFrame
 {
     ThresholdLevel getThresholdLevel() const override;
-    ClaimClaimableBalanceResult&
-    innerResult(OperationResult& res) const
+    ClaimClaimableBalanceResult& innerResult(OperationResult& res) const
     {
         return res.tr().claimClaimableBalanceResult();
     }
@@ -33,8 +32,8 @@ class ClaimClaimableBalanceOpFrame : public OperationFrame
                  OperationMetaBuilder& opMeta) const override;
     bool doCheckValid(uint32_t ledgerVersion,
                       OperationResult& res) const override;
-    void
-    insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const override;
+    void insertLedgerKeysToPrefetch(
+        UnorderedSet<LedgerKey>& keys) const override;
 
     static ClaimClaimableBalanceResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/ClawbackClaimableBalanceOpFrame.cpp
+++ b/src/transactions/ClawbackClaimableBalanceOpFrame.cpp
@@ -19,18 +19,16 @@ ClawbackClaimableBalanceOpFrame::ClawbackClaimableBalanceOpFrame(
 {
 }
 
-bool
-ClawbackClaimableBalanceOpFrame::isOpSupported(LedgerHeader const& header) const
+bool ClawbackClaimableBalanceOpFrame::isOpSupported(
+    LedgerHeader const& header) const
 {
     return protocolVersionStartsFrom(header.ledgerVersion,
                                      ProtocolVersion::V_17);
 }
 
-bool
-ClawbackClaimableBalanceOpFrame::doApply(AppConnector& app,
-                                         AbstractLedgerTxn& ltx,
-                                         OperationResult& res,
-                                         OperationMetaBuilder& opMeta) const
+bool ClawbackClaimableBalanceOpFrame::doApply(
+    AppConnector& app, AbstractLedgerTxn& ltx, OperationResult& res,
+    OperationMetaBuilder& opMeta) const
 {
     ZoneNamedN(applyZone, "ClawbackClaimableBalanceOp apply", true);
 
@@ -83,15 +81,13 @@ ClawbackClaimableBalanceOpFrame::doApply(AppConnector& app,
     return true;
 }
 
-bool
-ClawbackClaimableBalanceOpFrame::doCheckValid(uint32_t ledgerVersion,
-                                              OperationResult& res) const
+bool ClawbackClaimableBalanceOpFrame::doCheckValid(uint32_t ledgerVersion,
+                                                   OperationResult& res) const
 {
     return true;
 }
 
-void
-ClawbackClaimableBalanceOpFrame::insertLedgerKeysToPrefetch(
+void ClawbackClaimableBalanceOpFrame::insertLedgerKeysToPrefetch(
     UnorderedSet<LedgerKey>& keys) const
 {
     keys.emplace(claimableBalanceKey(mClawbackClaimableBalance.balanceID));

--- a/src/transactions/ClawbackClaimableBalanceOpFrame.h
+++ b/src/transactions/ClawbackClaimableBalanceOpFrame.h
@@ -13,8 +13,7 @@ class AbstractLedgerTxn;
 
 class ClawbackClaimableBalanceOpFrame : public OperationFrame
 {
-    ClawbackClaimableBalanceResult&
-    innerResult(OperationResult& res) const
+    ClawbackClaimableBalanceResult& innerResult(OperationResult& res) const
     {
         return res.tr().clawbackClaimableBalanceResult();
     }
@@ -32,8 +31,8 @@ class ClawbackClaimableBalanceOpFrame : public OperationFrame
                  OperationMetaBuilder& opMeta) const override;
     bool doCheckValid(uint32_t ledgerVersion,
                       OperationResult& res) const override;
-    void
-    insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const override;
+    void insertLedgerKeysToPrefetch(
+        UnorderedSet<LedgerKey>& keys) const override;
 
     static ClawbackClaimableBalanceResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/ClawbackOpFrame.cpp
+++ b/src/transactions/ClawbackOpFrame.cpp
@@ -17,17 +17,15 @@ ClawbackOpFrame::ClawbackOpFrame(Operation const& op,
 {
 }
 
-bool
-ClawbackOpFrame::isOpSupported(LedgerHeader const& header) const
+bool ClawbackOpFrame::isOpSupported(LedgerHeader const& header) const
 {
     return protocolVersionStartsFrom(header.ledgerVersion,
                                      ProtocolVersion::V_17);
 }
 
-bool
-ClawbackOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
-                         OperationResult& res,
-                         OperationMetaBuilder& opMeta) const
+bool ClawbackOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
+                              OperationResult& res,
+                              OperationMetaBuilder& opMeta) const
 {
     ZoneNamedN(applyZone, "ClawbackOp apply", true);
 
@@ -60,9 +58,8 @@ ClawbackOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
     return true;
 }
 
-bool
-ClawbackOpFrame::doCheckValid(uint32_t ledgerVersion,
-                              OperationResult& res) const
+bool ClawbackOpFrame::doCheckValid(uint32_t ledgerVersion,
+                                   OperationResult& res) const
 {
     if (mClawback.from == toMuxedAccount(getSourceID()))
     {
@@ -97,8 +94,8 @@ ClawbackOpFrame::doCheckValid(uint32_t ledgerVersion,
     return true;
 }
 
-void
-ClawbackOpFrame::insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const
+void ClawbackOpFrame::insertLedgerKeysToPrefetch(
+    UnorderedSet<LedgerKey>& keys) const
 {
     if (mClawback.asset.type() != ASSET_TYPE_NATIVE)
     {

--- a/src/transactions/ClawbackOpFrame.h
+++ b/src/transactions/ClawbackOpFrame.h
@@ -13,8 +13,7 @@ class AbstractLedgerTxn;
 
 class ClawbackOpFrame : public OperationFrame
 {
-    ClawbackResult&
-    innerResult(OperationResult& res) const
+    ClawbackResult& innerResult(OperationResult& res) const
     {
         return res.tr().clawbackResult();
     }
@@ -31,11 +30,10 @@ class ClawbackOpFrame : public OperationFrame
                  OperationMetaBuilder& opMeta) const override;
     bool doCheckValid(uint32_t ledgerVersion,
                       OperationResult& res) const override;
-    void
-    insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const override;
+    void insertLedgerKeysToPrefetch(
+        UnorderedSet<LedgerKey>& keys) const override;
 
-    static ClawbackResultCode
-    getInnerCode(OperationResult const& res)
+    static ClawbackResultCode getInnerCode(OperationResult const& res)
     {
         return res.tr().clawbackResult().code();
     }

--- a/src/transactions/CreateAccountOpFrame.cpp
+++ b/src/transactions/CreateAccountOpFrame.cpp
@@ -32,9 +32,8 @@ CreateAccountOpFrame::CreateAccountOpFrame(Operation const& op,
 {
 }
 
-bool
-CreateAccountOpFrame::doApplyBeforeV14(AbstractLedgerTxn& ltx,
-                                       OperationResult& res) const
+bool CreateAccountOpFrame::doApplyBeforeV14(AbstractLedgerTxn& ltx,
+                                            OperationResult& res) const
 {
     auto header = ltx.loadHeader();
     if (mCreateAccount.startingBalance <
@@ -79,9 +78,8 @@ CreateAccountOpFrame::doApplyBeforeV14(AbstractLedgerTxn& ltx,
     return true;
 }
 
-bool
-CreateAccountOpFrame::doApplyFromV14(AbstractLedgerTxn& ltxOuter,
-                                     OperationResult& res) const
+bool CreateAccountOpFrame::doApplyFromV14(AbstractLedgerTxn& ltxOuter,
+                                          OperationResult& res) const
 {
     LedgerTxn ltx(ltxOuter);
     auto header = ltx.loadHeader();
@@ -136,10 +134,9 @@ CreateAccountOpFrame::doApplyFromV14(AbstractLedgerTxn& ltxOuter,
     return true;
 }
 
-bool
-CreateAccountOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
-                              OperationResult& res,
-                              OperationMetaBuilder& opMeta) const
+bool CreateAccountOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
+                                   OperationResult& res,
+                                   OperationMetaBuilder& opMeta) const
 {
     ZoneNamedN(applyZone, "CreateAccountOp apply", true);
     if (stellar::loadAccount(ltx, mCreateAccount.destination))
@@ -171,9 +168,8 @@ CreateAccountOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
     return success;
 }
 
-bool
-CreateAccountOpFrame::doCheckValid(uint32_t ledgerVersion,
-                                   OperationResult& res) const
+bool CreateAccountOpFrame::doCheckValid(uint32_t ledgerVersion,
+                                        OperationResult& res) const
 {
     int64_t minStartingBalance =
         protocolVersionStartsFrom(ledgerVersion, ProtocolVersion::V_14) ? 0 : 1;
@@ -192,8 +188,7 @@ CreateAccountOpFrame::doCheckValid(uint32_t ledgerVersion,
     return true;
 }
 
-void
-CreateAccountOpFrame::insertLedgerKeysToPrefetch(
+void CreateAccountOpFrame::insertLedgerKeysToPrefetch(
     UnorderedSet<LedgerKey>& keys) const
 {
     keys.emplace(accountKey(mCreateAccount.destination));

--- a/src/transactions/CreateAccountOpFrame.h
+++ b/src/transactions/CreateAccountOpFrame.h
@@ -13,8 +13,7 @@ class AbstractLedgerTxn;
 
 class CreateAccountOpFrame : public OperationFrame
 {
-    CreateAccountResult&
-    innerResult(OperationResult& res) const
+    CreateAccountResult& innerResult(OperationResult& res) const
     {
         return res.tr().createAccountResult();
     }
@@ -32,11 +31,10 @@ class CreateAccountOpFrame : public OperationFrame
                  OperationMetaBuilder& opMeta) const override;
     bool doCheckValid(uint32_t ledgerVersion,
                       OperationResult& res) const override;
-    void
-    insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const override;
+    void insertLedgerKeysToPrefetch(
+        UnorderedSet<LedgerKey>& keys) const override;
 
-    static CreateAccountResultCode
-    getInnerCode(OperationResult const& res)
+    static CreateAccountResultCode getInnerCode(OperationResult const& res)
     {
         return res.tr().createAccountResult().code();
     }

--- a/src/transactions/CreateClaimableBalanceOpFrame.cpp
+++ b/src/transactions/CreateClaimableBalanceOpFrame.cpp
@@ -17,8 +17,7 @@
 namespace stellar
 {
 
-static int64_t
-relativeToAbsolute(TimePoint closeTime, int64_t relative)
+static int64_t relativeToAbsolute(TimePoint closeTime, int64_t relative)
 {
     return closeTime > static_cast<uint64_t>(INT64_MAX - relative)
                ? INT64_MAX
@@ -26,8 +25,7 @@ relativeToAbsolute(TimePoint closeTime, int64_t relative)
 }
 
 // convert all relative predicates to absolute predicates
-static void
-updatePredicatesForApply(ClaimPredicate& pred, TimePoint closeTime)
+static void updatePredicatesForApply(ClaimPredicate& pred, TimePoint closeTime)
 {
     switch (pred.type())
     {
@@ -71,8 +69,7 @@ updatePredicatesForApply(ClaimPredicate& pred, TimePoint closeTime)
     }
 }
 
-static bool
-validatePredicate(ClaimPredicate const& pred, uint32_t depth)
+static bool validatePredicate(ClaimPredicate const& pred, uint32_t depth)
 {
     if (depth > 4)
     {
@@ -132,18 +129,17 @@ CreateClaimableBalanceOpFrame::CreateClaimableBalanceOpFrame(
 {
 }
 
-bool
-CreateClaimableBalanceOpFrame::isOpSupported(LedgerHeader const& header) const
+bool CreateClaimableBalanceOpFrame::isOpSupported(
+    LedgerHeader const& header) const
 {
     return protocolVersionStartsFrom(header.ledgerVersion,
                                      ProtocolVersion::V_14);
 }
 
-bool
-CreateClaimableBalanceOpFrame::doApply(AppConnector& app,
-                                       AbstractLedgerTxn& ltx,
-                                       OperationResult& res,
-                                       OperationMetaBuilder& opMeta) const
+bool CreateClaimableBalanceOpFrame::doApply(AppConnector& app,
+                                            AbstractLedgerTxn& ltx,
+                                            OperationResult& res,
+                                            OperationMetaBuilder& opMeta) const
 {
     ZoneNamedN(applyZone, "CreateClaimableBalanceOpFrame apply", true);
 
@@ -259,9 +255,8 @@ CreateClaimableBalanceOpFrame::doApply(AppConnector& app,
     return true;
 }
 
-bool
-CreateClaimableBalanceOpFrame::doCheckValid(uint32_t ledgerVersion,
-                                            OperationResult& res) const
+bool CreateClaimableBalanceOpFrame::doCheckValid(uint32_t ledgerVersion,
+                                                 OperationResult& res) const
 {
     auto const& claimants = mCreateClaimableBalance.claimants;
 
@@ -296,8 +291,7 @@ CreateClaimableBalanceOpFrame::doCheckValid(uint32_t ledgerVersion,
     return true;
 }
 
-void
-CreateClaimableBalanceOpFrame::insertLedgerKeysToPrefetch(
+void CreateClaimableBalanceOpFrame::insertLedgerKeysToPrefetch(
     UnorderedSet<LedgerKey>& keys) const
 {
     // Prefetch trustline for non-native assets
@@ -308,8 +302,7 @@ CreateClaimableBalanceOpFrame::insertLedgerKeysToPrefetch(
     }
 }
 
-Hash
-CreateClaimableBalanceOpFrame::getBalanceID() const
+Hash CreateClaimableBalanceOpFrame::getBalanceID() const
 {
     HashIDPreimage hashPreimage;
     hashPreimage.type(ENVELOPE_TYPE_OP_ID);

--- a/src/transactions/CreateClaimableBalanceOpFrame.h
+++ b/src/transactions/CreateClaimableBalanceOpFrame.h
@@ -15,8 +15,7 @@ class CreateClaimableBalanceOpFrame : public OperationFrame
 {
     virtual Hash getBalanceID() const;
 
-    CreateClaimableBalanceResult&
-    innerResult(OperationResult& res) const
+    CreateClaimableBalanceResult& innerResult(OperationResult& res) const
     {
         return res.tr().createClaimableBalanceResult();
     }
@@ -36,8 +35,8 @@ class CreateClaimableBalanceOpFrame : public OperationFrame
                  OperationMetaBuilder& opMeta) const override;
     bool doCheckValid(uint32_t ledgerVersion,
                       OperationResult& res) const override;
-    void
-    insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const override;
+    void insertLedgerKeysToPrefetch(
+        UnorderedSet<LedgerKey>& keys) const override;
 
     static CreateClaimableBalanceResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/EndSponsoringFutureReservesOpFrame.cpp
+++ b/src/transactions/EndSponsoringFutureReservesOpFrame.cpp
@@ -18,19 +18,16 @@ EndSponsoringFutureReservesOpFrame::EndSponsoringFutureReservesOpFrame(
 {
 }
 
-bool
-EndSponsoringFutureReservesOpFrame::isOpSupported(
+bool EndSponsoringFutureReservesOpFrame::isOpSupported(
     LedgerHeader const& header) const
 {
     return protocolVersionStartsFrom(header.ledgerVersion,
                                      ProtocolVersion::V_14);
 }
 
-bool
-EndSponsoringFutureReservesOpFrame::doApply(AppConnector& app,
-                                            AbstractLedgerTxn& ltx,
-                                            OperationResult& res,
-                                            OperationMetaBuilder& opMeta) const
+bool EndSponsoringFutureReservesOpFrame::doApply(
+    AppConnector& app, AbstractLedgerTxn& ltx, OperationResult& res,
+    OperationMetaBuilder& opMeta) const
 {
     ZoneNamedN(applyZone, "EndSponsoringFutureReservesOpFrame apply", true);
 
@@ -67,9 +64,8 @@ EndSponsoringFutureReservesOpFrame::doApply(AppConnector& app,
     return true;
 }
 
-bool
-EndSponsoringFutureReservesOpFrame::doCheckValid(uint32_t ledgerVersion,
-                                                 OperationResult& res) const
+bool EndSponsoringFutureReservesOpFrame::doCheckValid(
+    uint32_t ledgerVersion, OperationResult& res) const
 {
     return true;
 }

--- a/src/transactions/EndSponsoringFutureReservesOpFrame.h
+++ b/src/transactions/EndSponsoringFutureReservesOpFrame.h
@@ -13,8 +13,7 @@ class EndSponsoringFutureReservesOpFrame : public OperationFrame
 {
     bool isOpSupported(LedgerHeader const& header) const override;
 
-    EndSponsoringFutureReservesResult&
-    innerResult(OperationResult& res) const
+    EndSponsoringFutureReservesResult& innerResult(OperationResult& res) const
     {
         return res.tr().endSponsoringFutureReservesResult();
     }

--- a/src/transactions/EventManager.cpp
+++ b/src/transactions/EventManager.cpp
@@ -9,8 +9,7 @@ namespace stellar
 {
 namespace
 {
-bool
-classicEventsEnabled(uint32_t protocolVersion, Config const& config)
+bool classicEventsEnabled(uint32_t protocolVersion, Config const& config)
 {
     if (protocolVersionStartsFrom(protocolVersion, ProtocolVersion::V_23))
     {
@@ -20,8 +19,8 @@ classicEventsEnabled(uint32_t protocolVersion, Config const& config)
 }
 } // namespace
 
-std::optional<Asset>
-getAssetFromEvent(ContractEvent const& event, Hash const& networkID)
+std::optional<Asset> getAssetFromEvent(ContractEvent const& event,
+                                       Hash const& networkID)
 {
     if (!event.contractID)
     {
@@ -101,9 +100,8 @@ getAssetFromEvent(ContractEvent const& event, Hash const& networkID)
     return asset;
 }
 
-SCVal
-getPossibleMuxedData(SCAddress const& to, int64 amount, Memo const& memo,
-                     bool allowMuxedIdOrMemo)
+SCVal getPossibleMuxedData(SCAddress const& to, int64 amount, Memo const& memo,
+                           bool allowMuxedIdOrMemo)
 {
     bool is_to_mux = to.type() == SC_ADDRESS_TYPE_MUXED_ACCOUNT;
 
@@ -135,10 +133,8 @@ getPossibleMuxedData(SCAddress const& to, int64 amount, Memo const& memo,
     }
 }
 
-DiagnosticEventManager
-DiagnosticEventManager::createForApply(bool metaEnabled,
-                                       TransactionFrameBase const& tx,
-                                       Config const& config)
+DiagnosticEventManager DiagnosticEventManager::createForApply(
+    bool metaEnabled, TransactionFrameBase const& tx, Config const& config)
 {
     bool enabled = metaEnabled && tx.isSoroban() &&
                    config.ENABLE_SOROBAN_DIAGNOSTIC_EVENTS;
@@ -151,14 +147,12 @@ DiagnosticEventManager::createForValidation(Config const& config)
     return DiagnosticEventManager(config.ENABLE_DIAGNOSTICS_FOR_TX_SUBMISSION);
 }
 
-DiagnosticEventManager
-DiagnosticEventManager::createDisabled()
+DiagnosticEventManager DiagnosticEventManager::createDisabled()
 {
     return DiagnosticEventManager(false);
 }
 
-void
-DiagnosticEventManager::pushEvent(DiagnosticEvent&& event)
+void DiagnosticEventManager::pushEvent(DiagnosticEvent&& event)
 {
     if (mEnabled)
     {
@@ -171,10 +165,9 @@ DiagnosticEventManager::DiagnosticEventManager(bool enabled) : mEnabled(enabled)
 {
 }
 
-void
-DiagnosticEventManager::pushError(SCErrorType ty, SCErrorCode code,
-                                  std::string&& message,
-                                  xdr::xvector<SCVal>&& args)
+void DiagnosticEventManager::pushError(SCErrorType ty, SCErrorCode code,
+                                       std::string&& message,
+                                       xdr::xvector<SCVal>&& args)
 {
     if (!mEnabled)
     {
@@ -209,22 +202,19 @@ DiagnosticEventManager::pushError(SCErrorType ty, SCErrorCode code,
     mBuffer.emplace_back(false, std::move(ce));
 }
 
-bool
-DiagnosticEventManager::isEnabled() const
+bool DiagnosticEventManager::isEnabled() const
 {
     return mEnabled;
 }
 
-xdr::xvector<DiagnosticEvent>
-DiagnosticEventManager::finalize()
+xdr::xvector<DiagnosticEvent> DiagnosticEventManager::finalize()
 {
     releaseAssert(!mFinalized);
     mFinalized = true;
     return std::move(mBuffer);
 }
 
-void
-DiagnosticEventManager::debugLogEvents() const
+void DiagnosticEventManager::debugLogEvents() const
 {
     for (auto const& event : mBuffer)
     {
@@ -245,8 +235,7 @@ OpEventManager::OpEventManager(bool metaEnabled, bool isSoroban,
         protocolVersionIsBefore(protocolVersion, ProtocolVersion::V_23);
 }
 
-void
-OpEventManager::eventsForClaimAtoms(
+void OpEventManager::eventsForClaimAtoms(
     MuxedAccount const& source,
     xdr::xvector<stellar::ClaimAtom> const& claimAtoms)
 {
@@ -315,12 +304,11 @@ OpEventManager::eventsForClaimAtoms(
     }
 }
 
-void
-OpEventManager::eventForTransferWithIssuerCheck(Asset const& asset,
-                                                SCAddress const& from,
-                                                SCAddress const& to,
-                                                int64 amount,
-                                                bool allowMuxedIdOrMemo)
+void OpEventManager::eventForTransferWithIssuerCheck(Asset const& asset,
+                                                     SCAddress const& from,
+                                                     SCAddress const& to,
+                                                     int64 amount,
+                                                     bool allowMuxedIdOrMemo)
 {
     if (!mEnabled)
     {
@@ -348,10 +336,9 @@ OpEventManager::eventForTransferWithIssuerCheck(Asset const& asset,
     }
 }
 
-void
-OpEventManager::newTransferEvent(Asset const& asset, SCAddress const& from,
-                                 SCAddress const& to, int64 amount,
-                                 bool allowMuxedIdOrMemo)
+void OpEventManager::newTransferEvent(Asset const& asset, SCAddress const& from,
+                                      SCAddress const& to, int64 amount,
+                                      bool allowMuxedIdOrMemo)
 {
     if (!mEnabled)
     {
@@ -373,9 +360,9 @@ OpEventManager::newTransferEvent(Asset const& asset, SCAddress const& from,
     mContractEvents.emplace_back(std::move(ev));
 }
 
-ContractEvent
-OpEventManager::makeMintEvent(Asset const& asset, SCAddress const& to,
-                              int64 amount, bool allowMuxedIdOrMemo)
+ContractEvent OpEventManager::makeMintEvent(Asset const& asset,
+                                            SCAddress const& to, int64 amount,
+                                            bool allowMuxedIdOrMemo)
 {
     releaseAssert(!mFinalized);
     ContractEvent ev;
@@ -393,9 +380,8 @@ OpEventManager::makeMintEvent(Asset const& asset, SCAddress const& to,
     return ev;
 }
 
-ContractEvent
-OpEventManager::makeBurnEvent(Asset const& asset, SCAddress const& from,
-                              int64 amount)
+ContractEvent OpEventManager::makeBurnEvent(Asset const& asset,
+                                            SCAddress const& from, int64 amount)
 {
     releaseAssert(!mFinalized);
     ContractEvent ev;
@@ -412,10 +398,9 @@ OpEventManager::makeBurnEvent(Asset const& asset, SCAddress const& from,
     return ev;
 }
 
-void
-OpEventManager::newMintEvent(Asset const& asset, SCAddress const& to,
-                             int64 amount, bool allowMuxedIdOrMemo,
-                             bool insertAtBeginning)
+void OpEventManager::newMintEvent(Asset const& asset, SCAddress const& to,
+                                  int64 amount, bool allowMuxedIdOrMemo,
+                                  bool insertAtBeginning)
 {
     if (!mEnabled)
     {
@@ -438,9 +423,8 @@ OpEventManager::newMintEvent(Asset const& asset, SCAddress const& to,
     }
 }
 
-void
-OpEventManager::newBurnEvent(Asset const& asset, SCAddress const& from,
-                             int64 amount)
+void OpEventManager::newBurnEvent(Asset const& asset, SCAddress const& from,
+                                  int64 amount)
 {
     if (!mEnabled)
     {
@@ -452,9 +436,8 @@ OpEventManager::newBurnEvent(Asset const& asset, SCAddress const& from,
     mContractEvents.emplace_back(std::move(ev));
 }
 
-void
-OpEventManager::newClawbackEvent(Asset const& asset, SCAddress const& from,
-                                 int64 amount)
+void OpEventManager::newClawbackEvent(Asset const& asset, SCAddress const& from,
+                                      int64 amount)
 {
     if (!mEnabled)
     {
@@ -475,9 +458,8 @@ OpEventManager::newClawbackEvent(Asset const& asset, SCAddress const& from,
     mContractEvents.emplace_back(std::move(ev));
 }
 
-void
-OpEventManager::newSetAuthorizedEvent(Asset const& asset, AccountID const& id,
-                                      bool authorize)
+void OpEventManager::newSetAuthorizedEvent(Asset const& asset,
+                                           AccountID const& id, bool authorize)
 {
     if (!mEnabled)
     {
@@ -500,8 +482,7 @@ OpEventManager::newSetAuthorizedEvent(Asset const& asset, AccountID const& id,
     mContractEvents.emplace_back(std::move(ev));
 }
 
-void
-OpEventManager::setEvents(xdr::xvector<ContractEvent>&& events)
+void OpEventManager::setEvents(xdr::xvector<ContractEvent>&& events)
 {
     if (!mEnabled)
     {
@@ -573,20 +554,17 @@ OpEventManager::setEvents(xdr::xvector<ContractEvent>&& events)
     }
 }
 
-xdr::xvector<ContractEvent> const&
-OpEventManager::getEvents()
+xdr::xvector<ContractEvent> const& OpEventManager::getEvents()
 {
     return mContractEvents;
 }
 
-bool
-OpEventManager::isEnabled() const
+bool OpEventManager::isEnabled() const
 {
     return mEnabled;
 }
 
-xdr::xvector<ContractEvent>
-OpEventManager::finalize()
+xdr::xvector<ContractEvent> OpEventManager::finalize()
 {
     releaseAssert(!mFinalized);
     mFinalized = true;
@@ -600,9 +578,8 @@ TxEventManager::TxEventManager(bool metaEnabled, uint32_t protocolVersion,
     mEnabled = metaEnabled && classicEventsEnabled(protocolVersion, config);
 }
 
-void
-TxEventManager::newFeeEvent(AccountID const& feeSource, int64_t amount,
-                            TransactionEventStage stage)
+void TxEventManager::newFeeEvent(AccountID const& feeSource, int64_t amount,
+                                 TransactionEventStage stage)
 {
     // We don't emit 0 fee events. This is relevant for Soroban transactions
     // that end up with no refunds.
@@ -623,14 +600,12 @@ TxEventManager::newFeeEvent(AccountID const& feeSource, int64_t amount,
     mTxEvents.emplace_back(stage, std::move(ev));
 }
 
-bool
-TxEventManager::isEnabled() const
+bool TxEventManager::isEnabled() const
 {
     return mEnabled;
 }
 
-xdr::xvector<TransactionEvent>
-TxEventManager::finalize()
+xdr::xvector<TransactionEvent> TxEventManager::finalize()
 {
     releaseAssert(!mFinalized);
     mFinalized = true;

--- a/src/transactions/EventManager.h
+++ b/src/transactions/EventManager.h
@@ -83,9 +83,9 @@ class OpEventManager
     void setEvents(xdr::xvector<ContractEvent>&& events);
 
     // Creates transfer events corresponding to provided claim atoms.
-    void
-    eventsForClaimAtoms(MuxedAccount const& source,
-                        xdr::xvector<stellar::ClaimAtom> const& claimAtoms);
+    void eventsForClaimAtoms(
+        MuxedAccount const& source,
+        xdr::xvector<stellar::ClaimAtom> const& claimAtoms);
 
     // This will check if the issuer is involved, and emit a mint/burn instead
     // of a transfer if so

--- a/src/transactions/ExtendFootprintTTLOpFrame.cpp
+++ b/src/transactions/ExtendFootprintTTLOpFrame.cpp
@@ -17,8 +17,7 @@
 namespace stellar
 {
 
-static ExtendFootprintTTLResult&
-innerResult(OperationResult& res)
+static ExtendFootprintTTLResult& innerResult(OperationResult& res)
 {
     return res.tr().extendFootprintTTLResult();
 }
@@ -37,8 +36,7 @@ struct ExtendFootprintTTLMetrics
     {
         mMetrics.mExtFpTtlOpReadLedgerByte.Mark(mLedgerReadByte);
     }
-    medida::TimerContext
-    getExecTimer()
+    medida::TimerContext getExecTimer()
     {
         return mMetrics.mExtFpTtlOpExec.TimeScope();
     }
@@ -51,8 +49,7 @@ ExtendFootprintTTLOpFrame::ExtendFootprintTTLOpFrame(
 {
 }
 
-bool
-ExtendFootprintTTLOpFrame::isOpSupported(LedgerHeader const& header) const
+bool ExtendFootprintTTLOpFrame::isOpSupported(LedgerHeader const& header) const
 {
     return protocolVersionStartsFrom(header.ledgerVersion,
                                      SOROBAN_PROTOCOL_VERSION);
@@ -60,7 +57,6 @@ ExtendFootprintTTLOpFrame::isOpSupported(LedgerHeader const& header) const
 
 class ExtendFootprintTTLApplyHelper : virtual public LedgerAccessHelper
 {
-
   protected:
     AppConnector& mApp;
     OperationResult& mRes;
@@ -96,8 +92,7 @@ class ExtendFootprintTTLApplyHelper : virtual public LedgerAccessHelper
 
     virtual bool checkReadBytesResourceLimit(uint32_t entrySize) = 0;
 
-    virtual bool
-    apply()
+    virtual bool apply()
     {
         ZoneNamedN(applyZone, "ExtendFootprintTTLOpFrame apply", true);
         releaseAssertOrThrow(mRefundableFeeTracker);
@@ -211,8 +206,7 @@ class ExtendFootprintTTLPreV23ApplyHelper
         , PreV23LedgerAccessHelper(ltx)
     {
     }
-    virtual bool
-    checkReadBytesResourceLimit(uint32_t entrySize) override
+    virtual bool checkReadBytesResourceLimit(uint32_t entrySize) override
     {
         mMetrics.mLedgerReadByte += entrySize;
         if (mResources.diskReadBytes < mMetrics.mLedgerReadByte)
@@ -246,21 +240,18 @@ class ExtendFootprintTTLParallelApplyHelper
         , ParallelLedgerAccessHelper(threadState, ledgerInfo)
     {
     }
-    virtual bool
-    checkReadBytesResourceLimit(uint32_t entrySize) override
+    virtual bool checkReadBytesResourceLimit(uint32_t entrySize) override
     {
         return true;
     }
 
-    OpModifiedEntryMap
-    takeOpEntryMap()
+    OpModifiedEntryMap takeOpEntryMap()
     {
         return std::move(mOpState.takeSuccess().getModifiedEntryMap());
     }
 };
 
-ParallelTxReturnVal
-ExtendFootprintTTLOpFrame::doParallelApply(
+ParallelTxReturnVal ExtendFootprintTTLOpFrame::doParallelApply(
     AppConnector& app, ThreadParallelApplyLedgerState const& threadState,
     Config const& appConfig, Hash const& _txPrngSeed,
     ParallelLedgerInfo const& ledgerInfo, SorobanMetrics& sorobanMetrics,
@@ -284,8 +275,7 @@ ExtendFootprintTTLOpFrame::doParallelApply(
     }
 }
 
-bool
-ExtendFootprintTTLOpFrame::doApplyForSoroban(
+bool ExtendFootprintTTLOpFrame::doApplyForSoroban(
     AppConnector& app, AbstractLedgerTxn& ltx,
     SorobanNetworkConfig const& sorobanConfig, Hash const& sorobanBasePrngSeed,
     OperationResult& res,
@@ -301,17 +291,16 @@ ExtendFootprintTTLOpFrame::doApplyForSoroban(
     return helper.apply();
 }
 
-bool
-ExtendFootprintTTLOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
-                                   OperationResult& res,
-                                   OperationMetaBuilder& opMeta) const
+bool ExtendFootprintTTLOpFrame::doApply(AppConnector& app,
+                                        AbstractLedgerTxn& ltx,
+                                        OperationResult& res,
+                                        OperationMetaBuilder& opMeta) const
 {
     throw std::runtime_error(
         "ExtendFootprintTTLOpFrame may only be applied via doApplyForSoroban");
 }
 
-bool
-ExtendFootprintTTLOpFrame::doCheckValidForSoroban(
+bool ExtendFootprintTTLOpFrame::doCheckValidForSoroban(
     SorobanNetworkConfig const& networkConfig, Config const& appConfig,
     uint32_t ledgerVersion, OperationResult& res,
     DiagnosticEventManager& diagnosticEvents) const
@@ -360,28 +349,24 @@ ExtendFootprintTTLOpFrame::doCheckValidForSoroban(
     return true;
 }
 
-bool
-ExtendFootprintTTLOpFrame::doCheckValid(uint32_t ledgerVersion,
-                                        OperationResult& res) const
+bool ExtendFootprintTTLOpFrame::doCheckValid(uint32_t ledgerVersion,
+                                             OperationResult& res) const
 {
     throw std::runtime_error(
         "ExtendFootprintTTLOpFrame::doCheckValid needs Config");
 }
 
-void
-ExtendFootprintTTLOpFrame::insertLedgerKeysToPrefetch(
+void ExtendFootprintTTLOpFrame::insertLedgerKeysToPrefetch(
     UnorderedSet<LedgerKey>& keys) const
 {
 }
 
-bool
-ExtendFootprintTTLOpFrame::isSoroban() const
+bool ExtendFootprintTTLOpFrame::isSoroban() const
 {
     return true;
 }
 
-ThresholdLevel
-ExtendFootprintTTLOpFrame::getThresholdLevel() const
+ThresholdLevel ExtendFootprintTTLOpFrame::getThresholdLevel() const
 {
     return ThresholdLevel::LOW;
 }

--- a/src/transactions/ExtendFootprintTTLOpFrame.h
+++ b/src/transactions/ExtendFootprintTTLOpFrame.h
@@ -14,7 +14,6 @@ class MutableTransactionResultBase;
 
 class ExtendFootprintTTLOpFrame : public OperationFrame
 {
-
     ExtendFootprintTTLOp const& mExtendFootprintTTLOp;
 
   public:
@@ -23,12 +22,12 @@ class ExtendFootprintTTLOpFrame : public OperationFrame
 
     bool isOpSupported(LedgerHeader const& header) const override;
 
-    bool
-    doApplyForSoroban(AppConnector& app, AbstractLedgerTxn& ltx,
-                      SorobanNetworkConfig const& sorobanConfig,
-                      Hash const& sorobanBasePrngSeed, OperationResult& res,
-                      std::optional<RefundableFeeTracker>& refundableFeeTracker,
-                      OperationMetaBuilder& opMeta) const override;
+    bool doApplyForSoroban(
+        AppConnector& app, AbstractLedgerTxn& ltx,
+        SorobanNetworkConfig const& sorobanConfig,
+        Hash const& sorobanBasePrngSeed, OperationResult& res,
+        std::optional<RefundableFeeTracker>& refundableFeeTracker,
+        OperationMetaBuilder& opMeta) const override;
     bool doApply(AppConnector& app, AbstractLedgerTxn& ltx,
                  OperationResult& res,
                  OperationMetaBuilder& opMeta) const override;
@@ -49,11 +48,10 @@ class ExtendFootprintTTLOpFrame : public OperationFrame
                     std::optional<RefundableFeeTracker>& refundableFeeTracker,
                     OperationMetaBuilder& opMeta) const override;
 
-    void
-    insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const override;
+    void insertLedgerKeysToPrefetch(
+        UnorderedSet<LedgerKey>& keys) const override;
 
-    static ExtendFootprintTTLResultCode
-    getInnerCode(OperationResult const& res)
+    static ExtendFootprintTTLResultCode getInnerCode(OperationResult const& res)
     {
         return res.tr().extendFootprintTTLResult().code();
     }

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -39,20 +39,17 @@ FeeBumpTransactionFrame::convertInnerTxToV1(TransactionEnvelope const& envelope)
     return e;
 }
 
-bool
-FeeBumpTransactionFrame::hasDexOperations() const
+bool FeeBumpTransactionFrame::hasDexOperations() const
 {
     return mInnerTx->hasDexOperations();
 }
 
-bool
-FeeBumpTransactionFrame::isSoroban() const
+bool FeeBumpTransactionFrame::isSoroban() const
 {
     return mInnerTx->isSoroban();
 }
 
-SorobanResources const&
-FeeBumpTransactionFrame::sorobanResources() const
+SorobanResources const& FeeBumpTransactionFrame::sorobanResources() const
 {
     return mInnerTx->sorobanResources();
 }
@@ -81,8 +78,7 @@ FeeBumpTransactionFrame::FeeBumpTransactionFrame(
 }
 #endif
 
-void
-FeeBumpTransactionFrame::preParallelApply(
+void FeeBumpTransactionFrame::preParallelApply(
     AppConnector& app, AbstractLedgerTxn& ltx, TransactionMetaBuilder& meta,
     MutableTransactionResultBase& txResult,
     SorobanNetworkConfig const& sorobanConfig) const
@@ -118,8 +114,7 @@ FeeBumpTransactionFrame::preParallelApply(
     }
 }
 
-ParallelTxReturnVal
-FeeBumpTransactionFrame::parallelApply(
+ParallelTxReturnVal FeeBumpTransactionFrame::parallelApply(
     AppConnector& app, ThreadParallelApplyLedgerState const& threadState,
     Config const& config, ParallelLedgerInfo const& ledgerInfo,
     MutableTransactionResultBase& txResult, SorobanMetrics& sorobanMetrics,
@@ -149,8 +144,7 @@ FeeBumpTransactionFrame::parallelApply(
     }
 }
 
-bool
-FeeBumpTransactionFrame::apply(
+bool FeeBumpTransactionFrame::apply(
     AppConnector& app, AbstractLedgerTxn& ltx, TransactionMetaBuilder& meta,
     MutableTransactionResultBase& txResult,
     std::optional<SorobanNetworkConfig const> const& sorobanConfig,
@@ -194,8 +188,7 @@ FeeBumpTransactionFrame::apply(
     }
 }
 
-void
-FeeBumpTransactionFrame::processPostApply(
+void FeeBumpTransactionFrame::processPostApply(
     AppConnector& app, AbstractLedgerTxn& ltx, TransactionMetaBuilder& meta,
     MutableTransactionResultBase& txResult) const
 {
@@ -216,8 +209,7 @@ FeeBumpTransactionFrame::processPostApply(
     }
 }
 
-void
-FeeBumpTransactionFrame::processPostTxSetApply(
+void FeeBumpTransactionFrame::processPostTxSetApply(
     AppConnector& app, AbstractLedgerTxn& ltx,
     MutableTransactionResultBase& txResult,
     TxEventManager& txEventManager) const
@@ -226,10 +218,9 @@ FeeBumpTransactionFrame::processPostTxSetApply(
                             txEventManager);
 }
 
-bool
-FeeBumpTransactionFrame::checkSignature(SignatureChecker& signatureChecker,
-                                        LedgerEntryWrapper const& account,
-                                        int32_t neededWeight) const
+bool FeeBumpTransactionFrame::checkSignature(SignatureChecker& signatureChecker,
+                                             LedgerEntryWrapper const& account,
+                                             int32_t neededWeight) const
 {
     auto& acc = account.current().data.account();
     std::vector<Signer> signers;
@@ -243,8 +234,7 @@ FeeBumpTransactionFrame::checkSignature(SignatureChecker& signatureChecker,
     return signatureChecker.checkSignature(signers, neededWeight);
 }
 
-bool
-FeeBumpTransactionFrame::checkOperationSignatures(
+bool FeeBumpTransactionFrame::checkOperationSignatures(
     SignatureChecker& signatureChecker, LedgerSnapshot const& ls,
     MutableTransactionResultBase* txResult) const
 {
@@ -253,8 +243,7 @@ FeeBumpTransactionFrame::checkOperationSignatures(
     return true;
 }
 
-bool
-FeeBumpTransactionFrame::checkAllTransactionSignatures(
+bool FeeBumpTransactionFrame::checkAllTransactionSignatures(
     SignatureChecker& signatureChecker, LedgerEntryWrapper const& feeSource,
     uint32_t ledgerVersion) const
 {
@@ -268,8 +257,7 @@ FeeBumpTransactionFrame::checkAllTransactionSignatures(
         feeSource.current().data.account().thresholds[THRESHOLD_LOW]);
 }
 
-MutableTxResultPtr
-FeeBumpTransactionFrame::checkValid(
+MutableTxResultPtr FeeBumpTransactionFrame::checkValid(
     AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
     uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
     DiagnosticEventManager& diagnosticEvents) const
@@ -310,8 +298,7 @@ FeeBumpTransactionFrame::checkValid(
     return txResult;
 }
 
-bool
-FeeBumpTransactionFrame::checkSorobanResources(
+bool FeeBumpTransactionFrame::checkSorobanResources(
     SorobanNetworkConfig const& cfg, uint32_t ledgerVersion,
     DiagnosticEventManager& diagnosticEvents) const
 {
@@ -319,8 +306,7 @@ FeeBumpTransactionFrame::checkSorobanResources(
                                            diagnosticEvents);
 }
 
-std::optional<LedgerEntryWrapper>
-FeeBumpTransactionFrame::commonValidPreSeqNum(
+std::optional<LedgerEntryWrapper> FeeBumpTransactionFrame::commonValidPreSeqNum(
     LedgerSnapshot const& ls, MutableTransactionResultBase& txResult) const
 {
     // this function does validations that are independent of the account state
@@ -397,8 +383,7 @@ FeeBumpTransactionFrame::commonValidPreSeqNum(
     return feeSource;
 }
 
-FeeBumpTransactionFrame::ValidationType
-FeeBumpTransactionFrame::commonValid(
+FeeBumpTransactionFrame::ValidationType FeeBumpTransactionFrame::commonValid(
     SignatureChecker& signatureChecker, LedgerSnapshot const& ls, bool applying,
     MutableTransactionResultBase& txResult) const
 {
@@ -438,21 +423,18 @@ FeeBumpTransactionFrame::commonValid(
     return ValidationType::kFullyValid;
 }
 
-TransactionEnvelope const&
-FeeBumpTransactionFrame::getEnvelope() const
+TransactionEnvelope const& FeeBumpTransactionFrame::getEnvelope() const
 {
     return mEnvelope;
 }
 
 #ifdef BUILD_TESTS
-TransactionEnvelope&
-FeeBumpTransactionFrame::getMutableEnvelope() const
+TransactionEnvelope& FeeBumpTransactionFrame::getMutableEnvelope() const
 {
     return mEnvelope;
 }
 
-void
-FeeBumpTransactionFrame::clearCached() const
+void FeeBumpTransactionFrame::clearCached() const
 {
     Hash zero;
     mContentsHash = zero;
@@ -461,33 +443,28 @@ FeeBumpTransactionFrame::clearCached() const
 }
 #endif
 
-bool
-FeeBumpTransactionFrame::validateSorobanTxForFlooding(
+bool FeeBumpTransactionFrame::validateSorobanTxForFlooding(
     UnorderedSet<LedgerKey> const& keysToFilter) const
 {
     return mInnerTx->validateSorobanTxForFlooding(keysToFilter);
 }
 
-bool
-FeeBumpTransactionFrame::validateSorobanMemo() const
+bool FeeBumpTransactionFrame::validateSorobanMemo() const
 {
     return mInnerTx->validateSorobanMemo();
 }
 
-int64_t
-FeeBumpTransactionFrame::getFullFee() const
+int64_t FeeBumpTransactionFrame::getFullFee() const
 {
     return mEnvelope.feeBump().tx.fee;
 }
 
-int64
-FeeBumpTransactionFrame::declaredSorobanResourceFee() const
+int64 FeeBumpTransactionFrame::declaredSorobanResourceFee() const
 {
     return mInnerTx->declaredSorobanResourceFee();
 }
 
-int64_t
-FeeBumpTransactionFrame::getInclusionFee() const
+int64_t FeeBumpTransactionFrame::getInclusionFee() const
 {
     if (isSoroban())
     {
@@ -496,8 +473,7 @@ FeeBumpTransactionFrame::getInclusionFee() const
     return getFullFee();
 }
 
-bool
-FeeBumpTransactionFrame::XDRProvidesValidFee() const
+bool FeeBumpTransactionFrame::XDRProvidesValidFee() const
 {
     if (getFullFee() < 0)
     {
@@ -506,16 +482,14 @@ FeeBumpTransactionFrame::XDRProvidesValidFee() const
     return mInnerTx->XDRProvidesValidFee();
 }
 
-bool
-FeeBumpTransactionFrame::isRestoreFootprintTx() const
+bool FeeBumpTransactionFrame::isRestoreFootprintTx() const
 {
     return mInnerTx->isRestoreFootprintTx();
 }
 
-int64_t
-FeeBumpTransactionFrame::getFee(LedgerHeader const& header,
-                                std::optional<int64_t> baseFee,
-                                bool applying) const
+int64_t FeeBumpTransactionFrame::getFee(LedgerHeader const& header,
+                                        std::optional<int64_t> baseFee,
+                                        bool applying) const
 {
     if (!baseFee)
     {
@@ -537,8 +511,7 @@ FeeBumpTransactionFrame::getFee(LedgerHeader const& header,
     }
 }
 
-Hash const&
-FeeBumpTransactionFrame::getContentsHash() const
+Hash const& FeeBumpTransactionFrame::getContentsHash() const
 {
     if (isZero(mContentsHash))
     {
@@ -548,8 +521,7 @@ FeeBumpTransactionFrame::getContentsHash() const
     return mContentsHash;
 }
 
-Hash const&
-FeeBumpTransactionFrame::getFullHash() const
+Hash const& FeeBumpTransactionFrame::getFullHash() const
 {
     if (isZero(mFullHash))
     {
@@ -558,14 +530,12 @@ FeeBumpTransactionFrame::getFullHash() const
     return mFullHash;
 }
 
-Hash const&
-FeeBumpTransactionFrame::getInnerFullHash() const
+Hash const& FeeBumpTransactionFrame::getInnerFullHash() const
 {
     return mInnerTx->getFullHash();
 }
 
-uint32_t
-FeeBumpTransactionFrame::getNumOperations() const
+uint32_t FeeBumpTransactionFrame::getNumOperations() const
 {
     return mInnerTx->getNumOperations() + 1;
 }
@@ -576,35 +546,30 @@ FeeBumpTransactionFrame::getOperationFrames() const
     return mInnerTx->getOperationFrames();
 }
 
-Resource
-FeeBumpTransactionFrame::getResources(bool useByteLimitInClassic,
-                                      uint32_t ledgerVersion) const
+Resource FeeBumpTransactionFrame::getResources(bool useByteLimitInClassic,
+                                               uint32_t ledgerVersion) const
 {
     auto res = mInnerTx->getResources(useByteLimitInClassic, ledgerVersion);
     res.setVal(Resource::Type::OPERATIONS, getNumOperations());
     return res;
 }
 
-std::vector<Operation> const&
-FeeBumpTransactionFrame::getRawOperations() const
+std::vector<Operation> const& FeeBumpTransactionFrame::getRawOperations() const
 {
     return mInnerTx->getRawOperations();
 }
 
-SequenceNumber
-FeeBumpTransactionFrame::getSeqNum() const
+SequenceNumber FeeBumpTransactionFrame::getSeqNum() const
 {
     return mInnerTx->getSeqNum();
 }
 
-AccountID
-FeeBumpTransactionFrame::getFeeSourceID() const
+AccountID FeeBumpTransactionFrame::getFeeSourceID() const
 {
     return toAccountID(mEnvelope.feeBump().tx.feeSource);
 }
 
-AccountID
-FeeBumpTransactionFrame::getSourceID() const
+AccountID FeeBumpTransactionFrame::getSourceID() const
 {
     return mInnerTx->getSourceID();
 }
@@ -615,28 +580,24 @@ FeeBumpTransactionFrame::getMinSeqNum() const
     return mInnerTx->getMinSeqNum();
 }
 
-Duration
-FeeBumpTransactionFrame::getMinSeqAge() const
+Duration FeeBumpTransactionFrame::getMinSeqAge() const
 {
     return mInnerTx->getMinSeqAge();
 }
 
-uint32
-FeeBumpTransactionFrame::getMinSeqLedgerGap() const
+uint32 FeeBumpTransactionFrame::getMinSeqLedgerGap() const
 {
     return mInnerTx->getMinSeqLedgerGap();
 }
 
-void
-FeeBumpTransactionFrame::insertKeysForFeeProcessing(
+void FeeBumpTransactionFrame::insertKeysForFeeProcessing(
     UnorderedSet<LedgerKey>& keys) const
 {
     keys.emplace(accountKey(getFeeSourceID()));
     mInnerTx->insertKeysForFeeProcessing(keys);
 }
 
-void
-FeeBumpTransactionFrame::insertKeysForTxApply(
+void FeeBumpTransactionFrame::insertKeysForTxApply(
     UnorderedSet<LedgerKey>& keys) const
 {
     mInnerTx->insertKeysForTxApply(keys);
@@ -671,8 +632,7 @@ FeeBumpTransactionFrame::processFeeSeqNum(AbstractLedgerTxn& ltx,
                                                           innerFeeCharged);
 }
 
-void
-FeeBumpTransactionFrame::removeOneTimeSignerKeyFromFeeSource(
+void FeeBumpTransactionFrame::removeOneTimeSignerKeyFromFeeSource(
     AbstractLedgerTxn& ltx) const
 {
     auto account = stellar::loadAccount(ltx, getFeeSourceID());
@@ -692,8 +652,7 @@ FeeBumpTransactionFrame::removeOneTimeSignerKeyFromFeeSource(
     }
 }
 
-MutableTxResultPtr
-FeeBumpTransactionFrame::createTxErrorResult(
+MutableTxResultPtr FeeBumpTransactionFrame::createTxErrorResult(
     TransactionResultCode txErrorCode) const
 {
     return FeeBumpMutableTransactionResult::createTxError(txErrorCode);
@@ -714,8 +673,7 @@ FeeBumpTransactionFrame::toStellarMessage() const
     return msg;
 }
 
-void
-FeeBumpTransactionFrame::withInnerTx(
+void FeeBumpTransactionFrame::withInnerTx(
     std::function<void(TransactionFrameBaseConstPtr)> fn) const
 {
     fn(mInnerTx);

--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -72,8 +72,7 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
     TransactionEnvelope& getMutableEnvelope() const override;
     void clearCached() const override;
 
-    bool
-    isTestTx() const override
+    bool isTestTx() const override
     {
         return false;
     }
@@ -81,11 +80,10 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
 
     ~FeeBumpTransactionFrame() override = default;
 
-    void
-    preParallelApply(AppConnector& app, AbstractLedgerTxn& ltx,
-                     TransactionMetaBuilder& meta,
-                     MutableTransactionResultBase& txResult,
-                     SorobanNetworkConfig const& sorobanConfig) const override;
+    void preParallelApply(
+        AppConnector& app, AbstractLedgerTxn& ltx, TransactionMetaBuilder& meta,
+        MutableTransactionResultBase& txResult,
+        SorobanNetworkConfig const& sorobanConfig) const override;
 
     ParallelTxReturnVal parallelApply(
         AppConnector& app, ThreadParallelApplyLedgerState const& threadState,
@@ -100,10 +98,9 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
                std::optional<SorobanNetworkConfig const> const& sorobanConfig,
                Hash const& sorobanBasePrngSeed) const override;
 
-    void
-    processPostApply(AppConnector& app, AbstractLedgerTxn& ltx,
-                     TransactionMetaBuilder& meta,
-                     MutableTransactionResultBase& txResult) const override;
+    void processPostApply(
+        AppConnector& app, AbstractLedgerTxn& ltx, TransactionMetaBuilder& meta,
+        MutableTransactionResultBase& txResult) const override;
 
     void processPostTxSetApply(AppConnector& app, AbstractLedgerTxn& ltx,
                                MutableTransactionResultBase& txResult,
@@ -153,8 +150,8 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
     Duration getMinSeqAge() const override;
     uint32 getMinSeqLedgerGap() const override;
 
-    void
-    insertKeysForFeeProcessing(UnorderedSet<LedgerKey>& keys) const override;
+    void insertKeysForFeeProcessing(
+        UnorderedSet<LedgerKey>& keys) const override;
     void insertKeysForTxApply(UnorderedSet<LedgerKey>& keys) const override;
 
     MutableTxResultPtr

--- a/src/transactions/InflationOpFrame.cpp
+++ b/src/transactions/InflationOpFrame.cpp
@@ -28,10 +28,9 @@ InflationOpFrame::InflationOpFrame(Operation const& op,
 {
 }
 
-bool
-InflationOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
-                          OperationResult& res,
-                          OperationMetaBuilder& opMeta) const
+bool InflationOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
+                               OperationResult& res,
+                               OperationMetaBuilder& opMeta) const
 {
     auto header = ltx.loadHeader();
     auto& lh = header.current();
@@ -127,21 +126,18 @@ InflationOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
     return true;
 }
 
-bool
-InflationOpFrame::doCheckValid(uint32_t ledgerVersion,
-                               OperationResult& res) const
+bool InflationOpFrame::doCheckValid(uint32_t ledgerVersion,
+                                    OperationResult& res) const
 {
     return true;
 }
 
-bool
-InflationOpFrame::isOpSupported(LedgerHeader const& header) const
+bool InflationOpFrame::isOpSupported(LedgerHeader const& header) const
 {
     return protocolVersionIsBefore(header.ledgerVersion, ProtocolVersion::V_12);
 }
 
-ThresholdLevel
-InflationOpFrame::getThresholdLevel() const
+ThresholdLevel InflationOpFrame::getThresholdLevel() const
 {
     return ThresholdLevel::LOW;
 }

--- a/src/transactions/InflationOpFrame.h
+++ b/src/transactions/InflationOpFrame.h
@@ -12,8 +12,7 @@ class AbstractLedgerTxn;
 
 class InflationOpFrame : public OperationFrame
 {
-    InflationResult&
-    innerResult(OperationResult& res) const
+    InflationResult& innerResult(OperationResult& res) const
     {
         return res.tr().inflationResult();
     }
@@ -30,8 +29,7 @@ class InflationOpFrame : public OperationFrame
                       OperationResult& res) const override;
     bool isOpSupported(LedgerHeader const& header) const override;
 
-    static InflationResultCode
-    getInnerCode(OperationResult const& res)
+    static InflationResultCode getInnerCode(OperationResult const& res)
     {
         return res.tr().inflationResult().code();
     }

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -39,10 +39,10 @@ namespace stellar
 {
 namespace
 {
-CxxLedgerInfo
-getLedgerInfo(SorobanNetworkConfig const& sorobanConfig, uint32_t ledgerVersion,
-              uint32_t ledgerSeq, uint32_t baseReserve, TimePoint closeTime,
-              Hash const& networkID)
+CxxLedgerInfo getLedgerInfo(SorobanNetworkConfig const& sorobanConfig,
+                            uint32_t ledgerVersion, uint32_t ledgerSeq,
+                            uint32_t baseReserve, TimePoint closeTime,
+                            Hash const& networkID)
 {
     CxxLedgerInfo info{};
     info.base_reserve = baseReserve;
@@ -70,8 +70,7 @@ getLedgerInfo(SorobanNetworkConfig const& sorobanConfig, uint32_t ledgerVersion,
     return info;
 }
 
-DiagnosticEvent
-metricsEvent(bool success, std::string&& topic, uint64_t value)
+DiagnosticEvent metricsEvent(bool success, std::string&& topic, uint64_t value)
 {
     DiagnosticEvent de;
     de.inSuccessfulContractCall = success;
@@ -85,10 +84,9 @@ metricsEvent(bool success, std::string&& topic, uint64_t value)
     return de;
 }
 
-void
-maybePopulateOutputDiagnosticEvents(Config const& cfg,
-                                    InvokeHostFunctionOutput const& output,
-                                    DiagnosticEventManager& buffer)
+void maybePopulateOutputDiagnosticEvents(Config const& cfg,
+                                         InvokeHostFunctionOutput const& output,
+                                         DiagnosticEventManager& buffer)
 {
     if (!cfg.ENABLE_SOROBAN_DIAGNOSTIC_EVENTS)
     {
@@ -206,8 +204,8 @@ struct HostFunctionMetrics
         }
     }
 
-    void
-    noteDiskReadEntry(bool isCodeEntry, uint32_t keySize, uint32_t entrySize)
+    void noteDiskReadEntry(bool isCodeEntry, uint32_t keySize,
+                           uint32_t entrySize)
     {
         mReadEntry++;
         mReadKeyByte += keySize;
@@ -225,8 +223,7 @@ struct HostFunctionMetrics
         }
     }
 
-    void
-    noteWriteEntry(bool isCodeEntry, uint32_t keySize, uint32_t entrySize)
+    void noteWriteEntry(bool isCodeEntry, uint32_t keySize, uint32_t entrySize)
     {
         mWriteEntry++;
         mMaxReadWriteKeyByte = std::max(mMaxReadWriteKeyByte, keySize);
@@ -243,8 +240,7 @@ struct HostFunctionMetrics
         }
     }
 
-    std::optional<medida::TimerContext>
-    getExecTimer()
+    std::optional<medida::TimerContext> getExecTimer()
     {
         if (!mDisableMetrics)
         {
@@ -330,9 +326,8 @@ class InvokeHostFunctionApplyHelper : virtual LedgerAccessHelper
     // resource usage. Returns false if the operation
     // should fail and populates result code and
     // diagnostic events.
-    bool
-    meterDiskReadResource(LedgerKey const& lk, uint32_t keySize,
-                          uint32_t entrySize)
+    bool meterDiskReadResource(LedgerKey const& lk, uint32_t keySize,
+                               uint32_t entrySize)
     {
         mMetrics.noteDiskReadEntry(isContractCodeEntry(lk), keySize, entrySize);
         if (mResources.diskReadBytes < mMetrics.mLedgerReadByte)
@@ -356,8 +351,7 @@ class InvokeHostFunctionApplyHelper : virtual LedgerAccessHelper
     // if the operation should fail and populates
     // result code and diagnostic events. Returns true
     // if no failure occurred.
-    bool
-    addReads(xdr::xvector<LedgerKey> const& footprintKeys, bool isReadOnly)
+    bool addReads(xdr::xvector<LedgerKey> const& footprintKeys, bool isReadOnly)
     {
         ZoneScoped;
         auto ledgerSeq = getLedgerSeq();
@@ -504,8 +498,7 @@ class InvokeHostFunctionApplyHelper : virtual LedgerAccessHelper
         return true;
     }
 
-    bool
-    addFootprint()
+    bool addFootprint()
     {
         ZoneScoped;
         if (!addReads(mResources.footprint.readOnly,
@@ -523,8 +516,7 @@ class InvokeHostFunctionApplyHelper : virtual LedgerAccessHelper
         return true;
     }
 
-    bool
-    invokeHostFunction(InvokeHostFunctionOutput& out)
+    bool invokeHostFunction(InvokeHostFunctionOutput& out)
     {
         ZoneScoped;
         rust::Vec<CxxBuf> authEntryCxxBufs;
@@ -607,8 +599,7 @@ class InvokeHostFunctionApplyHelper : virtual LedgerAccessHelper
         return true;
     }
 
-    bool
-    recordStorageChanges(InvokeHostFunctionOutput const& out)
+    bool recordStorageChanges(InvokeHostFunctionOutput const& out)
     {
         ZoneScoped;
         // Create or update every entry returned.
@@ -696,9 +687,8 @@ class InvokeHostFunctionApplyHelper : virtual LedgerAccessHelper
         return true;
     }
 
-    bool
-    collectEvents(InvokeHostFunctionOutput const& out,
-                  InvokeHostFunctionSuccessPreImage& success)
+    bool collectEvents(InvokeHostFunctionOutput const& out,
+                       InvokeHostFunctionSuccessPreImage& success)
     {
         ZoneScoped;
         // We collect the events into a preimage that will be hashed
@@ -746,8 +736,7 @@ class InvokeHostFunctionApplyHelper : virtual LedgerAccessHelper
         return true;
     }
 
-    bool
-    consumeRefundableResources(InvokeHostFunctionOutput const& out)
+    bool consumeRefundableResources(InvokeHostFunctionOutput const& out)
     {
         if (!mRefundableFeeTracker->consumeRefundableSorobanResources(
                 mMetrics.mEmitEventByte, out.rent_fee, getLedgerVersion(),
@@ -761,8 +750,7 @@ class InvokeHostFunctionApplyHelper : virtual LedgerAccessHelper
         return true;
     }
 
-    void
-    setEvents(InvokeHostFunctionSuccessPreImage& success)
+    void setEvents(InvokeHostFunctionSuccessPreImage& success)
     {
         if (!mProtocol23SACReconciliationEvents.empty())
         {
@@ -805,9 +793,8 @@ class InvokeHostFunctionApplyHelper : virtual LedgerAccessHelper
         }
     }
 
-    void
-    finalizeSuccess(InvokeHostFunctionOutput const& out,
-                    InvokeHostFunctionSuccessPreImage& success)
+    void finalizeSuccess(InvokeHostFunctionOutput const& out,
+                         InvokeHostFunctionSuccessPreImage& success)
     {
         xdr::xdr_from_opaque(out.result_value.data, success.returnValue);
         mOpFrame.innerResult(mRes).code(INVOKE_HOST_FUNCTION_SUCCESS);
@@ -821,9 +808,8 @@ class InvokeHostFunctionApplyHelper : virtual LedgerAccessHelper
         mMetrics.mSuccess = true;
     }
 
-    void
-    maybePopulateMetricsInDiagnosticEvents(Config const& cfg,
-                                           DiagnosticEventManager& buffer)
+    void maybePopulateMetricsInDiagnosticEvents(Config const& cfg,
+                                                DiagnosticEventManager& buffer)
     {
         if (!cfg.ENABLE_SOROBAN_DIAGNOSTIC_EVENTS)
         {
@@ -873,8 +859,7 @@ class InvokeHostFunctionApplyHelper : virtual LedgerAccessHelper
                                       mMetrics.mMaxEmitEventByte));
     }
 
-    bool
-    doApply()
+    bool doApply()
     {
         ZoneNamedN(applyZone, "InvokeHostFunctionOpFrame doApply", true);
         auto timeScope = mMetrics.getExecTimer();
@@ -912,8 +897,7 @@ class InvokeHostFunctionApplyHelper : virtual LedgerAccessHelper
     }
 
   public:
-    bool
-    apply()
+    bool apply()
     {
         bool success = doApply();
         // Log the diagnostic events, but not the metrics, as these seem too
@@ -931,10 +915,9 @@ class InvokeHostFunctionPreV23ApplyHelper
       virtual public PreV23LedgerAccessHelper
 {
   private:
-    bool
-    handleArchivedEntry(LedgerKey const& lk, LedgerEntry const& le,
-                        bool isReadOnly, uint32_t restoredLiveUntilLedger,
-                        bool isHotArchiveEntry, uint32_t index) override
+    bool handleArchivedEntry(LedgerKey const& lk, LedgerEntry const& le,
+                             bool isReadOnly, uint32_t restoredLiveUntilLedger,
+                             bool isHotArchiveEntry, uint32_t index) override
     {
         // Before p23, archived entries are never valid
         if (lk.type() == CONTRACT_CODE)
@@ -958,14 +941,12 @@ class InvokeHostFunctionPreV23ApplyHelper
     }
 
     // Entries can't be restored from the hot archive before p23
-    bool
-    previouslyRestoredFromHotArchive(LedgerKey const& lk) override
+    bool previouslyRestoredFromHotArchive(LedgerKey const& lk) override
     {
         return false;
     }
 
-    CxxLedgerInfo
-    getLedgerInfo() override
+    CxxLedgerInfo getLedgerInfo() override
     {
         auto hdr = mLtx.loadHeader();
         auto const& lh = hdr.current();
@@ -1006,10 +987,9 @@ class InvokeHostFunctionParallelApplyHelper
     // Helper called on all archived keys in the footprint. Returns false if
     // the operation should fail and populates result code and diagnostic
     // events. Returns true if no failure occurred.
-    bool
-    handleArchivedEntry(LedgerKey const& lk, LedgerEntry const& le,
-                        bool isReadOnly, uint32_t restoredLiveUntilLedger,
-                        bool isHotArchiveEntry, uint32_t index) override
+    bool handleArchivedEntry(LedgerKey const& lk, LedgerEntry const& le,
+                             bool isReadOnly, uint32_t restoredLiveUntilLedger,
+                             bool isHotArchiveEntry, uint32_t index) override
     {
         // autorestore support started in p23. Entry must be in the read write
         // footprint and must be marked as in the archivedSorobanEntries vector.
@@ -1128,8 +1108,7 @@ class InvokeHostFunctionParallelApplyHelper
         return false;
     }
 
-    bool
-    previouslyRestoredFromHotArchive(LedgerKey const& lk) override
+    bool previouslyRestoredFromHotArchive(LedgerKey const& lk) override
     {
         return mOpState.entryWasRestored(lk);
     }
@@ -1137,10 +1116,8 @@ class InvokeHostFunctionParallelApplyHelper
     // Returns true if the given key is marked for
     // autorestore, false otherwise. Assumes that lk is
     // a read-write key.
-    bool
-    checkIfReadWriteEntryIsMarkedForAutorestore(uint32_t index)
+    bool checkIfReadWriteEntryIsMarkedForAutorestore(uint32_t index)
     {
-
         // If the autorestore vector is empty, there
         // are no entries to restore
         if (mAutorestoredEntries.empty())
@@ -1151,8 +1128,7 @@ class InvokeHostFunctionParallelApplyHelper
         return mAutorestoredEntries.at(index);
     }
 
-    CxxLedgerInfo
-    getLedgerInfo() override
+    CxxLedgerInfo getLedgerInfo() override
     {
         return stellar::getLedgerInfo(
             mSorobanConfig, mLedgerInfo.getLedgerVersion(),
@@ -1197,8 +1173,7 @@ class InvokeHostFunctionParallelApplyHelper
         }
     }
 
-    ParallelTxReturnVal
-    takeResults(bool applySucceeded)
+    ParallelTxReturnVal takeResults(bool applySucceeded)
     {
         if (applySucceeded)
         {
@@ -1218,15 +1193,13 @@ InvokeHostFunctionOpFrame::InvokeHostFunctionOpFrame(
 {
 }
 
-bool
-InvokeHostFunctionOpFrame::isOpSupported(LedgerHeader const& header) const
+bool InvokeHostFunctionOpFrame::isOpSupported(LedgerHeader const& header) const
 {
     return protocolVersionStartsFrom(header.ledgerVersion,
                                      SOROBAN_PROTOCOL_VERSION);
 }
 
-bool
-InvokeHostFunctionOpFrame::doApplyForSoroban(
+bool InvokeHostFunctionOpFrame::doApplyForSoroban(
     AppConnector& app, AbstractLedgerTxn& ltx,
     SorobanNetworkConfig const& sorobanConfig, Hash const& sorobanBasePrngSeed,
     OperationResult& res,
@@ -1247,17 +1220,16 @@ InvokeHostFunctionOpFrame::doApplyForSoroban(
     return helper.apply();
 }
 
-bool
-InvokeHostFunctionOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
-                                   OperationResult& res,
-                                   OperationMetaBuilder& opMeta) const
+bool InvokeHostFunctionOpFrame::doApply(AppConnector& app,
+                                        AbstractLedgerTxn& ltx,
+                                        OperationResult& res,
+                                        OperationMetaBuilder& opMeta) const
 {
     throw std::runtime_error(
         "InvokeHostFunctionOpFrame may only be applied via doApplyForSoroban");
 }
 
-ParallelTxReturnVal
-InvokeHostFunctionOpFrame::doParallelApply(
+ParallelTxReturnVal InvokeHostFunctionOpFrame::doParallelApply(
     AppConnector& app, ThreadParallelApplyLedgerState const& threadState,
     Config const& appConfig, Hash const& txPrngSeed,
     ParallelLedgerInfo const& ledgerInfo, SorobanMetrics& sorobanMetrics,
@@ -1279,8 +1251,7 @@ InvokeHostFunctionOpFrame::doParallelApply(
     return helper.takeResults(success);
 }
 
-bool
-InvokeHostFunctionOpFrame::doCheckValidForSoroban(
+bool InvokeHostFunctionOpFrame::doCheckValidForSoroban(
     SorobanNetworkConfig const& networkConfig, Config const& appConfig,
     uint32_t ledgerVersion, OperationResult& res,
     DiagnosticEventManager& diagnosticEvents) const
@@ -1311,22 +1282,19 @@ InvokeHostFunctionOpFrame::doCheckValidForSoroban(
     return true;
 }
 
-bool
-InvokeHostFunctionOpFrame::doCheckValid(uint32_t ledgerVersion,
-                                        OperationResult& res) const
+bool InvokeHostFunctionOpFrame::doCheckValid(uint32_t ledgerVersion,
+                                             OperationResult& res) const
 {
     throw std::runtime_error(
         "InvokeHostFunctionOpFrame::doCheckValid needs Config");
 }
 
-void
-InvokeHostFunctionOpFrame::insertLedgerKeysToPrefetch(
+void InvokeHostFunctionOpFrame::insertLedgerKeysToPrefetch(
     UnorderedSet<LedgerKey>& keys) const
 {
 }
 
-bool
-InvokeHostFunctionOpFrame::isSoroban() const
+bool InvokeHostFunctionOpFrame::isSoroban() const
 {
     return true;
 }

--- a/src/transactions/InvokeHostFunctionOpFrame.h
+++ b/src/transactions/InvokeHostFunctionOpFrame.h
@@ -24,8 +24,7 @@ class ParallelApplyHelper;
 
 class InvokeHostFunctionOpFrame : public OperationFrame
 {
-    InvokeHostFunctionResult&
-    innerResult(OperationResult& res) const
+    InvokeHostFunctionResult& innerResult(OperationResult& res) const
     {
         return res.tr().invokeHostFunctionResult();
     }
@@ -38,12 +37,12 @@ class InvokeHostFunctionOpFrame : public OperationFrame
 
     bool isOpSupported(LedgerHeader const& header) const override;
 
-    bool
-    doApplyForSoroban(AppConnector& app, AbstractLedgerTxn& ltx,
-                      SorobanNetworkConfig const& sorobanConfig,
-                      Hash const& sorobanBasePrngSeed, OperationResult& res,
-                      std::optional<RefundableFeeTracker>& refundableFeeTracker,
-                      OperationMetaBuilder& opMeta) const override;
+    bool doApplyForSoroban(
+        AppConnector& app, AbstractLedgerTxn& ltx,
+        SorobanNetworkConfig const& sorobanConfig,
+        Hash const& sorobanBasePrngSeed, OperationResult& res,
+        std::optional<RefundableFeeTracker>& refundableFeeTracker,
+        OperationMetaBuilder& opMeta) const override;
 
     bool doApply(AppConnector& app, AbstractLedgerTxn& ltx,
                  OperationResult& res,
@@ -65,11 +64,10 @@ class InvokeHostFunctionOpFrame : public OperationFrame
                     std::optional<RefundableFeeTracker>& refundableFeeTracker,
                     OperationMetaBuilder& opMeta) const override;
 
-    void
-    insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const override;
+    void insertLedgerKeysToPrefetch(
+        UnorderedSet<LedgerKey>& keys) const override;
 
-    static InvokeHostFunctionResultCode
-    getInnerCode(OperationResult const& res)
+    static InvokeHostFunctionResultCode getInnerCode(OperationResult const& res)
     {
         return res.tr().invokeHostFunctionResult().code();
     }

--- a/src/transactions/LiquidityPoolDepositOpFrame.cpp
+++ b/src/transactions/LiquidityPoolDepositOpFrame.cpp
@@ -21,17 +21,16 @@ LiquidityPoolDepositOpFrame::LiquidityPoolDepositOpFrame(
 {
 }
 
-bool
-LiquidityPoolDepositOpFrame::isOpSupported(LedgerHeader const& header) const
+bool LiquidityPoolDepositOpFrame::isOpSupported(
+    LedgerHeader const& header) const
 {
     return protocolVersionStartsFrom(header.ledgerVersion,
                                      ProtocolVersion::V_18) &&
            !isPoolDepositDisabled(header);
 }
 
-static bool
-isBadPrice(int64_t amountA, int64_t amountB, Price const& minPrice,
-           Price const& maxPrice)
+static bool isBadPrice(int64_t amountA, int64_t amountB, Price const& minPrice,
+                       Price const& maxPrice)
 {
     // a * d < b * n is equivalent to a/b < n/d but avoids rounding.
     if (amountA == 0 || amountB == 0 ||
@@ -43,8 +42,7 @@ isBadPrice(int64_t amountA, int64_t amountB, Price const& minPrice,
     return false;
 }
 
-bool
-LiquidityPoolDepositOpFrame::depositIntoEmptyPool(
+bool LiquidityPoolDepositOpFrame::depositIntoEmptyPool(
     int64_t& amountA, int64_t& amountB, int64_t& amountPoolShares,
     int64_t availableA, int64_t availableB, int64_t availableLimitPoolShares,
     OperationResult& res) const
@@ -75,8 +73,8 @@ LiquidityPoolDepositOpFrame::depositIntoEmptyPool(
     return true;
 }
 
-static bool
-minAmongValid(int64_t& res, int64_t x, bool xValid, int64_t y, bool yValid)
+static bool minAmongValid(int64_t& res, int64_t x, bool xValid, int64_t y,
+                          bool yValid)
 {
     if (xValid && yValid)
     {
@@ -97,8 +95,7 @@ minAmongValid(int64_t& res, int64_t x, bool xValid, int64_t y, bool yValid)
     return true;
 }
 
-bool
-LiquidityPoolDepositOpFrame::depositIntoNonEmptyPool(
+bool LiquidityPoolDepositOpFrame::depositIntoNonEmptyPool(
     int64_t& amountA, int64_t& amountB, int64_t& amountPoolShares,
     int64_t availableA, int64_t availableB, int64_t availableLimitPoolShares,
     LiquidityPoolConstantProduct const& cp, OperationResult& res) const
@@ -168,9 +165,8 @@ LiquidityPoolDepositOpFrame::depositIntoNonEmptyPool(
     return true;
 }
 
-static void
-updateBalance(LedgerTxnHeader& header, TrustLineWrapper& tl,
-              LedgerTxnEntry& acc, int64_t delta)
+static void updateBalance(LedgerTxnHeader& header, TrustLineWrapper& tl,
+                          LedgerTxnEntry& acc, int64_t delta)
 {
     if (tl)
     {
@@ -188,10 +184,10 @@ updateBalance(LedgerTxnHeader& header, TrustLineWrapper& tl,
     }
 }
 
-bool
-LiquidityPoolDepositOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
-                                     OperationResult& res,
-                                     OperationMetaBuilder& opMeta) const
+bool LiquidityPoolDepositOpFrame::doApply(AppConnector& app,
+                                          AbstractLedgerTxn& ltx,
+                                          OperationResult& res,
+                                          OperationMetaBuilder& opMeta) const
 {
     ZoneNamedN(applyZone, "LiquidityPoolDepositOpFrame apply", true);
 
@@ -327,9 +323,8 @@ LiquidityPoolDepositOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
     return true;
 }
 
-bool
-LiquidityPoolDepositOpFrame::doCheckValid(uint32_t ledgerVersion,
-                                          OperationResult& res) const
+bool LiquidityPoolDepositOpFrame::doCheckValid(uint32_t ledgerVersion,
+                                               OperationResult& res) const
 {
     if (mLiquidityPoolDeposit.maxAmountA <= 0 ||
         mLiquidityPoolDeposit.maxAmountB <= 0)
@@ -367,8 +362,7 @@ LiquidityPoolDepositOpFrame::doCheckValid(uint32_t ledgerVersion,
     return true;
 }
 
-void
-LiquidityPoolDepositOpFrame::insertLedgerKeysToPrefetch(
+void LiquidityPoolDepositOpFrame::insertLedgerKeysToPrefetch(
     UnorderedSet<LedgerKey>& keys) const
 {
     keys.emplace(liquidityPoolKey(mLiquidityPoolDeposit.liquidityPoolID));

--- a/src/transactions/LiquidityPoolDepositOpFrame.h
+++ b/src/transactions/LiquidityPoolDepositOpFrame.h
@@ -16,8 +16,7 @@ typedef LiquidityPoolEntry::_body_t::_constantProduct_t
 
 class LiquidityPoolDepositOpFrame : public OperationFrame
 {
-    LiquidityPoolDepositResult&
-    innerResult(OperationResult& res) const
+    LiquidityPoolDepositResult& innerResult(OperationResult& res) const
     {
         return res.tr().liquidityPoolDepositResult();
     }
@@ -48,8 +47,8 @@ class LiquidityPoolDepositOpFrame : public OperationFrame
                  OperationMetaBuilder& opMeta) const override;
     bool doCheckValid(uint32_t ledgerVersion,
                       OperationResult& res) const override;
-    void
-    insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const override;
+    void insertLedgerKeysToPrefetch(
+        UnorderedSet<LedgerKey>& keys) const override;
 
     static LiquidityPoolDepositResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/LiquidityPoolWithdrawOpFrame.cpp
+++ b/src/transactions/LiquidityPoolWithdrawOpFrame.cpp
@@ -20,18 +20,18 @@ LiquidityPoolWithdrawOpFrame::LiquidityPoolWithdrawOpFrame(
 {
 }
 
-bool
-LiquidityPoolWithdrawOpFrame::isOpSupported(LedgerHeader const& header) const
+bool LiquidityPoolWithdrawOpFrame::isOpSupported(
+    LedgerHeader const& header) const
 {
     return protocolVersionStartsFrom(header.ledgerVersion,
                                      ProtocolVersion::V_18) &&
            !isPoolWithdrawalDisabled(header);
 }
 
-bool
-LiquidityPoolWithdrawOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
-                                      OperationResult& res,
-                                      OperationMetaBuilder& opMeta) const
+bool LiquidityPoolWithdrawOpFrame::doApply(AppConnector& app,
+                                           AbstractLedgerTxn& ltx,
+                                           OperationResult& res,
+                                           OperationMetaBuilder& opMeta) const
 {
     ZoneNamedN(applyZone, "LiquidityPoolWithdrawOpFrame apply", true);
 
@@ -113,9 +113,8 @@ LiquidityPoolWithdrawOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
     return true;
 }
 
-bool
-LiquidityPoolWithdrawOpFrame::doCheckValid(uint32_t ledgerVersion,
-                                           OperationResult& res) const
+bool LiquidityPoolWithdrawOpFrame::doCheckValid(uint32_t ledgerVersion,
+                                                OperationResult& res) const
 {
     if (mLiquidityPoolWithdraw.amount <= 0 ||
         mLiquidityPoolWithdraw.minAmountA < 0 ||
@@ -127,8 +126,7 @@ LiquidityPoolWithdrawOpFrame::doCheckValid(uint32_t ledgerVersion,
     return true;
 }
 
-void
-LiquidityPoolWithdrawOpFrame::insertLedgerKeysToPrefetch(
+void LiquidityPoolWithdrawOpFrame::insertLedgerKeysToPrefetch(
     UnorderedSet<LedgerKey>& keys) const
 {
     keys.emplace(liquidityPoolKey(mLiquidityPoolWithdraw.liquidityPoolID));
@@ -136,8 +134,7 @@ LiquidityPoolWithdrawOpFrame::insertLedgerKeysToPrefetch(
                                        mLiquidityPoolWithdraw.liquidityPoolID));
 }
 
-bool
-LiquidityPoolWithdrawOpFrame::tryAddAssetBalance(
+bool LiquidityPoolWithdrawOpFrame::tryAddAssetBalance(
     AbstractLedgerTxn& ltx, OperationResult& res, LedgerTxnHeader const& header,
     Asset const& asset, int64_t minAmount, int64_t amount) const
 {

--- a/src/transactions/LiquidityPoolWithdrawOpFrame.h
+++ b/src/transactions/LiquidityPoolWithdrawOpFrame.h
@@ -13,8 +13,7 @@ class AbstractLedgerTxn;
 
 class LiquidityPoolWithdrawOpFrame : public OperationFrame
 {
-    LiquidityPoolWithdrawResult&
-    innerResult(OperationResult& res) const
+    LiquidityPoolWithdrawResult& innerResult(OperationResult& res) const
     {
         return res.tr().liquidityPoolWithdrawResult();
     }
@@ -35,8 +34,8 @@ class LiquidityPoolWithdrawOpFrame : public OperationFrame
                  OperationMetaBuilder& opMeta) const override;
     bool doCheckValid(uint32_t ledgerVersion,
                       OperationResult& res) const override;
-    void
-    insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const override;
+    void insertLedgerKeysToPrefetch(
+        UnorderedSet<LedgerKey>& keys) const override;
 
     static LiquidityPoolWithdrawResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/LumenEventReconciler.cpp
+++ b/src/transactions/LumenEventReconciler.cpp
@@ -14,8 +14,7 @@ namespace stellar
 namespace
 {
 
-int64_t
-calculateDeltaBalance(
+int64_t calculateDeltaBalance(
     std::shared_ptr<InternalLedgerEntry const> const& genCurrent,
     std::shared_ptr<InternalLedgerEntry const> const& genPrevious)
 {
@@ -42,9 +41,9 @@ calculateDeltaBalance(
 
 }
 
-void
-reconcileEvents(AccountID const& txSourceAccount, Operation const& operation,
-                LedgerTxnDelta const& ltxDelta, OpEventManager& opEventManager)
+void reconcileEvents(AccountID const& txSourceAccount,
+                     Operation const& operation, LedgerTxnDelta const& ltxDelta,
+                     OpEventManager& opEventManager)
 {
     // Should only be called pre protocol 8
     int64_t deltaBalances = std::accumulate(

--- a/src/transactions/ManageBuyOfferOpFrame.cpp
+++ b/src/transactions/ManageBuyOfferOpFrame.cpp
@@ -14,8 +14,7 @@
 namespace stellar
 {
 
-static Price
-getInversePrice(Price const& price)
+static Price getInversePrice(Price const& price)
 {
     return Price{price.d, price.n};
 }
@@ -30,27 +29,23 @@ ManageBuyOfferOpFrame::ManageBuyOfferOpFrame(Operation const& op,
 {
 }
 
-bool
-ManageBuyOfferOpFrame::isOpSupported(LedgerHeader const& header) const
+bool ManageBuyOfferOpFrame::isOpSupported(LedgerHeader const& header) const
 {
     return protocolVersionStartsFrom(header.ledgerVersion,
                                      ProtocolVersion::V_11);
 }
 
-bool
-ManageBuyOfferOpFrame::isAmountValid() const
+bool ManageBuyOfferOpFrame::isAmountValid() const
 {
     return mManageBuyOffer.buyAmount >= 0;
 }
 
-bool
-ManageBuyOfferOpFrame::isDeleteOffer() const
+bool ManageBuyOfferOpFrame::isDeleteOffer() const
 {
     return mManageBuyOffer.buyAmount == 0;
 }
 
-int64_t
-ManageBuyOfferOpFrame::getOfferBuyingLiabilities() const
+int64_t ManageBuyOfferOpFrame::getOfferBuyingLiabilities() const
 {
     auto res = exchangeV10WithoutPriceErrorThresholds(
         getInversePrice(mManageBuyOffer.price), INT64_MAX, INT64_MAX, INT64_MAX,
@@ -58,8 +53,7 @@ ManageBuyOfferOpFrame::getOfferBuyingLiabilities() const
     return res.numSheepSend;
 }
 
-int64_t
-ManageBuyOfferOpFrame::getOfferSellingLiabilities() const
+int64_t ManageBuyOfferOpFrame::getOfferSellingLiabilities() const
 {
     auto res = exchangeV10WithoutPriceErrorThresholds(
         getInversePrice(mManageBuyOffer.price), INT64_MAX, INT64_MAX, INT64_MAX,
@@ -67,18 +61,15 @@ ManageBuyOfferOpFrame::getOfferSellingLiabilities() const
     return res.numWheatReceived;
 }
 
-void
-ManageBuyOfferOpFrame::applyOperationSpecificLimits(int64_t& maxSheepSend,
-                                                    int64_t sheepSent,
-                                                    int64_t& maxWheatReceive,
-                                                    int64_t wheatReceived) const
+void ManageBuyOfferOpFrame::applyOperationSpecificLimits(
+    int64_t& maxSheepSend, int64_t sheepSent, int64_t& maxWheatReceive,
+    int64_t wheatReceived) const
 {
     maxWheatReceive =
         std::min(mManageBuyOffer.buyAmount - wheatReceived, maxWheatReceive);
 }
 
-void
-ManageBuyOfferOpFrame::getExchangeParametersBeforeV10(
+void ManageBuyOfferOpFrame::getExchangeParametersBeforeV10(
     int64_t& maxSheepSend, int64_t& maxWheatReceive) const
 {
     throw std::runtime_error("ManageBuyOffer used before protocol version 10");
@@ -90,80 +81,69 @@ ManageBuyOfferOpFrame::getSuccessResult(OperationResult& res) const
     return res.tr().manageBuyOfferResult().success();
 }
 
-void
-ManageBuyOfferOpFrame::setResultSuccess(OperationResult& res) const
+void ManageBuyOfferOpFrame::setResultSuccess(OperationResult& res) const
 {
     res.tr().manageBuyOfferResult().code(MANAGE_BUY_OFFER_SUCCESS);
 }
 
-void
-ManageBuyOfferOpFrame::setResultMalformed(OperationResult& res) const
+void ManageBuyOfferOpFrame::setResultMalformed(OperationResult& res) const
 {
     res.tr().manageBuyOfferResult().code(MANAGE_BUY_OFFER_MALFORMED);
 }
 
-void
-ManageBuyOfferOpFrame::setResultSellNoTrust(OperationResult& res) const
+void ManageBuyOfferOpFrame::setResultSellNoTrust(OperationResult& res) const
 {
     res.tr().manageBuyOfferResult().code(MANAGE_BUY_OFFER_SELL_NO_TRUST);
 }
 
-void
-ManageBuyOfferOpFrame::setResultBuyNoTrust(OperationResult& res) const
+void ManageBuyOfferOpFrame::setResultBuyNoTrust(OperationResult& res) const
 {
     res.tr().manageBuyOfferResult().code(MANAGE_BUY_OFFER_BUY_NO_TRUST);
 }
 
-void
-ManageBuyOfferOpFrame::setResultSellNotAuthorized(OperationResult& res) const
+void ManageBuyOfferOpFrame::setResultSellNotAuthorized(
+    OperationResult& res) const
 {
     res.tr().manageBuyOfferResult().code(MANAGE_BUY_OFFER_SELL_NOT_AUTHORIZED);
 }
 
-void
-ManageBuyOfferOpFrame::setResultBuyNotAuthorized(OperationResult& res) const
+void ManageBuyOfferOpFrame::setResultBuyNotAuthorized(
+    OperationResult& res) const
 {
     res.tr().manageBuyOfferResult().code(MANAGE_BUY_OFFER_BUY_NOT_AUTHORIZED);
 }
 
-void
-ManageBuyOfferOpFrame::setResultLineFull(OperationResult& res) const
+void ManageBuyOfferOpFrame::setResultLineFull(OperationResult& res) const
 {
     res.tr().manageBuyOfferResult().code(MANAGE_BUY_OFFER_LINE_FULL);
 }
 
-void
-ManageBuyOfferOpFrame::setResultUnderfunded(OperationResult& res) const
+void ManageBuyOfferOpFrame::setResultUnderfunded(OperationResult& res) const
 {
     res.tr().manageBuyOfferResult().code(MANAGE_BUY_OFFER_UNDERFUNDED);
 }
 
-void
-ManageBuyOfferOpFrame::setResultCrossSelf(OperationResult& res) const
+void ManageBuyOfferOpFrame::setResultCrossSelf(OperationResult& res) const
 {
     res.tr().manageBuyOfferResult().code(MANAGE_BUY_OFFER_CROSS_SELF);
 }
 
-void
-ManageBuyOfferOpFrame::setResultSellNoIssuer(OperationResult& res) const
+void ManageBuyOfferOpFrame::setResultSellNoIssuer(OperationResult& res) const
 {
     res.tr().manageBuyOfferResult().code(MANAGE_BUY_OFFER_SELL_NO_ISSUER);
 }
 
-void
-ManageBuyOfferOpFrame::setResultBuyNoIssuer(OperationResult& res) const
+void ManageBuyOfferOpFrame::setResultBuyNoIssuer(OperationResult& res) const
 {
     res.tr().manageBuyOfferResult().code(MANAGE_BUY_OFFER_BUY_NO_ISSUER);
 }
 
-void
-ManageBuyOfferOpFrame::setResultNotFound(OperationResult& res) const
+void ManageBuyOfferOpFrame::setResultNotFound(OperationResult& res) const
 {
     res.tr().manageBuyOfferResult().code(MANAGE_BUY_OFFER_NOT_FOUND);
 }
 
-void
-ManageBuyOfferOpFrame::setResultLowReserve(OperationResult& res) const
+void ManageBuyOfferOpFrame::setResultLowReserve(OperationResult& res) const
 {
     res.tr().manageBuyOfferResult().code(MANAGE_BUY_OFFER_LOW_RESERVE);
 }

--- a/src/transactions/ManageBuyOfferOpFrame.h
+++ b/src/transactions/ManageBuyOfferOpFrame.h
@@ -17,8 +17,7 @@ class ManageBuyOfferOpFrame : public ManageOfferOpFrameBase
 
     bool isOpSupported(LedgerHeader const& header) const override;
 
-    ManageBuyOfferResult&
-    innerResult(OperationResult& res) const
+    ManageBuyOfferResult& innerResult(OperationResult& res) const
     {
         return res.tr().manageBuyOfferResult();
     }
@@ -36,9 +35,8 @@ class ManageBuyOfferOpFrame : public ManageOfferOpFrameBase
     void applyOperationSpecificLimits(int64_t& maxSheepSend, int64_t sheepSent,
                                       int64_t& maxWheatReceive,
                                       int64_t wheatReceived) const override;
-    void
-    getExchangeParametersBeforeV10(int64_t& maxSheepSend,
-                                   int64_t& maxWheatReceive) const override;
+    void getExchangeParametersBeforeV10(
+        int64_t& maxSheepSend, int64_t& maxWheatReceive) const override;
 
     ManageOfferSuccessResult&
     getSuccessResult(OperationResult& res) const override;
@@ -57,8 +55,7 @@ class ManageBuyOfferOpFrame : public ManageOfferOpFrameBase
     void setResultNotFound(OperationResult& res) const override;
     void setResultLowReserve(OperationResult& res) const override;
 
-    static ManageBuyOfferResultCode
-    getInnerCode(OperationResult const& res)
+    static ManageBuyOfferResultCode getInnerCode(OperationResult const& res)
     {
         return res.tr().manageBuyOfferResult().code();
     }

--- a/src/transactions/ManageDataOpFrame.cpp
+++ b/src/transactions/ManageDataOpFrame.cpp
@@ -28,10 +28,9 @@ ManageDataOpFrame::ManageDataOpFrame(Operation const& op,
 {
 }
 
-bool
-ManageDataOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
-                           OperationResult& res,
-                           OperationMetaBuilder& opMeta) const
+bool ManageDataOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
+                                OperationResult& res,
+                                OperationMetaBuilder& opMeta) const
 {
     ZoneNamedN(applyZone, "ManageDataOp apply", true);
     auto header = ltx.loadHeader();
@@ -101,9 +100,8 @@ ManageDataOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
     return true;
 }
 
-bool
-ManageDataOpFrame::doCheckValid(uint32_t ledgerVersion,
-                                OperationResult& res) const
+bool ManageDataOpFrame::doCheckValid(uint32_t ledgerVersion,
+                                     OperationResult& res) const
 {
     if (protocolVersionIsBefore(ledgerVersion, ProtocolVersion::V_2))
     {
@@ -121,8 +119,7 @@ ManageDataOpFrame::doCheckValid(uint32_t ledgerVersion,
     return true;
 }
 
-void
-ManageDataOpFrame::insertLedgerKeysToPrefetch(
+void ManageDataOpFrame::insertLedgerKeysToPrefetch(
     UnorderedSet<LedgerKey>& keys) const
 {
     keys.emplace(dataKey(getSourceID(), mManageData.dataName));

--- a/src/transactions/ManageDataOpFrame.h
+++ b/src/transactions/ManageDataOpFrame.h
@@ -12,9 +12,7 @@ class AbstractLedgerTxn;
 
 class ManageDataOpFrame : public OperationFrame
 {
-
-    ManageDataResult&
-    innerResult(OperationResult& res) const
+    ManageDataResult& innerResult(OperationResult& res) const
     {
         return res.tr().manageDataResult();
     }
@@ -29,11 +27,10 @@ class ManageDataOpFrame : public OperationFrame
                  OperationMetaBuilder& opMeta) const override;
     bool doCheckValid(uint32_t ledgerVersion,
                       OperationResult& res) const override;
-    void
-    insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const override;
+    void insertLedgerKeysToPrefetch(
+        UnorderedSet<LedgerKey>& keys) const override;
 
-    static ManageDataResultCode
-    getInnerCode(OperationResult const& res)
+    static ManageDataResultCode getInnerCode(OperationResult const& res)
     {
         return res.tr().manageDataResult().code();
     }

--- a/src/transactions/ManageOfferOpFrameBase.cpp
+++ b/src/transactions/ManageOfferOpFrameBase.cpp
@@ -30,9 +30,8 @@ ManageOfferOpFrameBase::ManageOfferOpFrameBase(
 {
 }
 
-bool
-ManageOfferOpFrameBase::checkOfferValid(AbstractLedgerTxn& ltxOuter,
-                                        OperationResult& res) const
+bool ManageOfferOpFrameBase::checkOfferValid(AbstractLedgerTxn& ltxOuter,
+                                             OperationResult& res) const
 {
     LedgerTxn ltx(ltxOuter); // ltx will always be rolled back
 
@@ -103,8 +102,7 @@ ManageOfferOpFrameBase::checkOfferValid(AbstractLedgerTxn& ltxOuter,
     return true;
 }
 
-bool
-ManageOfferOpFrameBase::computeOfferExchangeParameters(
+bool ManageOfferOpFrameBase::computeOfferExchangeParameters(
     AbstractLedgerTxn& ltxOuter, OperationResult& res, bool creatingNewOffer,
     int64_t& maxSheepSend, int64_t& maxWheatReceive) const
 {
@@ -211,10 +209,10 @@ ManageOfferOpFrameBase::computeOfferExchangeParameters(
     return true;
 }
 
-bool
-ManageOfferOpFrameBase::doApply(AppConnector& app, AbstractLedgerTxn& ltxOuter,
-                                OperationResult& res,
-                                OperationMetaBuilder& opMeta) const
+bool ManageOfferOpFrameBase::doApply(AppConnector& app,
+                                     AbstractLedgerTxn& ltxOuter,
+                                     OperationResult& res,
+                                     OperationMetaBuilder& opMeta) const
 {
     ZoneNamedN(applyZone, "ManageOfferOp apply", true);
     std::string pairStr = assetToString(mSheep);
@@ -545,8 +543,7 @@ ManageOfferOpFrameBase::doApply(AppConnector& app, AbstractLedgerTxn& ltxOuter,
     return true;
 }
 
-bool
-ManageOfferOpFrameBase::isDexOperation() const
+bool ManageOfferOpFrameBase::isDexOperation() const
 {
     return !isDeleteOffer();
 }
@@ -577,9 +574,8 @@ ManageOfferOpFrameBase::buildOffer(int64_t amount, uint32_t flags,
 }
 
 // makes sure the currencies are different
-bool
-ManageOfferOpFrameBase::doCheckValid(uint32_t ledgerVersion,
-                                     OperationResult& res) const
+bool ManageOfferOpFrameBase::doCheckValid(uint32_t ledgerVersion,
+                                          OperationResult& res) const
 {
     if (!isAssetValid(mSheep, ledgerVersion) ||
         !isAssetValid(mWheat, ledgerVersion))
@@ -624,8 +620,7 @@ ManageOfferOpFrameBase::doCheckValid(uint32_t ledgerVersion,
     return true;
 }
 
-void
-ManageOfferOpFrameBase::insertLedgerKeysToPrefetch(
+void ManageOfferOpFrameBase::insertLedgerKeysToPrefetch(
     UnorderedSet<LedgerKey>& keys) const
 {
     // Prefetch existing offer

--- a/src/transactions/ManageOfferOpFrameBase.h
+++ b/src/transactions/ManageOfferOpFrameBase.h
@@ -49,8 +49,8 @@ class ManageOfferOpFrameBase : public OperationFrame
 
     bool isDexOperation() const override;
 
-    void
-    insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const override;
+    void insertLedgerKeysToPrefetch(
+        UnorderedSet<LedgerKey>& keys) const override;
 
     virtual bool isAmountValid() const = 0;
     virtual bool isDeleteOffer() const = 0;

--- a/src/transactions/ManageSellOfferOpFrame.cpp
+++ b/src/transactions/ManageSellOfferOpFrame.cpp
@@ -42,20 +42,17 @@ ManageSellOfferOpFrame::ManageSellOfferOpFrame(Operation const& op,
 {
 }
 
-bool
-ManageSellOfferOpFrame::isAmountValid() const
+bool ManageSellOfferOpFrame::isAmountValid() const
 {
     return mManageSellOffer.amount >= 0;
 }
 
-bool
-ManageSellOfferOpFrame::isDeleteOffer() const
+bool ManageSellOfferOpFrame::isDeleteOffer() const
 {
     return mManageSellOffer.amount == 0;
 }
 
-int64_t
-ManageSellOfferOpFrame::getOfferBuyingLiabilities() const
+int64_t ManageSellOfferOpFrame::getOfferBuyingLiabilities() const
 {
     auto res = exchangeV10WithoutPriceErrorThresholds(
         mManageSellOffer.price, mManageSellOffer.amount, INT64_MAX, INT64_MAX,
@@ -63,8 +60,7 @@ ManageSellOfferOpFrame::getOfferBuyingLiabilities() const
     return res.numSheepSend;
 }
 
-int64_t
-ManageSellOfferOpFrame::getOfferSellingLiabilities() const
+int64_t ManageSellOfferOpFrame::getOfferSellingLiabilities() const
 {
     auto res = exchangeV10WithoutPriceErrorThresholds(
         mManageSellOffer.price, mManageSellOffer.amount, INT64_MAX, INT64_MAX,
@@ -72,16 +68,14 @@ ManageSellOfferOpFrame::getOfferSellingLiabilities() const
     return res.numWheatReceived;
 }
 
-void
-ManageSellOfferOpFrame::applyOperationSpecificLimits(
+void ManageSellOfferOpFrame::applyOperationSpecificLimits(
     int64_t& maxSheepSend, int64_t sheepSent, int64_t& maxWheatReceive,
     int64_t wheatReceived) const
 {
     maxSheepSend = std::min(mManageSellOffer.amount - sheepSent, maxSheepSend);
 }
 
-void
-ManageSellOfferOpFrame::getExchangeParametersBeforeV10(
+void ManageSellOfferOpFrame::getExchangeParametersBeforeV10(
     int64_t& maxSheepSend, int64_t& maxWheatReceive) const
 {
     int64_t maxSheepBasedOnWheat;
@@ -102,81 +96,70 @@ ManageSellOfferOpFrame::getSuccessResult(OperationResult& res) const
     return res.tr().manageSellOfferResult().success();
 }
 
-void
-ManageSellOfferOpFrame::setResultSuccess(OperationResult& res) const
+void ManageSellOfferOpFrame::setResultSuccess(OperationResult& res) const
 {
     res.tr().manageSellOfferResult().code(MANAGE_SELL_OFFER_SUCCESS);
 }
 
-void
-ManageSellOfferOpFrame::setResultMalformed(OperationResult& res) const
+void ManageSellOfferOpFrame::setResultMalformed(OperationResult& res) const
 {
     res.tr().manageSellOfferResult().code(MANAGE_SELL_OFFER_MALFORMED);
 }
 
-void
-ManageSellOfferOpFrame::setResultSellNoTrust(OperationResult& res) const
+void ManageSellOfferOpFrame::setResultSellNoTrust(OperationResult& res) const
 {
     res.tr().manageSellOfferResult().code(MANAGE_SELL_OFFER_SELL_NO_TRUST);
 }
 
-void
-ManageSellOfferOpFrame::setResultBuyNoTrust(OperationResult& res) const
+void ManageSellOfferOpFrame::setResultBuyNoTrust(OperationResult& res) const
 {
     res.tr().manageSellOfferResult().code(MANAGE_SELL_OFFER_BUY_NO_TRUST);
 }
 
-void
-ManageSellOfferOpFrame::setResultSellNotAuthorized(OperationResult& res) const
+void ManageSellOfferOpFrame::setResultSellNotAuthorized(
+    OperationResult& res) const
 {
     res.tr().manageSellOfferResult().code(
         MANAGE_SELL_OFFER_SELL_NOT_AUTHORIZED);
 }
 
-void
-ManageSellOfferOpFrame::setResultBuyNotAuthorized(OperationResult& res) const
+void ManageSellOfferOpFrame::setResultBuyNotAuthorized(
+    OperationResult& res) const
 {
     res.tr().manageSellOfferResult().code(MANAGE_SELL_OFFER_BUY_NOT_AUTHORIZED);
 }
 
-void
-ManageSellOfferOpFrame::setResultLineFull(OperationResult& res) const
+void ManageSellOfferOpFrame::setResultLineFull(OperationResult& res) const
 {
     res.tr().manageSellOfferResult().code(MANAGE_SELL_OFFER_LINE_FULL);
 }
 
-void
-ManageSellOfferOpFrame::setResultUnderfunded(OperationResult& res) const
+void ManageSellOfferOpFrame::setResultUnderfunded(OperationResult& res) const
 {
     res.tr().manageSellOfferResult().code(MANAGE_SELL_OFFER_UNDERFUNDED);
 }
 
-void
-ManageSellOfferOpFrame::setResultCrossSelf(OperationResult& res) const
+void ManageSellOfferOpFrame::setResultCrossSelf(OperationResult& res) const
 {
     res.tr().manageSellOfferResult().code(MANAGE_SELL_OFFER_CROSS_SELF);
 }
 
-void
-ManageSellOfferOpFrame::setResultSellNoIssuer(OperationResult& res) const
+void ManageSellOfferOpFrame::setResultSellNoIssuer(OperationResult& res) const
 {
     res.tr().manageSellOfferResult().code(MANAGE_SELL_OFFER_SELL_NO_ISSUER);
 }
 
-void
-ManageSellOfferOpFrame::setResultBuyNoIssuer(OperationResult& res) const
+void ManageSellOfferOpFrame::setResultBuyNoIssuer(OperationResult& res) const
 {
     res.tr().manageSellOfferResult().code(MANAGE_SELL_OFFER_BUY_NO_ISSUER);
 }
 
-void
-ManageSellOfferOpFrame::setResultNotFound(OperationResult& res) const
+void ManageSellOfferOpFrame::setResultNotFound(OperationResult& res) const
 {
     res.tr().manageSellOfferResult().code(MANAGE_SELL_OFFER_NOT_FOUND);
 }
 
-void
-ManageSellOfferOpFrame::setResultLowReserve(OperationResult& res) const
+void ManageSellOfferOpFrame::setResultLowReserve(OperationResult& res) const
 {
     res.tr().manageSellOfferResult().code(MANAGE_SELL_OFFER_LOW_RESERVE);
 }

--- a/src/transactions/ManageSellOfferOpFrame.h
+++ b/src/transactions/ManageSellOfferOpFrame.h
@@ -15,8 +15,7 @@ class ManageSellOfferOpFrame : public ManageOfferOpFrameBase
 {
     ManageSellOfferOp const& mManageSellOffer;
 
-    ManageSellOfferResult&
-    innerResult(OperationResult& res) const
+    ManageSellOfferResult& innerResult(OperationResult& res) const
     {
         return res.tr().manageSellOfferResult();
     }
@@ -36,9 +35,8 @@ class ManageSellOfferOpFrame : public ManageOfferOpFrameBase
     void applyOperationSpecificLimits(int64_t& maxSheepSend, int64_t sheepSent,
                                       int64_t& maxWheatReceive,
                                       int64_t wheatReceived) const override;
-    void
-    getExchangeParametersBeforeV10(int64_t& maxSheepSend,
-                                   int64_t& maxWheatReceive) const override;
+    void getExchangeParametersBeforeV10(
+        int64_t& maxSheepSend, int64_t& maxWheatReceive) const override;
 
     ManageOfferSuccessResult&
     getSuccessResult(OperationResult& res) const override;
@@ -57,8 +55,7 @@ class ManageSellOfferOpFrame : public ManageOfferOpFrameBase
     void setResultNotFound(OperationResult& res) const override;
     void setResultLowReserve(OperationResult& res) const override;
 
-    static ManageSellOfferResultCode
-    getInnerCode(OperationResult const& res)
+    static ManageSellOfferResultCode getInnerCode(OperationResult const& res)
     {
         return res.tr().manageSellOfferResult().code();
     }

--- a/src/transactions/MergeOpFrame.cpp
+++ b/src/transactions/MergeOpFrame.cpp
@@ -26,16 +26,14 @@ MergeOpFrame::MergeOpFrame(Operation const& op,
 {
 }
 
-ThresholdLevel
-MergeOpFrame::getThresholdLevel() const
+ThresholdLevel MergeOpFrame::getThresholdLevel() const
 {
     return ThresholdLevel::HIGH;
 }
 
-bool
-MergeOpFrame::isSeqnumTooFar(AbstractLedgerTxn& ltx,
-                             LedgerTxnHeader const& header,
-                             AccountEntry const& sourceAccount) const
+bool MergeOpFrame::isSeqnumTooFar(AbstractLedgerTxn& ltx,
+                                  LedgerTxnHeader const& header,
+                                  AccountEntry const& sourceAccount) const
 {
     // don't allow the account to be merged if recreating it would cause it
     // to jump backwards
@@ -60,9 +58,9 @@ MergeOpFrame::isSeqnumTooFar(AbstractLedgerTxn& ltx,
 // make sure the we delete all the offers
 // make sure the we delete all the trustlines
 // move the XLM to the new account
-bool
-MergeOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
-                      OperationResult& res, OperationMetaBuilder& opMeta) const
+bool MergeOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
+                           OperationResult& res,
+                           OperationMetaBuilder& opMeta) const
 {
     ZoneNamedN(applyZone, "MergeOp apply", true);
 
@@ -77,9 +75,9 @@ MergeOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
     }
 }
 
-bool
-MergeOpFrame::doApplyBeforeV16(AbstractLedgerTxn& ltx, OperationResult& res,
-                               OpEventManager& opEventManager) const
+bool MergeOpFrame::doApplyBeforeV16(AbstractLedgerTxn& ltx,
+                                    OperationResult& res,
+                                    OpEventManager& opEventManager) const
 {
     auto header = ltx.loadHeader();
 
@@ -192,9 +190,8 @@ MergeOpFrame::doApplyBeforeV16(AbstractLedgerTxn& ltx, OperationResult& res,
     return true;
 }
 
-bool
-MergeOpFrame::doApplyFromV16(AbstractLedgerTxn& ltx, OperationResult& res,
-                             OpEventManager& opEventManager) const
+bool MergeOpFrame::doApplyFromV16(AbstractLedgerTxn& ltx, OperationResult& res,
+                                  OpEventManager& opEventManager) const
 {
     auto header = ltx.loadHeader();
 
@@ -274,8 +271,8 @@ MergeOpFrame::doApplyFromV16(AbstractLedgerTxn& ltx, OperationResult& res,
     return true;
 }
 
-bool
-MergeOpFrame::doCheckValid(uint32_t ledgerVersion, OperationResult& res) const
+bool MergeOpFrame::doCheckValid(uint32_t ledgerVersion,
+                                OperationResult& res) const
 {
     // makes sure not merging into self
     if (getSourceID() == toAccountID(mOperation.body.destination()))

--- a/src/transactions/MergeOpFrame.h
+++ b/src/transactions/MergeOpFrame.h
@@ -13,8 +13,7 @@ class LedgerTxnHeader;
 
 class MergeOpFrame : public OperationFrame
 {
-    AccountMergeResult&
-    innerResult(OperationResult& res) const
+    AccountMergeResult& innerResult(OperationResult& res) const
     {
         return res.tr().accountMergeResult();
     }
@@ -39,8 +38,7 @@ class MergeOpFrame : public OperationFrame
     bool doCheckValid(uint32_t ledgerVersion,
                       OperationResult& res) const override;
 
-    static AccountMergeResultCode
-    getInnerCode(OperationResult const& res)
+    static AccountMergeResultCode getInnerCode(OperationResult const& res)
     {
         return res.tr().accountMergeResult().code();
     }

--- a/src/transactions/MutableTransactionResult.cpp
+++ b/src/transactions/MutableTransactionResult.cpp
@@ -16,8 +16,7 @@ namespace stellar
 namespace
 {
 template <typename T>
-void
-initializeOperationResults(TransactionFrame const& tx, T& txResult)
+void initializeOperationResults(TransactionFrame const& tx, T& txResult)
 {
     auto const& ops = tx.getOperations();
 
@@ -35,8 +34,7 @@ initializeOperationResults(TransactionFrame const& tx, T& txResult)
 }
 } // namespace
 
-bool
-RefundableFeeTracker::consumeRefundableSorobanResources(
+bool RefundableFeeTracker::consumeRefundableSorobanResources(
     uint32_t contractEventSizeBytes, int64_t rentFee, uint32_t protocolVersion,
     SorobanNetworkConfig const& sorobanConfig, Config const& cfg,
     TransactionFrame const& tx, DiagnosticEventManager& diagnosticEvents)
@@ -79,20 +77,17 @@ RefundableFeeTracker::consumeRefundableSorobanResources(
     return true;
 }
 
-int64_t
-RefundableFeeTracker::getFeeRefund() const
+int64_t RefundableFeeTracker::getFeeRefund() const
 {
     return mMaximumRefundableFee - mConsumedRefundableFee;
 }
 
-int64_t
-RefundableFeeTracker::getConsumedRentFee() const
+int64_t RefundableFeeTracker::getConsumedRentFee() const
 {
     return mConsumedRentFee;
 }
 
-int64_t
-RefundableFeeTracker::getConsumedRefundableFee() const
+int64_t RefundableFeeTracker::getConsumedRefundableFee() const
 {
     return mConsumedRefundableFee;
 }
@@ -102,8 +97,7 @@ RefundableFeeTracker::RefundableFeeTracker(int64_t maximumRefundableFee)
 {
 }
 
-void
-RefundableFeeTracker::resetConsumedFee()
+void RefundableFeeTracker::resetConsumedFee()
 {
     mConsumedContractEventsSizeBytes = 0;
     mConsumedRentFee = 0;
@@ -117,8 +111,7 @@ MutableTransactionResultBase::MutableTransactionResultBase(
     mTxResult.feeCharged = 0;
 }
 
-void
-MutableTransactionResultBase::initializeRefundableFeeTracker(
+void MutableTransactionResultBase::initializeRefundableFeeTracker(
     int64_t totalRefundableFee)
 {
     releaseAssert(!mRefundableFeeTracker);
@@ -132,20 +125,17 @@ MutableTransactionResultBase::getRefundableFeeTracker()
     return mRefundableFeeTracker;
 }
 
-TransactionResult const&
-MutableTransactionResultBase::getXDR() const
+TransactionResult const& MutableTransactionResultBase::getXDR() const
 {
     return mTxResult;
 }
 
-TransactionResultCode
-MutableTransactionResultBase::getResultCode() const
+TransactionResultCode MutableTransactionResultBase::getResultCode() const
 {
     return mTxResult.result.code();
 }
 
-void
-MutableTransactionResultBase::setError(TransactionResultCode code)
+void MutableTransactionResultBase::setError(TransactionResultCode code)
 {
     // Due to the way `applyCheck` is setup we set the same error code twice
     // on the same result. This is generally not necessary, but requires
@@ -164,8 +154,7 @@ MutableTransactionResultBase::setError(TransactionResultCode code)
     }
 }
 
-int64_t
-MutableTransactionResultBase::getFeeCharged() const
+int64_t MutableTransactionResultBase::getFeeCharged() const
 {
     return mTxResult.feeCharged;
 }
@@ -179,27 +168,24 @@ MutableTransactionResult::clone() const
         new MutableTransactionResult(*this));
 }
 
-void
-MutableTransactionResultBase::overrideFeeCharged(int64_t feeCharged)
+void MutableTransactionResultBase::overrideFeeCharged(int64_t feeCharged)
 {
     mTxResult.feeCharged = feeCharged;
 }
 
-void
-MutableTransactionResultBase::overrideXDR(TransactionResult const& resultXDR)
+void MutableTransactionResultBase::overrideXDR(
+    TransactionResult const& resultXDR)
 {
     mTxResult = resultXDR;
 }
 
-void
-MutableTransactionResultBase::setReplayTransactionResult(
+void MutableTransactionResultBase::setReplayTransactionResult(
     TransactionResult const& replayResult)
 {
     mReplayTransactionResult.emplace(replayResult);
 }
 
-bool
-MutableTransactionResultBase::adoptFailedReplayResult()
+bool MutableTransactionResultBase::adoptFailedReplayResult()
 {
     if (!mReplayTransactionResult)
     {
@@ -226,15 +212,13 @@ MutableTransactionResultBase::adoptFailedReplayResult()
     }
     return true;
 }
-bool
-MutableTransactionResultBase::hasReplayTransactionResult() const
+bool MutableTransactionResultBase::hasReplayTransactionResult() const
 {
     return mReplayTransactionResult.has_value();
 }
 #endif
 
-void
-MutableTransactionResultBase::setInsufficientFeeErrorWithFeeCharged(
+void MutableTransactionResultBase::setInsufficientFeeErrorWithFeeCharged(
     int64_t feeCharged)
 {
     setError(txINSUFFICIENT_FEE);
@@ -256,8 +240,7 @@ MutableTransactionResult::MutableTransactionResult(TransactionFrame const& tx,
 }
 
 #ifdef BUILD_TESTS
-void
-MutableTransactionResult::copyReplayResultWithoutFeeCharged()
+void MutableTransactionResult::copyReplayResultWithoutFeeCharged()
 {
     releaseAssert(mReplayTransactionResult);
     auto feeCharged = getFeeCharged();
@@ -284,20 +267,17 @@ MutableTransactionResult::createSuccess(TransactionFrame const& tx,
         new MutableTransactionResult(tx, feeCharged));
 }
 
-TransactionResultCode
-MutableTransactionResult::getInnermostResultCode() const
+TransactionResultCode MutableTransactionResult::getInnermostResultCode() const
 {
     return getResultCode();
 }
 
-void
-MutableTransactionResult::setInnermostError(TransactionResultCode code)
+void MutableTransactionResult::setInnermostError(TransactionResultCode code)
 {
     setError(code);
 }
 
-void
-MutableTransactionResult::finalizeFeeRefund(uint32_t ledgerVersion)
+void MutableTransactionResult::finalizeFeeRefund(uint32_t ledgerVersion)
 {
     if (mRefundableFeeTracker)
     {
@@ -305,14 +285,12 @@ MutableTransactionResult::finalizeFeeRefund(uint32_t ledgerVersion)
     }
 }
 
-OperationResult&
-MutableTransactionResult::getOpResultAt(size_t index)
+OperationResult& MutableTransactionResult::getOpResultAt(size_t index)
 {
     return mTxResult.result.results().at(index);
 }
 
-bool
-MutableTransactionResult::isSuccess() const
+bool MutableTransactionResult::isSuccess() const
 {
     return mTxResult.result.code() == txSUCCESS;
 }
@@ -338,8 +316,7 @@ FeeBumpMutableTransactionResult::FeeBumpMutableTransactionResult(
 }
 
 #ifdef BUILD_TESTS
-void
-FeeBumpMutableTransactionResult::copyReplayResultWithoutFeeCharged()
+void FeeBumpMutableTransactionResult::copyReplayResultWithoutFeeCharged()
 {
     releaseAssert(mReplayTransactionResult);
     auto feeCharged = getFeeCharged();
@@ -350,8 +327,7 @@ FeeBumpMutableTransactionResult::copyReplayResultWithoutFeeCharged()
 }
 #endif
 
-InnerTransactionResult&
-FeeBumpMutableTransactionResult::getInnerResult()
+InnerTransactionResult& FeeBumpMutableTransactionResult::getInnerResult()
 {
     releaseAssert(mTxResult.result.code() == txFEE_BUMP_INNER_SUCCESS ||
                   mTxResult.result.code() == txFEE_BUMP_INNER_FAILED);
@@ -390,8 +366,8 @@ FeeBumpMutableTransactionResult::getInnermostResultCode() const
     return getInnerResult().result.code();
 }
 
-void
-FeeBumpMutableTransactionResult::setInnermostError(TransactionResultCode code)
+void FeeBumpMutableTransactionResult::setInnermostError(
+    TransactionResultCode code)
 {
     auto& innerRes = getInnerResult();
     releaseAssert(code != txSUCCESS && code != txFEE_BUMP_INNER_SUCCESS &&
@@ -405,20 +381,18 @@ FeeBumpMutableTransactionResult::setInnermostError(TransactionResultCode code)
     }
 }
 
-OperationResult&
-FeeBumpMutableTransactionResult::getOpResultAt(size_t index)
+OperationResult& FeeBumpMutableTransactionResult::getOpResultAt(size_t index)
 {
     return getInnerResult().result.results().at(index);
 }
 
-bool
-FeeBumpMutableTransactionResult::isSuccess() const
+bool FeeBumpMutableTransactionResult::isSuccess() const
 {
     return mTxResult.result.code() == txFEE_BUMP_INNER_SUCCESS;
 }
 
-void
-FeeBumpMutableTransactionResult::finalizeFeeRefund(uint32_t protocolVersion)
+void FeeBumpMutableTransactionResult::finalizeFeeRefund(
+    uint32_t protocolVersion)
 {
     if (!mRefundableFeeTracker)
     {

--- a/src/transactions/OfferExchange.cpp
+++ b/src/transactions/OfferExchange.cpp
@@ -28,10 +28,10 @@ namespace stellar
 {
 // returns the amount of wheat that would be traded
 // while buying as much sheep as possible
-int64_t
-canSellAtMostBasedOnSheep(LedgerTxnHeader const& header, Asset const& sheep,
-                          ConstTrustLineWrapper const& sheepLine,
-                          Price const& wheatPrice)
+int64_t canSellAtMostBasedOnSheep(LedgerTxnHeader const& header,
+                                  Asset const& sheep,
+                                  ConstTrustLineWrapper const& sheepLine,
+                                  Price const& wheatPrice)
 {
     if (sheep.type() == ASSET_TYPE_NATIVE)
     {
@@ -51,9 +51,9 @@ canSellAtMostBasedOnSheep(LedgerTxnHeader const& header, Asset const& sheep,
     return wheatAmount;
 }
 
-int64_t
-canSellAtMost(LedgerTxnHeader const& header, LedgerTxnEntry const& account,
-              Asset const& asset, TrustLineWrapper const& trustLine)
+int64_t canSellAtMost(LedgerTxnHeader const& header,
+                      LedgerTxnEntry const& account, Asset const& asset,
+                      TrustLineWrapper const& trustLine)
 {
     if (asset.type() == ASSET_TYPE_NATIVE)
     {
@@ -69,9 +69,9 @@ canSellAtMost(LedgerTxnHeader const& header, LedgerTxnEntry const& account,
     return 0;
 }
 
-int64_t
-canSellAtMost(LedgerTxnHeader const& header, ConstLedgerTxnEntry const& account,
-              Asset const& asset, ConstTrustLineWrapper const& trustLine)
+int64_t canSellAtMost(LedgerTxnHeader const& header,
+                      ConstLedgerTxnEntry const& account, Asset const& asset,
+                      ConstTrustLineWrapper const& trustLine)
 {
     if (asset.type() == ASSET_TYPE_NATIVE)
     {
@@ -87,9 +87,9 @@ canSellAtMost(LedgerTxnHeader const& header, ConstLedgerTxnEntry const& account,
     return 0;
 }
 
-int64_t
-canBuyAtMost(LedgerTxnHeader const& header, LedgerTxnEntry const& account,
-             Asset const& asset, TrustLineWrapper const& trustLine)
+int64_t canBuyAtMost(LedgerTxnHeader const& header,
+                     LedgerTxnEntry const& account, Asset const& asset,
+                     TrustLineWrapper const& trustLine)
 {
     if (asset.type() == ASSET_TYPE_NATIVE)
     {
@@ -103,9 +103,9 @@ canBuyAtMost(LedgerTxnHeader const& header, LedgerTxnEntry const& account,
     }
 }
 
-int64_t
-canBuyAtMost(LedgerTxnHeader const& header, ConstLedgerTxnEntry const& account,
-             Asset const& asset, ConstTrustLineWrapper const& trustLine)
+int64_t canBuyAtMost(LedgerTxnHeader const& header,
+                     ConstLedgerTxnEntry const& account, Asset const& asset,
+                     ConstTrustLineWrapper const& trustLine)
 {
     if (asset.type() == ASSET_TYPE_NATIVE)
     {
@@ -119,9 +119,8 @@ canBuyAtMost(LedgerTxnHeader const& header, ConstLedgerTxnEntry const& account,
     }
 }
 
-ExchangeResult
-exchangeV2(int64_t wheatReceived, Price price, int64_t maxWheatReceive,
-           int64_t maxSheepSend)
+ExchangeResult exchangeV2(int64_t wheatReceived, Price price,
+                          int64_t maxWheatReceive, int64_t maxSheepSend)
 {
     ZoneScoped;
     auto result = ExchangeResult{};
@@ -144,9 +143,8 @@ exchangeV2(int64_t wheatReceived, Price price, int64_t maxWheatReceive,
     return result;
 }
 
-ExchangeResult
-exchangeV3(int64_t wheatReceived, Price price, int64_t maxWheatReceive,
-           int64_t maxSheepSend)
+ExchangeResult exchangeV3(int64_t wheatReceived, Price price,
+                          int64_t maxWheatReceive, int64_t maxSheepSend)
 {
     ZoneScoped;
     auto result = ExchangeResult{};
@@ -183,9 +181,8 @@ exchangeV3(int64_t wheatReceived, Price price, int64_t maxWheatReceive,
 // the relative error between the price and the effective price does not exceed
 // 1% if it is favoring the seller of sheep. The functionality of canFavorWheat
 // is required for PathPayment.
-bool
-checkPriceErrorBound(Price price, int64_t wheatReceive, int64_t sheepSend,
-                     bool canFavorWheat)
+bool checkPriceErrorBound(Price price, int64_t wheatReceive, int64_t sheepSend,
+                          bool canFavorWheat)
 {
     // Let K = 100 / threshold, where threshold is the maximum relative error in
     // percent (so in this case, threshold = 1%). Then we can rearrange the
@@ -215,9 +212,8 @@ checkPriceErrorBound(Price price, int64_t wheatReceive, int64_t sheepSend,
     return (absDiff <= cap);
 }
 
-static uint128_t
-calculateOfferValue(int32_t priceN, int32_t priceD, int64_t maxSend,
-                    int64_t maxReceive)
+static uint128_t calculateOfferValue(int32_t priceN, int32_t priceD,
+                                     int64_t maxSend, int64_t maxReceive)
 {
     uint128_t sendValue = bigMultiply(maxSend, priceN);
     uint128_t receiveValue = bigMultiply(maxReceive, priceD);
@@ -548,9 +544,9 @@ calculateOfferValue(int32_t priceN, int32_t priceD, int64_t maxSend,
 // operation fails. If sheepSend < maxSheepSend and wheatReceive <
 // maxWheatReceive, then the operation will cross additional offers since
 // !wheatStays.
-ExchangeResultV10
-exchangeV10(Price price, int64_t maxWheatSend, int64_t maxWheatReceive,
-            int64_t maxSheepSend, int64_t maxSheepReceive, RoundingType round)
+ExchangeResultV10 exchangeV10(Price price, int64_t maxWheatSend,
+                              int64_t maxWheatReceive, int64_t maxSheepSend,
+                              int64_t maxSheepReceive, RoundingType round)
 {
     ZoneScoped;
     auto beforeThresholds = exchangeV10WithoutPriceErrorThresholds(
@@ -628,12 +624,9 @@ exchangeV10(Price price, int64_t maxWheatSend, int64_t maxWheatReceive,
 // should have already been removed from the order book because no more can be
 // received. In either case, we have reached a contradiction because we would
 // not be crossing in either case. We conclude that sheepSend > 0.
-ExchangeResultV10
-exchangeV10WithoutPriceErrorThresholds(Price price, int64_t maxWheatSend,
-                                       int64_t maxWheatReceive,
-                                       int64_t maxSheepSend,
-                                       int64_t maxSheepReceive,
-                                       RoundingType round)
+ExchangeResultV10 exchangeV10WithoutPriceErrorThresholds(
+    Price price, int64_t maxWheatSend, int64_t maxWheatReceive,
+    int64_t maxSheepSend, int64_t maxSheepReceive, RoundingType round)
 {
     uint128_t wheatValue =
         calculateOfferValue(price.n, price.d, maxWheatSend, maxSheepReceive);
@@ -699,9 +692,9 @@ exchangeV10WithoutPriceErrorThresholds(Price price, int64_t maxWheatSend,
 }
 
 // See comment before exchangeV10.
-ExchangeResultV10
-applyPriceErrorThresholds(Price price, int64_t wheatReceive, int64_t sheepSend,
-                          bool wheatStays, RoundingType round)
+ExchangeResultV10 applyPriceErrorThresholds(Price price, int64_t wheatReceive,
+                                            int64_t sheepSend, bool wheatStays,
+                                            RoundingType round)
 {
     if (wheatReceive > 0 && sheepSend > 0)
     {
@@ -780,11 +773,10 @@ applyPriceErrorThresholds(Price price, int64_t wheatReceive, int64_t sheepSend,
     return res;
 }
 
-void
-adjustOffer(LedgerTxnHeader const& header, LedgerTxnEntry& offer,
-            LedgerTxnEntry const& account, Asset const& wheat,
-            TrustLineWrapper const& wheatLine, Asset const& sheep,
-            TrustLineWrapper const& sheepLine)
+void adjustOffer(LedgerTxnHeader const& header, LedgerTxnEntry& offer,
+                 LedgerTxnEntry const& account, Asset const& wheat,
+                 TrustLineWrapper const& wheatLine, Asset const& sheep,
+                 TrustLineWrapper const& sheepLine)
 {
     OfferEntry& oe = offer.current().data.offer();
     int64_t maxWheatSend =
@@ -918,8 +910,8 @@ adjustOffer(LedgerTxnHeader const& header, LedgerTxnEntry& offer,
 //                   = ceil(sheepSend * price.d / price.n)
 //                   = wheatReceive
 // so we conclude that the adjusted offer is not modified by adjustOffer.
-int64_t
-adjustOffer(Price const& price, int64_t maxWheatSend, int64_t maxSheepReceive)
+int64_t adjustOffer(Price const& price, int64_t maxWheatSend,
+                    int64_t maxSheepReceive)
 {
     ZoneScoped;
     auto res = exchangeV10(price, maxWheatSend, INT64_MAX, INT64_MAX,
@@ -980,11 +972,12 @@ performExchange(LedgerTxnHeader const& header,
     return ExchangeResultType::NORMAL;
 }
 
-static CrossOfferResult
-crossOffer(AbstractLedgerTxn& ltx, LedgerTxnEntry& sellingWheatOffer,
-           int64_t maxWheatReceived, int64_t& numWheatReceived,
-           int64_t maxSheepSend, int64_t& numSheepSend,
-           std::vector<ClaimAtom>& offerTrail)
+static CrossOfferResult crossOffer(AbstractLedgerTxn& ltx,
+                                   LedgerTxnEntry& sellingWheatOffer,
+                                   int64_t maxWheatReceived,
+                                   int64_t& numWheatReceived,
+                                   int64_t maxSheepSend, int64_t& numSheepSend,
+                                   std::vector<ClaimAtom>& offerTrail)
 {
     ZoneScoped;
     releaseAssertOrThrow(maxWheatReceived > 0);
@@ -1238,10 +1231,10 @@ crossOfferV10(AbstractLedgerTxn& ltx, LedgerTxnEntry& sellingWheatOffer,
 // the asset that will be received from the pool. Compared to the interface of
 // exchangeV10, "ToPool" is analogous to "sheep" and "FromPool" is analogous to
 // "wheat".
-bool
-exchangeWithPool(int64_t reservesToPool, int64_t maxSendToPool, int64_t& toPool,
-                 int64_t reservesFromPool, int64_t maxReceiveFromPool,
-                 int64_t& fromPool, int32_t feeBps, RoundingType round)
+bool exchangeWithPool(int64_t reservesToPool, int64_t maxSendToPool,
+                      int64_t& toPool, int64_t reservesFromPool,
+                      int64_t maxReceiveFromPool, int64_t& fromPool,
+                      int32_t feeBps, RoundingType round)
 {
     ZoneScoped;
 
@@ -1367,8 +1360,7 @@ exchangeWithPool(int64_t reservesToPool, int64_t maxSendToPool, int64_t& toPool,
     }
 }
 
-PoolID
-getPoolID(Asset const& x, Asset const& y, int32_t feeBps)
+PoolID getPoolID(Asset const& x, Asset const& y, int32_t feeBps)
 {
     LiquidityPoolParameters lpp(LIQUIDITY_POOL_CONSTANT_PRODUCT);
     auto& cp = lpp.constantProduct();
@@ -1378,12 +1370,11 @@ getPoolID(Asset const& x, Asset const& y, int32_t feeBps)
     return xdrSha256(lpp);
 }
 
-static bool
-exchangeWithPool(AbstractLedgerTxn& ltxOuter, Asset const& toPoolAsset,
-                 int64_t maxSendToPool, int64_t& toPool,
-                 Asset const& fromPoolAsset, int64_t maxReceiveFromPool,
-                 int64_t& fromPool, RoundingType round,
-                 int64_t maxOffersToCross)
+static bool exchangeWithPool(AbstractLedgerTxn& ltxOuter,
+                             Asset const& toPoolAsset, int64_t maxSendToPool,
+                             int64_t& toPool, Asset const& fromPoolAsset,
+                             int64_t maxReceiveFromPool, int64_t& fromPool,
+                             RoundingType round, int64_t maxOffersToCross)
 {
     LedgerTxn ltx(ltxOuter);
 
@@ -1478,8 +1469,7 @@ exchangeWithPool(AbstractLedgerTxn& ltxOuter, Asset const& toPoolAsset,
     return res;
 }
 
-static ConvertResult
-convertWithOffers(
+static ConvertResult convertWithOffers(
     AbstractLedgerTxn& ltxOuter, Asset const& sheep, int64_t maxSheepSend,
     int64_t& sheepSend, Asset const& wheat, int64_t maxWheatReceive,
     int64_t& wheatReceived, RoundingType round,
@@ -1645,8 +1635,7 @@ shouldConvertWithOffers(std::optional<ExchangedQuantities> const& poolExchange,
 }
 
 // returns true if converting with offers, false otherwise
-static bool
-maybeConvertWithOffers(
+static bool maybeConvertWithOffers(
     AbstractLedgerTxn& ltxOuter, Asset const& sheep, int64_t maxSheepSend,
     int64_t& sheepSend, Asset const& wheat, int64_t maxWheatReceive,
     int64_t& wheatReceived, RoundingType round,
@@ -1693,8 +1682,7 @@ maybeConvertWithOffers(
     return false;
 }
 
-ConvertResult
-convertWithOffersAndPools(
+ConvertResult convertWithOffersAndPools(
     AbstractLedgerTxn& ltxOuter, Asset const& sheep, int64_t maxSheepSend,
     int64_t& sheepSend, Asset const& wheat, int64_t maxWheatReceive,
     int64_t& wheatReceived, RoundingType round,

--- a/src/transactions/OfferExchange.h
+++ b/src/transactions/OfferExchange.h
@@ -225,8 +225,7 @@ struct ExchangeResult
     int64_t numSheepSend;
     bool reduced;
 
-    ExchangeResultType
-    type() const
+    ExchangeResultType type() const
     {
         if (numWheatReceived != 0 && numSheepSend != 0)
             return ExchangeResultType::NORMAL;

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -45,9 +45,8 @@ namespace stellar
 
 using namespace std;
 
-static int32_t
-getNeededThreshold(LedgerEntryWrapper const& account,
-                   ThresholdLevel const level)
+static int32_t getNeededThreshold(LedgerEntryWrapper const& account,
+                                  ThresholdLevel const level)
 {
     auto const& acc = account.current().data.account();
     switch (level)
@@ -136,8 +135,7 @@ OperationFrame::OperationFrame(Operation const& op,
 {
 }
 
-bool
-OperationFrame::apply(
+bool OperationFrame::apply(
     AppConnector& app, SignatureChecker& signatureChecker,
     AbstractLedgerTxn& ltx,
     std::optional<SorobanNetworkConfig const> const& sorobanConfig,
@@ -172,8 +170,7 @@ OperationFrame::apply(
     return applyRes;
 }
 
-ParallelTxReturnVal
-OperationFrame::parallelApply(
+ParallelTxReturnVal OperationFrame::parallelApply(
     AppConnector& app, ThreadParallelApplyLedgerState const& threadState,
     Config const& config, ParallelLedgerInfo const& ledgerInfo,
     SorobanMetrics& sorobanMetrics, OperationResult& res,
@@ -188,8 +185,7 @@ OperationFrame::parallelApply(
                            sorobanMetrics, res, refundableFeeTracker, opMeta);
 }
 
-ParallelTxReturnVal
-OperationFrame::doParallelApply(
+ParallelTxReturnVal OperationFrame::doParallelApply(
     AppConnector& app, ThreadParallelApplyLedgerState const& threadState,
     Config const& appConfig, Hash const& txPrngSeed,
     ParallelLedgerInfo const& ledgerInfo, SorobanMetrics& sorobanMetrics,
@@ -201,22 +197,19 @@ OperationFrame::doParallelApply(
         "Cannot call doParallelApply on a non Soroban operation");
 }
 
-ThresholdLevel
-OperationFrame::getThresholdLevel() const
+ThresholdLevel OperationFrame::getThresholdLevel() const
 {
     return ThresholdLevel::MEDIUM;
 }
 
-bool
-OperationFrame::isOpSupported(LedgerHeader const&) const
+bool OperationFrame::isOpSupported(LedgerHeader const&) const
 {
     return true;
 }
 
-bool
-OperationFrame::checkSignature(SignatureChecker& signatureChecker,
-                               LedgerSnapshot const& ls, OperationResult* res,
-                               bool forApply) const
+bool OperationFrame::checkSignature(SignatureChecker& signatureChecker,
+                                    LedgerSnapshot const& ls,
+                                    OperationResult* res, bool forApply) const
 {
     ZoneScoped;
     auto header = ls.getLedgerHeader();
@@ -260,15 +253,13 @@ OperationFrame::checkSignature(SignatureChecker& signatureChecker,
     return true;
 }
 
-AccountID
-OperationFrame::getSourceID() const
+AccountID OperationFrame::getSourceID() const
 {
     return mOperation.sourceAccount ? toAccountID(*mOperation.sourceAccount)
                                     : mParentTx.getSourceID();
 }
 
-MuxedAccount
-OperationFrame::getSourceAccount() const
+MuxedAccount OperationFrame::getSourceAccount() const
 {
     return mOperation.sourceAccount ? *mOperation.sourceAccount
                                     : mParentTx.getSourceAccount();
@@ -278,13 +269,12 @@ OperationFrame::getSourceAccount() const
 // called when determining if we should flood
 // make sure sig is correct
 // verifies that the operation is well formed (operation specific)
-bool
-OperationFrame::checkValid(AppConnector& app,
-                           SignatureChecker& signatureChecker,
-                           SorobanNetworkConfig const* cfg,
-                           LedgerSnapshot const& ls, bool forApply,
-                           OperationResult& res,
-                           DiagnosticEventManager& diagnosticEvents) const
+bool OperationFrame::checkValid(AppConnector& app,
+                                SignatureChecker& signatureChecker,
+                                SorobanNetworkConfig const* cfg,
+                                LedgerSnapshot const& ls, bool forApply,
+                                OperationResult& res,
+                                DiagnosticEventManager& diagnosticEvents) const
 {
     ZoneScoped;
     bool validationResult = false;
@@ -358,8 +348,7 @@ OperationFrame::checkValid(AppConnector& app,
     return validationResult;
 }
 
-bool
-OperationFrame::doCheckValidForSoroban(
+bool OperationFrame::doCheckValidForSoroban(
     SorobanNetworkConfig const& config, Config const& appConfig,
     uint32_t ledgerVersion, OperationResult& res,
     DiagnosticEventManager& diagnosticEvents) const
@@ -367,8 +356,7 @@ OperationFrame::doCheckValidForSoroban(
     return doCheckValid(ledgerVersion, res);
 }
 
-bool
-OperationFrame::doApplyForSoroban(
+bool OperationFrame::doApplyForSoroban(
     AppConnector& app, AbstractLedgerTxn& ltx,
     SorobanNetworkConfig const& sorobanConfig, Hash const& sorobanBasePrngSeed,
     OperationResult& res,
@@ -386,40 +374,35 @@ OperationFrame::loadSourceAccount(AbstractLedgerTxn& ltx,
     return mParentTx.loadAccount(ltx, header, getSourceID());
 }
 
-bool
-OperationFrame::isDexOperation() const
+bool OperationFrame::isDexOperation() const
 {
     return false;
 }
 
-bool
-OperationFrame::isSoroban() const
+bool OperationFrame::isSoroban() const
 {
     return false;
 }
 
-void
-OperationFrame::insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const
+void OperationFrame::insertLedgerKeysToPrefetch(
+    UnorderedSet<LedgerKey>& keys) const
 {
     // Do nothing by default
     return;
 }
 
-SorobanResources const&
-OperationFrame::getSorobanResources() const
+SorobanResources const& OperationFrame::getSorobanResources() const
 {
     releaseAssertOrThrow(isSoroban());
     return mParentTx.sorobanResources();
 }
 
-Memo const&
-OperationFrame::getTxMemo() const
+Memo const& OperationFrame::getTxMemo() const
 {
     return mParentTx.getMemo();
 }
 
-SorobanTransactionData::_ext_t const&
-OperationFrame::getResourcesExt() const
+SorobanTransactionData::_ext_t const& OperationFrame::getResourcesExt() const
 {
     return mParentTx.getResourcesExt();
 }

--- a/src/transactions/OperationFrame.h
+++ b/src/transactions/OperationFrame.h
@@ -115,8 +115,7 @@ class OperationFrame
         std::optional<RefundableFeeTracker>& refundableFeeTracker,
         OperationMetaBuilder& opMeta, Hash const& sorobanBasePrngSeed) const;
 
-    Operation const&
-    getOperation() const
+    Operation const& getOperation() const
     {
         return mOperation;
     }

--- a/src/transactions/ParallelApplyStage.cpp
+++ b/src/transactions/ParallelApplyStage.cpp
@@ -12,10 +12,8 @@ ApplyStage::Iterator::Iterator(std::vector<Cluster> const& clusters,
 {
 }
 
-TxBundle const&
-ApplyStage::Iterator::operator*() const
+TxBundle const& ApplyStage::Iterator::operator*() const
 {
-
     if (mClusterIndex >= mClusters.size() ||
         mTxIndex >= mClusters[mClusterIndex].size())
     {
@@ -24,8 +22,7 @@ ApplyStage::Iterator::operator*() const
     return mClusters[mClusterIndex][mTxIndex];
 }
 
-ApplyStage::Iterator&
-ApplyStage::Iterator::operator++()
+ApplyStage::Iterator& ApplyStage::Iterator::operator++()
 {
     if (mClusterIndex >= mClusters.size())
     {
@@ -40,47 +37,40 @@ ApplyStage::Iterator::operator++()
     return *this;
 }
 
-ApplyStage::Iterator
-ApplyStage::Iterator::operator++(int)
+ApplyStage::Iterator ApplyStage::Iterator::operator++(int)
 {
     auto it = *this;
     ++(*this);
     return it;
 }
 
-bool
-ApplyStage::Iterator::operator==(Iterator const& other) const
+bool ApplyStage::Iterator::operator==(Iterator const& other) const
 {
     return mClusterIndex == other.mClusterIndex && mTxIndex == other.mTxIndex &&
            &mClusters == &other.mClusters;
 }
 
-bool
-ApplyStage::Iterator::operator!=(Iterator const& other) const
+bool ApplyStage::Iterator::operator!=(Iterator const& other) const
 {
     return !(*this == other);
 }
 
-ApplyStage::Iterator
-ApplyStage::begin() const
+ApplyStage::Iterator ApplyStage::begin() const
 {
     return ApplyStage::Iterator(mClusters, 0);
 }
 
-ApplyStage::Iterator
-ApplyStage::end() const
+ApplyStage::Iterator ApplyStage::end() const
 {
     return ApplyStage::Iterator(mClusters, mClusters.size());
 }
 
-Cluster const&
-ApplyStage::getCluster(size_t i) const
+Cluster const& ApplyStage::getCluster(size_t i) const
 {
     return mClusters.at(i);
 }
 
-size_t
-ApplyStage::numClusters() const
+size_t ApplyStage::numClusters() const
 {
     return mClusters.size();
 }

--- a/src/transactions/ParallelApplyStage.h
+++ b/src/transactions/ParallelApplyStage.h
@@ -25,26 +25,23 @@ class TxEffects
     {
     }
 
-    TransactionMetaBuilder&
-    getMeta()
+    TransactionMetaBuilder& getMeta()
     {
         return mMeta;
     }
-    LedgerTxnDelta const&
-    getDelta()
+    LedgerTxnDelta const& getDelta()
     {
         return mDelta;
     }
 
-    void
-    setDeltaEntry(LedgerKey const& key, LedgerTxnDelta::EntryDelta const& delta)
+    void setDeltaEntry(LedgerKey const& key,
+                       LedgerTxnDelta::EntryDelta const& delta)
     {
         auto [_, inserted] = mDelta.entry.emplace(key, delta);
         releaseAssertOrThrow(inserted);
     }
 
-    void
-    setDeltaHeader(LedgerHeader const& header)
+    void setDeltaHeader(LedgerHeader const& header)
     {
         mDelta.header.current = header;
         mDelta.header.previous = header;
@@ -71,23 +68,19 @@ class TxBundle
     {
     }
 
-    TransactionFrameBasePtr
-    getTx() const
+    TransactionFrameBasePtr getTx() const
     {
         return mTx;
     }
-    MutableTransactionResultBase&
-    getResPayload() const
+    MutableTransactionResultBase& getResPayload() const
     {
         return mResPayload;
     }
-    uint64_t
-    getTxNum() const
+    uint64_t getTxNum() const
     {
         return mTxNum;
     }
-    TxEffects&
-    getEffects() const
+    TxEffects& getEffects() const
     {
         return *mEffects;
     }

--- a/src/transactions/ParallelApplyUtils.cpp
+++ b/src/transactions/ParallelApplyUtils.cpp
@@ -96,8 +96,7 @@ using namespace stellar;
 // total order, B could save this fee, but we would lose the ability to run A
 // and B in parallel in the future. CAP 0063 explicitly chose this tradeoff.
 
-std::unordered_set<LedgerKey>
-getReadWriteKeysForStage(ApplyStage const& stage)
+std::unordered_set<LedgerKey> getReadWriteKeysForStage(ApplyStage const& stage)
 {
     ZoneScoped;
     std::unordered_set<LedgerKey> res;
@@ -117,10 +116,10 @@ getReadWriteKeysForStage(ApplyStage const& stage)
     return res;
 }
 
-bool
-maybeMergeRoTTLBumps(LedgerKey const& key, ParallelApplyEntry const& newEntry,
-                     ParallelApplyEntry& oldEntry,
-                     std::unordered_set<LedgerKey> const& readWriteSet)
+bool maybeMergeRoTTLBumps(LedgerKey const& key,
+                          ParallelApplyEntry const& newEntry,
+                          ParallelApplyEntry& oldEntry,
+                          std::unordered_set<LedgerKey> const& readWriteSet)
 {
     // Read Only bumps will always be updating a pre-existing value. TTL
     // creation (!oldEntry) or deletion (!newEntry) are write conflicts that
@@ -143,8 +142,7 @@ maybeMergeRoTTLBumps(LedgerKey const& key, ParallelApplyEntry const& newEntry,
     return false;
 }
 
-void
-preParallelApplyAndCollectModifiedClassicEntries(
+void preParallelApplyAndCollectModifiedClassicEntries(
     AppConnector& app, AbstractLedgerTxn& ltx,
     std::vector<ApplyStage> const& stages,
     ParallelApplyEntryMap& globalEntryMap,
@@ -207,26 +205,22 @@ preParallelApplyAndCollectModifiedClassicEntries(
     }
 }
 
-inline uint32_t&
-ttl(LedgerEntry& le)
+inline uint32_t& ttl(LedgerEntry& le)
 {
     return le.data.ttl().liveUntilLedgerSeq;
 }
 
-inline uint32_t const&
-ttl(LedgerEntry const& le)
+inline uint32_t const& ttl(LedgerEntry const& le)
 {
     return le.data.ttl().liveUntilLedgerSeq;
 }
 
-inline uint32_t&
-ttl(std::optional<LedgerEntry>& le)
+inline uint32_t& ttl(std::optional<LedgerEntry>& le)
 {
     return ttl(le.value());
 }
 
-inline uint32_t const&
-ttl(std::optional<LedgerEntry> const& le)
+inline uint32_t const& ttl(std::optional<LedgerEntry> const& le)
 {
     return ttl(le.value());
 }
@@ -235,8 +229,7 @@ ttl(std::optional<LedgerEntry> const& le)
 // (code-or-data) keys named in the footprint of the `txBundle`. Note
 // that since RO and RW footprints are disjoint, we only have to look
 // at the RO set.
-UnorderedSet<LedgerKey>
-buildRoTTLSet(TxBundle const& txBundle)
+UnorderedSet<LedgerKey> buildRoTTLSet(TxBundle const& txBundle)
 {
     UnorderedSet<LedgerKey> isReadOnlyTTLSet;
     for (auto const& ro :
@@ -253,10 +246,9 @@ buildRoTTLSet(TxBundle const& txBundle)
 
 // Accumulate into the buffer of `roTTLBumps` the max of any existing entry and
 // the provided `updatedLE`, which must be a non-nullopt TTL LE.
-void
-updateMaxOfRoTTLBump(UnorderedMap<LedgerKey, uint32_t>& roTTLBumps,
-                     LedgerKey const& lk,
-                     std::optional<LedgerEntry> const& updatedLe)
+void updateMaxOfRoTTLBump(UnorderedMap<LedgerKey, uint32_t>& roTTLBumps,
+                          LedgerKey const& lk,
+                          std::optional<LedgerEntry> const& updatedLe)
 {
     auto [it, emplaced] = roTTLBumps.emplace(lk, ttl(updatedLe));
     if (!emplaced)
@@ -286,21 +278,18 @@ PreV23LedgerAccessHelper::getLedgerEntryOpt(LedgerKey const& key)
     return std::nullopt;
 }
 
-uint32_t
-PreV23LedgerAccessHelper::getLedgerVersion()
+uint32_t PreV23LedgerAccessHelper::getLedgerVersion()
 {
     return mLtx.loadHeader().current().ledgerVersion;
 }
 
-uint32_t
-PreV23LedgerAccessHelper::getLedgerSeq()
+uint32_t PreV23LedgerAccessHelper::getLedgerSeq()
 {
     return mLtx.loadHeader().current().ledgerSeq;
 }
 
-bool
-PreV23LedgerAccessHelper::upsertLedgerEntry(LedgerKey const& key,
-                                            LedgerEntry const& entry)
+bool PreV23LedgerAccessHelper::upsertLedgerEntry(LedgerKey const& key,
+                                                 LedgerEntry const& entry)
 {
     auto ltxe = mLtx.load(key);
     if (ltxe)
@@ -315,8 +304,7 @@ PreV23LedgerAccessHelper::upsertLedgerEntry(LedgerKey const& key,
     }
 }
 
-bool
-PreV23LedgerAccessHelper::eraseLedgerEntryIfExists(LedgerKey const& key)
+bool PreV23LedgerAccessHelper::eraseLedgerEntryIfExists(LedgerKey const& key)
 {
     auto ltxe = mLtx.load(key);
     if (ltxe)
@@ -342,29 +330,25 @@ ParallelLedgerAccessHelper::getLedgerEntryOpt(LedgerKey const& key)
     return mOpState.getLiveEntryOpt(key);
 }
 
-uint32_t
-ParallelLedgerAccessHelper::getLedgerSeq()
+uint32_t ParallelLedgerAccessHelper::getLedgerSeq()
 {
     auto applySeq = mLedgerInfo.getLedgerSeq();
     releaseAssertOrThrow(applySeq == mOpState.getSnapshotLedgerSeq() + 1);
     return applySeq;
 }
 
-uint32_t
-ParallelLedgerAccessHelper::getLedgerVersion()
+uint32_t ParallelLedgerAccessHelper::getLedgerVersion()
 {
     return mLedgerInfo.getLedgerVersion();
 }
 
-bool
-ParallelLedgerAccessHelper::upsertLedgerEntry(LedgerKey const& key,
-                                              LedgerEntry const& entry)
+bool ParallelLedgerAccessHelper::upsertLedgerEntry(LedgerKey const& key,
+                                                   LedgerEntry const& entry)
 {
     return mOpState.upsertEntry(key, entry, mLedgerInfo.getLedgerSeq());
 }
 
-bool
-ParallelLedgerAccessHelper::eraseLedgerEntryIfExists(LedgerKey const& key)
+bool ParallelLedgerAccessHelper::eraseLedgerEntryIfExists(LedgerKey const& key)
 {
     return mOpState.eraseEntryIfExists(key);
 }
@@ -410,8 +394,7 @@ GlobalParallelApplyLedgerState::GlobalParallelApplyLedgerState(
         app, ltx, stages, mGlobalEntryMap, mSorobanConfig);
 }
 
-void
-GlobalParallelApplyLedgerState::commitChangesToLedgerTxn(
+void GlobalParallelApplyLedgerState::commitChangesToLedgerTxn(
     AbstractLedgerTxn& ltx) const
 {
     ZoneScoped;
@@ -465,8 +448,7 @@ GlobalParallelApplyLedgerState::commitChangesToLedgerTxn(
     ltxInner.commit();
 }
 
-uint32_t
-GlobalParallelApplyLedgerState::getSnapshotLedgerSeq() const
+uint32_t GlobalParallelApplyLedgerState::getSnapshotLedgerSeq() const
 {
     releaseAssertOrThrow(mLiveSnapshot->getLedgerSeq() ==
                          mHotArchiveSnapshot->getLedgerSeq());
@@ -487,8 +469,7 @@ GlobalParallelApplyLedgerState::getRestoredEntries() const
     return mGlobalRestoredEntries;
 }
 
-void
-GlobalParallelApplyLedgerState::commitChangeFromThread(
+void GlobalParallelApplyLedgerState::commitChangeFromThread(
     LedgerKey const& key, ParallelApplyEntry const& parEntry,
     std::unordered_set<LedgerKey> const& readWriteSet)
 {
@@ -506,8 +487,7 @@ GlobalParallelApplyLedgerState::commitChangeFromThread(
     }
 }
 
-void
-GlobalParallelApplyLedgerState::commitChangesFromThread(
+void GlobalParallelApplyLedgerState::commitChangesFromThread(
     AppConnector& app, ThreadParallelApplyLedgerState const& thread,
     std::unordered_set<LedgerKey> const& readWriteSet)
 {
@@ -519,8 +499,7 @@ GlobalParallelApplyLedgerState::commitChangesFromThread(
     mGlobalRestoredEntries.addRestoresFrom(thread.getRestoredEntries());
 }
 
-void
-GlobalParallelApplyLedgerState::commitChangesFromThreads(
+void GlobalParallelApplyLedgerState::commitChangesFromThreads(
     AppConnector& app,
     std::vector<std::unique_ptr<ThreadParallelApplyLedgerState>> const& threads,
     ApplyStage const& stage)
@@ -536,8 +515,7 @@ GlobalParallelApplyLedgerState::commitChangesFromThreads(
     }
 }
 
-void
-ThreadParallelApplyLedgerState::collectClusterFootprintEntriesFromGlobal(
+void ThreadParallelApplyLedgerState::collectClusterFootprintEntriesFromGlobal(
     AppConnector& app, GlobalParallelApplyLedgerState const& global,
     Cluster const& cluster)
 {
@@ -608,8 +586,7 @@ ThreadParallelApplyLedgerState::ThreadParallelApplyLedgerState(
     collectClusterFootprintEntriesFromGlobal(app, global, cluster);
 }
 
-void
-ThreadParallelApplyLedgerState::flushRoTTLBumpsInTxWriteFootprint(
+void ThreadParallelApplyLedgerState::flushRoTTLBumpsInTxWriteFootprint(
     const TxBundle& txBundle)
 {
     auto const& readWrite =
@@ -639,8 +616,7 @@ ThreadParallelApplyLedgerState::flushRoTTLBumpsInTxWriteFootprint(
     }
 }
 
-void
-ThreadParallelApplyLedgerState::flushRemainingRoTTLBumps()
+void ThreadParallelApplyLedgerState::flushRemainingRoTTLBumps()
 {
     for (auto const& [lk, ttlBump] : mRoTTLBumps)
     {
@@ -657,8 +633,7 @@ ThreadParallelApplyLedgerState::flushRemainingRoTTLBumps()
     }
 }
 
-ParallelApplyEntryMap const&
-ThreadParallelApplyLedgerState::getEntryMap() const
+ParallelApplyEntryMap const& ThreadParallelApplyLedgerState::getEntryMap() const
 {
     return mThreadEntryMap;
 }
@@ -707,24 +682,21 @@ ThreadParallelApplyLedgerState::getLiveEntryOpt(LedgerKey const& key) const
     return res ? std::make_optional(*res) : std::nullopt;
 }
 
-void
-ThreadParallelApplyLedgerState::upsertEntry(LedgerKey const& key,
-                                            LedgerEntry const& entry,
-                                            uint32_t ledgerSeq)
+void ThreadParallelApplyLedgerState::upsertEntry(LedgerKey const& key,
+                                                 LedgerEntry const& entry,
+                                                 uint32_t ledgerSeq)
 {
     // Weird syntax avoid extra map lookup
     auto& mapEntry = mThreadEntryMap[key] =
         ParallelApplyEntry::dirtyPopulated(entry);
     mapEntry.mLedgerEntry->lastModifiedLedgerSeq = ledgerSeq;
 }
-void
-ThreadParallelApplyLedgerState::eraseEntry(LedgerKey const& key)
+void ThreadParallelApplyLedgerState::eraseEntry(LedgerKey const& key)
 {
     mThreadEntryMap[key] = ParallelApplyEntry::dirtyEmpty();
 }
 
-void
-ThreadParallelApplyLedgerState::commitChangeFromSuccessfulOp(
+void ThreadParallelApplyLedgerState::commitChangeFromSuccessfulOp(
     LedgerKey const& key, std::optional<LedgerEntry> const& entryOpt,
     UnorderedSet<LedgerKey> const& roTTLSet)
 {
@@ -745,8 +717,7 @@ ThreadParallelApplyLedgerState::commitChangeFromSuccessfulOp(
     }
 }
 
-void
-ThreadParallelApplyLedgerState::setEffectsDeltaFromSuccessfulOp(
+void ThreadParallelApplyLedgerState::setEffectsDeltaFromSuccessfulOp(
     ParallelTxReturnVal const& res, ParallelLedgerInfo const& ledgerInfo,
     TxEffects& effects) const
 {
@@ -784,8 +755,7 @@ ThreadParallelApplyLedgerState::setEffectsDeltaFromSuccessfulOp(
     }
 }
 
-void
-ThreadParallelApplyLedgerState::commitChangesFromSuccessfulOp(
+void ThreadParallelApplyLedgerState::commitChangesFromSuccessfulOp(
     ParallelTxReturnVal const& res, TxBundle const& txBundle)
 {
     releaseAssertOrThrow(res.getSuccess());
@@ -797,15 +767,14 @@ ThreadParallelApplyLedgerState::commitChangesFromSuccessfulOp(
     mThreadRestoredEntries.addRestoresFrom(res.getRestoredEntries());
 }
 
-bool
-ThreadParallelApplyLedgerState::entryWasRestored(LedgerKey const& key) const
+bool ThreadParallelApplyLedgerState::entryWasRestored(
+    LedgerKey const& key) const
 {
     return mThreadRestoredEntries.entryWasRestored(key) ||
            mPreviouslyRestoredEntries.entryWasRestored(key);
 }
 
-uint32_t
-ThreadParallelApplyLedgerState::getSnapshotLedgerSeq() const
+uint32_t ThreadParallelApplyLedgerState::getSnapshotLedgerSeq() const
 {
     releaseAssertOrThrow(mLiveSnapshot->getLedgerSeq() ==
                          mHotArchiveSnapshot->getLedgerSeq());
@@ -858,10 +827,9 @@ OpParallelApplyLedgerState::getLiveEntryOpt(LedgerKey const& key) const
     }
 }
 
-bool
-OpParallelApplyLedgerState::upsertEntry(LedgerKey const& key,
-                                        LedgerEntry const& entry,
-                                        uint32_t ledgerSeq)
+bool OpParallelApplyLedgerState::upsertEntry(LedgerKey const& key,
+                                             LedgerEntry const& entry,
+                                             uint32_t ledgerSeq)
 {
     ZoneScoped;
     // There are 4 cases:
@@ -901,8 +869,7 @@ OpParallelApplyLedgerState::upsertEntry(LedgerKey const& key,
     return !liveEntryExistedAlready;
 }
 
-bool
-OpParallelApplyLedgerState::eraseEntryIfExists(LedgerKey const& key)
+bool OpParallelApplyLedgerState::eraseEntryIfExists(LedgerKey const& key)
 {
     bool liveEntryExistedAlready = getLiveEntryOpt(key).has_value();
     if (liveEntryExistedAlready)
@@ -925,8 +892,7 @@ OpParallelApplyLedgerState::eraseEntryIfExists(LedgerKey const& key)
     return liveEntryExistedAlready;
 }
 
-bool
-OpParallelApplyLedgerState::entryWasRestored(LedgerKey const& key) const
+bool OpParallelApplyLedgerState::entryWasRestored(LedgerKey const& key) const
 {
     if (mOpRestoredEntries.entryWasRestored(key))
     {
@@ -935,19 +901,16 @@ OpParallelApplyLedgerState::entryWasRestored(LedgerKey const& key) const
     return mThreadState.entryWasRestored(key);
 }
 
-void
-OpParallelApplyLedgerState::addHotArchiveRestore(LedgerKey const& key,
-                                                 LedgerEntry const& entry,
-                                                 LedgerKey const& ttlKey,
-                                                 LedgerEntry const& ttlEntry)
+void OpParallelApplyLedgerState::addHotArchiveRestore(
+    LedgerKey const& key, LedgerEntry const& entry, LedgerKey const& ttlKey,
+    LedgerEntry const& ttlEntry)
 {
     CLOG_TRACE(Tx, "parallel apply thread {} hot-restoring {}",
                std::this_thread::get_id(), xdr::xdr_to_string(key, "key"));
     mOpRestoredEntries.addHotArchiveRestore(key, entry, ttlKey, ttlEntry);
 }
 
-void
-OpParallelApplyLedgerState::addLiveBucketlistRestore(
+void OpParallelApplyLedgerState::addLiveBucketlistRestore(
     LedgerKey const& key, LedgerEntry const& entry, LedgerKey const& ttlKey,
     LedgerEntry const& ttlEntry)
 {
@@ -956,8 +919,7 @@ OpParallelApplyLedgerState::addLiveBucketlistRestore(
     mOpRestoredEntries.addLiveBucketlistRestore(key, entry, ttlKey, ttlEntry);
 }
 
-ParallelTxReturnVal
-OpParallelApplyLedgerState::takeSuccess()
+ParallelTxReturnVal OpParallelApplyLedgerState::takeSuccess()
 {
     CLOG_TRACE(Tx, "parallel apply thread {} succeeded with {} dirty entries",
                std::this_thread::get_id(), mOpEntryMap.size());
@@ -965,16 +927,14 @@ OpParallelApplyLedgerState::takeSuccess()
                                std::move(mOpRestoredEntries)};
 }
 
-ParallelTxReturnVal
-OpParallelApplyLedgerState::takeFailure()
+ParallelTxReturnVal OpParallelApplyLedgerState::takeFailure()
 {
     CLOG_TRACE(Tx, "parallel apply thread {} failed with {} dirty entries",
                std::this_thread::get_id(), mOpEntryMap.size());
     return ParallelTxReturnVal{false, {}};
 }
 
-uint32_t
-OpParallelApplyLedgerState::getSnapshotLedgerSeq() const
+uint32_t OpParallelApplyLedgerState::getSnapshotLedgerSeq() const
 {
     return mThreadState.getSnapshotLedgerSeq();
 }

--- a/src/transactions/ParallelApplyUtils.h
+++ b/src/transactions/ParallelApplyUtils.h
@@ -19,7 +19,6 @@ class GlobalParallelApplyLedgerState;
 
 class ParallelLedgerInfo
 {
-
   public:
     ParallelLedgerInfo(uint32_t version, uint32_t seq, uint32_t reserve,
                        TimePoint time, Hash const& id)
@@ -31,28 +30,23 @@ class ParallelLedgerInfo
     {
     }
 
-    uint32_t
-    getLedgerVersion() const
+    uint32_t getLedgerVersion() const
     {
         return ledgerVersion;
     }
-    uint32_t
-    getLedgerSeq() const
+    uint32_t getLedgerSeq() const
     {
         return ledgerSeq;
     }
-    uint32_t
-    getBaseReserve() const
+    uint32_t getBaseReserve() const
     {
         return baseReserve;
     }
-    TimePoint
-    getCloseTime() const
+    TimePoint getCloseTime() const
     {
         return closeTime;
     }
-    Hash
-    getNetworkID() const
+    Hash getNetworkID() const
     {
         return networkID;
     }
@@ -114,10 +108,9 @@ class ThreadParallelApplyLedgerState
     void upsertEntry(LedgerKey const& key, LedgerEntry const& entry,
                      uint32_t ledgerSeq);
     void eraseEntry(LedgerKey const& key);
-    void
-    commitChangeFromSuccessfulOp(LedgerKey const& key,
-                                 std::optional<LedgerEntry> const& entryOpt,
-                                 UnorderedSet<LedgerKey> const& roTTLSet);
+    void commitChangeFromSuccessfulOp(
+        LedgerKey const& key, std::optional<LedgerEntry> const& entryOpt,
+        UnorderedSet<LedgerKey> const& roTTLSet);
 
   public:
     ThreadParallelApplyLedgerState(AppConnector& app,
@@ -223,15 +216,13 @@ class GlobalParallelApplyLedgerState
     //    after -- as well as written back to the ltx at the phase's end.
     ParallelApplyEntryMap mGlobalEntryMap;
 
-    void
-    commitChangeFromThread(LedgerKey const& key,
-                           ParallelApplyEntry const& parEntry,
-                           std::unordered_set<LedgerKey> const& readWriteSet);
+    void commitChangeFromThread(
+        LedgerKey const& key, ParallelApplyEntry const& parEntry,
+        std::unordered_set<LedgerKey> const& readWriteSet);
 
-    void
-    commitChangesFromThread(AppConnector& app,
-                            ThreadParallelApplyLedgerState const& thread,
-                            std::unordered_set<LedgerKey> const& readWriteSet);
+    void commitChangesFromThread(
+        AppConnector& app, ThreadParallelApplyLedgerState const& thread,
+        std::unordered_set<LedgerKey> const& readWriteSet);
 
   public:
     GlobalParallelApplyLedgerState(AppConnector& app, AbstractLedgerTxn& ltx,
@@ -348,7 +339,6 @@ class PreV23LedgerAccessHelper : virtual public LedgerAccessHelper
 
 class ParallelLedgerAccessHelper : virtual public LedgerAccessHelper
 {
-
   protected:
     ParallelLedgerAccessHelper(
         ThreadParallelApplyLedgerState const& threadState,

--- a/src/transactions/PathPaymentOpFrameBase.cpp
+++ b/src/transactions/PathPaymentOpFrameBase.cpp
@@ -21,14 +21,12 @@ PathPaymentOpFrameBase::PathPaymentOpFrameBase(Operation const& op,
 {
 }
 
-AccountID
-PathPaymentOpFrameBase::getDestID() const
+AccountID PathPaymentOpFrameBase::getDestID() const
 {
     return toAccountID(getDestMuxedAccount());
 }
 
-void
-PathPaymentOpFrameBase::insertLedgerKeysToPrefetch(
+void PathPaymentOpFrameBase::insertLedgerKeysToPrefetch(
     UnorderedSet<LedgerKey>& keys) const
 {
     auto destID = getDestID();
@@ -44,17 +42,16 @@ PathPaymentOpFrameBase::insertLedgerKeysToPrefetch(
     }
 }
 
-bool
-PathPaymentOpFrameBase::isDexOperation() const
+bool PathPaymentOpFrameBase::isDexOperation() const
 {
     auto const& src = getSourceAsset();
     auto const& dest = getDestAsset();
     return !getPath().empty() || !(src == dest);
 }
 
-bool
-PathPaymentOpFrameBase::checkIssuer(AbstractLedgerTxn& ltx, Asset const& asset,
-                                    OperationResult& res) const
+bool PathPaymentOpFrameBase::checkIssuer(AbstractLedgerTxn& ltx,
+                                         Asset const& asset,
+                                         OperationResult& res) const
 {
     if (asset.type() != ASSET_TYPE_NATIVE)
     {
@@ -69,8 +66,7 @@ PathPaymentOpFrameBase::checkIssuer(AbstractLedgerTxn& ltx, Asset const& asset,
     return true;
 }
 
-bool
-PathPaymentOpFrameBase::convert(
+bool PathPaymentOpFrameBase::convert(
     AbstractLedgerTxn& ltx, int64_t maxOffersToCross, Asset const& sendAsset,
     int64_t maxSend, int64_t& amountSend, Asset const& recvAsset,
     int64_t maxRecv, int64_t& amountRecv, RoundingType round,
@@ -123,8 +119,7 @@ PathPaymentOpFrameBase::convert(
     return true;
 }
 
-bool
-PathPaymentOpFrameBase::shouldBypassIssuerCheck(
+bool PathPaymentOpFrameBase::shouldBypassIssuerCheck(
     std::vector<Asset> const& path) const
 {
     // if the payment doesn't involve intermediate accounts
@@ -136,12 +131,9 @@ PathPaymentOpFrameBase::shouldBypassIssuerCheck(
            (getIssuer(getDestAsset()) == getDestID());
 }
 
-bool
-PathPaymentOpFrameBase::updateSourceBalance(AbstractLedgerTxn& ltx,
-                                            OperationResult& res,
-                                            int64_t amount,
-                                            bool bypassIssuerCheck,
-                                            bool doesSourceAccountExist) const
+bool PathPaymentOpFrameBase::updateSourceBalance(
+    AbstractLedgerTxn& ltx, OperationResult& res, int64_t amount,
+    bool bypassIssuerCheck, bool doesSourceAccountExist) const
 {
     auto const& asset = getSourceAsset();
 
@@ -208,11 +200,10 @@ PathPaymentOpFrameBase::updateSourceBalance(AbstractLedgerTxn& ltx,
     return true;
 }
 
-bool
-PathPaymentOpFrameBase::updateDestBalance(AbstractLedgerTxn& ltx,
-                                          int64_t amount,
-                                          bool bypassIssuerCheck,
-                                          OperationResult& res) const
+bool PathPaymentOpFrameBase::updateDestBalance(AbstractLedgerTxn& ltx,
+                                               int64_t amount,
+                                               bool bypassIssuerCheck,
+                                               OperationResult& res) const
 {
     auto destID = getDestID();
     auto const& asset = getDestAsset();

--- a/src/transactions/PathPaymentOpFrameBase.h
+++ b/src/transactions/PathPaymentOpFrameBase.h
@@ -36,8 +36,8 @@ class PathPaymentOpFrameBase : public OperationFrame
     PathPaymentOpFrameBase(Operation const& op,
                            TransactionFrame const& parentTx);
 
-    void
-    insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const override;
+    void insertLedgerKeysToPrefetch(
+        UnorderedSet<LedgerKey>& keys) const override;
 
     bool isDexOperation() const override;
 

--- a/src/transactions/PathPaymentStrictReceiveOpFrame.cpp
+++ b/src/transactions/PathPaymentStrictReceiveOpFrame.cpp
@@ -23,11 +23,9 @@ PathPaymentStrictReceiveOpFrame::PathPaymentStrictReceiveOpFrame(
 {
 }
 
-bool
-PathPaymentStrictReceiveOpFrame::doApply(AppConnector& app,
-                                         AbstractLedgerTxn& ltx,
-                                         OperationResult& res,
-                                         OperationMetaBuilder& opMeta) const
+bool PathPaymentStrictReceiveOpFrame::doApply(
+    AppConnector& app, AbstractLedgerTxn& ltx, OperationResult& res,
+    OperationMetaBuilder& opMeta) const
 {
     ZoneNamedN(applyZone, "PathPaymentStrictReceiveOp apply", true);
     std::string pathStr = assetToString(getSourceAsset());
@@ -147,9 +145,8 @@ PathPaymentStrictReceiveOpFrame::doApply(AppConnector& app,
     return true;
 }
 
-bool
-PathPaymentStrictReceiveOpFrame::doCheckValid(uint32_t ledgerVersion,
-                                              OperationResult& res) const
+bool PathPaymentStrictReceiveOpFrame::doCheckValid(uint32_t ledgerVersion,
+                                                   OperationResult& res) const
 {
     if (mPathPayment.destAmount <= 0 || mPathPayment.sendMax <= 0)
     {
@@ -173,122 +170,108 @@ PathPaymentStrictReceiveOpFrame::doCheckValid(uint32_t ledgerVersion,
     return true;
 }
 
-bool
-PathPaymentStrictReceiveOpFrame::checkTransfer(int64_t maxSend,
-                                               int64_t amountSend,
-                                               int64_t maxRecv,
-                                               int64_t amountRecv) const
+bool PathPaymentStrictReceiveOpFrame::checkTransfer(int64_t maxSend,
+                                                    int64_t amountSend,
+                                                    int64_t maxRecv,
+                                                    int64_t amountRecv) const
 {
     return maxRecv == amountRecv;
 }
 
-Asset const&
-PathPaymentStrictReceiveOpFrame::getSourceAsset() const
+Asset const& PathPaymentStrictReceiveOpFrame::getSourceAsset() const
 {
     return mPathPayment.sendAsset;
 }
 
-Asset const&
-PathPaymentStrictReceiveOpFrame::getDestAsset() const
+Asset const& PathPaymentStrictReceiveOpFrame::getDestAsset() const
 {
     return mPathPayment.destAsset;
 }
 
-MuxedAccount const&
-PathPaymentStrictReceiveOpFrame::getDestMuxedAccount() const
+MuxedAccount const& PathPaymentStrictReceiveOpFrame::getDestMuxedAccount() const
 {
     return mPathPayment.destination;
 }
 
-xdr::xvector<Asset, 5> const&
-PathPaymentStrictReceiveOpFrame::getPath() const
+xdr::xvector<Asset, 5> const& PathPaymentStrictReceiveOpFrame::getPath() const
 {
     return mPathPayment.path;
 }
 
-void
-PathPaymentStrictReceiveOpFrame::setResultSuccess(OperationResult& res) const
+void PathPaymentStrictReceiveOpFrame::setResultSuccess(
+    OperationResult& res) const
 {
     innerResult(res).code(PATH_PAYMENT_STRICT_RECEIVE_SUCCESS);
 }
 
-void
-PathPaymentStrictReceiveOpFrame::setResultMalformed(OperationResult& res) const
+void PathPaymentStrictReceiveOpFrame::setResultMalformed(
+    OperationResult& res) const
 {
     innerResult(res).code(PATH_PAYMENT_STRICT_RECEIVE_MALFORMED);
 }
 
-void
-PathPaymentStrictReceiveOpFrame::setResultUnderfunded(
+void PathPaymentStrictReceiveOpFrame::setResultUnderfunded(
     OperationResult& res) const
 {
     innerResult(res).code(PATH_PAYMENT_STRICT_RECEIVE_UNDERFUNDED);
 }
 
-void
-PathPaymentStrictReceiveOpFrame::setResultSourceNoTrust(
+void PathPaymentStrictReceiveOpFrame::setResultSourceNoTrust(
     OperationResult& res) const
 {
     innerResult(res).code(PATH_PAYMENT_STRICT_RECEIVE_SRC_NO_TRUST);
 }
 
-void
-PathPaymentStrictReceiveOpFrame::setResultSourceNotAuthorized(
+void PathPaymentStrictReceiveOpFrame::setResultSourceNotAuthorized(
     OperationResult& res) const
 {
     innerResult(res).code(PATH_PAYMENT_STRICT_RECEIVE_SRC_NOT_AUTHORIZED);
 }
 
-void
-PathPaymentStrictReceiveOpFrame::setResultNoDest(OperationResult& res) const
+void PathPaymentStrictReceiveOpFrame::setResultNoDest(
+    OperationResult& res) const
 {
     innerResult(res).code(PATH_PAYMENT_STRICT_RECEIVE_NO_DESTINATION);
 }
 
-void
-PathPaymentStrictReceiveOpFrame::setResultDestNoTrust(
+void PathPaymentStrictReceiveOpFrame::setResultDestNoTrust(
     OperationResult& res) const
 {
     innerResult(res).code(PATH_PAYMENT_STRICT_RECEIVE_NO_TRUST);
 }
 
-void
-PathPaymentStrictReceiveOpFrame::setResultDestNotAuthorized(
+void PathPaymentStrictReceiveOpFrame::setResultDestNotAuthorized(
     OperationResult& res) const
 {
     innerResult(res).code(PATH_PAYMENT_STRICT_RECEIVE_NOT_AUTHORIZED);
 }
 
-void
-PathPaymentStrictReceiveOpFrame::setResultLineFull(OperationResult& res) const
+void PathPaymentStrictReceiveOpFrame::setResultLineFull(
+    OperationResult& res) const
 {
     innerResult(res).code(PATH_PAYMENT_STRICT_RECEIVE_LINE_FULL);
 }
 
-void
-PathPaymentStrictReceiveOpFrame::setResultNoIssuer(Asset const& asset,
-                                                   OperationResult& res) const
+void PathPaymentStrictReceiveOpFrame::setResultNoIssuer(
+    Asset const& asset, OperationResult& res) const
 {
     innerResult(res).code(PATH_PAYMENT_STRICT_RECEIVE_NO_ISSUER);
     innerResult(res).noIssuer() = asset;
 }
 
-void
-PathPaymentStrictReceiveOpFrame::setResultTooFewOffers(
+void PathPaymentStrictReceiveOpFrame::setResultTooFewOffers(
     OperationResult& res) const
 {
     innerResult(res).code(PATH_PAYMENT_STRICT_RECEIVE_TOO_FEW_OFFERS);
 }
 
-void
-PathPaymentStrictReceiveOpFrame::setResultOfferCrossSelf(
+void PathPaymentStrictReceiveOpFrame::setResultOfferCrossSelf(
     OperationResult& res) const
 {
     innerResult(res).code(PATH_PAYMENT_STRICT_RECEIVE_OFFER_CROSS_SELF);
 }
 
-void
-PathPaymentStrictReceiveOpFrame::setResultConstraintNotMet(
+void PathPaymentStrictReceiveOpFrame::setResultConstraintNotMet(
     OperationResult& res) const
 {
     innerResult(res).code(PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX);

--- a/src/transactions/PathPaymentStrictReceiveOpFrame.h
+++ b/src/transactions/PathPaymentStrictReceiveOpFrame.h
@@ -13,8 +13,7 @@ class PathPaymentStrictReceiveOpFrame : public PathPaymentOpFrameBase
 {
     PathPaymentStrictReceiveOp const& mPathPayment;
 
-    PathPaymentStrictReceiveResult&
-    innerResult(OperationResult& res) const
+    PathPaymentStrictReceiveResult& innerResult(OperationResult& res) const
     {
         return res.tr().pathPaymentStrictReceiveResult();
     }

--- a/src/transactions/PathPaymentStrictSendOpFrame.cpp
+++ b/src/transactions/PathPaymentStrictSendOpFrame.cpp
@@ -23,17 +23,17 @@ PathPaymentStrictSendOpFrame::PathPaymentStrictSendOpFrame(
 {
 }
 
-bool
-PathPaymentStrictSendOpFrame::isOpSupported(LedgerHeader const& header) const
+bool PathPaymentStrictSendOpFrame::isOpSupported(
+    LedgerHeader const& header) const
 {
     return protocolVersionStartsFrom(header.ledgerVersion,
                                      ProtocolVersion::V_12);
 }
 
-bool
-PathPaymentStrictSendOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
-                                      OperationResult& res,
-                                      OperationMetaBuilder& opMeta) const
+bool PathPaymentStrictSendOpFrame::doApply(AppConnector& app,
+                                           AbstractLedgerTxn& ltx,
+                                           OperationResult& res,
+                                           OperationMetaBuilder& opMeta) const
 {
     ZoneNamedN(applyZone, "PathPaymentStrictSendOp apply", true);
     std::string pathStr = assetToString(getSourceAsset());
@@ -139,9 +139,8 @@ PathPaymentStrictSendOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
     return true;
 }
 
-bool
-PathPaymentStrictSendOpFrame::doCheckValid(uint32_t ledgerVersion,
-                                           OperationResult& res) const
+bool PathPaymentStrictSendOpFrame::doCheckValid(uint32_t ledgerVersion,
+                                                OperationResult& res) const
 {
     if (mPathPayment.sendAmount <= 0 || mPathPayment.destMin <= 0)
     {
@@ -165,117 +164,105 @@ PathPaymentStrictSendOpFrame::doCheckValid(uint32_t ledgerVersion,
     return true;
 }
 
-bool
-PathPaymentStrictSendOpFrame::checkTransfer(int64_t maxSend, int64_t amountSend,
-                                            int64_t maxRecv,
-                                            int64_t amountRecv) const
+bool PathPaymentStrictSendOpFrame::checkTransfer(int64_t maxSend,
+                                                 int64_t amountSend,
+                                                 int64_t maxRecv,
+                                                 int64_t amountRecv) const
 {
     return maxSend == amountSend;
 }
 
-Asset const&
-PathPaymentStrictSendOpFrame::getSourceAsset() const
+Asset const& PathPaymentStrictSendOpFrame::getSourceAsset() const
 {
     return mPathPayment.sendAsset;
 }
 
-Asset const&
-PathPaymentStrictSendOpFrame::getDestAsset() const
+Asset const& PathPaymentStrictSendOpFrame::getDestAsset() const
 {
     return mPathPayment.destAsset;
 }
 
-MuxedAccount const&
-PathPaymentStrictSendOpFrame::getDestMuxedAccount() const
+MuxedAccount const& PathPaymentStrictSendOpFrame::getDestMuxedAccount() const
 {
     return mPathPayment.destination;
 }
 
-xdr::xvector<Asset, 5> const&
-PathPaymentStrictSendOpFrame::getPath() const
+xdr::xvector<Asset, 5> const& PathPaymentStrictSendOpFrame::getPath() const
 {
     return mPathPayment.path;
 }
 
-void
-PathPaymentStrictSendOpFrame::setResultSuccess(OperationResult& res) const
+void PathPaymentStrictSendOpFrame::setResultSuccess(OperationResult& res) const
 {
     innerResult(res).code(PATH_PAYMENT_STRICT_SEND_SUCCESS);
 }
 
-void
-PathPaymentStrictSendOpFrame::setResultMalformed(OperationResult& res) const
+void PathPaymentStrictSendOpFrame::setResultMalformed(
+    OperationResult& res) const
 {
     innerResult(res).code(PATH_PAYMENT_STRICT_SEND_MALFORMED);
 }
 
-void
-PathPaymentStrictSendOpFrame::setResultUnderfunded(OperationResult& res) const
+void PathPaymentStrictSendOpFrame::setResultUnderfunded(
+    OperationResult& res) const
 {
     innerResult(res).code(PATH_PAYMENT_STRICT_SEND_UNDERFUNDED);
 }
 
-void
-PathPaymentStrictSendOpFrame::setResultSourceNoTrust(OperationResult& res) const
+void PathPaymentStrictSendOpFrame::setResultSourceNoTrust(
+    OperationResult& res) const
 {
     innerResult(res).code(PATH_PAYMENT_STRICT_SEND_SRC_NO_TRUST);
 }
 
-void
-PathPaymentStrictSendOpFrame::setResultSourceNotAuthorized(
+void PathPaymentStrictSendOpFrame::setResultSourceNotAuthorized(
     OperationResult& res) const
 {
     innerResult(res).code(PATH_PAYMENT_STRICT_SEND_SRC_NOT_AUTHORIZED);
 }
 
-void
-PathPaymentStrictSendOpFrame::setResultNoDest(OperationResult& res) const
+void PathPaymentStrictSendOpFrame::setResultNoDest(OperationResult& res) const
 {
     innerResult(res).code(PATH_PAYMENT_STRICT_SEND_NO_DESTINATION);
 }
 
-void
-PathPaymentStrictSendOpFrame::setResultDestNoTrust(OperationResult& res) const
+void PathPaymentStrictSendOpFrame::setResultDestNoTrust(
+    OperationResult& res) const
 {
     innerResult(res).code(PATH_PAYMENT_STRICT_SEND_NO_TRUST);
 }
 
-void
-PathPaymentStrictSendOpFrame::setResultDestNotAuthorized(
+void PathPaymentStrictSendOpFrame::setResultDestNotAuthorized(
     OperationResult& res) const
 {
     innerResult(res).code(PATH_PAYMENT_STRICT_SEND_NOT_AUTHORIZED);
 }
 
-void
-PathPaymentStrictSendOpFrame::setResultLineFull(OperationResult& res) const
+void PathPaymentStrictSendOpFrame::setResultLineFull(OperationResult& res) const
 {
     innerResult(res).code(PATH_PAYMENT_STRICT_SEND_LINE_FULL);
 }
 
-void
-PathPaymentStrictSendOpFrame::setResultNoIssuer(Asset const& asset,
-                                                OperationResult& res) const
+void PathPaymentStrictSendOpFrame::setResultNoIssuer(Asset const& asset,
+                                                     OperationResult& res) const
 {
     innerResult(res).code(PATH_PAYMENT_STRICT_SEND_NO_ISSUER);
     innerResult(res).noIssuer() = asset;
 }
 
-void
-PathPaymentStrictSendOpFrame::setResultTooFewOffers(OperationResult& res) const
+void PathPaymentStrictSendOpFrame::setResultTooFewOffers(
+    OperationResult& res) const
 {
     innerResult(res).code(PATH_PAYMENT_STRICT_SEND_TOO_FEW_OFFERS);
 }
 
-void
-PathPaymentStrictSendOpFrame::setResultOfferCrossSelf(
+void PathPaymentStrictSendOpFrame::setResultOfferCrossSelf(
     OperationResult& res) const
 {
     innerResult(res).code(PATH_PAYMENT_STRICT_SEND_OFFER_CROSS_SELF);
 }
 
-void
-PathPaymentStrictSendOpFrame::setResultConstraintNotMet(
+void PathPaymentStrictSendOpFrame::setResultConstraintNotMet(
     OperationResult& res) const
 {
     innerResult(res).code(PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN);

--- a/src/transactions/PathPaymentStrictSendOpFrame.h
+++ b/src/transactions/PathPaymentStrictSendOpFrame.h
@@ -13,8 +13,7 @@ class PathPaymentStrictSendOpFrame : public PathPaymentOpFrameBase
 {
     PathPaymentStrictSendOp const& mPathPayment;
 
-    PathPaymentStrictSendResult&
-    innerResult(OperationResult& res) const
+    PathPaymentStrictSendResult& innerResult(OperationResult& res) const
     {
         return res.tr().pathPaymentStrictSendResult();
     }

--- a/src/transactions/PaymentOpFrame.cpp
+++ b/src/transactions/PaymentOpFrame.cpp
@@ -24,10 +24,9 @@ PaymentOpFrame::PaymentOpFrame(Operation const& op,
 {
 }
 
-bool
-PaymentOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
-                        OperationResult& res,
-                        OperationMetaBuilder& opMeta) const
+bool PaymentOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
+                             OperationResult& res,
+                             OperationMetaBuilder& opMeta) const
 {
     ZoneNamedN(applyZone, "PaymentOp apply", true);
     std::string payStr = assetToString(mPayment.asset);
@@ -125,8 +124,8 @@ PaymentOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
     return true;
 }
 
-bool
-PaymentOpFrame::doCheckValid(uint32_t ledgerVersion, OperationResult& res) const
+bool PaymentOpFrame::doCheckValid(uint32_t ledgerVersion,
+                                  OperationResult& res) const
 {
     if (mPayment.amount <= 0)
     {
@@ -141,8 +140,8 @@ PaymentOpFrame::doCheckValid(uint32_t ledgerVersion, OperationResult& res) const
     return true;
 }
 
-void
-PaymentOpFrame::insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const
+void PaymentOpFrame::insertLedgerKeysToPrefetch(
+    UnorderedSet<LedgerKey>& keys) const
 {
     auto destID = toAccountID(mPayment.destination);
     keys.emplace(accountKey(destID));

--- a/src/transactions/PaymentOpFrame.h
+++ b/src/transactions/PaymentOpFrame.h
@@ -12,8 +12,7 @@ class AbstractLedgerTxn;
 
 class PaymentOpFrame : public OperationFrame
 {
-    PaymentResult&
-    innerResult(OperationResult& res) const
+    PaymentResult& innerResult(OperationResult& res) const
     {
         return res.tr().paymentResult();
     }
@@ -27,11 +26,10 @@ class PaymentOpFrame : public OperationFrame
                  OperationMetaBuilder& opMeta) const override;
     bool doCheckValid(uint32_t ledgerVersion,
                       OperationResult& res) const override;
-    void
-    insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const override;
+    void insertLedgerKeysToPrefetch(
+        UnorderedSet<LedgerKey>& keys) const override;
 
-    static PaymentResultCode
-    getInnerCode(OperationResult const& res)
+    static PaymentResultCode getInnerCode(OperationResult const& res)
     {
         return res.tr().paymentResult().code();
     }

--- a/src/transactions/RestoreFootprintOpFrame.cpp
+++ b/src/transactions/RestoreFootprintOpFrame.cpp
@@ -19,8 +19,7 @@
 namespace stellar
 {
 
-static RestoreFootprintResult&
-innerResult(OperationResult& res)
+static RestoreFootprintResult& innerResult(OperationResult& res)
 {
     return res.tr().restoreFootprintResult();
 }
@@ -41,8 +40,7 @@ struct RestoreFootprintMetrics
         mMetrics.mRestoreFpOpReadLedgerByte.Mark(mLedgerReadByte);
         mMetrics.mRestoreFpOpWriteLedgerByte.Mark(mLedgerWriteByte);
     }
-    medida::TimerContext
-    getExecTimer()
+    medida::TimerContext getExecTimer()
     {
         return mMetrics.mRestoreFpOpExec.TimeScope();
     }
@@ -57,7 +55,6 @@ RestoreFootprintOpFrame::RestoreFootprintOpFrame(
 
 class RestoreFootprintApplyHelper : virtual public LedgerAccessHelper
 {
-
   protected:
     AppConnector& mApp;
     OperationResult& mRes;
@@ -99,8 +96,7 @@ class RestoreFootprintApplyHelper : virtual public LedgerAccessHelper
                               std::optional<LedgerEntry> const& ttlEntryOpt,
                               uint32_t restoredLiveUntilLedger) = 0;
 
-    virtual bool
-    apply()
+    virtual bool apply()
     {
         ZoneNamedN(applyZone, "RestoreFootprintOpFrame apply", true);
         auto timeScope = mMetrics.getExecTimer();
@@ -261,24 +257,21 @@ class RestoreFootprintPreV23ApplyHelper
     {
     }
 
-    std::optional<LedgerEntry>
-    getHotArchiveEntry(LedgerKey const& key) override
+    std::optional<LedgerEntry> getHotArchiveEntry(LedgerKey const& key) override
     {
         // There is no hot archive pre-23.
         return std::nullopt;
     }
-    bool
-    entryWasRestored(LedgerKey const& key) override
+    bool entryWasRestored(LedgerKey const& key) override
     {
         // NB: even though pre-23 can answer this question precisely, the code
         // in pre-23 wasn't sensitive to it, so we preserve that functionality.
         return false;
     }
-    void
-    restoreEntry(LedgerKey const& lk, LedgerEntry const& entry,
-                 LedgerKey const& ttlKey,
-                 std::optional<LedgerEntry> const& ttlEntryOpt,
-                 uint32_t restoredLiveUntilLedger) override
+    void restoreEntry(LedgerKey const& lk, LedgerEntry const& entry,
+                      LedgerKey const& ttlKey,
+                      std::optional<LedgerEntry> const& ttlEntryOpt,
+                      uint32_t restoredLiveUntilLedger) override
     {
         mLtx.restoreFromLiveBucketList(entry, restoredLiveUntilLedger);
     }
@@ -303,8 +296,7 @@ class RestoreFootprintParallelApplyHelper
     {
     }
 
-    std::optional<LedgerEntry>
-    getHotArchiveEntry(LedgerKey const& key) override
+    std::optional<LedgerEntry> getHotArchiveEntry(LedgerKey const& key) override
     {
         auto ptr = mHotArchive->load(key);
         if (ptr)
@@ -317,17 +309,15 @@ class RestoreFootprintParallelApplyHelper
         }
     }
 
-    bool
-    entryWasRestored(LedgerKey const& key) override
+    bool entryWasRestored(LedgerKey const& key) override
     {
         return mOpState.entryWasRestored(key);
     }
 
-    void
-    restoreEntry(LedgerKey const& lk, LedgerEntry const& entry,
-                 LedgerKey const& ttlKey,
-                 std::optional<LedgerEntry> const& ttlEntryOpt,
-                 uint32_t restoredLiveUntilLedger) override
+    void restoreEntry(LedgerKey const& lk, LedgerEntry const& entry,
+                      LedgerKey const& ttlKey,
+                      std::optional<LedgerEntry> const& ttlEntryOpt,
+                      uint32_t restoredLiveUntilLedger) override
     {
         if (!ttlEntryOpt)
         {
@@ -352,8 +342,7 @@ class RestoreFootprintParallelApplyHelper
         }
     }
 
-    ParallelTxReturnVal
-    takeResults(bool applySucceeded)
+    ParallelTxReturnVal takeResults(bool applySucceeded)
     {
         if (applySucceeded)
         {
@@ -366,15 +355,13 @@ class RestoreFootprintParallelApplyHelper
     }
 };
 
-bool
-RestoreFootprintOpFrame::isOpSupported(LedgerHeader const& header) const
+bool RestoreFootprintOpFrame::isOpSupported(LedgerHeader const& header) const
 {
     return protocolVersionStartsFrom(header.ledgerVersion,
                                      SOROBAN_PROTOCOL_VERSION);
 }
 
-ParallelTxReturnVal
-RestoreFootprintOpFrame::doParallelApply(
+ParallelTxReturnVal RestoreFootprintOpFrame::doParallelApply(
     AppConnector& app, ThreadParallelApplyLedgerState const& threadState,
     Config const& appConfig, Hash const& txPrngSeed,
     ParallelLedgerInfo const& ledgerInfo, SorobanMetrics& sorobanMetrics,
@@ -382,7 +369,6 @@ RestoreFootprintOpFrame::doParallelApply(
     std::optional<RefundableFeeTracker>& refundableFeeTracker,
     OperationMetaBuilder& opMeta) const
 {
-
     releaseAssertOrThrow(
         protocolVersionStartsFrom(ledgerInfo.getLedgerVersion(),
                                   PARALLEL_SOROBAN_PHASE_PROTOCOL_VERSION));
@@ -393,8 +379,7 @@ RestoreFootprintOpFrame::doParallelApply(
     return helper.takeResults(success);
 }
 
-bool
-RestoreFootprintOpFrame::doApplyForSoroban(
+bool RestoreFootprintOpFrame::doApplyForSoroban(
     AppConnector& app, AbstractLedgerTxn& ltx,
     SorobanNetworkConfig const& sorobanConfig, Hash const& sorobanBasePrngSeed,
     OperationResult& res,
@@ -410,17 +395,15 @@ RestoreFootprintOpFrame::doApplyForSoroban(
     return helper.apply();
 }
 
-bool
-RestoreFootprintOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
-                                 OperationResult& res,
-                                 OperationMetaBuilder& opMeta) const
+bool RestoreFootprintOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
+                                      OperationResult& res,
+                                      OperationMetaBuilder& opMeta) const
 {
     throw std::runtime_error(
         "RestoreFootprintOpFrame may only be applied via doApplyForSoroban");
 }
 
-bool
-RestoreFootprintOpFrame::doCheckValidForSoroban(
+bool RestoreFootprintOpFrame::doCheckValidForSoroban(
     SorobanNetworkConfig const& networkConfig, Config const& appConfig,
     uint32_t ledgerVersion, OperationResult& res,
     DiagnosticEventManager& diagnosticEvents) const
@@ -451,28 +434,24 @@ RestoreFootprintOpFrame::doCheckValidForSoroban(
     return true;
 }
 
-bool
-RestoreFootprintOpFrame::doCheckValid(uint32_t ledgerVersion,
-                                      OperationResult& res) const
+bool RestoreFootprintOpFrame::doCheckValid(uint32_t ledgerVersion,
+                                           OperationResult& res) const
 {
     throw std::runtime_error(
         "RestoreFootprintOpFrame::doCheckValid needs Config");
 }
 
-void
-RestoreFootprintOpFrame::insertLedgerKeysToPrefetch(
+void RestoreFootprintOpFrame::insertLedgerKeysToPrefetch(
     UnorderedSet<LedgerKey>& keys) const
 {
 }
 
-bool
-RestoreFootprintOpFrame::isSoroban() const
+bool RestoreFootprintOpFrame::isSoroban() const
 {
     return true;
 }
 
-ThresholdLevel
-RestoreFootprintOpFrame::getThresholdLevel() const
+ThresholdLevel RestoreFootprintOpFrame::getThresholdLevel() const
 {
     return ThresholdLevel::LOW;
 }

--- a/src/transactions/RestoreFootprintOpFrame.h
+++ b/src/transactions/RestoreFootprintOpFrame.h
@@ -48,11 +48,10 @@ class RestoreFootprintOpFrame : public OperationFrame
                     std::optional<RefundableFeeTracker>& refundableFeeTracker,
                     OperationMetaBuilder& opMeta) const override;
 
-    void
-    insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const override;
+    void insertLedgerKeysToPrefetch(
+        UnorderedSet<LedgerKey>& keys) const override;
 
-    static RestoreFootprintResultCode
-    getInnerCode(OperationResult const& res)
+    static RestoreFootprintResultCode getInnerCode(OperationResult const& res)
     {
         return res.tr().restoreFootprintResult().code();
     }

--- a/src/transactions/RevokeSponsorshipOpFrame.cpp
+++ b/src/transactions/RevokeSponsorshipOpFrame.cpp
@@ -22,15 +22,13 @@ RevokeSponsorshipOpFrame::RevokeSponsorshipOpFrame(
 {
 }
 
-bool
-RevokeSponsorshipOpFrame::isOpSupported(LedgerHeader const& header) const
+bool RevokeSponsorshipOpFrame::isOpSupported(LedgerHeader const& header) const
 {
     return protocolVersionStartsFrom(header.ledgerVersion,
                                      ProtocolVersion::V_14);
 }
 
-static AccountID const&
-getAccountID(LedgerEntry const& le)
+static AccountID const& getAccountID(LedgerEntry const& le)
 {
     switch (le.data.type())
     {
@@ -49,9 +47,8 @@ getAccountID(LedgerEntry const& le)
     }
 }
 
-bool
-RevokeSponsorshipOpFrame::processSponsorshipResult(SponsorshipResult sr,
-                                                   OperationResult& res) const
+bool RevokeSponsorshipOpFrame::processSponsorshipResult(
+    SponsorshipResult sr, OperationResult& res) const
 {
     switch (sr)
     {
@@ -71,8 +68,7 @@ RevokeSponsorshipOpFrame::processSponsorshipResult(SponsorshipResult sr,
     }
 }
 
-bool
-RevokeSponsorshipOpFrame::updateLedgerEntrySponsorship(
+bool RevokeSponsorshipOpFrame::updateLedgerEntrySponsorship(
     AbstractLedgerTxn& ltx, OperationResult& res) const
 {
     auto ltxe = ltx.load(mRevokeSponsorshipOp.ledgerKey());
@@ -213,8 +209,7 @@ RevokeSponsorshipOpFrame::updateLedgerEntrySponsorship(
     return true;
 }
 
-bool
-RevokeSponsorshipOpFrame::tryRemoveEntrySponsorship(
+bool RevokeSponsorshipOpFrame::tryRemoveEntrySponsorship(
     AbstractLedgerTxn& ltx, LedgerTxnHeader const& header, LedgerEntry& le,
     LedgerEntry& sponsoringAcc, LedgerEntry& sponsoredAcc,
     OperationResult& res) const
@@ -228,8 +223,7 @@ RevokeSponsorshipOpFrame::tryRemoveEntrySponsorship(
     removeEntrySponsorship(le, sponsoringAcc, &sponsoredAcc);
     return true;
 }
-bool
-RevokeSponsorshipOpFrame::tryEstablishEntrySponsorship(
+bool RevokeSponsorshipOpFrame::tryEstablishEntrySponsorship(
     AbstractLedgerTxn& ltx, LedgerTxnHeader const& header, LedgerEntry& le,
     LedgerEntry& sponsoringAcc, LedgerEntry& sponsoredAcc,
     OperationResult& res) const
@@ -244,9 +238,8 @@ RevokeSponsorshipOpFrame::tryEstablishEntrySponsorship(
     return true;
 }
 
-bool
-RevokeSponsorshipOpFrame::updateSignerSponsorship(AbstractLedgerTxn& ltx,
-                                                  OperationResult& res) const
+bool RevokeSponsorshipOpFrame::updateSignerSponsorship(
+    AbstractLedgerTxn& ltx, OperationResult& res) const
 {
     auto const& accountID = mRevokeSponsorshipOp.signer().accountID;
     auto sponsoredAcc = loadAccount(ltx, accountID);
@@ -381,10 +374,10 @@ RevokeSponsorshipOpFrame::updateSignerSponsorship(AbstractLedgerTxn& ltx,
     return true;
 }
 
-bool
-RevokeSponsorshipOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
-                                  OperationResult& res,
-                                  OperationMetaBuilder& opMeta) const
+bool RevokeSponsorshipOpFrame::doApply(AppConnector& app,
+                                       AbstractLedgerTxn& ltx,
+                                       OperationResult& res,
+                                       OperationMetaBuilder& opMeta) const
 {
     ZoneNamedN(applyZone, "RevokeSponsorshipOpFrame apply", true);
 
@@ -399,9 +392,8 @@ RevokeSponsorshipOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
     }
 }
 
-bool
-RevokeSponsorshipOpFrame::doCheckValid(uint32_t ledgerVersion,
-                                       OperationResult& res) const
+bool RevokeSponsorshipOpFrame::doCheckValid(uint32_t ledgerVersion,
+                                            OperationResult& res) const
 {
     if (mRevokeSponsorshipOp.type() == REVOKE_SPONSORSHIP_LEDGER_ENTRY)
     {

--- a/src/transactions/RevokeSponsorshipOpFrame.h
+++ b/src/transactions/RevokeSponsorshipOpFrame.h
@@ -14,8 +14,7 @@ class RevokeSponsorshipOpFrame : public OperationFrame
 {
     bool isOpSupported(LedgerHeader const& header) const override;
 
-    RevokeSponsorshipResult&
-    innerResult(OperationResult& res) const
+    RevokeSponsorshipResult& innerResult(OperationResult& res) const
     {
         return res.tr().revokeSponsorshipResult();
     }
@@ -51,8 +50,7 @@ class RevokeSponsorshipOpFrame : public OperationFrame
     bool doCheckValid(uint32_t ledgerVersion,
                       OperationResult& res) const override;
 
-    static RevokeSponsorshipResultCode
-    getInnerCode(OperationResult const& res)
+    static RevokeSponsorshipResultCode getInnerCode(OperationResult const& res)
     {
         return res.tr().revokeSponsorshipResult().code();
     }

--- a/src/transactions/SetOptionsOpFrame.cpp
+++ b/src/transactions/SetOptionsOpFrame.cpp
@@ -28,8 +28,7 @@ SetOptionsOpFrame::SetOptionsOpFrame(Operation const& op,
 {
 }
 
-ThresholdLevel
-SetOptionsOpFrame::getThresholdLevel() const
+ThresholdLevel SetOptionsOpFrame::getThresholdLevel() const
 {
     // updating thresholds or signer requires high threshold
     if (mSetOptions.masterWeight || mSetOptions.lowThreshold ||
@@ -41,9 +40,8 @@ SetOptionsOpFrame::getThresholdLevel() const
     return ThresholdLevel::MEDIUM;
 }
 
-bool
-SetOptionsOpFrame::addOrChangeSigner(AbstractLedgerTxn& ltx,
-                                     OperationResult& res) const
+bool SetOptionsOpFrame::addOrChangeSigner(AbstractLedgerTxn& ltx,
+                                          OperationResult& res) const
 {
     auto header = ltx.loadHeader();
     auto sourceAccount = loadSourceAccount(ltx, header);
@@ -103,10 +101,9 @@ SetOptionsOpFrame::addOrChangeSigner(AbstractLedgerTxn& ltx,
     return true;
 }
 
-void
-SetOptionsOpFrame::deleteSigner(AbstractLedgerTxn& ltx,
-                                LedgerTxnHeader const& header,
-                                LedgerTxnEntry& sourceAccount) const
+void SetOptionsOpFrame::deleteSigner(AbstractLedgerTxn& ltx,
+                                     LedgerTxnHeader const& header,
+                                     LedgerTxnEntry& sourceAccount) const
 {
     auto& account = sourceAccount.current().data.account();
     auto& signers = account.signers;
@@ -120,10 +117,9 @@ SetOptionsOpFrame::deleteSigner(AbstractLedgerTxn& ltx,
     }
 }
 
-bool
-SetOptionsOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
-                           OperationResult& res,
-                           OperationMetaBuilder& opMeta) const
+bool SetOptionsOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
+                                OperationResult& res,
+                                OperationMetaBuilder& opMeta) const
 {
     ZoneNamedN(applyZone, "SetOptionsOp apply", true);
 
@@ -227,9 +223,8 @@ SetOptionsOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
     return true;
 }
 
-bool
-SetOptionsOpFrame::doCheckValid(uint32_t ledgerVersion,
-                                OperationResult& res) const
+bool SetOptionsOpFrame::doCheckValid(uint32_t ledgerVersion,
+                                     OperationResult& res) const
 {
     if ((mSetOptions.setFlags &&
          !accountFlagMaskCheckIsValid(*mSetOptions.setFlags, ledgerVersion)) ||

--- a/src/transactions/SetOptionsOpFrame.h
+++ b/src/transactions/SetOptionsOpFrame.h
@@ -13,8 +13,7 @@ class AbstractLedgerTxn;
 class SetOptionsOpFrame : public OperationFrame
 {
     ThresholdLevel getThresholdLevel() const override;
-    SetOptionsResult&
-    innerResult(OperationResult& res) const
+    SetOptionsResult& innerResult(OperationResult& res) const
     {
         return res.tr().setOptionsResult();
     }
@@ -33,8 +32,7 @@ class SetOptionsOpFrame : public OperationFrame
     bool doCheckValid(uint32_t ledgerVersion,
                       OperationResult& res) const override;
 
-    static SetOptionsResultCode
-    getInnerCode(OperationResult const& res)
+    static SetOptionsResultCode getInnerCode(OperationResult const& res)
     {
         return res.tr().setOptionsResult().code();
     }

--- a/src/transactions/SetTrustLineFlagsOpFrame.cpp
+++ b/src/transactions/SetTrustLineFlagsOpFrame.cpp
@@ -22,59 +22,51 @@ SetTrustLineFlagsOpFrame::SetTrustLineFlagsOpFrame(
 {
 }
 
-bool
-SetTrustLineFlagsOpFrame::isOpSupported(LedgerHeader const& header) const
+bool SetTrustLineFlagsOpFrame::isOpSupported(LedgerHeader const& header) const
 {
     return protocolVersionStartsFrom(header.ledgerVersion,
                                      ProtocolVersion::V_17);
 }
 
-void
-SetTrustLineFlagsOpFrame::setResultSelfNotAllowed(OperationResult& res) const
+void SetTrustLineFlagsOpFrame::setResultSelfNotAllowed(
+    OperationResult& res) const
 {
     throw std::runtime_error("Not implemented.");
 }
 
-void
-SetTrustLineFlagsOpFrame::setResultNoTrustLine(OperationResult& res) const
+void SetTrustLineFlagsOpFrame::setResultNoTrustLine(OperationResult& res) const
 {
     innerResult(res).code(SET_TRUST_LINE_FLAGS_NO_TRUST_LINE);
 }
 
-void
-SetTrustLineFlagsOpFrame::setResultLowReserve(OperationResult& res) const
+void SetTrustLineFlagsOpFrame::setResultLowReserve(OperationResult& res) const
 {
     innerResult(res).code(SET_TRUST_LINE_FLAGS_LOW_RESERVE);
 }
 
-void
-SetTrustLineFlagsOpFrame::setResultSuccess(OperationResult& res) const
+void SetTrustLineFlagsOpFrame::setResultSuccess(OperationResult& res) const
 {
     innerResult(res).code(SET_TRUST_LINE_FLAGS_SUCCESS);
 }
 
-AccountID const&
-SetTrustLineFlagsOpFrame::getOpTrustor() const
+AccountID const& SetTrustLineFlagsOpFrame::getOpTrustor() const
 {
     return mSetTrustLineFlags.trustor;
 }
 
-Asset const&
-SetTrustLineFlagsOpFrame::getOpAsset() const
+Asset const& SetTrustLineFlagsOpFrame::getOpAsset() const
 {
     return mSetTrustLineFlags.asset;
 }
 
-uint32_t
-SetTrustLineFlagsOpFrame::getOpIndex() const
+uint32_t SetTrustLineFlagsOpFrame::getOpIndex() const
 {
     return mOpIndex;
 }
 
-bool
-SetTrustLineFlagsOpFrame::calcExpectedFlagValue(LedgerTxnEntry const& trust,
-                                                uint32_t& expectedVal,
-                                                OperationResult& res) const
+bool SetTrustLineFlagsOpFrame::calcExpectedFlagValue(
+    LedgerTxnEntry const& trust, uint32_t& expectedVal,
+    OperationResult& res) const
 {
     expectedVal = trust.current().data.trustLine().flags;
     expectedVal &= ~mSetTrustLineFlags.clearFlags;
@@ -88,18 +80,16 @@ SetTrustLineFlagsOpFrame::calcExpectedFlagValue(LedgerTxnEntry const& trust,
     return true;
 }
 
-void
-SetTrustLineFlagsOpFrame::setFlagValue(AbstractLedgerTxn& ltx,
-                                       LedgerKey const& key,
-                                       uint32_t flagVal) const
+void SetTrustLineFlagsOpFrame::setFlagValue(AbstractLedgerTxn& ltx,
+                                            LedgerKey const& key,
+                                            uint32_t flagVal) const
 {
     auto trust = ltx.load(key);
     trust.current().data.trustLine().flags = flagVal;
 }
 
-bool
-SetTrustLineFlagsOpFrame::doCheckValid(uint32_t ledgerVersion,
-                                       OperationResult& res) const
+bool SetTrustLineFlagsOpFrame::doCheckValid(uint32_t ledgerVersion,
+                                            OperationResult& res) const
 {
     if (mSetTrustLineFlags.asset.type() == ASSET_TYPE_NATIVE)
     {
@@ -150,8 +140,7 @@ SetTrustLineFlagsOpFrame::doCheckValid(uint32_t ledgerVersion,
     return true;
 }
 
-void
-SetTrustLineFlagsOpFrame::insertLedgerKeysToPrefetch(
+void SetTrustLineFlagsOpFrame::insertLedgerKeysToPrefetch(
     UnorderedSet<LedgerKey>& keys) const
 {
     if (mSetTrustLineFlags.asset.type() == ASSET_TYPE_NATIVE)
@@ -163,12 +152,10 @@ SetTrustLineFlagsOpFrame::insertLedgerKeysToPrefetch(
         trustlineKey(mSetTrustLineFlags.trustor, mSetTrustLineFlags.asset));
 }
 
-bool
-SetTrustLineFlagsOpFrame::isAuthRevocationValid(AbstractLedgerTxn& ltx,
-                                                bool& authRevocable,
-                                                OperationResult& res) const
+bool SetTrustLineFlagsOpFrame::isAuthRevocationValid(AbstractLedgerTxn& ltx,
+                                                     bool& authRevocable,
+                                                     OperationResult& res) const
 {
-
     // Load the source account entry
     LedgerTxn ltxSource(ltx); // ltxSource will be rolled back
     auto header = ltxSource.loadHeader();
@@ -209,8 +196,7 @@ SetTrustLineFlagsOpFrame::isAuthRevocationValid(AbstractLedgerTxn& ltx,
     return isValid;
 }
 
-bool
-SetTrustLineFlagsOpFrame::isRevocationToMaintainLiabilitiesValid(
+bool SetTrustLineFlagsOpFrame::isRevocationToMaintainLiabilitiesValid(
     bool authRevocable, LedgerTxnEntry const& trust, uint32_t flags,
     OperationResult& res) const
 {

--- a/src/transactions/SetTrustLineFlagsOpFrame.h
+++ b/src/transactions/SetTrustLineFlagsOpFrame.h
@@ -12,8 +12,7 @@ class AbstractLedgerTxn;
 
 class SetTrustLineFlagsOpFrame : public TrustFlagsOpFrameBase
 {
-    SetTrustLineFlagsResult&
-    innerResult(OperationResult& res) const
+    SetTrustLineFlagsResult& innerResult(OperationResult& res) const
     {
         return res.tr().setTrustLineFlagsResult();
     }
@@ -52,11 +51,10 @@ class SetTrustLineFlagsOpFrame : public TrustFlagsOpFrameBase
 
     bool doCheckValid(uint32_t ledgerVersion,
                       OperationResult& res) const override;
-    void
-    insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const override;
+    void insertLedgerKeysToPrefetch(
+        UnorderedSet<LedgerKey>& keys) const override;
 
-    static SetTrustLineFlagsResultCode
-    getInnerCode(OperationResult const& res)
+    static SetTrustLineFlagsResultCode getInnerCode(OperationResult const& res)
     {
         return res.tr().setTrustLineFlagsResult().code();
     }

--- a/src/transactions/SignatureChecker.cpp
+++ b/src/transactions/SignatureChecker.cpp
@@ -30,9 +30,8 @@ SignatureChecker::SignatureChecker(
     mUsedSignatures.resize(mSignatures.size());
 }
 
-bool
-SignatureChecker::checkSignature(std::vector<Signer> const& signersV,
-                                 int neededWeight)
+bool SignatureChecker::checkSignature(std::vector<Signer> const& signersV,
+                                      int neededWeight)
 {
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     return true;
@@ -143,8 +142,7 @@ SignatureChecker::checkSignature(std::vector<Signer> const& signersV,
     return false;
 }
 
-bool
-SignatureChecker::checkAllSignaturesUsed() const
+bool SignatureChecker::checkAllSignaturesUsed() const
 {
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     return true;
@@ -165,8 +163,7 @@ SignatureChecker::checkAllSignaturesUsed() const
     return true;
 }
 
-std::pair<uint64_t, uint64_t>
-SignatureChecker::flushTxSigCacheCounts()
+std::pair<uint64_t, uint64_t> SignatureChecker::flushTxSigCacheCounts()
 {
     std::lock_guard<std::mutex> lock(gCheckValidOrApplyTxSigCacheMetricsMutex);
     auto res = std::make_pair(gCheckValidOrApplyTxSigCacheHits,
@@ -176,14 +173,12 @@ SignatureChecker::flushTxSigCacheCounts()
     return res;
 }
 
-void
-SignatureChecker::disableCacheMetricsTracking()
+void SignatureChecker::disableCacheMetricsTracking()
 {
     mTrackCacheMetrics = false;
 }
 
-void
-SignatureChecker::updateTxSigCacheMetrics(
+void SignatureChecker::updateTxSigCacheMetrics(
     PubKeyUtils::VerifySigCacheLookupResult cacheLookupRes)
 {
     if (!mTrackCacheMetrics)

--- a/src/transactions/SignatureChecker.h
+++ b/src/transactions/SignatureChecker.h
@@ -81,13 +81,11 @@ class AlwaysValidSignatureChecker : public SignatureChecker
     {
     }
 
-    bool
-    checkSignature(std::vector<Signer> const&, int32_t) override
+    bool checkSignature(std::vector<Signer> const&, int32_t) override
     {
         return true;
     }
-    bool
-    checkAllSignaturesUsed() const override
+    bool checkAllSignaturesUsed() const override
     {
         return true;
     }

--- a/src/transactions/SignatureUtils.cpp
+++ b/src/transactions/SignatureUtils.cpp
@@ -17,8 +17,7 @@ namespace stellar
 namespace SignatureUtils
 {
 
-DecoratedSignature
-sign(SecretKey const& secretKey, Hash const& hash)
+DecoratedSignature sign(SecretKey const& secretKey, Hash const& hash)
 {
     ZoneScoped;
     DecoratedSignature result;
@@ -27,16 +26,16 @@ sign(SecretKey const& secretKey, Hash const& hash)
     return result;
 }
 
-PubKeyUtils::VerifySigResult
-verify(DecoratedSignature const& sig, SignerKey const& signerKey,
-       Hash const& hash)
+PubKeyUtils::VerifySigResult verify(DecoratedSignature const& sig,
+                                    SignerKey const& signerKey,
+                                    Hash const& hash)
 {
     auto pubKey = KeyUtils::convertKey<PublicKey>(signerKey);
     return verify(sig, pubKey, hash);
 }
 
-PubKeyUtils::VerifySigResult
-verify(DecoratedSignature const& sig, PublicKey const& pubKey, Hash const& hash)
+PubKeyUtils::VerifySigResult verify(DecoratedSignature const& sig,
+                                    PublicKey const& pubKey, Hash const& hash)
 {
     if (!doesHintMatch(pubKey.ed25519(), sig.hint))
     {
@@ -60,8 +59,7 @@ verifyEd25519SignedPayload(DecoratedSignature const& sig,
     return PubKeyUtils::verifySig(pubKey, sig.signature, signedPayload.payload);
 }
 
-DecoratedSignature
-signHashX(const ByteSlice& x)
+DecoratedSignature signHashX(const ByteSlice& x)
 {
     ZoneScoped;
     DecoratedSignature result;
@@ -80,8 +78,7 @@ signHashX(const ByteSlice& x)
     return result;
 }
 
-bool
-verifyHashX(DecoratedSignature const& sig, SignerKey const& signerKey)
+bool verifyHashX(DecoratedSignature const& sig, SignerKey const& signerKey)
 {
     ZoneScoped;
     if (!doesHintMatch(signerKey.hashX(), sig.hint))
@@ -104,8 +101,7 @@ getSignedPayloadHint(SignerKey::_ed25519SignedPayload_t const& signedPayload)
     return hint;
 }
 
-SignatureHint
-getHint(ByteSlice const& bs)
+SignatureHint getHint(ByteSlice const& bs)
 {
     if (bs.empty())
     {
@@ -124,8 +120,7 @@ getHint(ByteSlice const& bs)
     return res;
 }
 
-bool
-doesHintMatch(ByteSlice const& bs, SignatureHint const& hint)
+bool doesHintMatch(ByteSlice const& bs, SignatureHint const& hint)
 {
     if (bs.size() < hint.size())
     {

--- a/src/transactions/SponsorshipUtils.cpp
+++ b/src/transactions/SponsorshipUtils.cpp
@@ -17,9 +17,9 @@ using namespace stellar;
 
 namespace detail
 {
-static bool
-isSponsoringSubentrySumIncreaseValid(LedgerHeader const& lh,
-                                     LedgerEntry const& acc, uint32_t mult)
+static bool isSponsoringSubentrySumIncreaseValid(LedgerHeader const& lh,
+                                                 LedgerEntry const& acc,
+                                                 uint32_t mult)
 {
     return protocolVersionIsBefore(lh.ledgerVersion, ProtocolVersion::V_18) ||
            ((uint64_t)getNumSponsoring(acc) +
@@ -28,8 +28,8 @@ isSponsoringSubentrySumIncreaseValid(LedgerHeader const& lh,
 }
 }
 
-static bool
-tooManySponsoring(LedgerHeader const& lh, LedgerEntry const& acc, uint32_t mult)
+static bool tooManySponsoring(LedgerHeader const& lh, LedgerEntry const& acc,
+                              uint32_t mult)
 {
     if (getNumSponsoring(acc) > UINT32_MAX - mult)
     {
@@ -39,9 +39,8 @@ tooManySponsoring(LedgerHeader const& lh, LedgerEntry const& acc, uint32_t mult)
     return !detail::isSponsoringSubentrySumIncreaseValid(lh, acc, mult);
 }
 
-static bool
-tooManyNumSubEntries(LedgerHeader const& lh, LedgerEntry const& acc,
-                     uint32_t mult)
+static bool tooManyNumSubEntries(LedgerHeader const& lh, LedgerEntry const& acc,
+                                 uint32_t mult)
 {
     if (protocolVersionStartsFrom(lh.ledgerVersion,
                                   FIRST_PROTOCOL_SUPPORTING_OPERATION_LIMITS) &&
@@ -115,9 +114,8 @@ canTransferSponsorshipHelper(LedgerHeader const& lh,
     return canEstablishSponsorshipHelper(lh, newSponsoringAcc, nullptr, mult);
 }
 
-static void
-accountIsSponsor(SponsorshipDescriptor const& sponsoringID,
-                 LedgerEntry const& sponsoringAcc)
+static void accountIsSponsor(SponsorshipDescriptor const& sponsoringID,
+                             LedgerEntry const& sponsoringAcc)
 {
     if (!sponsoringID ||
         !(*sponsoringID == sponsoringAcc.data.account().accountID))
@@ -134,8 +132,7 @@ namespace stellar
 // Sponsorship "getters"
 //
 ////////////////////////////////////////////////////////////////////////////////
-uint32_t
-getNumSponsored(LedgerEntry const& le)
+uint32_t getNumSponsored(LedgerEntry const& le)
 {
     auto const& ae = le.data.account();
     if (hasAccountEntryExtV2(ae))
@@ -145,8 +142,7 @@ getNumSponsored(LedgerEntry const& le)
     return 0;
 }
 
-uint32_t
-getNumSponsoring(LedgerEntry const& le)
+uint32_t getNumSponsoring(LedgerEntry const& le)
 {
     auto const& ae = le.data.account();
     if (hasAccountEntryExtV2(ae))
@@ -186,8 +182,7 @@ isSignerSponsored(std::vector<Signer>::const_iterator const& signerIt,
 // Utility functions to check if you can establish/remove/transfer sponsorships
 //
 ////////////////////////////////////////////////////////////////////////////////
-int32_t
-computeMultiplier(LedgerEntry const& le)
+int32_t computeMultiplier(LedgerEntry const& le)
 {
     switch (le.data.type())
     {
@@ -214,8 +209,7 @@ computeMultiplier(LedgerEntry const& le)
     }
 }
 
-static bool
-isSubentry(LedgerEntry const& le)
+static bool isSubentry(LedgerEntry const& le)
 {
     switch (le.data.type())
     {
@@ -238,10 +232,10 @@ isSubentry(LedgerEntry const& le)
     }
 }
 
-SponsorshipResult
-canEstablishEntrySponsorship(LedgerHeader const& lh, LedgerEntry const& le,
-                             LedgerEntry const& sponsoringAcc,
-                             LedgerEntry const* sponsoredAcc)
+SponsorshipResult canEstablishEntrySponsorship(LedgerHeader const& lh,
+                                               LedgerEntry const& le,
+                                               LedgerEntry const& sponsoringAcc,
+                                               LedgerEntry const* sponsoredAcc)
 {
     if (protocolVersionIsBefore(lh.ledgerVersion, ProtocolVersion::V_14))
     {
@@ -256,10 +250,10 @@ canEstablishEntrySponsorship(LedgerHeader const& lh, LedgerEntry const& le,
     return canEstablishSponsorshipHelper(lh, sponsoringAcc, sponsoredAcc, mult);
 }
 
-SponsorshipResult
-canRemoveEntrySponsorship(LedgerHeader const& lh, LedgerEntry const& le,
-                          LedgerEntry const& sponsoringAcc,
-                          LedgerEntry const* sponsoredAcc)
+SponsorshipResult canRemoveEntrySponsorship(LedgerHeader const& lh,
+                                            LedgerEntry const& le,
+                                            LedgerEntry const& sponsoringAcc,
+                                            LedgerEntry const* sponsoredAcc)
 {
     if (protocolVersionIsBefore(lh.ledgerVersion, ProtocolVersion::V_14))
     {
@@ -298,8 +292,7 @@ canTransferEntrySponsorship(LedgerHeader const& lh, LedgerEntry const& le,
                                         mult);
 }
 
-SponsorshipResult
-canEstablishSignerSponsorship(
+SponsorshipResult canEstablishSignerSponsorship(
     LedgerHeader const& lh, std::vector<Signer>::const_iterator const& signerIt,
     LedgerEntry const& sponsoringAcc, LedgerEntry const& sponsoredAcc)
 {
@@ -316,11 +309,9 @@ canEstablishSignerSponsorship(
     return canEstablishSponsorshipHelper(lh, sponsoringAcc, &sponsoredAcc, 1);
 }
 
-SponsorshipResult
-canRemoveSignerSponsorship(LedgerHeader const& lh,
-                           std::vector<Signer>::const_iterator const& signerIt,
-                           LedgerEntry const& sponsoringAcc,
-                           LedgerEntry const& sponsoredAcc)
+SponsorshipResult canRemoveSignerSponsorship(
+    LedgerHeader const& lh, std::vector<Signer>::const_iterator const& signerIt,
+    LedgerEntry const& sponsoringAcc, LedgerEntry const& sponsoredAcc)
 {
     if (protocolVersionIsBefore(lh.ledgerVersion, ProtocolVersion::V_14))
     {
@@ -335,8 +326,7 @@ canRemoveSignerSponsorship(LedgerHeader const& lh,
     return canRemoveSponsorshipHelper(lh, sponsoringAcc, &sponsoredAcc, 1);
 }
 
-SponsorshipResult
-canTransferSignerSponsorship(
+SponsorshipResult canTransferSignerSponsorship(
     LedgerHeader const& lh, std::vector<Signer>::const_iterator const& signerIt,
     LedgerEntry const& oldSponsoringAcc, LedgerEntry const& newSponsoringAcc,
     LedgerEntry const& sponsoredAcc)
@@ -360,9 +350,8 @@ canTransferSignerSponsorship(
 // Utility functions to establish/remove/transfer sponsorships
 //
 ////////////////////////////////////////////////////////////////////////////////
-void
-establishEntrySponsorship(LedgerEntry& le, LedgerEntry& sponsoringAcc,
-                          LedgerEntry* sponsoredAcc)
+void establishEntrySponsorship(LedgerEntry& le, LedgerEntry& sponsoringAcc,
+                               LedgerEntry* sponsoredAcc)
 {
     uint32_t mult = computeMultiplier(le);
     prepareLedgerEntryExtensionV1(le).sponsoringID.activate() =
@@ -376,9 +365,8 @@ establishEntrySponsorship(LedgerEntry& le, LedgerEntry& sponsoringAcc,
     }
 }
 
-void
-removeEntrySponsorship(LedgerEntry& le, LedgerEntry& sponsoringAcc,
-                       LedgerEntry* sponsoredAcc)
+void removeEntrySponsorship(LedgerEntry& le, LedgerEntry& sponsoringAcc,
+                            LedgerEntry* sponsoredAcc)
 {
     auto& sponsoringID = getLedgerEntryExtensionV1(le).sponsoringID;
     accountIsSponsor(sponsoringID, sponsoringAcc);
@@ -394,9 +382,8 @@ removeEntrySponsorship(LedgerEntry& le, LedgerEntry& sponsoringAcc,
     }
 }
 
-void
-transferEntrySponsorship(LedgerEntry& le, LedgerEntry& oldSponsoringAcc,
-                         LedgerEntry& newSponsoringAcc)
+void transferEntrySponsorship(LedgerEntry& le, LedgerEntry& oldSponsoringAcc,
+                              LedgerEntry& newSponsoringAcc)
 {
     auto& sponsoringID = getLedgerEntryExtensionV1(le).sponsoringID;
     accountIsSponsor(sponsoringID, oldSponsoringAcc);
@@ -412,10 +399,9 @@ transferEntrySponsorship(LedgerEntry& le, LedgerEntry& oldSponsoringAcc,
         mult;
 }
 
-void
-establishSignerSponsorship(std::vector<Signer>::const_iterator const& signerIt,
-                           LedgerEntry& sponsoringAcc,
-                           LedgerEntry& sponsoredAcc)
+void establishSignerSponsorship(
+    std::vector<Signer>::const_iterator const& signerIt,
+    LedgerEntry& sponsoringAcc, LedgerEntry& sponsoredAcc)
 {
     size_t n = signerIt - sponsoredAcc.data.account().signers.begin();
 
@@ -427,9 +413,9 @@ establishSignerSponsorship(std::vector<Signer>::const_iterator const& signerIt,
           .numSponsoring;
 }
 
-void
-removeSignerSponsorship(std::vector<Signer>::const_iterator const& signerIt,
-                        LedgerEntry& sponsoringAcc, LedgerEntry& sponsoredAcc)
+void removeSignerSponsorship(
+    std::vector<Signer>::const_iterator const& signerIt,
+    LedgerEntry& sponsoringAcc, LedgerEntry& sponsoredAcc)
 {
     size_t n = signerIt - sponsoredAcc.data.account().signers.begin();
 
@@ -442,11 +428,10 @@ removeSignerSponsorship(std::vector<Signer>::const_iterator const& signerIt,
     --getAccountEntryExtensionV2(sponsoringAcc.data.account()).numSponsoring;
 }
 
-void
-transferSignerSponsorship(std::vector<Signer>::const_iterator const& signerIt,
-                          LedgerEntry& oldSponsoringAcc,
-                          LedgerEntry& newSponsoringAcc,
-                          LedgerEntry& sponsoredAcc)
+void transferSignerSponsorship(
+    std::vector<Signer>::const_iterator const& signerIt,
+    LedgerEntry& oldSponsoringAcc, LedgerEntry& newSponsoringAcc,
+    LedgerEntry& sponsoredAcc)
 {
     size_t n = signerIt - sponsoredAcc.data.account().signers.begin();
 
@@ -469,9 +454,9 @@ transferSignerSponsorship(std::vector<Signer>::const_iterator const& signerIt,
 // sponsorship
 //
 ////////////////////////////////////////////////////////////////////////////////
-SponsorshipResult
-canCreateEntryWithoutSponsorship(LedgerHeader const& lh, LedgerEntry const& le,
-                                 LedgerEntry const& acc)
+SponsorshipResult canCreateEntryWithoutSponsorship(LedgerHeader const& lh,
+                                                   LedgerEntry const& le,
+                                                   LedgerEntry const& acc)
 {
     if (le.data.type() != ACCOUNT)
     {
@@ -535,9 +520,9 @@ canCreateEntryWithSponsorship(LedgerHeader const& lh, LedgerEntry const& le,
     return canEstablishEntrySponsorship(lh, le, sponsoringAcc, sponsoredAcc);
 }
 
-void
-canRemoveEntryWithoutSponsorship(LedgerHeader const& lh, LedgerEntry const& le,
-                                 LedgerEntry const& acc)
+void canRemoveEntryWithoutSponsorship(LedgerHeader const& lh,
+                                      LedgerEntry const& le,
+                                      LedgerEntry const& acc)
 {
     if (le.data.type() != ACCOUNT)
     {
@@ -549,10 +534,10 @@ canRemoveEntryWithoutSponsorship(LedgerHeader const& lh, LedgerEntry const& le,
     }
 }
 
-void
-canRemoveEntryWithSponsorship(LedgerHeader const& lh, LedgerEntry const& le,
-                              LedgerEntry const& sponsoringAcc,
-                              LedgerEntry const* sponsoredAcc)
+void canRemoveEntryWithSponsorship(LedgerHeader const& lh,
+                                   LedgerEntry const& le,
+                                   LedgerEntry const& sponsoringAcc,
+                                   LedgerEntry const* sponsoredAcc)
 {
     if (protocolVersionIsBefore(lh.ledgerVersion, ProtocolVersion::V_14))
     {
@@ -578,9 +563,8 @@ canRemoveEntryWithSponsorship(LedgerHeader const& lh, LedgerEntry const& le,
     }
 }
 
-SponsorshipResult
-canCreateSignerWithoutSponsorship(LedgerHeader const& lh,
-                                  LedgerEntry const& acc)
+SponsorshipResult canCreateSignerWithoutSponsorship(LedgerHeader const& lh,
+                                                    LedgerEntry const& acc)
 {
     if (tooManyNumSubEntries(lh, acc, 1))
     {
@@ -595,8 +579,7 @@ canCreateSignerWithoutSponsorship(LedgerHeader const& lh,
     return SponsorshipResult::SUCCESS;
 }
 
-SponsorshipResult
-canCreateSignerWithSponsorship(
+SponsorshipResult canCreateSignerWithSponsorship(
     LedgerHeader const& lh, std::vector<Signer>::const_iterator const& signerIt,
     LedgerEntry const& sponsoringAcc, LedgerEntry const& sponsoredAcc)
 {
@@ -614,9 +597,8 @@ canCreateSignerWithSponsorship(
                                          sponsoredAcc);
 }
 
-void
-canRemoveSignerWithoutSponsorship(LedgerHeader const& lh,
-                                  LedgerEntry const& acc)
+void canRemoveSignerWithoutSponsorship(LedgerHeader const& lh,
+                                       LedgerEntry const& acc)
 {
     if (acc.data.account().numSubEntries < 1)
     {
@@ -624,10 +606,9 @@ canRemoveSignerWithoutSponsorship(LedgerHeader const& lh,
     }
 }
 
-void
-canRemoveSignerWithSponsorship(LedgerHeader const& lh,
-                               LedgerEntry const& sponsoringAcc,
-                               LedgerEntry const& sponsoredAcc)
+void canRemoveSignerWithSponsorship(LedgerHeader const& lh,
+                                    LedgerEntry const& sponsoringAcc,
+                                    LedgerEntry const& sponsoredAcc)
 {
     if (protocolVersionIsBefore(lh.ledgerVersion, ProtocolVersion::V_14))
     {
@@ -651,8 +632,7 @@ canRemoveSignerWithSponsorship(LedgerHeader const& lh,
 // Utility functions to create/remove with/without sponsorship
 //
 ////////////////////////////////////////////////////////////////////////////////
-void
-createEntryWithoutSponsorship(LedgerEntry& le, LedgerEntry& acc)
+void createEntryWithoutSponsorship(LedgerEntry& le, LedgerEntry& acc)
 {
     if (isSubentry(le))
     {
@@ -660,9 +640,8 @@ createEntryWithoutSponsorship(LedgerEntry& le, LedgerEntry& acc)
     }
 }
 
-void
-createEntryWithSponsorship(LedgerEntry& le, LedgerEntry& sponsoringAcc,
-                           LedgerEntry* sponsoredAcc)
+void createEntryWithSponsorship(LedgerEntry& le, LedgerEntry& sponsoringAcc,
+                                LedgerEntry* sponsoredAcc)
 {
     if (sponsoredAcc)
     {
@@ -671,8 +650,7 @@ createEntryWithSponsorship(LedgerEntry& le, LedgerEntry& sponsoringAcc,
     establishEntrySponsorship(le, sponsoringAcc, sponsoredAcc);
 }
 
-void
-removeEntryWithoutSponsorship(LedgerEntry& le, LedgerEntry& acc)
+void removeEntryWithoutSponsorship(LedgerEntry& le, LedgerEntry& acc)
 {
     if (le.data.type() != ACCOUNT)
     {
@@ -680,9 +658,8 @@ removeEntryWithoutSponsorship(LedgerEntry& le, LedgerEntry& acc)
     }
 }
 
-void
-removeEntryWithSponsorship(LedgerEntry& le, LedgerEntry& sponsoringAcc,
-                           LedgerEntry* sponsoredAcc)
+void removeEntryWithSponsorship(LedgerEntry& le, LedgerEntry& sponsoringAcc,
+                                LedgerEntry* sponsoredAcc)
 {
     if (sponsoredAcc)
     {
@@ -691,24 +668,21 @@ removeEntryWithSponsorship(LedgerEntry& le, LedgerEntry& sponsoringAcc,
     removeEntrySponsorship(le, sponsoringAcc, sponsoredAcc);
 }
 
-void
-createSignerWithoutSponsorship(LedgerEntry& acc)
+void createSignerWithoutSponsorship(LedgerEntry& acc)
 {
     auto& ae = acc.data.account();
     ++ae.numSubEntries;
 }
 
-void
-createSignerWithSponsorship(std::vector<Signer>::const_iterator const& signerIt,
-                            LedgerEntry& sponsoringAcc,
-                            LedgerEntry& sponsoredAcc)
+void createSignerWithSponsorship(
+    std::vector<Signer>::const_iterator const& signerIt,
+    LedgerEntry& sponsoringAcc, LedgerEntry& sponsoredAcc)
 {
     createSignerWithoutSponsorship(sponsoredAcc);
     establishSignerSponsorship(signerIt, sponsoringAcc, sponsoredAcc);
 }
 
-void
-removeSignerWithoutSponsorship(
+void removeSignerWithoutSponsorship(
     std::vector<Signer>::const_iterator const& signerIt, LedgerEntry& acc)
 {
     auto& ae = acc.data.account();
@@ -722,10 +696,9 @@ removeSignerWithoutSponsorship(
     ae.signers.erase(signerIt);
 }
 
-void
-removeSignerWithSponsorship(std::vector<Signer>::const_iterator const& signerIt,
-                            LedgerEntry& sponsoringAcc,
-                            LedgerEntry& sponsoredAcc)
+void removeSignerWithSponsorship(
+    std::vector<Signer>::const_iterator const& signerIt,
+    LedgerEntry& sponsoringAcc, LedgerEntry& sponsoredAcc)
 {
     removeSignerSponsorship(signerIt, sponsoringAcc, sponsoredAcc);
     removeSignerWithoutSponsorship(signerIt, sponsoredAcc);
@@ -796,10 +769,9 @@ createEntryWithPossibleSponsorship(AbstractLedgerTxn& ltx,
     return res;
 }
 
-void
-removeEntryWithPossibleSponsorship(AbstractLedgerTxn& ltx,
-                                   LedgerTxnHeader const& header,
-                                   LedgerEntry& le, LedgerTxnEntry& acc)
+void removeEntryWithPossibleSponsorship(AbstractLedgerTxn& ltx,
+                                        LedgerTxnHeader const& header,
+                                        LedgerEntry& le, LedgerTxnEntry& acc)
 {
     if (le.ext.v() == 1 && le.ext.v1().sponsoringID)
     {
@@ -837,8 +809,7 @@ removeEntryWithPossibleSponsorship(AbstractLedgerTxn& ltx,
     }
 }
 
-SponsorshipResult
-createSignerWithPossibleSponsorship(
+SponsorshipResult createSignerWithPossibleSponsorship(
     AbstractLedgerTxn& ltx, LedgerTxnHeader const& header,
     std::vector<Signer>::const_iterator const& signerIt, LedgerTxnEntry& acc)
 {
@@ -871,8 +842,7 @@ createSignerWithPossibleSponsorship(
     return res;
 }
 
-void
-removeSignerWithPossibleSponsorship(
+void removeSignerWithPossibleSponsorship(
     AbstractLedgerTxn& ltx, LedgerTxnHeader const& header,
     std::vector<Signer>::const_iterator const& signerIt, LedgerTxnEntry& acc)
 {

--- a/src/transactions/SponsorshipUtils.h
+++ b/src/transactions/SponsorshipUtils.h
@@ -68,18 +68,16 @@ SponsorshipResult canTransferSignerSponsorship(
     LedgerEntry const& oldSponsoringAcc, LedgerEntry const& newSponsoringAcc,
     LedgerEntry const& sponsoredAcc);
 
-void
-establishSignerSponsorship(std::vector<Signer>::const_iterator const& signerIt,
-                           LedgerEntry& sponsoringAcc,
-                           LedgerEntry& sponsoredAcc);
-void
-removeSignerSponsorship(std::vector<Signer>::const_iterator const& signerIt,
-                        LedgerEntry& sponsoringAcc, LedgerEntry& sponsoredAcc);
-void
-transferSignerSponsorship(std::vector<Signer>::const_iterator const& signerIt,
-                          LedgerEntry& oldSponsoringAcc,
-                          LedgerEntry& newSponsoringAcc,
-                          LedgerEntry& sponsoredAcc);
+void establishSignerSponsorship(
+    std::vector<Signer>::const_iterator const& signerIt,
+    LedgerEntry& sponsoringAcc, LedgerEntry& sponsoredAcc);
+void removeSignerSponsorship(
+    std::vector<Signer>::const_iterator const& signerIt,
+    LedgerEntry& sponsoringAcc, LedgerEntry& sponsoredAcc);
+void transferSignerSponsorship(
+    std::vector<Signer>::const_iterator const& signerIt,
+    LedgerEntry& oldSponsoringAcc, LedgerEntry& newSponsoringAcc,
+    LedgerEntry& sponsoredAcc);
 
 SponsorshipResult canCreateEntryWithoutSponsorship(LedgerHeader const& lh,
                                                    LedgerEntry const& le,

--- a/src/transactions/TransactionBridge.cpp
+++ b/src/transactions/TransactionBridge.cpp
@@ -15,8 +15,7 @@ namespace stellar
 namespace txbridge
 {
 
-TransactionEnvelope
-convertForV13(TransactionEnvelope const& input)
+TransactionEnvelope convertForV13(TransactionEnvelope const& input)
 {
     if (input.type() != ENVELOPE_TYPE_TX_V0)
     {
@@ -62,8 +61,7 @@ getSignatures(TransactionEnvelope const& env)
     }
 }
 
-xdr::xvector<DecoratedSignature, 20>&
-getSignatures(TransactionEnvelope& env)
+xdr::xvector<DecoratedSignature, 20>& getSignatures(TransactionEnvelope& env)
 {
     switch (env.type())
     {
@@ -94,8 +92,7 @@ getSignaturesInner(TransactionEnvelope& env)
     }
 }
 
-xdr::xvector<Operation, MAX_OPS_PER_TX>&
-getOperations(TransactionEnvelope& env)
+xdr::xvector<Operation, MAX_OPS_PER_TX>& getOperations(TransactionEnvelope& env)
 {
     switch (env.type())
     {
@@ -112,14 +109,12 @@ getOperations(TransactionEnvelope& env)
 }
 
 #ifdef BUILD_TESTS
-xdr::xvector<DecoratedSignature, 20>&
-getSignatures(TransactionTestFramePtr tx)
+xdr::xvector<DecoratedSignature, 20>& getSignatures(TransactionTestFramePtr tx)
 {
     return getSignatures(tx->getMutableEnvelope());
 }
 
-void
-setSeqNum(TransactionTestFramePtr tx, int64_t seq)
+void setSeqNum(TransactionTestFramePtr tx, int64_t seq)
 {
     auto& env = tx->getMutableEnvelope();
     int64_t& s = env.type() == ENVELOPE_TYPE_TX_V0 ? env.v0().tx.seqNum
@@ -127,8 +122,7 @@ setSeqNum(TransactionTestFramePtr tx, int64_t seq)
     s = seq;
 }
 
-void
-setFullFee(TransactionTestFramePtr tx, uint32_t totalFee)
+void setFullFee(TransactionTestFramePtr tx, uint32_t totalFee)
 {
     auto& env = tx->getMutableEnvelope();
     uint32_t& f =
@@ -136,8 +130,8 @@ setFullFee(TransactionTestFramePtr tx, uint32_t totalFee)
     f = totalFee;
 }
 
-void
-setSorobanFees(TransactionTestFramePtr tx, uint32_t totalFee, int64 resourceFee)
+void setSorobanFees(TransactionTestFramePtr tx, uint32_t totalFee,
+                    int64 resourceFee)
 {
     setFullFee(tx, totalFee);
     auto& env = tx->getMutableEnvelope();
@@ -145,8 +139,7 @@ setSorobanFees(TransactionTestFramePtr tx, uint32_t totalFee, int64 resourceFee)
     sorobanData.resourceFee = resourceFee;
 }
 
-void
-setMemo(TransactionTestFramePtr tx, Memo memo)
+void setMemo(TransactionTestFramePtr tx, Memo memo)
 {
     auto& env = tx->getMutableEnvelope();
     Memo& m =
@@ -154,8 +147,7 @@ setMemo(TransactionTestFramePtr tx, Memo memo)
     m = memo;
 }
 
-void
-setMinTime(TransactionTestFramePtr tx, TimePoint minTime)
+void setMinTime(TransactionTestFramePtr tx, TimePoint minTime)
 {
     auto& env = tx->getMutableEnvelope();
     if (env.type() == ENVELOPE_TYPE_TX_V0)
@@ -179,8 +171,8 @@ setMinTime(TransactionTestFramePtr tx, TimePoint minTime)
     }
 }
 
-void
-setMaxTime(std::shared_ptr<TransactionTestFrame const> tx, TimePoint maxTime)
+void setMaxTime(std::shared_ptr<TransactionTestFrame const> tx,
+                TimePoint maxTime)
 {
     auto& env = tx->getMutableEnvelope();
     if (env.type() == ENVELOPE_TYPE_TX_V0)

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -61,10 +61,9 @@ namespace
 // roughly 112 million lumens.
 int64_t const MAX_RESOURCE_FEE = 1LL << 50;
 
-uint32_t
-getNumDiskReadEntries(SorobanResources const& resources,
-                      SorobanTransactionData::_ext_t const& ext,
-                      bool isRestoreFootprintOp)
+uint32_t getNumDiskReadEntries(SorobanResources const& resources,
+                               SorobanTransactionData::_ext_t const& ext,
+                               bool isRestoreFootprintOp)
 {
     // All restoreOp entries require disk reads
     if (isRestoreFootprintOp)
@@ -116,8 +115,7 @@ TransactionFrame::TransactionFrame(Hash const& networkID,
     }
 }
 
-Hash const&
-TransactionFrame::getFullHash() const
+Hash const& TransactionFrame::getFullHash() const
 {
     ZoneScoped;
     if (isZero(mFullHash))
@@ -127,8 +125,7 @@ TransactionFrame::getFullHash() const
     return (mFullHash);
 }
 
-Hash const&
-TransactionFrame::getContentsHash() const
+Hash const& TransactionFrame::getContentsHash() const
 {
     ZoneScoped;
 #ifdef _DEBUG
@@ -156,21 +153,18 @@ TransactionFrame::getContentsHash() const
     return (mContentsHash);
 }
 
-TransactionEnvelope const&
-TransactionFrame::getEnvelope() const
+TransactionEnvelope const& TransactionFrame::getEnvelope() const
 {
     return mEnvelope;
 }
 
 #ifdef BUILD_TESTS
-TransactionEnvelope&
-TransactionFrame::getMutableEnvelope() const
+TransactionEnvelope& TransactionFrame::getMutableEnvelope() const
 {
     return mEnvelope;
 }
 
-void
-TransactionFrame::clearCached() const
+void TransactionFrame::clearCached() const
 {
     Hash zero;
     mContentsHash = zero;
@@ -178,21 +172,18 @@ TransactionFrame::clearCached() const
 }
 #endif
 
-SequenceNumber
-TransactionFrame::getSeqNum() const
+SequenceNumber TransactionFrame::getSeqNum() const
 {
     return mEnvelope.type() == ENVELOPE_TYPE_TX_V0 ? mEnvelope.v0().tx.seqNum
                                                    : mEnvelope.v1().tx.seqNum;
 }
 
-AccountID
-TransactionFrame::getFeeSourceID() const
+AccountID TransactionFrame::getFeeSourceID() const
 {
     return getSourceID();
 }
 
-AccountID
-TransactionFrame::getSourceID() const
+AccountID TransactionFrame::getSourceID() const
 {
     if (mEnvelope.type() == ENVELOPE_TYPE_TX_V0)
     {
@@ -203,8 +194,7 @@ TransactionFrame::getSourceID() const
     return toAccountID(mEnvelope.v1().tx.sourceAccount);
 }
 
-MuxedAccount
-TransactionFrame::getSourceAccount() const
+MuxedAccount TransactionFrame::getSourceAccount() const
 {
     if (mEnvelope.type() == ENVELOPE_TYPE_TX_V0)
     {
@@ -215,8 +205,7 @@ TransactionFrame::getSourceAccount() const
     return mEnvelope.v1().tx.sourceAccount;
 }
 
-uint32_t
-TransactionFrame::getNumOperations() const
+uint32_t TransactionFrame::getNumOperations() const
 {
     return mEnvelope.type() == ENVELOPE_TYPE_TX_V0
                ? static_cast<uint32_t>(mEnvelope.v0().tx.operations.size())
@@ -229,9 +218,8 @@ TransactionFrame::getOperationFrames() const
     return mOperations;
 }
 
-Resource
-TransactionFrame::getResources(bool useByteLimitInClassic,
-                               uint32_t ledgerVersion) const
+Resource TransactionFrame::getResources(bool useByteLimitInClassic,
+                                        uint32_t ledgerVersion) const
 {
     auto txSize = static_cast<int64_t>(this->getSize());
     if (isSoroban())
@@ -270,16 +258,14 @@ TransactionFrame::getResources(bool useByteLimitInClassic,
     }
 }
 
-std::vector<Operation> const&
-TransactionFrame::getRawOperations() const
+std::vector<Operation> const& TransactionFrame::getRawOperations() const
 {
     return mEnvelope.type() == ENVELOPE_TYPE_TX_V0
                ? mEnvelope.v0().tx.operations
                : mEnvelope.v1().tx.operations;
 }
 
-bool
-TransactionFrame::validateSorobanTxForFlooding(
+bool TransactionFrame::validateSorobanTxForFlooding(
     UnorderedSet<LedgerKey> const& keysToFilter) const
 {
     if (!isSoroban() || mEnvelope.type() != ENVELOPE_TYPE_TX)
@@ -308,8 +294,7 @@ TransactionFrame::validateSorobanTxForFlooding(
            checkKeys(sorobanData.resources.footprint.readWrite);
 }
 
-bool
-TransactionFrame::validateSorobanMemo() const
+bool TransactionFrame::validateSorobanMemo() const
 {
     if (!isSoroban())
     {
@@ -339,15 +324,13 @@ TransactionFrame::validateSorobanMemo() const
     return true;
 }
 
-int64_t
-TransactionFrame::getFullFee() const
+int64_t TransactionFrame::getFullFee() const
 {
     return mEnvelope.type() == ENVELOPE_TYPE_TX_V0 ? mEnvelope.v0().tx.fee
                                                    : mEnvelope.v1().tx.fee;
 }
 
-int64_t
-TransactionFrame::getInclusionFee() const
+int64_t TransactionFrame::getInclusionFee() const
 {
     if (isSoroban())
     {
@@ -362,9 +345,9 @@ TransactionFrame::getInclusionFee() const
     return getFullFee();
 }
 
-int64_t
-TransactionFrame::getFee(LedgerHeader const& header,
-                         std::optional<int64_t> baseFee, bool applying) const
+int64_t TransactionFrame::getFee(LedgerHeader const& header,
+                                 std::optional<int64_t> baseFee,
+                                 bool applying) const
 {
     if (!baseFee)
     {
@@ -395,10 +378,9 @@ TransactionFrame::getFee(LedgerHeader const& header,
     }
 }
 
-bool
-TransactionFrame::checkSignature(SignatureChecker& signatureChecker,
-                                 LedgerEntryWrapper const& account,
-                                 int32_t neededWeight) const
+bool TransactionFrame::checkSignature(SignatureChecker& signatureChecker,
+                                      LedgerEntryWrapper const& account,
+                                      int32_t neededWeight) const
 {
     ZoneScoped;
     auto& acc = account.current().data.account();
@@ -413,9 +395,8 @@ TransactionFrame::checkSignature(SignatureChecker& signatureChecker,
     return signatureChecker.checkSignature(signers, neededWeight);
 }
 
-bool
-TransactionFrame::checkSignatureNoAccount(SignatureChecker& signatureChecker,
-                                          AccountID const& accountID) const
+bool TransactionFrame::checkSignatureNoAccount(
+    SignatureChecker& signatureChecker, AccountID const& accountID) const
 {
     ZoneScoped;
     std::vector<Signer> signers;
@@ -424,8 +405,8 @@ TransactionFrame::checkSignatureNoAccount(SignatureChecker& signatureChecker,
     return signatureChecker.checkSignature(signers, 0);
 }
 
-bool
-TransactionFrame::checkExtraSigners(SignatureChecker& signatureChecker) const
+bool TransactionFrame::checkExtraSigners(
+    SignatureChecker& signatureChecker) const
 {
     ZoneScoped;
     if (extraSignersExist())
@@ -450,8 +431,7 @@ TransactionFrame::checkExtraSigners(SignatureChecker& signatureChecker) const
     return true;
 }
 
-bool
-TransactionFrame::checkOperationSignatures(
+bool TransactionFrame::checkOperationSignatures(
     SignatureChecker& signatureChecker, LedgerSnapshot const& ls,
     MutableTransactionResultBase* txResult) const
 {
@@ -469,8 +449,7 @@ TransactionFrame::checkOperationSignatures(
     return allOpsValid;
 }
 
-bool
-TransactionFrame::checkAllTransactionSignatures(
+bool TransactionFrame::checkAllTransactionSignatures(
     SignatureChecker& signatureChecker, LedgerEntryWrapper const& sourceAccount,
     uint32_t ledgerVersion) const
 {
@@ -519,10 +498,9 @@ TransactionFrame::loadSourceAccount(AbstractLedgerTxn& ltx,
     return res;
 }
 
-LedgerTxnEntry
-TransactionFrame::loadAccount(AbstractLedgerTxn& ltx,
-                              LedgerTxnHeader const& header,
-                              AccountID const& accountID) const
+LedgerTxnEntry TransactionFrame::loadAccount(AbstractLedgerTxn& ltx,
+                                             LedgerTxnHeader const& header,
+                                             AccountID const& accountID) const
 {
     ZoneScoped;
     if (protocolVersionIsBefore(header.current().ledgerVersion,
@@ -552,8 +530,7 @@ TransactionFrame::loadAccount(AbstractLedgerTxn& ltx,
     }
 }
 
-bool
-TransactionFrame::hasDexOperations() const
+bool TransactionFrame::hasDexOperations() const
 {
     for (auto const& op : mOperations)
     {
@@ -565,21 +542,18 @@ TransactionFrame::hasDexOperations() const
     return false;
 }
 
-bool
-TransactionFrame::isSoroban() const
+bool TransactionFrame::isSoroban() const
 {
     return !mOperations.empty() && mOperations[0]->isSoroban();
 }
 
-SorobanResources const&
-TransactionFrame::sorobanResources() const
+SorobanResources const& TransactionFrame::sorobanResources() const
 {
     releaseAssertOrThrow(isSoroban());
     return mEnvelope.v1().tx.ext.sorobanData().resources;
 }
 
-SorobanTransactionData::_ext_t const&
-TransactionFrame::getResourcesExt() const
+SorobanTransactionData::_ext_t const& TransactionFrame::getResourcesExt() const
 {
     releaseAssertOrThrow(isSoroban());
     return mEnvelope.v1().tx.ext.sorobanData().ext;
@@ -591,14 +565,12 @@ TransactionFrame::createTxErrorResult(TransactionResultCode txErrorCode) const
     return MutableTransactionResult::createTxError(txErrorCode);
 }
 
-MutableTxResultPtr
-TransactionFrame::createValidationSuccessResult() const
+MutableTxResultPtr TransactionFrame::createValidationSuccessResult() const
 {
     return MutableTransactionResult::createSuccess(*this, 0);
 }
 
-std::optional<TimeBounds const> const
-TransactionFrame::getTimeBounds() const
+std::optional<TimeBounds const> const TransactionFrame::getTimeBounds() const
 {
     if (mEnvelope.type() == ENVELOPE_TYPE_TX_V0)
     {
@@ -646,8 +618,7 @@ TransactionFrame::getLedgerBounds() const
     return std::optional<LedgerBounds const>();
 }
 
-Duration
-TransactionFrame::getMinSeqAge() const
+Duration TransactionFrame::getMinSeqAge() const
 {
     if (mEnvelope.type() == ENVELOPE_TYPE_TX)
     {
@@ -658,8 +629,7 @@ TransactionFrame::getMinSeqAge() const
     return 0;
 }
 
-uint32
-TransactionFrame::getMinSeqLedgerGap() const
+uint32 TransactionFrame::getMinSeqLedgerGap() const
 {
     if (mEnvelope.type() == ENVELOPE_TYPE_TX)
     {
@@ -670,8 +640,7 @@ TransactionFrame::getMinSeqLedgerGap() const
     return 0;
 }
 
-std::optional<SequenceNumber const> const
-TransactionFrame::getMinSeqNum() const
+std::optional<SequenceNumber const> const TransactionFrame::getMinSeqNum() const
 {
     if (mEnvelope.type() == ENVELOPE_TYPE_TX)
     {
@@ -685,23 +654,20 @@ TransactionFrame::getMinSeqNum() const
     return std::optional<SequenceNumber const>();
 }
 
-bool
-TransactionFrame::extraSignersExist() const
+bool TransactionFrame::extraSignersExist() const
 {
     return mEnvelope.type() == ENVELOPE_TYPE_TX &&
            mEnvelope.v1().tx.cond.type() == PRECOND_V2 &&
            !mEnvelope.v1().tx.cond.v2().extraSigners.empty();
 }
 
-Memo const&
-TransactionFrame::getMemo() const
+Memo const& TransactionFrame::getMemo() const
 {
     return mEnvelope.type() == ENVELOPE_TYPE_TX_V0 ? mEnvelope.v0().tx.memo
                                                    : mEnvelope.v1().tx.memo;
 }
 
-bool
-TransactionFrame::validateSorobanOpsConsistency() const
+bool TransactionFrame::validateSorobanOpsConsistency() const
 {
     bool hasSorobanOp = mOperations[0]->isSoroban();
     for (auto const& op : mOperations)
@@ -721,8 +687,7 @@ TransactionFrame::validateSorobanOpsConsistency() const
     return true;
 }
 
-bool
-TransactionFrame::checkSorobanResources(
+bool TransactionFrame::checkSorobanResources(
     SorobanNetworkConfig const& config, uint32_t ledgerVersion,
     DiagnosticEventManager& diagnosticEvents) const
 {
@@ -981,8 +946,7 @@ TransactionFrame::refundSorobanFee(AbstractLedgerTxn& ltxOuter,
     return feeRefund;
 }
 
-void
-TransactionFrame::updateSorobanMetrics(AppConnector& app) const
+void TransactionFrame::updateSorobanMetrics(AppConnector& app) const
 {
     releaseAssertOrThrow(isSoroban());
     if (app.getConfig().DISABLE_SOROBAN_METRICS_FOR_TESTING)
@@ -1008,8 +972,7 @@ TransactionFrame::updateSorobanMetrics(AppConnector& app) const
     metrics.accumulateLedgerWriteByte(r.writeBytes);
 }
 
-FeePair
-TransactionFrame::computeSorobanResourceFee(
+FeePair TransactionFrame::computeSorobanResourceFee(
     uint32_t protocolVersion, SorobanResources const& txResources,
     uint32_t txSize, uint32_t eventsSize,
     SorobanNetworkConfig const& sorobanConfig, Config const& cfg,
@@ -1047,15 +1010,13 @@ TransactionFrame::computeSorobanResourceFee(
         sorobanConfig.rustBridgeFeeConfiguration(protocolVersion));
 }
 
-int64
-TransactionFrame::declaredSorobanResourceFee() const
+int64 TransactionFrame::declaredSorobanResourceFee() const
 {
     releaseAssertOrThrow(isSoroban());
     return mEnvelope.v1().tx.ext.sorobanData().resourceFee;
 }
 
-FeePair
-TransactionFrame::computePreApplySorobanResourceFee(
+FeePair TransactionFrame::computePreApplySorobanResourceFee(
     uint32_t protocolVersion, SorobanNetworkConfig const& sorobanConfig,
     Config const& cfg) const
 {
@@ -1071,9 +1032,8 @@ TransactionFrame::computePreApplySorobanResourceFee(
         0, sorobanConfig, cfg, getResourcesExt(), isRestoreFootprintTx());
 }
 
-bool
-TransactionFrame::isTooEarly(LedgerHeaderWrapper const& header,
-                             uint64_t lowerBoundCloseTimeOffset) const
+bool TransactionFrame::isTooEarly(LedgerHeaderWrapper const& header,
+                                  uint64_t lowerBoundCloseTimeOffset) const
 {
     auto const tb = getTimeBounds();
     if (tb)
@@ -1096,9 +1056,8 @@ TransactionFrame::isTooEarly(LedgerHeaderWrapper const& header,
     return false;
 }
 
-bool
-TransactionFrame::isTooLate(LedgerHeaderWrapper const& header,
-                            uint64_t upperBoundCloseTimeOffset) const
+bool TransactionFrame::isTooLate(LedgerHeaderWrapper const& header,
+                                 uint64_t upperBoundCloseTimeOffset) const
 {
     auto const tb = getTimeBounds();
     if (tb)
@@ -1124,10 +1083,9 @@ TransactionFrame::isTooLate(LedgerHeaderWrapper const& header,
     return false;
 }
 
-bool
-TransactionFrame::isTooEarlyForAccount(LedgerHeaderWrapper const& header,
-                                       LedgerEntryWrapper const& sourceAccount,
-                                       uint64_t lowerBoundCloseTimeOffset) const
+bool TransactionFrame::isTooEarlyForAccount(
+    LedgerHeaderWrapper const& header, LedgerEntryWrapper const& sourceAccount,
+    uint64_t lowerBoundCloseTimeOffset) const
 {
     if (protocolVersionIsBefore(header.current().ledgerVersion,
                                 ProtocolVersion::V_19))
@@ -1168,8 +1126,7 @@ TransactionFrame::isTooEarlyForAccount(LedgerHeaderWrapper const& header,
     return false;
 }
 
-std::optional<LedgerEntryWrapper>
-TransactionFrame::commonValidPreSeqNum(
+std::optional<LedgerEntryWrapper> TransactionFrame::commonValidPreSeqNum(
     AppConnector& app, SorobanNetworkConfig const* cfg,
     LedgerSnapshot const& ls, bool chargeFee,
     uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
@@ -1400,8 +1357,7 @@ TransactionFrame::commonValidPreSeqNum(
     return sourceAccount;
 }
 
-void
-TransactionFrame::processSeqNum(AbstractLedgerTxn& ltx) const
+void TransactionFrame::processSeqNum(AbstractLedgerTxn& ltx) const
 {
     ZoneScoped;
     auto header = ltx.loadHeader();
@@ -1419,8 +1375,7 @@ TransactionFrame::processSeqNum(AbstractLedgerTxn& ltx) const
     }
 }
 
-bool
-TransactionFrame::processSignatures(
+bool TransactionFrame::processSignatures(
     ValidationType cv, SignatureChecker& signatureChecker,
     AbstractLedgerTxn& ltxOuter, MutableTransactionResultBase& txResult) const
 {
@@ -1474,9 +1429,8 @@ TransactionFrame::processSignatures(
     return maybeValid;
 }
 
-bool
-TransactionFrame::isBadSeq(LedgerHeaderWrapper const& header,
-                           int64_t seqNum) const
+bool TransactionFrame::isBadSeq(LedgerHeaderWrapper const& header,
+                                int64_t seqNum) const
 {
     if (getSeqNum() == getStartingSequenceNumber(header.current()))
     {
@@ -1501,17 +1455,14 @@ TransactionFrame::isBadSeq(LedgerHeaderWrapper const& header,
     return seqNum == INT64_MAX || seqNum + 1 != getSeqNum();
 }
 
-TransactionFrame::ValidationType
-TransactionFrame::commonValid(AppConnector& app,
-                              SorobanNetworkConfig const* cfg,
-                              SignatureChecker& signatureChecker,
-                              LedgerSnapshot const& ls, SequenceNumber current,
-                              bool applying, bool chargeFee,
-                              uint64_t lowerBoundCloseTimeOffset,
-                              uint64_t upperBoundCloseTimeOffset,
-                              std::optional<FeePair> sorobanResourceFee,
-                              MutableTransactionResultBase& txResult,
-                              DiagnosticEventManager& diagnosticEvents) const
+TransactionFrame::ValidationType TransactionFrame::commonValid(
+    AppConnector& app, SorobanNetworkConfig const* cfg,
+    SignatureChecker& signatureChecker, LedgerSnapshot const& ls,
+    SequenceNumber current, bool applying, bool chargeFee,
+    uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+    std::optional<FeePair> sorobanResourceFee,
+    MutableTransactionResultBase& txResult,
+    DiagnosticEventManager& diagnosticEvents) const
 {
     ZoneScoped;
     ValidationType res = ValidationType::kInvalid;
@@ -1657,8 +1608,7 @@ TransactionFrame::processFeeSeqNum(AbstractLedgerTxn& ltx,
     return MutableTransactionResult::createSuccess(*this, fee);
 }
 
-bool
-TransactionFrame::XDRProvidesValidFee() const
+bool TransactionFrame::XDRProvidesValidFee() const
 {
     if (isSoroban())
     {
@@ -1676,15 +1626,13 @@ TransactionFrame::XDRProvidesValidFee() const
     return true;
 }
 
-bool
-TransactionFrame::isRestoreFootprintTx() const
+bool TransactionFrame::isRestoreFootprintTx() const
 {
     return isSoroban() &&
            mOperations.front()->getOperation().body.type() == RESTORE_FOOTPRINT;
 }
 
-void
-TransactionFrame::removeOneTimeSignerFromAllSourceAccounts(
+void TransactionFrame::removeOneTimeSignerFromAllSourceAccounts(
     AbstractLedgerTxn& ltx) const
 {
     auto ledgerVersion = ltx.loadHeader().current().ledgerVersion;
@@ -1706,10 +1654,9 @@ TransactionFrame::removeOneTimeSignerFromAllSourceAccounts(
     }
 }
 
-void
-TransactionFrame::removeAccountSigner(AbstractLedgerTxn& ltxOuter,
-                                      AccountID const& accountID,
-                                      SignerKey const& signerKey) const
+void TransactionFrame::removeAccountSigner(AbstractLedgerTxn& ltxOuter,
+                                           AccountID const& accountID,
+                                           SignerKey const& signerKey) const
 {
     ZoneScoped;
     LedgerTxn ltx(ltxOuter);
@@ -1731,8 +1678,7 @@ TransactionFrame::removeAccountSigner(AbstractLedgerTxn& ltxOuter,
     }
 }
 
-void
-TransactionFrame::checkValidWithOptionallyChargedFee(
+void TransactionFrame::checkValidWithOptionallyChargedFee(
     AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
     bool chargeFee, uint64_t lowerBoundCloseTimeOffset,
     uint64_t upperBoundCloseTimeOffset, MutableTransactionResultBase& txResult,
@@ -1787,12 +1733,10 @@ TransactionFrame::checkValidWithOptionallyChargedFee(
     }
 }
 
-MutableTxResultPtr
-TransactionFrame::checkValid(AppConnector& app, LedgerSnapshot const& ls,
-                             SequenceNumber current,
-                             uint64_t lowerBoundCloseTimeOffset,
-                             uint64_t upperBoundCloseTimeOffset,
-                             DiagnosticEventManager& diagnosticEvents) const
+MutableTxResultPtr TransactionFrame::checkValid(
+    AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
+    uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+    DiagnosticEventManager& diagnosticEvents) const
 {
 #ifdef BUILD_TESTS
     if (app.getRunInOverlayOnlyMode())
@@ -1828,15 +1772,13 @@ TransactionFrame::checkValid(AppConnector& app, LedgerSnapshot const& ls,
     return txResult;
 }
 
-void
-TransactionFrame::insertKeysForFeeProcessing(
+void TransactionFrame::insertKeysForFeeProcessing(
     UnorderedSet<LedgerKey>& keys) const
 {
     keys.emplace(accountKey(getSourceID()));
 }
 
-void
-TransactionFrame::insertKeysForTxApply(UnorderedSet<LedgerKey>& keys) const
+void TransactionFrame::insertKeysForTxApply(UnorderedSet<LedgerKey>& keys) const
 {
     for (auto const& op : mOperations)
     {
@@ -1849,8 +1791,7 @@ TransactionFrame::insertKeysForTxApply(UnorderedSet<LedgerKey>& keys) const
 }
 
 #ifdef BUILD_TESTS
-bool
-TransactionFrame::apply(
+bool TransactionFrame::apply(
     AppConnector& app, AbstractLedgerTxn& ltx,
     MutableTransactionResultBase& txResult,
     std::optional<SorobanNetworkConfig const> const& sorobanConfig,
@@ -1863,8 +1804,7 @@ TransactionFrame::apply(
 #endif
 
 #ifdef BUILD_TESTS
-void
-maybeTriggerTestInternalError(TransactionEnvelope const& env)
+void maybeTriggerTestInternalError(TransactionEnvelope const& env)
 {
     auto memo =
         env.type() == ENVELOPE_TYPE_TX_V0 ? env.v0().tx.memo : env.v1().tx.memo;
@@ -1876,8 +1816,7 @@ maybeTriggerTestInternalError(TransactionEnvelope const& env)
 }
 #endif
 
-std::unique_ptr<SignatureChecker>
-TransactionFrame::commonPreApply(
+std::unique_ptr<SignatureChecker> TransactionFrame::commonPreApply(
     bool chargeFee, AppConnector& app, AbstractLedgerTxn& ltx,
     TransactionMetaBuilder& meta, MutableTransactionResultBase& txResult,
     SorobanNetworkConfig const* sorobanConfig) const
@@ -1945,8 +1884,7 @@ TransactionFrame::commonPreApply(
     }
 }
 
-void
-TransactionFrame::preParallelApply(
+void TransactionFrame::preParallelApply(
     AppConnector& app, AbstractLedgerTxn& ltx, TransactionMetaBuilder& meta,
     MutableTransactionResultBase& resPayload,
     SorobanNetworkConfig const& sorobanConfig) const
@@ -1954,8 +1892,7 @@ TransactionFrame::preParallelApply(
     preParallelApply(true, app, ltx, meta, resPayload, sorobanConfig);
 }
 
-void
-TransactionFrame::preParallelApply(
+void TransactionFrame::preParallelApply(
     bool chargeFee, AppConnector& app, AbstractLedgerTxn& ltx,
     TransactionMetaBuilder& meta, MutableTransactionResultBase& txResult,
     SorobanNetworkConfig const& sorobanConfig) const
@@ -2005,8 +1942,7 @@ TransactionFrame::preParallelApply(
     }
 }
 
-ParallelTxReturnVal
-TransactionFrame::parallelApply(
+ParallelTxReturnVal TransactionFrame::parallelApply(
     AppConnector& app, ThreadParallelApplyLedgerState const& threadState,
     Config const& config, ParallelLedgerInfo const& ledgerInfo,
     MutableTransactionResultBase& txResult, SorobanMetrics& sorobanMetrics,
@@ -2113,8 +2049,7 @@ TransactionFrame::parallelApply(
     return {false, {}};
 }
 
-bool
-TransactionFrame::applyOperations(
+bool TransactionFrame::applyOperations(
     SignatureChecker& signatureChecker, AppConnector& app,
     AbstractLedgerTxn& ltx, TransactionMetaBuilder& outerMeta,
     MutableTransactionResultBase& txResult,
@@ -2310,8 +2245,7 @@ TransactionFrame::applyOperations(
     return false;
 }
 
-bool
-TransactionFrame::apply(
+bool TransactionFrame::apply(
     bool chargeFee, AppConnector& app, AbstractLedgerTxn& ltx,
     TransactionMetaBuilder& meta, MutableTransactionResultBase& txResult,
     std::optional<SorobanNetworkConfig const> const& sorobanConfig,
@@ -2365,8 +2299,7 @@ TransactionFrame::apply(
     }
 }
 
-bool
-TransactionFrame::apply(
+bool TransactionFrame::apply(
     AppConnector& app, AbstractLedgerTxn& ltx, TransactionMetaBuilder& meta,
     MutableTransactionResultBase& txResult,
     std::optional<SorobanNetworkConfig const> const& sorobanConfig,
@@ -2376,11 +2309,9 @@ TransactionFrame::apply(
                  sorobanBasePrngSeed);
 }
 
-void
-TransactionFrame::processPostApply(AppConnector& app,
-                                   AbstractLedgerTxn& ltxOuter,
-                                   TransactionMetaBuilder& meta,
-                                   MutableTransactionResultBase& txResult) const
+void TransactionFrame::processPostApply(
+    AppConnector& app, AbstractLedgerTxn& ltxOuter,
+    TransactionMetaBuilder& meta, MutableTransactionResultBase& txResult) const
 {
     if (protocolVersionIsBefore(ltxOuter.loadHeader().current().ledgerVersion,
                                 ProtocolVersion::V_23) &&
@@ -2394,22 +2325,21 @@ TransactionFrame::processPostApply(AppConnector& app,
     }
 }
 
-void
-TransactionFrame::processPostTxSetApply(AppConnector& app,
-                                        AbstractLedgerTxn& ltx,
-                                        MutableTransactionResultBase& txResult,
-                                        TxEventManager& txEventManager) const
+void TransactionFrame::processPostTxSetApply(
+    AppConnector& app, AbstractLedgerTxn& ltx,
+    MutableTransactionResultBase& txResult,
+    TxEventManager& txEventManager) const
 {
     processRefund(app, ltx, getSourceID(), txResult, txEventManager);
 }
 
 // This is a TransactionFrame specific function that should only be used by
 // FeeBumpTransactionFrame to forward a different account for the refund.
-void
-TransactionFrame::processRefund(AppConnector& app, AbstractLedgerTxn& ltxOuter,
-                                AccountID const& feeSource,
-                                MutableTransactionResultBase& txResult,
-                                TxEventManager& txEventManager) const
+void TransactionFrame::processRefund(AppConnector& app,
+                                     AbstractLedgerTxn& ltxOuter,
+                                     AccountID const& feeSource,
+                                     MutableTransactionResultBase& txResult,
+                                     TxEventManager& txEventManager) const
 {
     ZoneScoped;
     if (!isSoroban())
@@ -2431,8 +2361,7 @@ TransactionFrame::processRefund(AppConnector& app, AbstractLedgerTxn& ltxOuter,
     txEventManager.newFeeEvent(feeSource, -refund, stage);
 }
 
-std::shared_ptr<StellarMessage const>
-TransactionFrame::toStellarMessage() const
+std::shared_ptr<StellarMessage const> TransactionFrame::toStellarMessage() const
 {
     auto msg = std::make_shared<StellarMessage>();
     msg->type(TRANSACTION);
@@ -2440,15 +2369,13 @@ TransactionFrame::toStellarMessage() const
     return msg;
 }
 
-uint32_t
-TransactionFrame::getSize() const
+uint32_t TransactionFrame::getSize() const
 {
     ZoneScoped;
     return static_cast<uint32_t>(xdr::xdr_size(mEnvelope));
 }
 
-bool
-TransactionFrame::maybeAdoptFailedReplayResult(
+bool TransactionFrame::maybeAdoptFailedReplayResult(
     MutableTransactionResultBase& txResult) const
 {
 #ifdef BUILD_TESTS
@@ -2464,8 +2391,7 @@ TransactionFrame::maybeAdoptFailedReplayResult(
     return true;
 }
 
-void
-TransactionFrame::withInnerTx(
+void TransactionFrame::withInnerTx(
     std::function<void(TransactionFrameBaseConstPtr)> fn) const
 {
     // Nothing to do. TransactionFrame does not have an inner transaction.

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -53,8 +53,8 @@ class TransactionFrame : public TransactionFrameBase
   private:
     uint32_t getSize() const;
 
-    bool
-    maybeAdoptFailedReplayResult(MutableTransactionResultBase& txResult) const;
+    bool maybeAdoptFailedReplayResult(
+        MutableTransactionResultBase& txResult) const;
 
   protected:
 #ifdef BUILD_TESTS
@@ -178,8 +178,7 @@ class TransactionFrame : public TransactionFrameBase
     TransactionEnvelope& getMutableEnvelope() const override;
     void clearCached() const override;
 
-    bool
-    isTestTx() const override
+    bool isTestTx() const override
     {
         return false;
     }
@@ -252,8 +251,8 @@ class TransactionFrame : public TransactionFrameBase
 
     virtual MutableTxResultPtr createValidationSuccessResult() const override;
 
-    void
-    insertKeysForFeeProcessing(UnorderedSet<LedgerKey>& keys) const override;
+    void insertKeysForFeeProcessing(
+        UnorderedSet<LedgerKey>& keys) const override;
     void insertKeysForTxApply(UnorderedSet<LedgerKey>& keys) const override;
 
     // collect fee, consume sequence number
@@ -284,11 +283,10 @@ class TransactionFrame : public TransactionFrameBase
                           MutableTransactionResultBase& txResult,
                           SorobanNetworkConfig const& sorobanConfig) const;
 
-    void
-    preParallelApply(AppConnector& app, AbstractLedgerTxn& ltx,
-                     TransactionMetaBuilder& meta,
-                     MutableTransactionResultBase& txResult,
-                     SorobanNetworkConfig const& sorobanConfig) const override;
+    void preParallelApply(
+        AppConnector& app, AbstractLedgerTxn& ltx, TransactionMetaBuilder& meta,
+        MutableTransactionResultBase& txResult,
+        SorobanNetworkConfig const& sorobanConfig) const override;
 
     ParallelTxReturnVal parallelApply(
         AppConnector& app, ThreadParallelApplyLedgerState const& threadState,
@@ -314,10 +312,9 @@ class TransactionFrame : public TransactionFrameBase
     // This has to be called after both `processFeeSeqNum` and
     // `apply` have been called.
     // Currently this only takes care of Soroban fee refunds.
-    void
-    processPostApply(AppConnector& app, AbstractLedgerTxn& ltx,
-                     TransactionMetaBuilder& meta,
-                     MutableTransactionResultBase& txResult) const override;
+    void processPostApply(
+        AppConnector& app, AbstractLedgerTxn& ltx, TransactionMetaBuilder& meta,
+        MutableTransactionResultBase& txResult) const override;
 
     // After all transactions have been applied. Currently only used
     // for refunds in Soroban.

--- a/src/transactions/TransactionFrameBase.h
+++ b/src/transactions/TransactionFrameBase.h
@@ -56,23 +56,19 @@ struct ParallelApplyEntry
     // it due to hitting read limits.
     std::optional<LedgerEntry> mLedgerEntry;
     bool mIsDirty;
-    static ParallelApplyEntry
-    cleanPopulated(LedgerEntry const& e)
+    static ParallelApplyEntry cleanPopulated(LedgerEntry const& e)
     {
         return ParallelApplyEntry{e, false};
     }
-    static ParallelApplyEntry
-    dirtyPopulated(LedgerEntry const& e)
+    static ParallelApplyEntry dirtyPopulated(LedgerEntry const& e)
     {
         return ParallelApplyEntry{e, true};
     }
-    static ParallelApplyEntry
-    cleanEmpty()
+    static ParallelApplyEntry cleanEmpty()
     {
         return ParallelApplyEntry{std::nullopt, false};
     }
-    static ParallelApplyEntry
-    dirtyEmpty()
+    static ParallelApplyEntry dirtyEmpty()
     {
         return ParallelApplyEntry{std::nullopt, true};
     }
@@ -103,18 +99,15 @@ class ParallelTxReturnVal
     {
     }
 
-    bool
-    getSuccess() const
+    bool getSuccess() const
     {
         return mSuccess;
     }
-    OpModifiedEntryMap const&
-    getModifiedEntryMap() const
+    OpModifiedEntryMap const& getModifiedEntryMap() const
     {
         return mModifiedEntryMap;
     }
-    RestoredEntries const&
-    getRestoredEntries() const
+    RestoredEntries const& getRestoredEntries() const
     {
         return mRestoredEntries;
     }

--- a/src/transactions/TransactionMeta.cpp
+++ b/src/transactions/TransactionMeta.cpp
@@ -25,9 +25,7 @@ namespace stellar
 namespace
 {
 
-template <typename T>
-void
-vecAppend(xdr::xvector<T>& a, xdr::xvector<T>&& b)
+template <typename T> void vecAppend(xdr::xvector<T>& a, xdr::xvector<T>&& b)
 {
     std::move(b.begin(), b.end(), std::back_inserter(a));
 }
@@ -37,8 +35,7 @@ vecAppend(xdr::xvector<T>& a, xdr::xvector<T>&& b)
 // (mostly) logically a new entry creation from the perspective of ltx and
 // stellar-core as a whole, but this change type is reclassified to
 // LEDGER_ENTRY_RESTORED for easier consumption downstream.
-LedgerEntryChanges
-processOpLedgerEntryChanges(
+LedgerEntryChanges processOpLedgerEntryChanges(
     Config const& cfg, OperationFrame const& op,
     LedgerEntryChanges const& initialChanges,
     UnorderedMap<LedgerKey, LedgerEntry> const& hotArchiveRestores,
@@ -342,9 +339,8 @@ processOpLedgerEntryChanges(
 }
 } // namespace
 
-void
-OperationMetaBuilder::setLedgerChanges(AbstractLedgerTxn& opLtx,
-                                       uint32_t ledgerSeq)
+void OperationMetaBuilder::setLedgerChanges(AbstractLedgerTxn& opLtx,
+                                            uint32_t ledgerSeq)
 {
     if (!mEnabled)
     {
@@ -400,8 +396,7 @@ OperationMetaBuilder::setLedgerChanges(AbstractLedgerTxn& opLtx,
         mMeta);
 }
 
-void
-OperationMetaBuilder::setLedgerChangesFromSuccessfulOp(
+void OperationMetaBuilder::setLedgerChangesFromSuccessfulOp(
     ThreadParallelApplyLedgerState const& threadState,
     ParallelTxReturnVal const& res, uint32_t ledgerSeq)
 {
@@ -416,7 +411,6 @@ OperationMetaBuilder::setLedgerChangesFromSuccessfulOp(
     LedgerEntryChanges changes;
     for (auto const& [lk, le] : res.getModifiedEntryMap())
     {
-
         auto prevLe = threadState.getLiveEntryOpt(lk);
 
         if (prevLe)
@@ -470,8 +464,7 @@ OperationMetaBuilder::setLedgerChangesFromSuccessfulOp(
         mMeta);
 }
 
-void
-OperationMetaBuilder::setSorobanReturnValue(SCVal const& val)
+void OperationMetaBuilder::setSorobanReturnValue(SCVal const& val)
 {
     if (!mEnabled)
     {
@@ -481,14 +474,12 @@ OperationMetaBuilder::setSorobanReturnValue(SCVal const& val)
     mSorobanReturnValue.emplace(val);
 }
 
-OpEventManager&
-OperationMetaBuilder::getEventManager()
+OpEventManager& OperationMetaBuilder::getEventManager()
 {
     return mEventManager;
 }
 
-DiagnosticEventManager&
-OperationMetaBuilder::getDiagnosticEventManager()
+DiagnosticEventManager& OperationMetaBuilder::getDiagnosticEventManager()
 {
     return mDiagnosticEventManager;
 }
@@ -523,8 +514,7 @@ OperationMetaBuilder::OperationMetaBuilder(
 {
 }
 
-bool
-OperationMetaBuilder::maybeFinalizeOpEvents()
+bool OperationMetaBuilder::maybeFinalizeOpEvents()
 {
     return std::visit(
         [this](auto&& meta) {
@@ -582,8 +572,7 @@ TransactionMetaBuilder::TransactionMetaWrapper::getChangesBefore()
     }
 }
 
-void
-TransactionMetaBuilder::TransactionMetaWrapper::setOperationMetas(
+void TransactionMetaBuilder::TransactionMetaWrapper::setOperationMetas(
     xdr::xvector<OperationMeta>&& opMetas)
 {
     switch (mTransactionMeta.v())
@@ -599,8 +588,7 @@ TransactionMetaBuilder::TransactionMetaWrapper::setOperationMetas(
     }
 }
 
-void
-TransactionMetaBuilder::TransactionMetaWrapper::setOperationMetas(
+void TransactionMetaBuilder::TransactionMetaWrapper::setOperationMetas(
     xdr::xvector<OperationMetaV2>&& opMetas)
 {
     switch (mTransactionMeta.v())
@@ -645,8 +633,7 @@ TransactionMetaBuilder::TransactionMetaWrapper::getSorobanMetaExt()
     }
 }
 
-void
-TransactionMetaBuilder::TransactionMetaWrapper::setDiagnosticEvents(
+void TransactionMetaBuilder::TransactionMetaWrapper::setDiagnosticEvents(
     xdr::xvector<DiagnosticEvent>&& events)
 {
     switch (mTransactionMeta.v())
@@ -665,9 +652,8 @@ TransactionMetaBuilder::TransactionMetaWrapper::setDiagnosticEvents(
     }
 }
 
-void
-TransactionMetaBuilder::TransactionMetaWrapper::maybeSetContractEventsAtTxLevel(
-    xdr::xvector<ContractEvent>&& events)
+void TransactionMetaBuilder::TransactionMetaWrapper::
+    maybeSetContractEventsAtTxLevel(xdr::xvector<ContractEvent>&& events)
 {
     switch (mTransactionMeta.v())
     {
@@ -685,8 +671,7 @@ TransactionMetaBuilder::TransactionMetaWrapper::maybeSetContractEventsAtTxLevel(
     }
 }
 
-void
-TransactionMetaBuilder::TransactionMetaWrapper::maybeActivateSorobanMeta(
+void TransactionMetaBuilder::TransactionMetaWrapper::maybeActivateSorobanMeta(
     bool success)
 {
     switch (mTransactionMeta.v())
@@ -711,8 +696,7 @@ TransactionMetaBuilder::TransactionMetaWrapper::maybeActivateSorobanMeta(
     }
 }
 
-void
-TransactionMetaBuilder::TransactionMetaWrapper::setReturnValue(
+void TransactionMetaBuilder::TransactionMetaWrapper::setReturnValue(
     SCVal const& returnValue)
 {
     switch (mTransactionMeta.v())
@@ -731,8 +715,7 @@ TransactionMetaBuilder::TransactionMetaWrapper::setReturnValue(
     }
 }
 
-void
-TransactionMetaBuilder::TransactionMetaWrapper::setTransactionEvents(
+void TransactionMetaBuilder::TransactionMetaWrapper::setTransactionEvents(
     xdr::xvector<TransactionEvent>&& events)
 {
     switch (mTransactionMeta.v())
@@ -753,8 +736,7 @@ TransactionMetaFrame::TransactionMetaFrame(TransactionMeta const& meta)
     : mTransactionMeta(meta)
 {
 }
-size_t
-TransactionMetaFrame::getNumOperations() const
+size_t TransactionMetaFrame::getNumOperations() const
 {
     switch (mTransactionMeta.v())
     {
@@ -769,8 +751,7 @@ TransactionMetaFrame::getNumOperations() const
     }
 }
 
-size_t
-TransactionMetaFrame::getNumChangesBefore() const
+size_t TransactionMetaFrame::getNumChangesBefore() const
 {
     switch (mTransactionMeta.v())
     {
@@ -785,8 +766,7 @@ TransactionMetaFrame::getNumChangesBefore() const
     }
 }
 
-LedgerEntryChanges
-TransactionMetaFrame::getChangesBefore() const
+LedgerEntryChanges TransactionMetaFrame::getChangesBefore() const
 {
     switch (mTransactionMeta.v())
     {
@@ -801,8 +781,7 @@ TransactionMetaFrame::getChangesBefore() const
     }
 }
 
-LedgerEntryChanges
-TransactionMetaFrame::getChangesAfter() const
+LedgerEntryChanges TransactionMetaFrame::getChangesAfter() const
 {
     switch (mTransactionMeta.v())
     {
@@ -817,8 +796,7 @@ TransactionMetaFrame::getChangesAfter() const
     }
 }
 
-SCVal const&
-TransactionMetaFrame::getReturnValue() const
+SCVal const& TransactionMetaFrame::getReturnValue() const
 {
     switch (mTransactionMeta.v())
     {
@@ -834,8 +812,7 @@ TransactionMetaFrame::getReturnValue() const
     }
 }
 
-bool
-TransactionMetaFrame::eventsAreSupported() const
+bool TransactionMetaFrame::eventsAreSupported() const
 {
     return mTransactionMeta.v() >= 4;
 }
@@ -872,8 +849,7 @@ TransactionMetaFrame::getOpEventsAtOp(size_t opIdx) const
     }
 }
 
-xdr::xvector<TransactionEvent> const&
-TransactionMetaFrame::getTxEvents() const
+xdr::xvector<TransactionEvent> const& TransactionMetaFrame::getTxEvents() const
 {
     switch (mTransactionMeta.v())
     {
@@ -932,8 +908,7 @@ TransactionMetaFrame::getLedgerEntryChangesAtOp(size_t opIdx) const
     }
 }
 
-TransactionMeta const&
-TransactionMetaFrame::getXDR() const
+TransactionMeta const& TransactionMetaFrame::getXDR() const
 {
     return mTransactionMeta;
 }
@@ -992,8 +967,7 @@ TransactionMetaBuilder::TransactionMetaBuilder(bool metaEnabled,
     }
 }
 
-TxEventManager&
-TransactionMetaBuilder::getTxEventManager()
+TxEventManager& TransactionMetaBuilder::getTxEventManager()
 {
     return mTxEventManager;
 }
@@ -1004,20 +978,19 @@ TransactionMetaBuilder::getOperationMetaBuilderAt(size_t i)
     return mOperationMetaBuilders.at(i);
 }
 
-void
-TransactionMetaBuilder::pushTxChangesBefore(AbstractLedgerTxn& changesBeforeLtx)
+void TransactionMetaBuilder::pushTxChangesBefore(
+    AbstractLedgerTxn& changesBeforeLtx)
 {
     maybePushChanges(changesBeforeLtx, mTransactionMeta.getChangesBefore());
 }
 
-void
-TransactionMetaBuilder::pushTxChangesAfter(AbstractLedgerTxn& changesAfterLtx)
+void TransactionMetaBuilder::pushTxChangesAfter(
+    AbstractLedgerTxn& changesAfterLtx)
 {
     maybePushChanges(changesAfterLtx, mTransactionMeta.getChangesAfter());
 }
 
-void
-TransactionMetaBuilder::setNonRefundableResourceFee(int64_t fee)
+void TransactionMetaBuilder::setNonRefundableResourceFee(int64_t fee)
 {
     if (mEnabled && mSorobanMetaExtEnabled)
     {
@@ -1029,8 +1002,7 @@ TransactionMetaBuilder::setNonRefundableResourceFee(int64_t fee)
     }
 }
 
-void
-TransactionMetaBuilder::maybeSetRefundableFeeMeta(
+void TransactionMetaBuilder::maybeSetRefundableFeeMeta(
     std::optional<RefundableFeeTracker> const& refundableFeeTracker)
 {
     if (mEnabled && refundableFeeTracker && mSorobanMetaExtEnabled)
@@ -1045,14 +1017,12 @@ TransactionMetaBuilder::maybeSetRefundableFeeMeta(
     }
 }
 
-DiagnosticEventManager&
-TransactionMetaBuilder::getDiagnosticEventManager()
+DiagnosticEventManager& TransactionMetaBuilder::getDiagnosticEventManager()
 {
     return mDiagnosticEventManager;
 }
 
-TransactionMeta
-TransactionMetaBuilder::finalize(bool success)
+TransactionMeta TransactionMetaBuilder::finalize(bool success)
 {
     // Finalizing the meta only makes sense when it's enabled in the first
     // place.
@@ -1127,9 +1097,8 @@ TransactionMetaBuilder::finalize(bool success)
     return std::move(mTransactionMeta.mTransactionMeta);
 }
 
-void
-TransactionMetaBuilder::maybePushChanges(AbstractLedgerTxn& changesLtx,
-                                         LedgerEntryChanges& destChanges)
+void TransactionMetaBuilder::maybePushChanges(AbstractLedgerTxn& changesLtx,
+                                              LedgerEntryChanges& destChanges)
 {
     if (mEnabled)
     {

--- a/src/transactions/TransactionMeta.h
+++ b/src/transactions/TransactionMeta.h
@@ -151,8 +151,8 @@ class TransactionMetaBuilder
         void setReturnValue(SCVal const& returnValue);
         void setTransactionEvents(xdr::xvector<TransactionEvent>&& events);
         void setDiagnosticEvents(xdr::xvector<DiagnosticEvent>&& events);
-        void
-        maybeSetContractEventsAtTxLevel(xdr::xvector<ContractEvent>&& events);
+        void maybeSetContractEventsAtTxLevel(
+            xdr::xvector<ContractEvent>&& events);
         void maybeActivateSorobanMeta(bool success);
 
         TransactionMeta mTransactionMeta;

--- a/src/transactions/TransactionSQL.cpp
+++ b/src/transactions/TransactionSQL.cpp
@@ -55,8 +55,7 @@ class GeneralizedTxSetUnpacker
     }
 
     template <typename T>
-    typename std::enable_if<xdr_traits<T>::is_bytes>::type
-    operator()(T& t)
+    typename std::enable_if<xdr_traits<T>::is_bytes>::type operator()(T& t)
     {
         if (xdr_traits<T>::variable_nelem)
         {
@@ -92,8 +91,7 @@ class GeneralizedTxSetUnpacker
     }
 
   private:
-    void
-    check(std::size_t n) const
+    void check(std::size_t n) const
     {
         if (mCurrIndex + n > mBuffer.size())
         {
@@ -102,8 +100,7 @@ class GeneralizedTxSetUnpacker
         }
     }
 
-    void
-    getBytes(void* buf, size_t len)
+    void getBytes(void* buf, size_t len)
     {
         if (len != 0)
         {
@@ -150,8 +147,7 @@ readEncodedTxSets(Application& app, soci::session& sess, uint32_t ledgerSeq,
     return txSets;
 }
 
-void
-writeNonGeneralizedTxSetToStream(
+void writeNonGeneralizedTxSetToStream(
     Database& db, soci::session& sess, uint32 ledgerSeq,
     std::vector<TransactionFrameBasePtr> const& txs,
     TransactionHistoryResultEntry& results,
@@ -173,8 +169,8 @@ writeNonGeneralizedTxSetToStream(
                                            /* skipStartupCheck */ true);
 }
 
-void
-checkEncodedGeneralizedTxSetIsEmpty(std::vector<uint8_t> const& encodedTxSet)
+void checkEncodedGeneralizedTxSetIsEmpty(
+    std::vector<uint8_t> const& encodedTxSet)
 {
     ZoneScoped;
     UnorderedMap<Hash, TransactionFrameBase const*> txByHash;
@@ -185,12 +181,11 @@ checkEncodedGeneralizedTxSetIsEmpty(std::vector<uint8_t> const& encodedTxSet)
     xdr_argpack_archive(unpacker, txSet);
 }
 
-void
-writeGeneralizedTxSetToStream(uint32 ledgerSeq,
-                              std::vector<uint8_t> const& encodedTxSet,
-                              std::vector<TransactionFrameBasePtr> const& txs,
-                              TransactionHistoryResultEntry& results,
-                              CheckpointBuilder& checkpointBuilder)
+void writeGeneralizedTxSetToStream(
+    uint32 ledgerSeq, std::vector<uint8_t> const& encodedTxSet,
+    std::vector<TransactionFrameBasePtr> const& txs,
+    TransactionHistoryResultEntry& results,
+    CheckpointBuilder& checkpointBuilder)
 {
     ZoneScoped;
     UnorderedMap<Hash, TransactionFrameBase const*> txByHash;
@@ -209,8 +204,7 @@ writeGeneralizedTxSetToStream(uint32 ledgerSeq,
                                            /* skipStartupCheck */ true);
 }
 
-void
-writeTxSetToStream(
+void writeTxSetToStream(
     Database& db, soci::session& sess, uint32 ledgerSeq,
     std::vector<std::pair<uint32_t, std::vector<uint8_t>>> const& encodedTxSets,
     std::vector<std::pair<uint32_t, std::vector<uint8_t>>>::const_iterator&
@@ -254,10 +248,9 @@ writeTxSetToStream(
 
 } // namespace
 
-size_t
-populateCheckpointFilesFromDB(Application& app, soci::session& sess,
-                              uint32_t ledgerSeq, uint32_t ledgerCount,
-                              CheckpointBuilder& checkpointBuilder)
+size_t populateCheckpointFilesFromDB(Application& app, soci::session& sess,
+                                     uint32_t ledgerSeq, uint32_t ledgerCount,
+                                     CheckpointBuilder& checkpointBuilder)
 {
     ZoneScoped;
 
@@ -344,24 +337,21 @@ populateCheckpointFilesFromDB(Application& app, soci::session& sess,
     return n;
 }
 
-void
-dropSupportTransactionFeeHistory(Database& db)
+void dropSupportTransactionFeeHistory(Database& db)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
     db.getRawSession() << "DROP TABLE IF EXISTS txfeehistory";
 }
 
-void
-dropSupportTxSetHistory(Database& db)
+void dropSupportTxSetHistory(Database& db)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
     db.getRawSession() << "DROP TABLE IF EXISTS txsethistory";
 }
 
-void
-dropSupportTxHistory(Database& db)
+void dropSupportTxHistory(Database& db)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -34,14 +34,12 @@ namespace stellar
 static uint32_t PROD_CONST ACCOUNT_SUBENTRY_LIMIT = 1000;
 static size_t PROD_CONST MAX_OFFERS_TO_CROSS = 1000;
 
-uint32_t
-getAccountSubEntryLimit()
+uint32_t getAccountSubEntryLimit()
 {
     return ACCOUNT_SUBENTRY_LIMIT;
 }
 
-size_t
-getMaxOffersToCross()
+size_t getMaxOffersToCross()
 {
     return MAX_OFFERS_TO_CROSS;
 }
@@ -63,8 +61,7 @@ TempReduceLimitsForTesting::~TempReduceLimitsForTesting()
 }
 #endif
 
-AccountEntryExtensionV1&
-prepareAccountEntryExtensionV1(AccountEntry& ae)
+AccountEntryExtensionV1& prepareAccountEntryExtensionV1(AccountEntry& ae)
 {
     if (ae.ext.v() == 0)
     {
@@ -74,8 +71,7 @@ prepareAccountEntryExtensionV1(AccountEntry& ae)
     return ae.ext.v1();
 }
 
-AccountEntryExtensionV2&
-prepareAccountEntryExtensionV2(AccountEntry& ae)
+AccountEntryExtensionV2& prepareAccountEntryExtensionV2(AccountEntry& ae)
 {
     auto& extV1 = prepareAccountEntryExtensionV1(ae);
     if (extV1.ext.v() == 0)
@@ -88,8 +84,7 @@ prepareAccountEntryExtensionV2(AccountEntry& ae)
     return extV1.ext.v2();
 }
 
-AccountEntryExtensionV3&
-prepareAccountEntryExtensionV3(AccountEntry& ae)
+AccountEntryExtensionV3& prepareAccountEntryExtensionV3(AccountEntry& ae)
 {
     auto& extV2 = prepareAccountEntryExtensionV2(ae);
     if (extV2.ext.v() == 0)
@@ -113,8 +108,7 @@ prepareTrustLineEntryExtensionV1(TrustLineEntry& tl)
     return tl.ext.v1();
 }
 
-TrustLineEntryExtensionV2&
-prepareTrustLineEntryExtensionV2(TrustLineEntry& tl)
+TrustLineEntryExtensionV2& prepareTrustLineEntryExtensionV2(TrustLineEntry& tl)
 {
     auto& extV1 = prepareTrustLineEntryExtensionV1(tl);
 
@@ -126,8 +120,7 @@ prepareTrustLineEntryExtensionV2(TrustLineEntry& tl)
     return extV1.ext.v2();
 }
 
-LedgerEntryExtensionV1&
-prepareLedgerEntryExtensionV1(LedgerEntry& le)
+LedgerEntryExtensionV1& prepareLedgerEntryExtensionV1(LedgerEntry& le)
 {
     if (le.ext.v() == 0)
     {
@@ -137,8 +130,7 @@ prepareLedgerEntryExtensionV1(LedgerEntry& le)
     return le.ext.v1();
 }
 
-void
-setLedgerHeaderFlag(LedgerHeader& lh, uint32_t flags)
+void setLedgerHeaderFlag(LedgerHeader& lh, uint32_t flags)
 {
     if (lh.ext.v() == 0)
     {
@@ -148,8 +140,7 @@ setLedgerHeaderFlag(LedgerHeader& lh, uint32_t flags)
     lh.ext.v1().flags = flags;
 }
 
-AccountEntryExtensionV2&
-getAccountEntryExtensionV2(AccountEntry& ae)
+AccountEntryExtensionV2& getAccountEntryExtensionV2(AccountEntry& ae)
 {
     if (ae.ext.v() != 1 || ae.ext.v1().ext.v() != 2)
     {
@@ -169,8 +160,7 @@ getAccountEntryExtensionV3(AccountEntry const& ae)
     return ae.ext.v1().ext.v2().ext.v3();
 }
 
-TrustLineEntryExtensionV2&
-getTrustLineEntryExtensionV2(TrustLineEntry& tl)
+TrustLineEntryExtensionV2& getTrustLineEntryExtensionV2(TrustLineEntry& tl)
 {
     if (!hasTrustLineEntryExtV2(tl))
     {
@@ -180,8 +170,7 @@ getTrustLineEntryExtensionV2(TrustLineEntry& tl)
     return tl.ext.v1().ext.v2();
 }
 
-LedgerEntryExtensionV1&
-getLedgerEntryExtensionV1(LedgerEntry& le)
+LedgerEntryExtensionV1& getLedgerEntryExtensionV1(LedgerEntry& le)
 {
     if (le.ext.v() != 1)
     {
@@ -191,8 +180,8 @@ getLedgerEntryExtensionV1(LedgerEntry& le)
     return le.ext.v1();
 }
 
-static bool
-checkAuthorization(LedgerHeader const& header, LedgerEntry const& entry)
+static bool checkAuthorization(LedgerHeader const& header,
+                               LedgerEntry const& entry)
 {
     if (protocolVersionIsBefore(header.ledgerVersion, ProtocolVersion::V_10))
     {
@@ -209,22 +198,19 @@ checkAuthorization(LedgerHeader const& header, LedgerEntry const& entry)
     return true;
 }
 
-LedgerKey
-accountKey(AccountID const& accountID)
+LedgerKey accountKey(AccountID const& accountID)
 {
     LedgerKey key(ACCOUNT);
     key.account().accountID = accountID;
     return key;
 }
 
-LedgerKey
-trustlineKey(AccountID const& accountID, Asset const& asset)
+LedgerKey trustlineKey(AccountID const& accountID, Asset const& asset)
 {
     return trustlineKey(accountID, assetToTrustLineAsset(asset));
 }
 
-LedgerKey
-trustlineKey(AccountID const& accountID, TrustLineAsset const& asset)
+LedgerKey trustlineKey(AccountID const& accountID, TrustLineAsset const& asset)
 {
     LedgerKey key(TRUSTLINE);
     key.trustLine().accountID = accountID;
@@ -232,8 +218,7 @@ trustlineKey(AccountID const& accountID, TrustLineAsset const& asset)
     return key;
 }
 
-LedgerKey
-offerKey(AccountID const& sellerID, uint64_t offerID)
+LedgerKey offerKey(AccountID const& sellerID, uint64_t offerID)
 {
     LedgerKey key(OFFER);
     key.offer().sellerID = sellerID;
@@ -241,8 +226,7 @@ offerKey(AccountID const& sellerID, uint64_t offerID)
     return key;
 }
 
-LedgerKey
-dataKey(AccountID const& accountID, std::string const& dataName)
+LedgerKey dataKey(AccountID const& accountID, std::string const& dataName)
 {
     LedgerKey key(DATA);
     key.data().accountID = accountID;
@@ -250,24 +234,22 @@ dataKey(AccountID const& accountID, std::string const& dataName)
     return key;
 }
 
-LedgerKey
-claimableBalanceKey(ClaimableBalanceID const& balanceID)
+LedgerKey claimableBalanceKey(ClaimableBalanceID const& balanceID)
 {
     LedgerKey key(CLAIMABLE_BALANCE);
     key.claimableBalance().balanceID = balanceID;
     return key;
 }
 
-LedgerKey
-liquidityPoolKey(PoolID const& poolID)
+LedgerKey liquidityPoolKey(PoolID const& poolID)
 {
     LedgerKey key(LIQUIDITY_POOL);
     key.liquidityPool().liquidityPoolID = poolID;
     return key;
 }
 
-LedgerKey
-poolShareTrustLineKey(AccountID const& accountID, PoolID const& poolID)
+LedgerKey poolShareTrustLineKey(AccountID const& accountID,
+                                PoolID const& poolID)
 {
     LedgerKey key(TRUSTLINE);
     key.trustLine().accountID = accountID;
@@ -276,17 +258,15 @@ poolShareTrustLineKey(AccountID const& accountID, PoolID const& poolID)
     return key;
 }
 
-LedgerKey
-configSettingKey(ConfigSettingID const& configSettingID)
+LedgerKey configSettingKey(ConfigSettingID const& configSettingID)
 {
     LedgerKey key(CONFIG_SETTING);
     key.configSetting().configSettingID = configSettingID;
     return key;
 }
 
-LedgerKey
-contractDataKey(SCAddress const& contract, SCVal const& dataKey,
-                ContractDataDurability durability)
+LedgerKey contractDataKey(SCAddress const& contract, SCVal const& dataKey,
+                          ContractDataDurability durability)
 {
     LedgerKey key(CONTRACT_DATA);
     key.contractData().contract = contract;
@@ -295,88 +275,80 @@ contractDataKey(SCAddress const& contract, SCVal const& dataKey,
     return key;
 }
 
-LedgerKey
-contractCodeKey(Hash const& hash)
+LedgerKey contractCodeKey(Hash const& hash)
 {
     LedgerKey key(CONTRACT_CODE);
     key.contractCode().hash = hash;
     return key;
 }
 
-InternalLedgerKey
-sponsorshipKey(AccountID const& sponsoredID)
+InternalLedgerKey sponsorshipKey(AccountID const& sponsoredID)
 {
     return InternalLedgerKey::makeSponsorshipKey(sponsoredID);
 }
 
-InternalLedgerKey
-sponsorshipCounterKey(AccountID const& sponsoringID)
+InternalLedgerKey sponsorshipCounterKey(AccountID const& sponsoringID)
 {
     return InternalLedgerKey::makeSponsorshipCounterKey(sponsoringID);
 }
 
-InternalLedgerKey
-maxSeqNumToApplyKey(AccountID const& sourceAccount)
+InternalLedgerKey maxSeqNumToApplyKey(AccountID const& sourceAccount)
 {
     return InternalLedgerKey::makeMaxSeqNumToApplyKey(sourceAccount);
 }
 
-LedgerTxnEntry
-loadAccount(AbstractLedgerTxn& ltx, AccountID const& accountID)
+LedgerTxnEntry loadAccount(AbstractLedgerTxn& ltx, AccountID const& accountID)
 {
     ZoneScoped;
     return ltx.load(accountKey(accountID));
 }
 
-ConstLedgerTxnEntry
-loadAccountWithoutRecord(AbstractLedgerTxn& ltx, AccountID const& accountID)
+ConstLedgerTxnEntry loadAccountWithoutRecord(AbstractLedgerTxn& ltx,
+                                             AccountID const& accountID)
 {
     ZoneScoped;
     return ltx.loadWithoutRecord(accountKey(accountID));
 }
 
-LedgerTxnEntry
-loadData(AbstractLedgerTxn& ltx, AccountID const& accountID,
-         std::string const& dataName)
+LedgerTxnEntry loadData(AbstractLedgerTxn& ltx, AccountID const& accountID,
+                        std::string const& dataName)
 {
     ZoneScoped;
     return ltx.load(dataKey(accountID, dataName));
 }
 
-LedgerTxnEntry
-loadOffer(AbstractLedgerTxn& ltx, AccountID const& sellerID, int64_t offerID)
+LedgerTxnEntry loadOffer(AbstractLedgerTxn& ltx, AccountID const& sellerID,
+                         int64_t offerID)
 {
     ZoneScoped;
     return ltx.load(offerKey(sellerID, offerID));
 }
 
-LedgerTxnEntry
-loadClaimableBalance(AbstractLedgerTxn& ltx,
-                     ClaimableBalanceID const& balanceID)
+LedgerTxnEntry loadClaimableBalance(AbstractLedgerTxn& ltx,
+                                    ClaimableBalanceID const& balanceID)
 {
     ZoneScoped;
     return ltx.load(claimableBalanceKey(balanceID));
 }
 
-TrustLineWrapper
-loadTrustLine(AbstractLedgerTxn& ltx, AccountID const& accountID,
-              Asset const& asset)
+TrustLineWrapper loadTrustLine(AbstractLedgerTxn& ltx,
+                               AccountID const& accountID, Asset const& asset)
 {
     ZoneScoped;
     return TrustLineWrapper(ltx, accountID, asset);
 }
 
-ConstTrustLineWrapper
-loadTrustLineWithoutRecord(AbstractLedgerTxn& ltx, AccountID const& accountID,
-                           Asset const& asset)
+ConstTrustLineWrapper loadTrustLineWithoutRecord(AbstractLedgerTxn& ltx,
+                                                 AccountID const& accountID,
+                                                 Asset const& asset)
 {
     ZoneScoped;
     return ConstTrustLineWrapper(ltx, accountID, asset);
 }
 
-TrustLineWrapper
-loadTrustLineIfNotNative(AbstractLedgerTxn& ltx, AccountID const& accountID,
-                         Asset const& asset)
+TrustLineWrapper loadTrustLineIfNotNative(AbstractLedgerTxn& ltx,
+                                          AccountID const& accountID,
+                                          Asset const& asset)
 {
     ZoneScoped;
     if (asset.type() == ASSET_TYPE_NATIVE)
@@ -386,10 +358,8 @@ loadTrustLineIfNotNative(AbstractLedgerTxn& ltx, AccountID const& accountID,
     return TrustLineWrapper(ltx, accountID, asset);
 }
 
-ConstTrustLineWrapper
-loadTrustLineWithoutRecordIfNotNative(AbstractLedgerTxn& ltx,
-                                      AccountID const& accountID,
-                                      Asset const& asset)
+ConstTrustLineWrapper loadTrustLineWithoutRecordIfNotNative(
+    AbstractLedgerTxn& ltx, AccountID const& accountID, Asset const& asset)
 {
     ZoneScoped;
     if (asset.type() == ASSET_TYPE_NATIVE)
@@ -399,61 +369,60 @@ loadTrustLineWithoutRecordIfNotNative(AbstractLedgerTxn& ltx,
     return ConstTrustLineWrapper(ltx, accountID, asset);
 }
 
-LedgerTxnEntry
-loadSponsorship(AbstractLedgerTxn& ltx, AccountID const& sponsoredID)
+LedgerTxnEntry loadSponsorship(AbstractLedgerTxn& ltx,
+                               AccountID const& sponsoredID)
 {
     ZoneScoped;
     return ltx.load(sponsorshipKey(sponsoredID));
 }
 
-LedgerTxnEntry
-loadSponsorshipCounter(AbstractLedgerTxn& ltx, AccountID const& sponsoringID)
+LedgerTxnEntry loadSponsorshipCounter(AbstractLedgerTxn& ltx,
+                                      AccountID const& sponsoringID)
 {
     ZoneScoped;
     return ltx.load(sponsorshipCounterKey(sponsoringID));
 }
 
-LedgerTxnEntry
-loadMaxSeqNumToApply(AbstractLedgerTxn& ltx, AccountID const& sourceAccount)
+LedgerTxnEntry loadMaxSeqNumToApply(AbstractLedgerTxn& ltx,
+                                    AccountID const& sourceAccount)
 {
     ZoneScoped;
     return ltx.load(maxSeqNumToApplyKey(sourceAccount));
 }
 
-LedgerTxnEntry
-loadPoolShareTrustLine(AbstractLedgerTxn& ltx, AccountID const& accountID,
-                       PoolID const& poolID)
+LedgerTxnEntry loadPoolShareTrustLine(AbstractLedgerTxn& ltx,
+                                      AccountID const& accountID,
+                                      PoolID const& poolID)
 {
     ZoneScoped;
     return ltx.load(poolShareTrustLineKey(accountID, poolID));
 }
 
-LedgerTxnEntry
-loadLiquidityPool(AbstractLedgerTxn& ltx, PoolID const& poolID)
+LedgerTxnEntry loadLiquidityPool(AbstractLedgerTxn& ltx, PoolID const& poolID)
 {
     ZoneScoped;
     return ltx.load(liquidityPoolKey(poolID));
 }
 
-ConstLedgerTxnEntry
-loadContractData(AbstractLedgerTxn& ltx, SCAddress const& contract,
-                 SCVal const& dataKey, ContractDataDurability type)
+ConstLedgerTxnEntry loadContractData(AbstractLedgerTxn& ltx,
+                                     SCAddress const& contract,
+                                     SCVal const& dataKey,
+                                     ContractDataDurability type)
 {
     ZoneScoped;
     return ltx.loadWithoutRecord(contractDataKey(contract, dataKey, type));
 }
 
-ConstLedgerTxnEntry
-loadContractCode(AbstractLedgerTxn& ltx, Hash const& hash)
+ConstLedgerTxnEntry loadContractCode(AbstractLedgerTxn& ltx, Hash const& hash)
 {
     ZoneScoped;
     return ltx.loadWithoutRecord(contractCodeKey(hash));
 }
 
-static void
-acquireOrReleaseLiabilities(AbstractLedgerTxn& ltx,
-                            LedgerTxnHeader const& header,
-                            LedgerTxnEntry const& offerEntry, bool isAcquire)
+static void acquireOrReleaseLiabilities(AbstractLedgerTxn& ltx,
+                                        LedgerTxnHeader const& header,
+                                        LedgerTxnEntry const& offerEntry,
+                                        bool isAcquire)
 {
     ZoneScoped;
     // This should never happen
@@ -523,16 +492,14 @@ acquireOrReleaseLiabilities(AbstractLedgerTxn& ltx,
     }
 }
 
-void
-acquireLiabilities(AbstractLedgerTxn& ltx, LedgerTxnHeader const& header,
-                   LedgerTxnEntry const& offer)
+void acquireLiabilities(AbstractLedgerTxn& ltx, LedgerTxnHeader const& header,
+                        LedgerTxnEntry const& offer)
 {
     acquireOrReleaseLiabilities(ltx, header, offer, true);
 }
 
-bool
-addBalanceSkipAuthorization(LedgerTxnHeader const& header,
-                            LedgerTxnEntry& entry, int64_t amount)
+bool addBalanceSkipAuthorization(LedgerTxnHeader const& header,
+                                 LedgerTxnEntry& entry, int64_t amount)
 {
     auto& tl = entry.current().data.trustLine();
     auto newBalance = tl.balance;
@@ -557,8 +524,8 @@ addBalanceSkipAuthorization(LedgerTxnHeader const& header,
     return true;
 }
 
-bool
-addBalance(LedgerTxnHeader const& header, LedgerTxnEntry& entry, int64_t delta)
+bool addBalance(LedgerTxnHeader const& header, LedgerTxnEntry& entry,
+                int64_t delta)
 {
     if (entry.current().data.type() == ACCOUNT)
     {
@@ -611,9 +578,8 @@ addBalance(LedgerTxnHeader const& header, LedgerTxnEntry& entry, int64_t delta)
     }
 }
 
-bool
-addBuyingLiabilities(LedgerTxnHeader const& header, LedgerTxnEntry& entry,
-                     int64_t delta)
+bool addBuyingLiabilities(LedgerTxnHeader const& header, LedgerTxnEntry& entry,
+                          int64_t delta)
 {
     int64_t buyingLiab = getBuyingLiabilities(header, entry);
 
@@ -658,9 +624,8 @@ addBuyingLiabilities(LedgerTxnHeader const& header, LedgerTxnEntry& entry,
     }
 }
 
-bool
-addSellingLiabilities(LedgerTxnHeader const& header, LedgerTxnEntry& entry,
-                      int64_t delta)
+bool addSellingLiabilities(LedgerTxnHeader const& header, LedgerTxnEntry& entry,
+                           int64_t delta)
 {
     int64_t sellingLiab = getSellingLiabilities(header, entry);
 
@@ -711,14 +676,12 @@ addSellingLiabilities(LedgerTxnHeader const& header, LedgerTxnEntry& entry,
     }
 }
 
-uint64_t
-generateID(LedgerTxnHeader& header)
+uint64_t generateID(LedgerTxnHeader& header)
 {
     return ++header.current().idPool;
 }
 
-int64_t
-getAvailableBalance(LedgerHeader const& header, LedgerEntry const& le)
+int64_t getAvailableBalance(LedgerHeader const& header, LedgerEntry const& le)
 {
     int64_t avail = 0;
     if (le.data.type() == ACCOUNT)
@@ -746,21 +709,20 @@ getAvailableBalance(LedgerHeader const& header, LedgerEntry const& le)
     return avail;
 }
 
-int64_t
-getAvailableBalance(LedgerTxnHeader const& header, LedgerTxnEntry const& entry)
+int64_t getAvailableBalance(LedgerTxnHeader const& header,
+                            LedgerTxnEntry const& entry)
 {
     return getAvailableBalance(header.current(), entry.current());
 }
 
-int64_t
-getAvailableBalance(LedgerTxnHeader const& header,
-                    ConstLedgerTxnEntry const& entry)
+int64_t getAvailableBalance(LedgerTxnHeader const& header,
+                            ConstLedgerTxnEntry const& entry)
 {
     return getAvailableBalance(header.current(), entry.current());
 }
 
-int64_t
-getBuyingLiabilities(LedgerTxnHeader const& header, LedgerEntry const& le)
+int64_t getBuyingLiabilities(LedgerTxnHeader const& header,
+                             LedgerEntry const& le)
 {
     if (protocolVersionIsBefore(header.current().ledgerVersion,
                                 ProtocolVersion::V_10))
@@ -781,14 +743,14 @@ getBuyingLiabilities(LedgerTxnHeader const& header, LedgerEntry const& le)
     throw std::runtime_error("Unknown LedgerEntry type");
 }
 
-int64_t
-getBuyingLiabilities(LedgerTxnHeader const& header, LedgerTxnEntry const& entry)
+int64_t getBuyingLiabilities(LedgerTxnHeader const& header,
+                             LedgerTxnEntry const& entry)
 {
     return getBuyingLiabilities(header, entry.current());
 }
 
-int64_t
-getMaxAmountReceive(LedgerTxnHeader const& header, LedgerEntry const& le)
+int64_t getMaxAmountReceive(LedgerTxnHeader const& header,
+                            LedgerEntry const& le)
 {
     if (le.data.type() == ACCOUNT)
     {
@@ -823,21 +785,19 @@ getMaxAmountReceive(LedgerTxnHeader const& header, LedgerEntry const& le)
     }
 }
 
-int64_t
-getMaxAmountReceive(LedgerTxnHeader const& header, LedgerTxnEntry const& entry)
+int64_t getMaxAmountReceive(LedgerTxnHeader const& header,
+                            LedgerTxnEntry const& entry)
 {
     return getMaxAmountReceive(header, entry.current());
 }
 
-int64_t
-getMaxAmountReceive(LedgerTxnHeader const& header,
-                    ConstLedgerTxnEntry const& entry)
+int64_t getMaxAmountReceive(LedgerTxnHeader const& header,
+                            ConstLedgerTxnEntry const& entry)
 {
     return getMaxAmountReceive(header, entry.current());
 }
 
-int64_t
-getMinBalance(LedgerHeader const& header, AccountEntry const& acc)
+int64_t getMinBalance(LedgerHeader const& header, AccountEntry const& acc)
 {
     uint32_t numSponsoring = 0;
     uint32_t numSponsored = 0;
@@ -852,9 +812,8 @@ getMinBalance(LedgerHeader const& header, AccountEntry const& acc)
                          numSponsored);
 }
 
-int64_t
-getMinBalance(LedgerHeader const& lh, uint32_t numSubentries,
-              uint32_t numSponsoring, uint32_t numSponsored)
+int64_t getMinBalance(LedgerHeader const& lh, uint32_t numSubentries,
+                      uint32_t numSponsoring, uint32_t numSponsored)
 {
     if (protocolVersionIsBefore(lh.ledgerVersion, ProtocolVersion::V_14) &&
         (numSponsored != 0 || numSponsoring != 0))
@@ -880,8 +839,7 @@ getMinBalance(LedgerHeader const& lh, uint32_t numSubentries,
     }
 }
 
-int64_t
-getMinimumLimit(LedgerTxnHeader const& header, LedgerEntry const& le)
+int64_t getMinimumLimit(LedgerTxnHeader const& header, LedgerEntry const& le)
 {
     auto const& tl = le.data.trustLine();
     int64_t minLimit = tl.balance;
@@ -893,21 +851,20 @@ getMinimumLimit(LedgerTxnHeader const& header, LedgerEntry const& le)
     return minLimit;
 }
 
-int64_t
-getMinimumLimit(LedgerTxnHeader const& header, LedgerTxnEntry const& entry)
+int64_t getMinimumLimit(LedgerTxnHeader const& header,
+                        LedgerTxnEntry const& entry)
 {
     return getMinimumLimit(header, entry.current());
 }
 
-int64_t
-getMinimumLimit(LedgerTxnHeader const& header, ConstLedgerTxnEntry const& entry)
+int64_t getMinimumLimit(LedgerTxnHeader const& header,
+                        ConstLedgerTxnEntry const& entry)
 {
     return getMinimumLimit(header, entry.current());
 }
 
-int64_t
-getOfferBuyingLiabilities(LedgerTxnHeader const& header,
-                          LedgerEntry const& entry)
+int64_t getOfferBuyingLiabilities(LedgerTxnHeader const& header,
+                                  LedgerEntry const& entry)
 {
     if (protocolVersionIsBefore(header.current().ledgerVersion,
                                 ProtocolVersion::V_10))
@@ -922,16 +879,14 @@ getOfferBuyingLiabilities(LedgerTxnHeader const& header,
     return res.numSheepSend;
 }
 
-int64_t
-getOfferBuyingLiabilities(LedgerTxnHeader const& header,
-                          LedgerTxnEntry const& entry)
+int64_t getOfferBuyingLiabilities(LedgerTxnHeader const& header,
+                                  LedgerTxnEntry const& entry)
 {
     return getOfferBuyingLiabilities(header, entry.current());
 }
 
-int64_t
-getOfferSellingLiabilities(LedgerTxnHeader const& header,
-                           LedgerEntry const& entry)
+int64_t getOfferSellingLiabilities(LedgerTxnHeader const& header,
+                                   LedgerEntry const& entry)
 {
     if (protocolVersionIsBefore(header.current().ledgerVersion,
                                 ProtocolVersion::V_10))
@@ -946,15 +901,13 @@ getOfferSellingLiabilities(LedgerTxnHeader const& header,
     return res.numWheatReceived;
 }
 
-int64_t
-getOfferSellingLiabilities(LedgerTxnHeader const& header,
-                           LedgerTxnEntry const& entry)
+int64_t getOfferSellingLiabilities(LedgerTxnHeader const& header,
+                                   LedgerTxnEntry const& entry)
 {
     return getOfferSellingLiabilities(header, entry.current());
 }
 
-int64_t
-getSellingLiabilities(LedgerHeader const& header, LedgerEntry const& le)
+int64_t getSellingLiabilities(LedgerHeader const& header, LedgerEntry const& le)
 {
     if (protocolVersionIsBefore(header.ledgerVersion, ProtocolVersion::V_10))
     {
@@ -974,15 +927,13 @@ getSellingLiabilities(LedgerHeader const& header, LedgerEntry const& le)
     throw std::runtime_error("Unknown LedgerEntry type");
 }
 
-int64_t
-getSellingLiabilities(LedgerTxnHeader const& header,
-                      LedgerTxnEntry const& entry)
+int64_t getSellingLiabilities(LedgerTxnHeader const& header,
+                              LedgerTxnEntry const& entry)
 {
     return getSellingLiabilities(header.current(), entry.current());
 }
 
-SequenceNumber
-getStartingSequenceNumber(uint32_t ledgerSeq)
+SequenceNumber getStartingSequenceNumber(uint32_t ledgerSeq)
 {
     if (ledgerSeq > static_cast<uint32_t>(std::numeric_limits<int32_t>::max()))
     {
@@ -991,44 +942,37 @@ getStartingSequenceNumber(uint32_t ledgerSeq)
     return static_cast<SequenceNumber>(ledgerSeq) << 32;
 }
 
-SequenceNumber
-getStartingSequenceNumber(LedgerTxnHeader const& header)
+SequenceNumber getStartingSequenceNumber(LedgerTxnHeader const& header)
 {
     return getStartingSequenceNumber(header.current().ledgerSeq);
 }
 
-SequenceNumber
-getStartingSequenceNumber(LedgerHeader const& header)
+SequenceNumber getStartingSequenceNumber(LedgerHeader const& header)
 {
     return getStartingSequenceNumber(header.ledgerSeq);
 }
 
-bool
-isAuthorized(LedgerEntry const& le)
+bool isAuthorized(LedgerEntry const& le)
 {
     return (le.data.trustLine().flags & AUTHORIZED_FLAG) != 0;
 }
 
-bool
-isAuthorized(LedgerTxnEntry const& entry)
+bool isAuthorized(LedgerTxnEntry const& entry)
 {
     return isAuthorized(entry.current());
 }
 
-bool
-isAuthorized(ConstLedgerTxnEntry const& entry)
+bool isAuthorized(ConstLedgerTxnEntry const& entry)
 {
     return isAuthorized(entry.current());
 }
 
-bool
-isAuthorizedToMaintainLiabilitiesUnsafe(uint32_t flags)
+bool isAuthorizedToMaintainLiabilitiesUnsafe(uint32_t flags)
 {
     return (flags & TRUSTLINE_AUTH_FLAGS) != 0;
 }
 
-bool
-isAuthorizedToMaintainLiabilities(LedgerEntry const& le)
+bool isAuthorizedToMaintainLiabilities(LedgerEntry const& le)
 {
     if (le.data.trustLine().asset.type() == ASSET_TYPE_POOL_SHARE)
     {
@@ -1037,69 +981,58 @@ isAuthorizedToMaintainLiabilities(LedgerEntry const& le)
     return isAuthorizedToMaintainLiabilitiesUnsafe(le.data.trustLine().flags);
 }
 
-bool
-isAuthorizedToMaintainLiabilities(LedgerTxnEntry const& entry)
+bool isAuthorizedToMaintainLiabilities(LedgerTxnEntry const& entry)
 {
     return isAuthorizedToMaintainLiabilities(entry.current());
 }
 
-bool
-isAuthorizedToMaintainLiabilities(ConstLedgerTxnEntry const& entry)
+bool isAuthorizedToMaintainLiabilities(ConstLedgerTxnEntry const& entry)
 {
     return isAuthorizedToMaintainLiabilities(entry.current());
 }
 
-bool
-isAuthRequired(ConstLedgerTxnEntry const& entry)
+bool isAuthRequired(ConstLedgerTxnEntry const& entry)
 {
     return (entry.current().data.account().flags & AUTH_REQUIRED_FLAG) != 0;
 }
 
-bool
-isClawbackEnabledOnTrustline(TrustLineEntry const& tl)
+bool isClawbackEnabledOnTrustline(TrustLineEntry const& tl)
 {
     return (tl.flags & TRUSTLINE_CLAWBACK_ENABLED_FLAG) != 0;
 }
 
-bool
-isClawbackEnabledOnTrustline(LedgerTxnEntry const& entry)
+bool isClawbackEnabledOnTrustline(LedgerTxnEntry const& entry)
 {
     return isClawbackEnabledOnTrustline(entry.current().data.trustLine());
 }
 
-bool
-isClawbackEnabledOnClaimableBalance(ClaimableBalanceEntry const& entry)
+bool isClawbackEnabledOnClaimableBalance(ClaimableBalanceEntry const& entry)
 {
     return entry.ext.v() == 1 && (entry.ext.v1().flags &
                                   CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG) != 0;
 }
 
-bool
-isClawbackEnabledOnClaimableBalance(LedgerEntry const& entry)
+bool isClawbackEnabledOnClaimableBalance(LedgerEntry const& entry)
 {
     return isClawbackEnabledOnClaimableBalance(entry.data.claimableBalance());
 }
 
-bool
-isClawbackEnabledOnAccount(LedgerEntry const& entry)
+bool isClawbackEnabledOnAccount(LedgerEntry const& entry)
 {
     return (entry.data.account().flags & AUTH_CLAWBACK_ENABLED_FLAG) != 0;
 }
 
-bool
-isClawbackEnabledOnAccount(LedgerTxnEntry const& entry)
+bool isClawbackEnabledOnAccount(LedgerTxnEntry const& entry)
 {
     return isClawbackEnabledOnAccount(entry.current());
 }
 
-bool
-isClawbackEnabledOnAccount(ConstLedgerTxnEntry const& entry)
+bool isClawbackEnabledOnAccount(ConstLedgerTxnEntry const& entry)
 {
     return isClawbackEnabledOnAccount(entry.current());
 }
 
-void
-setClaimableBalanceClawbackEnabled(ClaimableBalanceEntry& cb)
+void setClaimableBalanceClawbackEnabled(ClaimableBalanceEntry& cb)
 {
     if (cb.ext.v() != 0)
     {
@@ -1111,54 +1044,46 @@ setClaimableBalanceClawbackEnabled(ClaimableBalanceEntry& cb)
     cb.ext.v1().flags = CLAIMABLE_BALANCE_CLAWBACK_ENABLED_FLAG;
 }
 
-bool
-isImmutableAuth(LedgerTxnEntry const& entry)
+bool isImmutableAuth(LedgerTxnEntry const& entry)
 {
     return (entry.current().data.account().flags & AUTH_IMMUTABLE_FLAG) != 0;
 }
 
-static bool
-isLedgerHeaderFlagSet(LedgerHeader const& header, uint32_t flag)
+static bool isLedgerHeaderFlagSet(LedgerHeader const& header, uint32_t flag)
 {
     return header.ext.v() == 1 && (header.ext.v1().flags & flag) != 0;
 }
 
-bool
-isPoolDepositDisabled(LedgerHeader const& header)
+bool isPoolDepositDisabled(LedgerHeader const& header)
 {
     return isLedgerHeaderFlagSet(header, DISABLE_LIQUIDITY_POOL_DEPOSIT_FLAG);
 }
 
-bool
-isPoolWithdrawalDisabled(LedgerHeader const& header)
+bool isPoolWithdrawalDisabled(LedgerHeader const& header)
 {
     return isLedgerHeaderFlagSet(header,
                                  DISABLE_LIQUIDITY_POOL_WITHDRAWAL_FLAG);
 }
 
-bool
-isPoolTradingDisabled(LedgerHeader const& header)
+bool isPoolTradingDisabled(LedgerHeader const& header)
 {
     return isLedgerHeaderFlagSet(header, DISABLE_LIQUIDITY_POOL_TRADING_FLAG);
 }
 
-void
-releaseLiabilities(AbstractLedgerTxn& ltx, LedgerTxnHeader const& header,
-                   LedgerTxnEntry const& offer)
+void releaseLiabilities(AbstractLedgerTxn& ltx, LedgerTxnHeader const& header,
+                        LedgerTxnEntry const& offer)
 {
     acquireOrReleaseLiabilities(ltx, header, offer, false);
 }
 
-bool
-trustLineFlagIsValid(uint32_t flag, uint32_t ledgerVersion)
+bool trustLineFlagIsValid(uint32_t flag, uint32_t ledgerVersion)
 {
     return trustLineFlagMaskCheckIsValid(flag, ledgerVersion) &&
            (protocolVersionIsBefore(ledgerVersion, ProtocolVersion::V_13) ||
             trustLineFlagAuthIsValid(flag));
 }
 
-bool
-trustLineFlagAuthIsValid(uint32_t flag)
+bool trustLineFlagAuthIsValid(uint32_t flag)
 {
     static_assert(TRUSTLINE_AUTH_FLAGS == 3,
                   "condition only works for two flags");
@@ -1171,8 +1096,7 @@ trustLineFlagAuthIsValid(uint32_t flag)
     return true;
 }
 
-bool
-trustLineFlagMaskCheckIsValid(uint32_t flag, uint32_t ledgerVersion)
+bool trustLineFlagMaskCheckIsValid(uint32_t flag, uint32_t ledgerVersion)
 {
     if (protocolVersionIsBefore(ledgerVersion, ProtocolVersion::V_13))
     {
@@ -1188,15 +1112,13 @@ trustLineFlagMaskCheckIsValid(uint32_t flag, uint32_t ledgerVersion)
     }
 }
 
-bool
-accountFlagIsValid(uint32_t flag, uint32_t ledgerVersion)
+bool accountFlagIsValid(uint32_t flag, uint32_t ledgerVersion)
 {
     return accountFlagMaskCheckIsValid(flag, ledgerVersion) &&
            accountFlagClawbackIsValid(flag, ledgerVersion);
 }
 
-bool
-accountFlagClawbackIsValid(uint32_t flag, uint32_t ledgerVersion)
+bool accountFlagClawbackIsValid(uint32_t flag, uint32_t ledgerVersion)
 {
     if (protocolVersionStartsFrom(ledgerVersion, ProtocolVersion::V_17) &&
         (flag & AUTH_CLAWBACK_ENABLED_FLAG) &&
@@ -1208,8 +1130,7 @@ accountFlagClawbackIsValid(uint32_t flag, uint32_t ledgerVersion)
     return true;
 }
 
-bool
-accountFlagMaskCheckIsValid(uint32_t flag, uint32_t ledgerVersion)
+bool accountFlagMaskCheckIsValid(uint32_t flag, uint32_t ledgerVersion)
 {
     if (protocolVersionIsBefore(ledgerVersion, ProtocolVersion::V_17))
     {
@@ -1219,8 +1140,7 @@ accountFlagMaskCheckIsValid(uint32_t flag, uint32_t ledgerVersion)
     return (flag & ~MASK_ACCOUNT_FLAGS_V17) == 0;
 }
 
-AccountID
-toAccountID(MuxedAccount const& m)
+AccountID toAccountID(MuxedAccount const& m)
 {
     AccountID ret(static_cast<PublicKeyType>(m.type() & 0xff));
     switch (m.type())
@@ -1238,8 +1158,7 @@ toAccountID(MuxedAccount const& m)
     return ret;
 }
 
-MuxedAccount
-toMuxedAccount(AccountID const& a, std::optional<uint64> id)
+MuxedAccount toMuxedAccount(AccountID const& a, std::optional<uint64> id)
 {
     switch (a.type())
     {
@@ -1263,14 +1182,12 @@ toMuxedAccount(AccountID const& a, std::optional<uint64> id)
     }
 }
 
-bool
-trustLineFlagIsValid(uint32_t flag, LedgerTxnHeader const& header)
+bool trustLineFlagIsValid(uint32_t flag, LedgerTxnHeader const& header)
 {
     return trustLineFlagIsValid(flag, header.current().ledgerVersion);
 }
 
-uint64_t
-getUpperBoundCloseTimeOffset(Application& app, uint64_t lastCloseTime)
+uint64_t getUpperBoundCloseTimeOffset(Application& app, uint64_t lastCloseTime)
 {
     uint64_t currentTime = VirtualClock::to_time_t(app.getClock().system_now());
 
@@ -1285,27 +1202,23 @@ getUpperBoundCloseTimeOffset(Application& app, uint64_t lastCloseTime)
            closeTimeDrift;
 }
 
-bool
-hasAccountEntryExtV2(AccountEntry const& ae)
+bool hasAccountEntryExtV2(AccountEntry const& ae)
 {
     return ae.ext.v() == 1 && ae.ext.v1().ext.v() == 2;
 }
 
-bool
-hasAccountEntryExtV3(AccountEntry const& ae)
+bool hasAccountEntryExtV3(AccountEntry const& ae)
 {
     return ae.ext.v() == 1 && ae.ext.v1().ext.v() == 2 &&
            ae.ext.v1().ext.v2().ext.v() == 3;
 }
 
-bool
-hasTrustLineEntryExtV2(TrustLineEntry const& tl)
+bool hasTrustLineEntryExtV2(TrustLineEntry const& tl)
 {
     return tl.ext.v() == 1 && tl.ext.v1().ext.v() == 2;
 }
 
-Asset
-getAsset(AccountID const& issuer, AssetCode const& assetCode)
+Asset getAsset(AccountID const& issuer, AssetCode const& assetCode)
 {
     Asset asset;
     asset.type(assetCode.type());
@@ -1327,8 +1240,7 @@ getAsset(AccountID const& issuer, AssetCode const& assetCode)
     return asset;
 }
 
-bool
-claimableBalanceFlagIsValid(ClaimableBalanceEntry const& cb)
+bool claimableBalanceFlagIsValid(ClaimableBalanceEntry const& cb)
 {
     if (cb.ext.v() == 1)
     {
@@ -1340,9 +1252,9 @@ claimableBalanceFlagIsValid(ClaimableBalanceEntry const& cb)
 
 // The following static methods are used for authorization revocation
 
-static void
-removeOffersByAccountAndAsset(AbstractLedgerTxn& ltx, AccountID const& account,
-                              Asset const& asset)
+static void removeOffersByAccountAndAsset(AbstractLedgerTxn& ltx,
+                                          AccountID const& account,
+                                          Asset const& asset)
 {
     LedgerTxn ltxInner(ltx);
 
@@ -1370,8 +1282,7 @@ removeOffersByAccountAndAsset(AbstractLedgerTxn& ltx, AccountID const& account,
     ltxInner.commit();
 }
 
-static bool
-tryGetEntrySponsor(LedgerTxnEntry& entry, AccountID& sponsor)
+static bool tryGetEntrySponsor(LedgerTxnEntry& entry, AccountID& sponsor)
 {
     if (entry.current().ext.v() == 1 &&
         getLedgerEntryExtensionV1(entry.current()).sponsoringID)
@@ -1383,8 +1294,7 @@ tryGetEntrySponsor(LedgerTxnEntry& entry, AccountID& sponsor)
     return false;
 }
 
-static AccountID
-getTrustLineBacker(LedgerTxnEntry& trustLine)
+static AccountID getTrustLineBacker(LedgerTxnEntry& trustLine)
 {
     AccountID sponsor;
     if (tryGetEntrySponsor(trustLine, sponsor))
@@ -1395,8 +1305,7 @@ getTrustLineBacker(LedgerTxnEntry& trustLine)
     return trustLine.current().data.trustLine().accountID;
 }
 
-static void
-prefetchForRevokeFromPoolShareTrustLines(
+static void prefetchForRevokeFromPoolShareTrustLines(
     AbstractLedgerTxn& ltx, AccountID const& accountID,
     std::vector<LedgerTxnEntry>& poolShareTrustLines)
 {
@@ -1442,9 +1351,9 @@ prefetchForRevokeFromPoolShareTrustLines(
     ltx.prefetch(keys);
 }
 
-static ClaimableBalanceID
-getRevokeID(AccountID const& txSourceID, SequenceNumber txSeqNum,
-            uint32_t opIndex, PoolID const& poolID, Asset const& asset)
+static ClaimableBalanceID getRevokeID(AccountID const& txSourceID,
+                                      SequenceNumber txSeqNum, uint32_t opIndex,
+                                      PoolID const& poolID, Asset const& asset)
 {
     HashIDPreimage hashPreimage;
     hashPreimage.type(ENVELOPE_TYPE_POOL_REVOKE_OP_ID);
@@ -1461,8 +1370,7 @@ getRevokeID(AccountID const& txSourceID, SequenceNumber txSeqNum,
     return balanceID;
 }
 
-static Claimant
-makeUnconditionalClaimant(AccountID const& accountID)
+static Claimant makeUnconditionalClaimant(AccountID const& accountID)
 {
     Claimant c;
     c.v0().destination = accountID;
@@ -1471,10 +1379,8 @@ makeUnconditionalClaimant(AccountID const& accountID)
     return c;
 }
 
-static std::vector<LedgerKey>
-prefetchPoolShareTrustLinesByAccountAndGetKeys(AbstractLedgerTxn& ltx,
-                                               AccountID const& accountID,
-                                               Asset const& asset)
+static std::vector<LedgerKey> prefetchPoolShareTrustLinesByAccountAndGetKeys(
+    AbstractLedgerTxn& ltx, AccountID const& accountID, Asset const& asset)
 {
     // always rolls back
     LedgerTxn ltxInner(ltx);
@@ -1500,13 +1406,10 @@ prefetchPoolShareTrustLinesByAccountAndGetKeys(AbstractLedgerTxn& ltx,
     return poolTLKeys;
 }
 
-RemoveResult
-removeOffersAndPoolShareTrustLines(AbstractLedgerTxn& ltx,
-                                   AccountID const& accountID,
-                                   Asset const& asset,
-                                   AccountID const& txSourceID,
-                                   SequenceNumber txSeqNum, uint32_t opIndex,
-                                   OpEventManager& opEventManager)
+RemoveResult removeOffersAndPoolShareTrustLines(
+    AbstractLedgerTxn& ltx, AccountID const& accountID, Asset const& asset,
+    AccountID const& txSourceID, SequenceNumber txSeqNum, uint32_t opIndex,
+    OpEventManager& opEventManager)
 {
     removeOffersByAccountAndAsset(ltx, accountID, asset);
 
@@ -1566,7 +1469,6 @@ removeOffersAndPoolShareTrustLines(AbstractLedgerTxn& ltx,
 
             if (isIssuer(accountID, assetInPool))
             {
-
                 opEventManager.newBurnEvent(
                     assetInPool, makeLiquidityPoolAddress(poolID), amount);
 
@@ -1722,8 +1624,7 @@ removeOffersAndPoolShareTrustLines(AbstractLedgerTxn& ltx,
     return RemoveResult::SUCCESS;
 }
 
-void
-decrementPoolSharesTrustLineCount(LedgerTxnEntry& liquidityPool)
+void decrementPoolSharesTrustLineCount(LedgerTxnEntry& liquidityPool)
 {
     auto poolTLCount = --liquidityPool.current()
                              .data.liquidityPool()
@@ -1739,9 +1640,8 @@ decrementPoolSharesTrustLineCount(LedgerTxnEntry& liquidityPool)
     }
 }
 
-void
-decrementLiquidityPoolUseCount(AbstractLedgerTxn& ltx, Asset const& asset,
-                               AccountID const& accountID)
+void decrementLiquidityPoolUseCount(AbstractLedgerTxn& ltx, Asset const& asset,
+                                    AccountID const& accountID)
 {
     LedgerTxn ltxInner(ltx);
     if (!isIssuer(accountID, asset) && asset.type() != ASSET_TYPE_NATIVE)
@@ -1762,9 +1662,7 @@ decrementLiquidityPoolUseCount(AbstractLedgerTxn& ltx, Asset const& asset,
     ltxInner.commit();
 }
 
-template <typename T>
-T
-assetConversionHelper(Asset const& asset)
+template <typename T> T assetConversionHelper(Asset const& asset)
 {
     T otherAsset;
     otherAsset.type(asset.type());
@@ -1788,20 +1686,17 @@ assetConversionHelper(Asset const& asset)
     return otherAsset;
 }
 
-TrustLineAsset
-assetToTrustLineAsset(Asset const& asset)
+TrustLineAsset assetToTrustLineAsset(Asset const& asset)
 {
     return assetConversionHelper<TrustLineAsset>(asset);
 }
 
-ChangeTrustAsset
-assetToChangeTrustAsset(Asset const& asset)
+ChangeTrustAsset assetToChangeTrustAsset(Asset const& asset)
 {
     return assetConversionHelper<ChangeTrustAsset>(asset);
 }
 
-TrustLineAsset
-changeTrustAssetToTrustLineAsset(ChangeTrustAsset const& ctAsset)
+TrustLineAsset changeTrustAssetToTrustLineAsset(ChangeTrustAsset const& ctAsset)
 {
     TrustLineAsset tlAsset;
     tlAsset.type(ctAsset.type());
@@ -1826,9 +1721,8 @@ changeTrustAssetToTrustLineAsset(ChangeTrustAsset const& ctAsset)
     return tlAsset;
 }
 
-int64_t
-getPoolWithdrawalAmount(int64_t amountPoolShares, int64_t totalPoolShares,
-                        int64_t reserve)
+int64_t getPoolWithdrawalAmount(int64_t amountPoolShares,
+                                int64_t totalPoolShares, int64_t reserve)
 {
     if (amountPoolShares > totalPoolShares)
     {
@@ -1839,9 +1733,8 @@ getPoolWithdrawalAmount(int64_t amountPoolShares, int64_t totalPoolShares,
                             ROUND_DOWN);
 }
 
-void
-maybeUpdateAccountOnLedgerSeqUpdate(LedgerTxnHeader const& header,
-                                    LedgerTxnEntry& account)
+void maybeUpdateAccountOnLedgerSeqUpdate(LedgerTxnHeader const& header,
+                                         LedgerTxnEntry& account)
 {
     if (protocolVersionStartsFrom(header.current().ledgerVersion,
                                   ProtocolVersion::V_19))
@@ -1853,9 +1746,9 @@ maybeUpdateAccountOnLedgerSeqUpdate(LedgerTxnHeader const& header,
     }
 }
 
-int64_t
-getMinInclusionFee(TransactionFrameBase const& tx, LedgerHeader const& header,
-                   std::optional<int64_t> baseFee)
+int64_t getMinInclusionFee(TransactionFrameBase const& tx,
+                           LedgerHeader const& header,
+                           std::optional<int64_t> baseFee)
 {
     int64_t effectiveBaseFee = header.baseFee;
     if (baseFee)
@@ -1865,12 +1758,11 @@ getMinInclusionFee(TransactionFrameBase const& tx, LedgerHeader const& header,
     return effectiveBaseFee * std::max<int64_t>(1, tx.getNumOperations());
 }
 
-bool
-validateContractLedgerEntry(LedgerKey const& lk, size_t entrySize,
-                            SorobanNetworkConfig const& config,
-                            Config const& appConfig,
-                            TransactionFrame const& parentTx,
-                            DiagnosticEventManager& diagnosticEvents)
+bool validateContractLedgerEntry(LedgerKey const& lk, size_t entrySize,
+                                 SorobanNetworkConfig const& config,
+                                 Config const& appConfig,
+                                 TransactionFrame const& parentTx,
+                                 DiagnosticEventManager& diagnosticEvents)
 {
     // check contract code size limit
     if (lk.type() == CONTRACT_CODE && config.maxContractSizeBytes() < entrySize)
@@ -1896,8 +1788,7 @@ validateContractLedgerEntry(LedgerKey const& lk, size_t entrySize,
     return true;
 }
 
-LumenContractInfo
-getLumenContractInfo(Hash const& networkID)
+LumenContractInfo getLumenContractInfo(Hash const& networkID)
 {
     Asset native;
 
@@ -1915,8 +1806,7 @@ getLumenContractInfo(Hash const& networkID)
     return {lumenContractID, balanceSymbol, amountSymbol};
 }
 
-Hash
-getAssetContractID(Hash const& networkID, Asset const& asset)
+Hash getAssetContractID(Hash const& networkID, Asset const& asset)
 {
     HashIDPreimage preImage;
     preImage.type(ENVELOPE_TYPE_CONTRACT_ID);
@@ -1927,64 +1817,56 @@ getAssetContractID(Hash const& networkID, Asset const& asset)
     return xdrSha256(preImage);
 }
 
-SCVal
-makeSymbolSCVal(std::string&& str)
+SCVal makeSymbolSCVal(std::string&& str)
 {
     SCVal val(SCV_SYMBOL);
     val.sym().assign(std::move(str));
     return val;
 }
 
-SCVal
-makeSymbolSCVal(std::string const& str)
+SCVal makeSymbolSCVal(std::string const& str)
 {
     SCVal val(SCV_SYMBOL);
     val.sym().assign(str);
     return val;
 }
 
-SCVal
-makeStringSCVal(std::string&& str)
+SCVal makeStringSCVal(std::string&& str)
 {
     SCVal val(SCV_STRING);
     val.str().assign(std::move(str));
     return val;
 }
 
-SCVal
-makeStringSCVal(std::string const& str)
+SCVal makeStringSCVal(std::string const& str)
 {
     SCVal val(SCV_STRING);
     val.str().assign(str);
     return val;
 }
 
-SCVal
-makeU32SCVal(uint32_t u)
+SCVal makeU32SCVal(uint32_t u)
 {
     SCVal val(SCV_U32);
     val.u32() = u;
     return val;
 }
 
-SCVal
-makeU64SCVal(uint64_t u)
+SCVal makeU64SCVal(uint64_t u)
 {
     SCVal val(SCV_U64);
     val.u64() = u;
     return val;
 }
 
-SCVal
-makeAddressSCVal(SCAddress const& address)
+SCVal makeAddressSCVal(SCAddress const& address)
 {
     SCVal val(SCV_ADDRESS);
     val.address() = address;
     return val;
 }
 
-SCVal
-makeI128SCVal(int64_t v)
+SCVal makeI128SCVal(int64_t v)
 {
     SCVal val(SCV_I128);
     auto cxxI128 = rust_bridge::i128_from_i64(v);
@@ -1993,16 +1875,14 @@ makeI128SCVal(int64_t v)
     return val;
 }
 
-SCVal
-makeAccountIDSCVal(AccountID const& id)
+SCVal makeAccountIDSCVal(AccountID const& id)
 {
     SCAddress addr(SC_ADDRESS_TYPE_ACCOUNT);
     addr.accountId() = id;
     return makeAddressSCVal(addr);
 }
 
-SCAddress
-makeMuxedAccountAddress(MuxedAccount const& account)
+SCAddress makeMuxedAccountAddress(MuxedAccount const& account)
 {
     switch (account.type())
     {
@@ -2025,32 +1905,28 @@ makeMuxedAccountAddress(MuxedAccount const& account)
     }
 }
 
-SCAddress
-makeAccountAddress(AccountID const& account)
+SCAddress makeAccountAddress(AccountID const& account)
 {
     SCAddress addr(SC_ADDRESS_TYPE_ACCOUNT);
     addr.accountId() = account;
     return addr;
 }
 
-SCAddress
-makeClaimableBalanceAddress(ClaimableBalanceID const& id)
+SCAddress makeClaimableBalanceAddress(ClaimableBalanceID const& id)
 {
     SCAddress addr(SC_ADDRESS_TYPE_CLAIMABLE_BALANCE);
     addr.claimableBalanceId() = id;
     return addr;
 }
 
-SCAddress
-makeLiquidityPoolAddress(PoolID const& id)
+SCAddress makeLiquidityPoolAddress(PoolID const& id)
 {
     SCAddress addr(SC_ADDRESS_TYPE_LIQUIDITY_POOL);
     addr.liquidityPoolId() = id;
     return addr;
 }
 
-SCAddress
-getAddressWithDroppedMuxedInfo(SCAddress const& addr)
+SCAddress getAddressWithDroppedMuxedInfo(SCAddress const& addr)
 {
     if (addr.type() == SC_ADDRESS_TYPE_MUXED_ACCOUNT)
     {
@@ -2061,8 +1937,7 @@ getAddressWithDroppedMuxedInfo(SCAddress const& addr)
     return addr;
 }
 
-bool
-isIssuer(SCAddress const& addr, Asset const& asset)
+bool isIssuer(SCAddress const& addr, Asset const& asset)
 {
     switch (addr.type())
     {
@@ -2081,8 +1956,7 @@ isIssuer(SCAddress const& addr, Asset const& asset)
     }
 }
 
-SCVal
-makeSep0011AssetStringSCVal(Asset const& asset)
+SCVal makeSep0011AssetStringSCVal(Asset const& asset)
 {
     if (asset.type() == ASSET_TYPE_NATIVE)
     {
@@ -2092,8 +1966,7 @@ makeSep0011AssetStringSCVal(Asset const& asset)
                            KeyUtils::toStrKey(getIssuer(asset)));
 }
 
-SCVal
-makeClassicMemoSCVal(Memo const& memo)
+SCVal makeClassicMemoSCVal(Memo const& memo)
 {
     switch (memo.type())
     {
@@ -2112,8 +1985,7 @@ makeClassicMemoSCVal(Memo const& memo)
     }
 }
 
-SCVal
-makeMuxIDSCVal(MuxedEd25519Account const& acc)
+SCVal makeMuxIDSCVal(MuxedEd25519Account const& acc)
 {
     return makeU64SCVal(acc.id);
 }
@@ -2124,8 +1996,7 @@ struct MuxChecker
 {
     bool mHasMuxedAccount{false};
 
-    void
-    operator()(stellar::MuxedAccount const& t)
+    void operator()(stellar::MuxedAccount const& t)
     {
         // checks if this is a multiplexed account,
         // such as KEY_TYPE_MUXED_ED25519
@@ -2155,18 +2026,17 @@ struct MuxChecker
 };
 } // namespace detail
 
-bool
-hasMuxedAccount(TransactionEnvelope const& e)
+bool hasMuxedAccount(TransactionEnvelope const& e)
 {
     detail::MuxChecker c;
     c(e);
     return c.mHasMuxedAccount;
 }
 
-ClaimAtom
-makeClaimAtom(uint32_t ledgerVersion, AccountID const& accountID,
-              int64_t offerID, Asset const& wheat, int64_t numWheatReceived,
-              Asset const& sheep, int64_t numSheepSend)
+ClaimAtom makeClaimAtom(uint32_t ledgerVersion, AccountID const& accountID,
+                        int64_t offerID, Asset const& wheat,
+                        int64_t numWheatReceived, Asset const& sheep,
+                        int64_t numSheepSend)
 {
     ClaimAtom atom;
     if (protocolVersionIsBefore(ledgerVersion, ProtocolVersion::V_18))
@@ -2184,8 +2054,7 @@ makeClaimAtom(uint32_t ledgerVersion, AccountID const& accountID,
     return atom;
 }
 
-CxxLedgerEntryRentChange
-createEntryRentChangeWithoutModification(
+CxxLedgerEntryRentChange createEntryRentChangeWithoutModification(
     LedgerEntry const& entry, uint32_t entrySize,
     std::optional<uint32_t> entryLiveUntilLedger, uint32_t newLiveUntilLedger,
     uint32_t ledgerVersion, SorobanNetworkConfig const& sorobanConfig)

--- a/src/transactions/TransactionUtils.h
+++ b/src/transactions/TransactionUtils.h
@@ -37,8 +37,8 @@ struct TransactionEnvelope;
 struct MuxedAccount;
 
 template <typename IterType>
-std::pair<IterType, bool>
-findSignerByKey(IterType begin, IterType end, SignerKey const& key)
+std::pair<IterType, bool> findSignerByKey(IterType begin, IterType end,
+                                          SignerKey const& key)
 {
     auto it =
         std::find_if(begin, end, [&](auto const& x) { return !(x.key < key); });
@@ -331,9 +331,7 @@ SCVal makeStringSCVal(std::string&& str);
 SCVal makeStringSCVal(std::string const& str);
 SCVal makeU32SCVal(uint32_t u);
 SCVal makeU64SCVal(uint64_t u);
-template <typename T>
-SCVal
-makeBytesSCVal(T const& bytes)
+template <typename T> SCVal makeBytesSCVal(T const& bytes)
 {
     SCVal val(SCV_BYTES);
     val.bytes().assign(bytes.begin(), bytes.end());
@@ -353,9 +351,7 @@ SCAddress makeLiquidityPoolAddress(PoolID const& id);
 SCAddress getAddressWithDroppedMuxedInfo(SCAddress const& addr);
 bool isIssuer(SCAddress const& addr, Asset const& asset);
 
-template <typename T>
-CxxBuf
-toCxxBuf(T const& t)
+template <typename T> CxxBuf toCxxBuf(T const& t)
 {
     return CxxBuf{
         std::make_unique<std::vector<uint8_t>>(xdr::xdr_to_opaque(t))};

--- a/src/transactions/TrustFlagsOpFrameBase.cpp
+++ b/src/transactions/TrustFlagsOpFrameBase.cpp
@@ -17,16 +17,14 @@ TrustFlagsOpFrameBase::TrustFlagsOpFrameBase(Operation const& op,
 {
 }
 
-ThresholdLevel
-TrustFlagsOpFrameBase::getThresholdLevel() const
+ThresholdLevel TrustFlagsOpFrameBase::getThresholdLevel() const
 {
     return ThresholdLevel::LOW;
 }
 
-bool
-TrustFlagsOpFrameBase::removeOffers(AbstractLedgerTxn& ltx,
-                                    OperationResult& res,
-                                    OpEventManager& opEventManager) const
+bool TrustFlagsOpFrameBase::removeOffers(AbstractLedgerTxn& ltx,
+                                         OperationResult& res,
+                                         OpEventManager& opEventManager) const
 {
     // Delete all offers owned by the trustor that are either buying or
     // selling the asset which had authorization revoked. Also redeem pool
@@ -51,10 +49,9 @@ TrustFlagsOpFrameBase::removeOffers(AbstractLedgerTxn& ltx,
     return true;
 }
 
-bool
-TrustFlagsOpFrameBase::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
-                               OperationResult& res,
-                               OperationMetaBuilder& opMeta) const
+bool TrustFlagsOpFrameBase::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
+                                    OperationResult& res,
+                                    OperationMetaBuilder& opMeta) const
 {
     ZoneNamedN(applyZone, "TrustFlagsOpFrameBase apply", true);
 

--- a/src/transactions/test/AllowTrustTests.cpp
+++ b/src/transactions/test/AllowTrustTests.cpp
@@ -43,36 +43,32 @@ namespace detail
 
 template <int V> struct TestStub
 {
-
-    static void
-    for_versions(uint32 from, uint32 to, Application& app,
-                 std::function<void()> const& f)
+    static void for_versions(uint32 from, uint32 to, Application& app,
+                             std::function<void()> const& f)
     {
         uint32 lbound = V == 0 ? 0 : 17;
         stellar::for_versions(std::max(from, lbound), to, app, f);
     }
 
-    static void
-    for_versions_to(uint32 to, Application& app, std::function<void()> const& f)
+    static void for_versions_to(uint32 to, Application& app,
+                                std::function<void()> const& f)
     {
         for_versions(0, to, app, f);
     }
 
-    static void
-    for_versions_from(uint32 from, Application& app,
-                      std::function<void()> const& f)
+    static void for_versions_from(uint32 from, Application& app,
+                                  std::function<void()> const& f)
     {
         for_versions(from, Config::CURRENT_LEDGER_PROTOCOL_VERSION, app, f);
     }
 
-    static void
-    for_all_versions(Application& app, std::function<void(void)> const& f)
+    static void for_all_versions(Application& app,
+                                 std::function<void(void)> const& f)
     {
         for_versions(0, Config::CURRENT_LEDGER_PROTOCOL_VERSION, app, f);
     }
 
-    static void
-    testAuthorizedToMaintainLiabilities()
+    static void testAuthorizedToMaintainLiabilities()
     {
         TrustFlagOp flagOp = V == 0 ? TrustFlagOp::ALLOW_TRUST
                                     : TrustFlagOp::SET_TRUST_LINE_FLAGS;
@@ -366,8 +362,7 @@ template <int V> struct TestStub
         });
     }
 
-    static void
-    testAllowTrust()
+    static void testAllowTrust()
     {
         TrustFlagOp flagOp = V == 0 ? TrustFlagOp::ALLOW_TRUST
                                     : TrustFlagOp::SET_TRUST_LINE_FLAGS;

--- a/src/transactions/test/BeginSponsoringFutureReservesTests.cpp
+++ b/src/transactions/test/BeginSponsoringFutureReservesTests.cpp
@@ -18,8 +18,8 @@
 using namespace stellar;
 using namespace stellar::txtest;
 
-static OperationResultCode
-getOperationResultCode(TransactionTestFrame& tx, size_t i)
+static OperationResultCode getOperationResultCode(TransactionTestFrame& tx,
+                                                  size_t i)
 {
     auto const& opRes = tx.getResult().result.results()[i];
     return opRes.code();

--- a/src/transactions/test/ClaimableBalanceTests.cpp
+++ b/src/transactions/test/ClaimableBalanceTests.cpp
@@ -20,8 +20,8 @@
 using namespace stellar;
 using namespace stellar::txtest;
 
-static Claimant
-makeClaimant(AccountID const& account, ClaimPredicate const& pred)
+static Claimant makeClaimant(AccountID const& account,
+                             ClaimPredicate const& pred)
 {
     Claimant c;
     c.v0().destination = account;
@@ -30,8 +30,7 @@ makeClaimant(AccountID const& account, ClaimPredicate const& pred)
     return c;
 }
 
-static ClaimPredicate
-makeSimplePredicate(uint32_t levels)
+static ClaimPredicate makeSimplePredicate(uint32_t levels)
 {
     ClaimPredicate pred;
     if (levels == 0)
@@ -48,9 +47,8 @@ makeSimplePredicate(uint32_t levels)
     return pred;
 }
 
-static void
-randomizePredicatePos(ClaimPredicate pred1, ClaimPredicate pred2,
-                      xdr::xvector<ClaimPredicate, 2>& vec)
+static void randomizePredicatePos(ClaimPredicate pred1, ClaimPredicate pred2,
+                                  xdr::xvector<ClaimPredicate, 2>& vec)
 {
     stellar::uniform_int_distribution<size_t> dist(0, 1);
     bool randBool = dist(Catch::rng());
@@ -62,9 +60,9 @@ randomizePredicatePos(ClaimPredicate pred1, ClaimPredicate pred2,
     vec.emplace_back(secondPred);
 }
 
-static ClaimPredicate
-makePredicate(ClaimPredicateType type, bool satisfied, TimePoint nextCloseTime,
-              uint32_t secondsToNextClose)
+static ClaimPredicate makePredicate(ClaimPredicateType type, bool satisfied,
+                                    TimePoint nextCloseTime,
+                                    uint32_t secondsToNextClose)
 {
     ClaimPredicate pred;
     pred.type(type);
@@ -116,8 +114,8 @@ makePredicate(ClaimPredicateType type, bool satisfied, TimePoint nextCloseTime,
     return pred;
 }
 
-static ClaimPredicate
-connectPredicate(bool isAnd, ClaimPredicate left, ClaimPredicate right)
+static ClaimPredicate connectPredicate(bool isAnd, ClaimPredicate left,
+                                       ClaimPredicate right)
 {
     ClaimPredicate pred;
     if (isAnd)
@@ -136,14 +134,11 @@ connectPredicate(bool isAnd, ClaimPredicate left, ClaimPredicate right)
     return pred;
 }
 
-static void
-validateBalancesOnCreateAndClaim(TestAccount& createAcc, TestAccount& claimAcc,
-                                 Asset const& asset, int64_t amount,
-                                 xdr::xvector<Claimant, 10> const& claimants,
-                                 TestApplication& app,
-                                 bool mergeCreateAcc = false,
-                                 bool createIsSponsored = false,
-                                 bool claimIsSponsored = false)
+static void validateBalancesOnCreateAndClaim(
+    TestAccount& createAcc, TestAccount& claimAcc, Asset const& asset,
+    int64_t amount, xdr::xvector<Claimant, 10> const& claimants,
+    TestApplication& app, bool mergeCreateAcc = false,
+    bool createIsSponsored = false, bool claimIsSponsored = false)
 {
     // use root to merge and/or sponsor entries if desired
     auto root = app.getRoot();

--- a/src/transactions/test/EndSponsoringFutureReservesTests.cpp
+++ b/src/transactions/test/EndSponsoringFutureReservesTests.cpp
@@ -16,8 +16,8 @@
 using namespace stellar;
 using namespace stellar::txtest;
 
-static OperationResultCode
-getOperationResultCode(TransactionTestFramePtr& tx, size_t i)
+static OperationResultCode getOperationResultCode(TransactionTestFramePtr& tx,
+                                                  size_t i)
 {
     auto const& opRes = tx->getResult().result.results()[i];
     return opRes.code();

--- a/src/transactions/test/FeeBumpTransactionTests.cpp
+++ b/src/transactions/test/FeeBumpTransactionTests.cpp
@@ -17,17 +17,18 @@
 using namespace stellar;
 using namespace stellar::txtest;
 
-static void
-sign(Hash const& networkID, SecretKey key, FeeBumpTransactionEnvelope& env)
+static void sign(Hash const& networkID, SecretKey key,
+                 FeeBumpTransactionEnvelope& env)
 {
     env.signatures.emplace_back(SignatureUtils::sign(
         key, sha256(xdr::xdr_to_opaque(networkID, ENVELOPE_TYPE_TX_FEE_BUMP,
                                        env.tx))));
 }
 
-static TransactionEnvelope
-feeBumpUnsigned(TestAccount& feeSource, TestAccount& source, TestAccount& dest,
-                int64_t outerFee, uint32_t innerFee, int64_t amount)
+static TransactionEnvelope feeBumpUnsigned(TestAccount& feeSource,
+                                           TestAccount& source,
+                                           TestAccount& dest, int64_t outerFee,
+                                           uint32_t innerFee, int64_t amount)
 {
     TransactionEnvelope fb(ENVELOPE_TYPE_TX_FEE_BUMP);
     fb.feeBump().tx.feeSource = toMuxedAccount(feeSource);

--- a/src/transactions/test/InflationTests.cpp
+++ b/src/transactions/test/InflationTests.cpp
@@ -29,18 +29,16 @@ using namespace stellar::txtest;
 
 static const unsigned maxWinners = 2000u;
 
-static SecretKey
-getTestAccount(int i)
+static SecretKey getTestAccount(int i)
 {
     std::stringstream name;
     name << "A" << i;
     return getAccount(name.str().c_str());
 }
 
-static void
-createTestAccounts(Application& app, int nbAccounts,
-                   std::function<int64(int)> getBalance,
-                   std::function<int(int)> getVote)
+static void createTestAccounts(Application& app, int nbAccounts,
+                               std::function<int64(int)> getBalance,
+                               std::function<int(int)> getVote)
 {
     // set up world
     auto root = app.getRoot();
@@ -171,10 +169,10 @@ simulateInflation(int ledgerVersion, int nbAccounts, int64& totCoins,
     return balRes;
 }
 
-static void
-doInflation(Application& app, int ledgerVersion, int nbAccounts,
-            std::function<int64(int)> getBalance,
-            std::function<int(int)> getVote, size_t expectedWinnerCount)
+static void doInflation(Application& app, int ledgerVersion, int nbAccounts,
+                        std::function<int64(int)> getBalance,
+                        std::function<int(int)> getVote,
+                        size_t expectedWinnerCount)
 {
     auto getFeePool = [&] {
         LedgerTxn ltx(app.getLedgerTxnRoot());

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -53,8 +53,8 @@ using namespace stellar::txtest;
 namespace
 {
 
-void
-checkResults(TransactionResultSet& r, int expectedSuccess, int expectedFailed)
+void checkResults(TransactionResultSet& r, int expectedSuccess,
+                  int expectedFailed)
 {
     int successCounter = 0;
     int failedCounter = 0;
@@ -70,8 +70,7 @@ checkResults(TransactionResultSet& r, int expectedSuccess, int expectedFailed)
     REQUIRE(expectedFailed == expectedFailed);
 };
 
-void
-overrideNetworkSettingsToMin(Application& app)
+void overrideNetworkSettingsToMin(Application& app)
 {
     LedgerTxn ltx(app.getLedgerTxnRoot());
 
@@ -1362,7 +1361,6 @@ TEST_CASE("Soroban footprint validation", "[tx][soroban]")
             appCfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION,
             ProtocolVersion::V_23))
     {
-
         auto const maxDiskReads = cfg.mTxMaxDiskReadEntries;
 
         // contract instance and WASM entry are already in the fooprint
@@ -2116,7 +2114,6 @@ TEST_CASE("resource fee exceeds uint32", "[tx][soroban][feebump]")
     auto runTests = [&](bool selfFeeBump) {
         SECTION("success")
         {
-
             SECTION("low inclusion fee")
             {
                 REQUIRE(runTest(10000 * stroopsInXlm, 200, expectedRentFee,
@@ -4530,7 +4527,6 @@ TEST_CASE_VERSIONS("state archival operation errors", "[tx][soroban][archival]")
 
     SECTION("extend operation")
     {
-
         SorobanResources extendResources;
         extendResources.footprint.readOnly = dataKeys;
         extendResources.diskReadBytes = 9'000;
@@ -6229,7 +6225,6 @@ TEST_CASE("Soroban classic account authentication", "[tx][soroban]")
         }
         SECTION("wrong key type")
         {
-
             fieldsMap[0].key = makeBytesSCVal(std::string("public_key"));
             REQUIRE(singleInvocation(signer, baseCredentials) ==
                     InvokeHostFunctionResultCode::INVOKE_HOST_FUNCTION_TRAPPED);
@@ -6988,7 +6983,6 @@ TEST_CASE("contract constructor support", "[tx][soroban]")
 
     SECTION("constructor with no arguments")
     {
-
         auto testNoArgConstructor =
             [&](ConstructorParams::HostFnVersion hostFnVersion,
                 ConstructorParams::HostFnVersion authFnVersion) {
@@ -7068,9 +7062,9 @@ TEST_CASE("contract constructor support", "[tx][soroban]")
     }
 }
 
-static TransactionFrameBasePtr
-makeAddTx(TestContract const& contract, int64_t instructions,
-          TestAccount& source)
+static TransactionFrameBasePtr makeAddTx(TestContract const& contract,
+                                         int64_t instructions,
+                                         TestAccount& source)
 {
     auto fnName = "add";
     auto sc7 = makeI32(7);
@@ -7085,8 +7079,7 @@ makeAddTx(TestContract const& contract, int64_t instructions,
     return invocation.createTx(&source);
 }
 
-static bool
-wasmsAreCached(Application& app, std::vector<Hash> const& wasms)
+static bool wasmsAreCached(Application& app, std::vector<Hash> const& wasms)
 {
     auto moduleCache = app.getLedgerManager().getModuleCacheForTesting();
     for (auto const& wasm : wasms)
@@ -7135,7 +7128,6 @@ TEST_CASE("reusable module cache", "[soroban][modulecache]")
         ttl = stest.getNetworkCfg().stateArchivalSettings().minPersistentTTL;
         for (auto const& wasm : testWasms)
         {
-
             stest.deployWasmContract(wasm);
             contractHashes.push_back(sha256(wasm));
         }
@@ -7251,7 +7243,6 @@ TEST_CASE("Module cache miss on immediate execution",
 
     SECTION("same ledger upload and execution")
     {
-
         // Here we're going to create 4 txs in the same ledger (so they have to
         // come from 4 separate accounts). The 1st uploads a contract wasm, the
         // 2nd creates a contract, and the 3rd and 4th run it.

--- a/src/transactions/test/LiquidityPoolTradeTests.cpp
+++ b/src/transactions/test/LiquidityPoolTradeTests.cpp
@@ -21,8 +21,8 @@
 using namespace stellar;
 using namespace stellar::txtest;
 
-void
-testLiquidityPoolTrading(Application& app, Asset const& cur1, Asset const& cur2)
+void testLiquidityPoolTrading(Application& app, Asset const& cur1,
+                              Asset const& cur2)
 {
     auto share12 = makeChangeTrustAssetPoolShare(
         std::min(cur1, cur2), std::max(cur1, cur2), LIQUIDITY_POOL_FEE_V18);
@@ -1213,8 +1213,8 @@ TEST_CASE_VERSIONS("liquidity pool trade", "[tx][liquiditypool]")
     });
 }
 
-static void
-testGetPoolID(Asset const& x, Asset const& y, std::string const& hex)
+static void testGetPoolID(Asset const& x, Asset const& y,
+                          std::string const& hex)
 {
     int64_t const feeBps = LIQUIDITY_POOL_FEE_V18;
 
@@ -1230,8 +1230,7 @@ testGetPoolID(Asset const& x, Asset const& y, std::string const& hex)
     }
 }
 
-static Asset
-makeAsset(std::string const& code, AccountID const& issuer)
+static Asset makeAsset(std::string const& code, AccountID const& issuer)
 {
     REQUIRE(!code.empty());
     REQUIRE(code.size() <= 12);

--- a/src/transactions/test/ManageBuyOfferTests.cpp
+++ b/src/transactions/test/ManageBuyOfferTests.cpp
@@ -26,9 +26,8 @@
 using namespace stellar;
 using namespace stellar::txtest;
 
-void
-for_current_and_previous_version_from(size_t minVersion, Application& app,
-                                      std::function<void(void)> const& f)
+void for_current_and_previous_version_from(size_t minVersion, Application& app,
+                                           std::function<void(void)> const& f)
 {
     REQUIRE(Config::CURRENT_LEDGER_PROTOCOL_VERSION >= 1);
     uint32_t const currentVersion = Config::CURRENT_LEDGER_PROTOCOL_VERSION;

--- a/src/transactions/test/ParallelApplyTest.cpp
+++ b/src/transactions/test/ParallelApplyTest.cpp
@@ -109,8 +109,7 @@ groupLedgerEntryChanges(LedgerEntryChanges const& changes)
     return changesByKey;
 }
 
-void
-expectTTLBump(std::vector<LedgerEntryChange> const& changes)
+void expectTTLBump(std::vector<LedgerEntryChange> const& changes)
 {
     REQUIRE(changes.size() == 2);
     REQUIRE(changes[0].type() == LEDGER_ENTRY_STATE);
@@ -122,9 +121,9 @@ expectTTLBump(std::vector<LedgerEntryChange> const& changes)
 // We only expect `res1` to ever be from protocol 22.
 // `singleStage` indicates that both results come from a single stage runs
 // (with any number of clusters).
-void
-compareResults(bool res1IsP22, bool singleStage, ResultType const& res1,
-               ResultType const& res2, uint32_t hotArchiveEntryCreatedLedger)
+void compareResults(bool res1IsP22, bool singleStage, ResultType const& res1,
+                    ResultType const& res2,
+                    uint32_t hotArchiveEntryCreatedLedger)
 {
     // Fees are different between the protocols. Since we observe
     // TTLs at the stage boundaries, we can only expect exactly the
@@ -382,12 +381,12 @@ compareResults(bool res1IsP22, bool singleStage, ResultType const& res1,
 // the footprint. When `autoRestore` is true, the test will also automatically
 // restore any expired entries that are being accessed (otherwise we just let
 // the transactions fail).
-ResultType
-applyTestTransactions(TestConfig const& testConfig, uint32_t protocolVersion,
-                      int64_t seed, bool autoRestore, int stageCount,
-                      int applyClusterCount,
-                      std::vector<RustBuf> const& randomWasms,
-                      uint32_t& hotArchiveEntryCreatedLedger)
+ResultType applyTestTransactions(TestConfig const& testConfig,
+                                 uint32_t protocolVersion, int64_t seed,
+                                 bool autoRestore, int stageCount,
+                                 int applyClusterCount,
+                                 std::vector<RustBuf> const& randomWasms,
+                                 uint32_t& hotArchiveEntryCreatedLedger)
 {
     int const INVOKE_HOST_FN_TX_COUNT =
         (testConfig.contractDataKeyCount + testConfig.randomWasmCount +
@@ -1181,10 +1180,9 @@ applyTestTransactions(TestConfig const& testConfig, uint32_t protocolVersion,
     return std::make_tuple(allTxs, resultSet, lcm, finalEntries);
 }
 
-void
-runTest(int64_t seed, std::vector<std::pair<int, int>> const& scenarios,
-        bool autoRestore, std::vector<RustBuf> const& randomWasms,
-        TestConfig const& testConfig)
+void runTest(int64_t seed, std::vector<std::pair<int, int>> const& scenarios,
+             bool autoRestore, std::vector<RustBuf> const& randomWasms,
+             TestConfig const& testConfig)
 {
     CAPTURE(seed, autoRestore);
     // Note: we could also compare results across different protocol
@@ -1225,8 +1223,7 @@ runTest(int64_t seed, std::vector<std::pair<int, int>> const& scenarios,
     }
 }
 
-void
-runTestCase(TestConfig const& testConfig)
+void runTestCase(TestConfig const& testConfig)
 {
     std::vector<RustBuf> randomWasms;
     stellar::uniform_int_distribution<int64_t> seedDist;

--- a/src/transactions/test/PathPaymentStrictSendTests.cpp
+++ b/src/transactions/test/PathPaymentStrictSendTests.cpp
@@ -20,8 +20,7 @@ using namespace stellar::txtest;
 namespace
 {
 
-int64_t
-operator*(int64_t x, const Price& y)
+int64_t operator*(int64_t x, const Price& y)
 {
     bool xNegative = (x < 0);
     int64_t m =
@@ -29,8 +28,7 @@ operator*(int64_t x, const Price& y)
     return xNegative ? -m : m;
 }
 
-Price
-operator*(const Price& x, const Price& y)
+Price operator*(const Price& x, const Price& y)
 {
     int64_t n = int64_t(x.n) * int64_t(y.n);
     int64_t d = int64_t(x.d) * int64_t(y.d);
@@ -41,17 +39,14 @@ operator*(const Price& x, const Price& y)
     return Price{(int32_t)n, (int32_t)d};
 }
 
-template <typename T>
-void
-rotateRight(std::deque<T>& d)
+template <typename T> void rotateRight(std::deque<T>& d)
 {
     auto e = d.back();
     d.pop_back();
     d.push_front(e);
 }
 
-std::string
-assetPathToString(const std::deque<Asset>& assets)
+std::string assetPathToString(const std::deque<Asset>& assets)
 {
     auto r = assetToString(assets[0]);
     for (auto i = assets.rbegin(); i != assets.rend(); i++)
@@ -61,8 +56,7 @@ assetPathToString(const std::deque<Asset>& assets)
     return r;
 };
 
-static Asset const&
-getAssetBought(ClaimAtom const& atom)
+static Asset const& getAssetBought(ClaimAtom const& atom)
 {
     switch (atom.type())
     {
@@ -75,8 +69,7 @@ getAssetBought(ClaimAtom const& atom)
     }
 }
 
-static Asset const&
-getAssetSold(ClaimAtom const& atom)
+static Asset const& getAssetSold(ClaimAtom const& atom)
 {
     switch (atom.type())
     {
@@ -89,8 +82,7 @@ getAssetSold(ClaimAtom const& atom)
     }
 }
 
-static int64_t
-getAmountBought(ClaimAtom const& atom)
+static int64_t getAmountBought(ClaimAtom const& atom)
 {
     switch (atom.type())
     {
@@ -103,8 +95,7 @@ getAmountBought(ClaimAtom const& atom)
     }
 }
 
-static int64_t
-getAmountSold(ClaimAtom const& atom)
+static int64_t getAmountSold(ClaimAtom const& atom)
 {
     switch (atom.type())
     {
@@ -117,10 +108,9 @@ getAmountSold(ClaimAtom const& atom)
     }
 }
 
-void
-checkClaimedOffers(std::vector<ClaimAtom> const& actual,
-                   std::vector<ClaimAtom> const& expected, int64_t sendAmount,
-                   int64_t destMinAmount)
+void checkClaimedOffers(std::vector<ClaimAtom> const& actual,
+                        std::vector<ClaimAtom> const& expected,
+                        int64_t sendAmount, int64_t destMinAmount)
 {
     REQUIRE(actual == expected);
 

--- a/src/transactions/test/PathPaymentTests.cpp
+++ b/src/transactions/test/PathPaymentTests.cpp
@@ -26,8 +26,7 @@ using namespace stellar::txtest;
 namespace
 {
 
-int64_t
-operator*(int64_t x, const Price& y)
+int64_t operator*(int64_t x, const Price& y)
 {
     bool xNegative = (x < 0);
     int64_t m =
@@ -35,8 +34,7 @@ operator*(int64_t x, const Price& y)
     return xNegative ? -m : m;
 }
 
-Price
-operator*(const Price& x, const Price& y)
+Price operator*(const Price& x, const Price& y)
 {
     int64_t n = int64_t(x.n) * int64_t(y.n);
     int64_t d = int64_t(x.d) * int64_t(y.d);
@@ -47,17 +45,14 @@ operator*(const Price& x, const Price& y)
     return Price{(int32_t)n, (int32_t)d};
 }
 
-template <typename T>
-void
-rotateRight(std::deque<T>& d)
+template <typename T> void rotateRight(std::deque<T>& d)
 {
     auto e = d.back();
     d.pop_back();
     d.push_front(e);
 }
 
-std::string
-assetPathToString(const std::deque<Asset>& assets)
+std::string assetPathToString(const std::deque<Asset>& assets)
 {
     auto r = assetToString(assets[0]);
     for (auto i = assets.rbegin(); i != assets.rend(); i++)

--- a/src/transactions/test/RevokeSponsorshipTests.cpp
+++ b/src/transactions/test/RevokeSponsorshipTests.cpp
@@ -23,8 +23,7 @@ getRevokeSponsorshipResultCode(TransactionTestFramePtr tx, size_t i)
     return opRes.tr().revokeSponsorshipResult().code();
 }
 
-Claimant
-getClaimant(TestAccount const& account)
+Claimant getClaimant(TestAccount const& account)
 {
     ClaimPredicate pred;
     pred.type(CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME).absBefore() = INT64_MAX;

--- a/src/transactions/test/SetTrustLineFlagsTests.cpp
+++ b/src/transactions/test/SetTrustLineFlagsTests.cpp
@@ -49,9 +49,8 @@ getRevokeBalanceID(TestAccount& testAccount, SequenceNumber sn,
     return balanceID;
 }
 
-static void
-checkPoolUseCounts(TestAccount const& account, Asset const& asset,
-                   int32_t count)
+static void checkPoolUseCounts(TestAccount const& account, Asset const& asset,
+                               int32_t count)
 {
     if (asset.type() == ASSET_TYPE_NATIVE)
     {
@@ -62,16 +61,14 @@ checkPoolUseCounts(TestAccount const& account, Asset const& asset,
     REQUIRE(getTrustLineEntryExtensionV2(tl).liquidityPoolUseCount == count);
 }
 
-static int64_t
-getBalance(TestAccount const& account, Asset const& asset)
+static int64_t getBalance(TestAccount const& account, Asset const& asset)
 {
     return asset.type() == ASSET_TYPE_NATIVE
                ? account.getBalance()
                : account.getTrustlineBalance(asset);
 }
 
-static uint32_t
-getNumSponsoring(Application& app, TestAccount const& account)
+static uint32_t getNumSponsoring(Application& app, TestAccount const& account)
 {
     LedgerTxn ltx(app.getLedgerTxnRoot());
 
@@ -79,8 +76,7 @@ getNumSponsoring(Application& app, TestAccount const& account)
     return getNumSponsoring(ltxe.current());
 }
 
-static uint32_t
-getNumSponsored(Application& app, TestAccount const& account)
+static uint32_t getNumSponsored(Application& app, TestAccount const& account)
 {
     LedgerTxn ltx(app.getLedgerTxnRoot());
 
@@ -88,15 +84,14 @@ getNumSponsored(Application& app, TestAccount const& account)
     return getNumSponsored(ltxe.current());
 }
 
-static void
-checkNumSponsoring(Application& app, TestAccount const& account,
-                   uint32_t numSponsoring)
+static void checkNumSponsoring(Application& app, TestAccount const& account,
+                               uint32_t numSponsoring)
 {
     REQUIRE(getNumSponsoring(app, account) == numSponsoring);
 }
 
-static uint32_t
-getNumOffers(Application& app, TestAccount const& account, Asset const& asset)
+static uint32_t getNumOffers(Application& app, TestAccount const& account,
+                             Asset const& asset)
 {
     LedgerTxn ltx(app.getLedgerTxnRoot());
     auto s = ltx.getOffersByAccountAndAsset(account, asset).size();

--- a/src/transactions/test/SorobanTxTestUtils.cpp
+++ b/src/transactions/test/SorobanTxTestUtils.cpp
@@ -21,9 +21,8 @@ namespace txtest
 {
 namespace
 {
-SCVal
-signPayloadForClassicAccount(std::vector<TestAccount*> const& signers,
-                             uint256 payload)
+SCVal signPayloadForClassicAccount(std::vector<TestAccount*> const& signers,
+                                   uint256 payload)
 {
     SCVal signatureStruct(SCV_VEC);
     auto& signatures = signatureStruct.vec().activate();
@@ -47,16 +46,14 @@ signPayloadForClassicAccount(std::vector<TestAccount*> const& signers,
 }
 } // namespace
 
-SCAddress
-makeContractAddress(Hash const& hash)
+SCAddress makeContractAddress(Hash const& hash)
 {
     SCAddress addr(SC_ADDRESS_TYPE_CONTRACT);
     addr.contractId() = hash;
     return addr;
 }
 
-SCAddress
-makeMuxedAccountAddress(AccountID const& accountID, uint64_t id)
+SCAddress makeMuxedAccountAddress(AccountID const& accountID, uint64_t id)
 {
     SCAddress addr(SC_ADDRESS_TYPE_MUXED_ACCOUNT);
     addr.muxedAccount().ed25519 = accountID.ed25519();
@@ -64,16 +61,14 @@ makeMuxedAccountAddress(AccountID const& accountID, uint64_t id)
     return addr;
 }
 
-SCVal
-makeI32(int32_t i32)
+SCVal makeI32(int32_t i32)
 {
     SCVal val(SCV_I32);
     val.i32() = i32;
     return val;
 }
 
-SCVal
-makeI128(uint64_t u64)
+SCVal makeI128(uint64_t u64)
 {
     Int128Parts p;
     p.hi = 0;
@@ -84,49 +79,43 @@ makeI128(uint64_t u64)
     return val;
 }
 
-SCSymbol
-makeSymbol(std::string const& str)
+SCSymbol makeSymbol(std::string const& str)
 {
     SCSymbol val;
     val.assign(str.begin(), str.end());
     return val;
 }
 
-SCVal
-makeU64(uint64_t u64)
+SCVal makeU64(uint64_t u64)
 {
     SCVal val(SCV_U64);
     val.u64() = u64;
     return val;
 }
 
-SCVal
-makeU32(uint32_t u32)
+SCVal makeU32(uint32_t u32)
 {
     SCVal val(SCV_U32);
     val.u32() = u32;
     return val;
 }
 
-SCVal
-makeVecSCVal(std::vector<SCVal> elems)
+SCVal makeVecSCVal(std::vector<SCVal> elems)
 {
     SCVal val(SCV_VEC);
     val.vec().activate().assign(elems.begin(), elems.end());
     return val;
 }
 
-SCVal
-makeBool(bool b)
+SCVal makeBool(bool b)
 {
     SCVal val(SCV_BOOL);
     val.b() = b;
     return val;
 }
 
-int64_t
-getContractBalance(Application& app, SCAddress const& contractID,
-                   SCVal const& accountVal)
+int64_t getContractBalance(Application& app, SCAddress const& contractID,
+                           SCVal const& accountVal)
 {
     LedgerKey balanceKey(CONTRACT_DATA);
     balanceKey.contractData().contract = contractID;
@@ -150,8 +139,7 @@ getContractBalance(Application& app, SCAddress const& contractID,
     return balance.lo;
 }
 
-ContractIDPreimage
-makeContractIDPreimage(TestAccount& source, uint256 salt)
+ContractIDPreimage makeContractIDPreimage(TestAccount& source, uint256 salt)
 {
     ContractIDPreimage idPreimage(CONTRACT_ID_PREIMAGE_FROM_ADDRESS);
     idPreimage.fromAddress().address.type(SC_ADDRESS_TYPE_ACCOUNT);
@@ -161,8 +149,7 @@ makeContractIDPreimage(TestAccount& source, uint256 salt)
     return idPreimage;
 }
 
-ContractIDPreimage
-makeContractIDPreimage(Asset const& asset)
+ContractIDPreimage makeContractIDPreimage(Asset const& asset)
 {
     ContractIDPreimage idPreimage(CONTRACT_ID_PREIMAGE_FROM_ASSET);
     idPreimage.fromAsset() = asset;
@@ -180,23 +167,20 @@ makeFullContractIdPreimage(Hash const& networkID,
     return fullPreImage;
 }
 
-ContractExecutable
-makeWasmExecutable(Hash const& wasmHash)
+ContractExecutable makeWasmExecutable(Hash const& wasmHash)
 {
     ContractExecutable executable(CONTRACT_EXECUTABLE_WASM);
     executable.wasm_hash() = wasmHash;
     return executable;
 }
 
-ContractExecutable
-makeAssetExecutable(Asset const& asset)
+ContractExecutable makeAssetExecutable(Asset const& asset)
 {
     ContractExecutable executable(CONTRACT_EXECUTABLE_STELLAR_ASSET);
     return executable;
 }
 
-LedgerKey
-makeContractInstanceKey(SCAddress const& contractAddress)
+LedgerKey makeContractInstanceKey(SCAddress const& contractAddress)
 {
     SCVal instanceContractDataKey(SCValType::SCV_LEDGER_KEY_CONTRACT_INSTANCE);
     return contractDataKey(contractAddress, instanceContractDataKey,
@@ -227,8 +211,7 @@ makeSorobanWasmUploadTx(Application& app, TestAccount& source,
                                           inclusionFee, uploadResourceFee);
 }
 
-bool
-isExpiredStatus(ExpirationStatus status)
+bool isExpiredStatus(ExpirationStatus status)
 {
     return status == ExpirationStatus::EXPIRED_IN_LIVE_STATE ||
            status == ExpirationStatus::HOT_ARCHIVE;
@@ -260,9 +243,9 @@ defaultUploadWasmResourcesWithoutFootprint(RustBuf const& wasm,
     return resources;
 }
 
-ContractEvent
-makeContractEvent(Hash const& contractId, std::vector<SCVal> const& topics,
-                  SCVal const& data)
+ContractEvent makeContractEvent(Hash const& contractId,
+                                std::vector<SCVal> const& topics,
+                                SCVal const& data)
 {
     ContractEvent event;
     event.type = ContractEventType::CONTRACT;
@@ -272,17 +255,16 @@ makeContractEvent(Hash const& contractId, std::vector<SCVal> const& topics,
     return event;
 }
 
-ContractEvent
-makeTransferEvent(SCAddress const& from, SCAddress const& to, int64_t amount,
-                  std::optional<int64_t> toMuxId)
+ContractEvent makeTransferEvent(SCAddress const& from, SCAddress const& to,
+                                int64_t amount, std::optional<int64_t> toMuxId)
 {
     return ContractEvent();
 }
 
-ContractEvent
-makeTransferEvent(const stellar::Hash& contractId, Asset const& asset,
-                  SCAddress const& from, SCAddress const& to, int64_t amount,
-                  std::optional<SCMapEntry> toMemoEntry)
+ContractEvent makeTransferEvent(const stellar::Hash& contractId,
+                                Asset const& asset, SCAddress const& from,
+                                SCAddress const& to, int64_t amount,
+                                std::optional<SCMapEntry> toMemoEntry)
 {
     std::string name;
     switch (asset.type())
@@ -323,10 +305,10 @@ makeTransferEvent(const stellar::Hash& contractId, Asset const& asset,
     return makeContractEvent(contractId, topics, data);
 }
 
-ContractEvent
-makeMintOrBurnEvent(bool isMint, const stellar::Hash& contractId,
-                    Asset const& asset, SCAddress const& addr, int64 amount,
-                    std::optional<SCMapEntry> memoEntry)
+ContractEvent makeMintOrBurnEvent(bool isMint, const stellar::Hash& contractId,
+                                  Asset const& asset, SCAddress const& addr,
+                                  int64 amount,
+                                  std::optional<SCMapEntry> memoEntry)
 {
     ContractEvent ev;
     ev.type = ContractEventType::CONTRACT;
@@ -356,9 +338,9 @@ makeMintOrBurnEvent(bool isMint, const stellar::Hash& contractId,
     return ev;
 }
 
-void
-validateFeeEvent(TransactionEvent const& feeEvent, PublicKey const& feeSource,
-                 int64_t feeCharged, uint32_t protocolVersion, bool isRefund)
+void validateFeeEvent(TransactionEvent const& feeEvent,
+                      PublicKey const& feeSource, int64_t feeCharged,
+                      uint32_t protocolVersion, bool isRefund)
 {
     auto const& feeEventTopics = feeEvent.event.body.v0().topics;
     REQUIRE(feeEventTopics.size() == 2);
@@ -397,19 +379,15 @@ validateFeeEvent(TransactionEvent const& feeEvent, PublicKey const& feeSource,
     }
 }
 
-SorobanResources
-defaultCreateWasmContractResources(RustBuf const& wasm)
+SorobanResources defaultCreateWasmContractResources(RustBuf const& wasm)
 {
     return SorobanResources();
 }
 
-TransactionFrameBaseConstPtr
-makeSorobanCreateContractTx(Application& app, TestAccount& source,
-                            ContractIDPreimage const& idPreimage,
-                            ContractExecutable const& executable,
-                            SorobanResources& createResources,
-                            uint32_t inclusionFee,
-                            ConstructorParams const& constructorParams)
+TransactionFrameBaseConstPtr makeSorobanCreateContractTx(
+    Application& app, TestAccount& source, ContractIDPreimage const& idPreimage,
+    ContractExecutable const& executable, SorobanResources& createResources,
+    uint32_t inclusionFee, ConstructorParams const& constructorParams)
 {
     // Default to V1 function when constructor has no arguments. This is just
     // to have some coverage after the protocol bump - constructor tests should
@@ -527,24 +505,20 @@ makeSorobanCreateContractTx(Application& app, TestAccount& source,
                                           inclusionFee, createResourceFee);
 }
 
-TransactionFrameBaseConstPtr
-makeSorobanCreateContractTx(Application& app, TestAccount& source,
-                            ContractIDPreimage const& idPreimage,
-                            ContractExecutable const& executable,
-                            SorobanResources& createResources,
-                            uint32_t inclusionFee)
+TransactionFrameBaseConstPtr makeSorobanCreateContractTx(
+    Application& app, TestAccount& source, ContractIDPreimage const& idPreimage,
+    ContractExecutable const& executable, SorobanResources& createResources,
+    uint32_t inclusionFee)
 {
     return makeSorobanCreateContractTx(app, source, idPreimage, executable,
                                        createResources, inclusionFee, {});
 }
 
-TransactionTestFramePtr
-sorobanTransactionFrameFromOps(Hash const& networkID, TestAccount& source,
-                               std::vector<Operation> const& ops,
-                               std::vector<SecretKey> const& opKeys,
-                               SorobanInvocationSpec const& spec,
-                               std::optional<std::string> memo,
-                               std::optional<SequenceNumber> seq)
+TransactionTestFramePtr sorobanTransactionFrameFromOps(
+    Hash const& networkID, TestAccount& source,
+    std::vector<Operation> const& ops, std::vector<SecretKey> const& opKeys,
+    SorobanInvocationSpec const& spec, std::optional<std::string> memo,
+    std::optional<SequenceNumber> seq)
 {
     return sorobanTransactionFrameFromOps(
         networkID, source, ops, opKeys, spec.getResources(),
@@ -563,26 +537,22 @@ SorobanInvocationSpec::SorobanInvocationSpec(SorobanResources const& resources,
 {
 }
 
-SorobanResources const&
-SorobanInvocationSpec::getResources() const
+SorobanResources const& SorobanInvocationSpec::getResources() const
 {
     return mResources;
 }
 
-uint32_t
-SorobanInvocationSpec::getFee() const
+uint32_t SorobanInvocationSpec::getFee() const
 {
     return mInclusionFee + getResourceFee();
 }
 
-uint32_t
-SorobanInvocationSpec::getResourceFee() const
+uint32_t SorobanInvocationSpec::getResourceFee() const
 {
     return mNonRefundableResourceFee + mRefundableResourceFee;
 }
 
-uint32_t
-SorobanInvocationSpec::getInclusionFee() const
+uint32_t SorobanInvocationSpec::getInclusionFee() const
 {
     return mInclusionFee;
 }
@@ -601,8 +571,7 @@ SorobanInvocationSpec::setInstructions(int64_t instructions) const
     return newSpec;
 }
 
-SorobanInvocationSpec
-SorobanInvocationSpec::setReadOnlyFootprint(
+SorobanInvocationSpec SorobanInvocationSpec::setReadOnlyFootprint(
     xdr::xvector<LedgerKey> const& keys) const
 {
     auto newSpec = *this;
@@ -610,8 +579,7 @@ SorobanInvocationSpec::setReadOnlyFootprint(
     return newSpec;
 }
 
-SorobanInvocationSpec
-SorobanInvocationSpec::setReadWriteFootprint(
+SorobanInvocationSpec SorobanInvocationSpec::setReadWriteFootprint(
     xdr::xvector<LedgerKey> const& keys) const
 {
     auto newSpec = *this;
@@ -619,8 +587,7 @@ SorobanInvocationSpec::setReadWriteFootprint(
     return newSpec;
 }
 
-SorobanInvocationSpec
-SorobanInvocationSpec::extendReadOnlyFootprint(
+SorobanInvocationSpec SorobanInvocationSpec::extendReadOnlyFootprint(
     xdr::xvector<LedgerKey> const& keys) const
 {
     auto newSpec = *this;
@@ -629,8 +596,7 @@ SorobanInvocationSpec::extendReadOnlyFootprint(
     return newSpec;
 }
 
-SorobanInvocationSpec
-SorobanInvocationSpec::extendReadWriteFootprint(
+SorobanInvocationSpec SorobanInvocationSpec::extendReadWriteFootprint(
     xdr::xvector<LedgerKey> const& keys) const
 {
     auto newSpec = *this;
@@ -671,16 +637,14 @@ SorobanInvocationSpec::setNonRefundableResourceFee(uint32_t fee) const
     return newSpec;
 }
 
-SorobanInvocationSpec
-SorobanInvocationSpec::setInclusionFee(uint32_t fee) const
+SorobanInvocationSpec SorobanInvocationSpec::setInclusionFee(uint32_t fee) const
 {
     auto newSpec = *this;
     newSpec.mInclusionFee = fee;
     return newSpec;
 }
 
-SorobanInvocationSpec
-SorobanInvocationSpec::setArchivedIndexes(
+SorobanInvocationSpec SorobanInvocationSpec::setArchivedIndexes(
     std::vector<uint32_t> const& indexes) const
 {
     auto newSpec = *this;
@@ -694,41 +658,35 @@ TestContract::TestContract(SorobanTest& test, SCAddress const& address,
 {
 }
 
-xdr::xvector<LedgerKey> const&
-TestContract::getKeys() const
+xdr::xvector<LedgerKey> const& TestContract::getKeys() const
 {
     return mContractKeys;
 }
 
-SCAddress const&
-TestContract::getAddress() const
+SCAddress const& TestContract::getAddress() const
 {
     return mAddress;
 }
 
-SorobanTest&
-TestContract::getTest() const
+SorobanTest& TestContract::getTest() const
 {
     return mTest;
 }
 
-LedgerKey
-TestContract::getDataKey(SCVal const& key, ContractDataDurability durability)
+LedgerKey TestContract::getDataKey(SCVal const& key,
+                                   ContractDataDurability durability)
 {
     return stellar::contractDataKey(mAddress, key, durability);
 }
 
-TestContract::Invocation
-TestContract::prepareInvocation(std::string const& functionName,
-                                std::vector<SCVal> const& args,
-                                SorobanInvocationSpec const& spec,
-                                bool addContractKeys) const
+TestContract::Invocation TestContract::prepareInvocation(
+    std::string const& functionName, std::vector<SCVal> const& args,
+    SorobanInvocationSpec const& spec, bool addContractKeys) const
 {
     return Invocation(*this, functionName, args, spec, addContractKeys);
 }
 
-void
-TestContract::Invocation::deduplicateFootprint()
+void TestContract::Invocation::deduplicateFootprint()
 {
     xdr::xvector<LedgerKey> readOnly;
     xdr::xvector<LedgerKey> readWrite;
@@ -769,8 +727,7 @@ TestContract::Invocation::Invocation(TestContract const& contract,
     }
 }
 
-TestContract::Invocation&
-TestContract::Invocation::withAuthorizedTopCall()
+TestContract::Invocation& TestContract::Invocation::withAuthorizedTopCall()
 {
     SorobanAuthorizedInvocation ai;
     ai.function.type(SOROBAN_AUTHORIZED_FUNCTION_TYPE_CONTRACT_FN);
@@ -789,8 +746,7 @@ TestContract::Invocation::withAuthorizedTopCall(SorobanSigner const& signer)
     return withAuthorization(ai, signer);
 }
 
-TestContract::Invocation&
-TestContract::Invocation::withAuthorization(
+TestContract::Invocation& TestContract::Invocation::withAuthorization(
     SorobanAuthorizedInvocation const& invocation,
     SorobanCredentials credentials)
 {
@@ -807,8 +763,7 @@ TestContract::Invocation::withAuthorization(
     return *this;
 }
 
-TestContract::Invocation&
-TestContract::Invocation::withAuthorization(
+TestContract::Invocation& TestContract::Invocation::withAuthorization(
     SorobanAuthorizedInvocation const& invocation, SorobanSigner const& signer)
 {
     mSpec = mSpec.extendReadOnlyFootprint(signer.getLedgerKeys());
@@ -823,8 +778,7 @@ TestContract::Invocation::withSourceAccountAuthorization(
     return withAuthorization(invocation, credentials);
 }
 
-TestContract::Invocation&
-TestContract::Invocation::withDeduplicatedFootprint()
+TestContract::Invocation& TestContract::Invocation::withDeduplicatedFootprint()
 {
     mDeduplicateFootprint = true;
     return *this;
@@ -837,8 +791,7 @@ TestContract::Invocation::withSpec(SorobanInvocationSpec const& spec)
     return *this;
 }
 
-SorobanInvocationSpec
-TestContract::Invocation::getSpec()
+SorobanInvocationSpec TestContract::Invocation::getSpec()
 {
     return mSpec;
 }
@@ -883,8 +836,7 @@ TestContract::Invocation::withExactNonRefundableResourceFee()
     return *this;
 }
 
-bool
-TestContract::Invocation::invoke(TestAccount* source)
+bool TestContract::Invocation::invoke(TestAccount* source)
 {
     auto tx = createTx(source);
     CLOG_INFO(Tx, "invoke tx {}", xdr::xdr_to_string(tx->getEnvelope()));
@@ -904,15 +856,13 @@ TestContract::Invocation::invoke(TestAccount* source)
     return isSuccessResult(result);
 }
 
-SCVal
-TestContract::Invocation::getReturnValue() const
+SCVal TestContract::Invocation::getReturnValue() const
 {
     REQUIRE(mTxMeta);
     return mTxMeta->getReturnValue();
 }
 
-TransactionMetaFrame const&
-TestContract::Invocation::getTxMeta() const
+TransactionMetaFrame const& TestContract::Invocation::getTxMeta() const
 {
     REQUIRE(mTxMeta);
     return *mTxMeta;
@@ -924,15 +874,13 @@ TestContract::Invocation::getResultCode() const
     return mResultCode;
 }
 
-int64_t
-TestContract::Invocation::getFeeCharged() const
+int64_t TestContract::Invocation::getFeeCharged() const
 {
     return mFeeCharged;
 }
 
-void
-SorobanTest::initialize(bool useTestLimits,
-                        std::function<void(SorobanNetworkConfig&)> cfgModifyFn)
+void SorobanTest::initialize(
+    bool useTestLimits, std::function<void(SorobanNetworkConfig&)> cfgModifyFn)
 {
     if (useTestLimits)
     {
@@ -965,27 +913,24 @@ SorobanTest::SorobanTest(Application::pointer app, Config cfg,
     initialize(useTestLimits, cfgModifyFn);
 }
 
-int64_t
-SorobanTest::computeFeePerIncrement(int64_t resourceVal, int64_t feeRate,
-                                    int64_t increment)
+int64_t SorobanTest::computeFeePerIncrement(int64_t resourceVal,
+                                            int64_t feeRate, int64_t increment)
 {
     // ceiling division for (resourceVal * feeRate) / increment
     int64_t num = (resourceVal * feeRate);
     return (num + increment - 1) / increment;
 };
 
-int64_t
-SorobanTest::getAccountBalance(TestAccount* source)
+int64_t SorobanTest::getAccountBalance(TestAccount* source)
 {
     auto& account = source ? *source : getRoot();
     return account.getBalance();
 }
 
-void
-SorobanTest::checkRefundableFee(int64_t initialBalance,
-                                TransactionFrameBaseConstPtr tx,
-                                int64_t expectedRentFeeCharged,
-                                size_t eventsSize, bool success)
+void SorobanTest::checkRefundableFee(int64_t initialBalance,
+                                     TransactionFrameBaseConstPtr tx,
+                                     int64_t expectedRentFeeCharged,
+                                     size_t eventsSize, bool success)
 {
     if (!success)
     {
@@ -1086,9 +1031,8 @@ SorobanTest::checkRefundableFee(int64_t initialBalance,
     }
 }
 
-void
-SorobanTest::invokeArchivalOp(TransactionFrameBaseConstPtr tx,
-                              int64_t expectedRefundableFeeCharged)
+void SorobanTest::invokeArchivalOp(TransactionFrameBaseConstPtr tx,
+                                   int64_t expectedRefundableFeeCharged)
 {
     MutableTxResultPtr result;
     {
@@ -1111,9 +1055,9 @@ SorobanTest::invokeArchivalOp(TransactionFrameBaseConstPtr tx,
     checkRefundableFee(initBalance, tx, expectedRefundableFeeCharged);
 }
 
-Hash
-SorobanTest::uploadWasm(RustBuf const& wasm, SorobanResources& uploadResources,
-                        int64_t additionalRefundableFee)
+Hash SorobanTest::uploadWasm(RustBuf const& wasm,
+                             SorobanResources& uploadResources,
+                             int64_t additionalRefundableFee)
 {
     SCBytes expectedWasm(wasm.data.begin(), wasm.data.end());
     Hash expectedWasmHash = sha256(expectedWasm);
@@ -1194,9 +1138,8 @@ SorobanTest::createContract(ContractIDPreimage const& idPreimage,
     return contractAddress;
 }
 
-int64_t
-SorobanTest::getRentFeeForExtension(xdr::xvector<LedgerKey> const& keys,
-                                    uint32_t newLifetime)
+int64_t SorobanTest::getRentFeeForExtension(xdr::xvector<LedgerKey> const& keys,
+                                            uint32_t newLifetime)
 
 {
     rust::Vec<CxxLedgerEntryRentChange> rustEntryRentChanges;
@@ -1223,8 +1166,7 @@ SorobanTest::getRentFeeForExtension(xdr::xvector<LedgerKey> const& keys,
         getLCLSeq());
 }
 
-Application&
-SorobanTest::getApp() const
+Application& SorobanTest::getApp() const
 {
     return *mApp;
 }
@@ -1272,8 +1214,7 @@ SorobanTest::deployWasmContract(RustBuf const& wasm,
     return *mContracts.back();
 }
 
-SCAddress
-SorobanTest::nextContractID()
+SCAddress SorobanTest::nextContractID()
 {
     auto idPreimage = makeContractIDPreimage(
         *mRoot, sha256(std::to_string(mContracts.size())));
@@ -1282,8 +1223,7 @@ SorobanTest::nextContractID()
     return makeContractAddress(contractID);
 }
 
-TestContract&
-SorobanTest::deployAssetContract(Asset const& asset)
+TestContract& SorobanTest::deployAssetContract(Asset const& asset)
 {
     SorobanResources createResources;
     createResources.instructions = 400'000;
@@ -1300,8 +1240,7 @@ SorobanTest::deployAssetContract(Asset const& asset)
     return *mContracts.back();
 }
 
-TestAccount&
-SorobanTest::getRoot()
+TestAccount& SorobanTest::getRoot()
 {
     // TestAccount caches the next seqno in-memory, assuming all invoked TXs
     // succeed. This is not true for these tests, so we load the seqno from
@@ -1310,20 +1249,17 @@ SorobanTest::getRoot()
     return *mRoot;
 }
 
-TestAccount&
-SorobanTest::getDummyAccount()
+TestAccount& SorobanTest::getDummyAccount()
 {
     return mDummyAccount;
 }
 
-SorobanNetworkConfig const&
-SorobanTest::getNetworkCfg()
+SorobanNetworkConfig const& SorobanTest::getNetworkCfg()
 {
     return getApp().getLedgerManager().getLastClosedSorobanNetworkConfig();
 }
 
-uint32_t
-SorobanTest::getLedgerVersion() const
+uint32_t SorobanTest::getLedgerVersion() const
 {
     return getApp()
         .getLedgerManager()
@@ -1331,8 +1267,7 @@ SorobanTest::getLedgerVersion() const
         .header.ledgerVersion;
 }
 
-uint32_t
-SorobanTest::getLCLSeq() const
+uint32_t SorobanTest::getLCLSeq() const
 {
     return getApp().getLedgerManager().getLastClosedLedgerNum();
 }
@@ -1364,8 +1299,7 @@ SorobanTest::createRestoreTx(SorobanResources const& resources,
                                           resourceFee);
 }
 
-bool
-SorobanTest::isTxValid(TransactionFrameBaseConstPtr tx)
+bool SorobanTest::isTxValid(TransactionFrameBaseConstPtr tx)
 {
     LedgerSnapshot ls(getApp());
     auto diagnostics = DiagnosticEventManager::createDisabled();
@@ -1374,8 +1308,7 @@ SorobanTest::isTxValid(TransactionFrameBaseConstPtr tx)
     return ret->isSuccess();
 }
 
-TransactionResult
-SorobanTest::invokeTx(TransactionFrameBaseConstPtr tx)
+TransactionResult SorobanTest::invokeTx(TransactionFrameBaseConstPtr tx)
 {
     {
         auto diagnostics = DiagnosticEventManager::createDisabled();
@@ -1391,14 +1324,12 @@ SorobanTest::invokeTx(TransactionFrameBaseConstPtr tx)
     return resultSet.results[0].result;
 }
 
-TransactionMetaFrame const&
-SorobanTest::getLastTxMeta(size_t index) const
+TransactionMetaFrame const& SorobanTest::getLastTxMeta(size_t index) const
 {
     return getApp().getLedgerManager().getLastClosedLedgerTxMeta().at(index);
 }
 
-LedgerCloseMetaFrame
-SorobanTest::getLastLcm() const
+LedgerCloseMetaFrame SorobanTest::getLastLcm() const
 {
     auto const& lcm =
         getApp().getLedgerManager().getLastClosedLedgerCloseMeta();
@@ -1406,8 +1337,7 @@ SorobanTest::getLastLcm() const
     return *lcm;
 }
 
-uint32_t
-SorobanTest::getTTL(LedgerKey const& k)
+uint32_t SorobanTest::getTTL(LedgerKey const& k)
 {
     LedgerTxn ltx(getApp().getLedgerTxnRoot());
     auto ltxe = ltx.loadWithoutRecord(k);
@@ -1419,8 +1349,7 @@ SorobanTest::getTTL(LedgerKey const& k)
     return ttlLtxe.current().data.ttl().liveUntilLedgerSeq;
 }
 
-bool
-SorobanTest::isEntryLive(LedgerKey const& k, uint32_t ledgerSeq)
+bool SorobanTest::isEntryLive(LedgerKey const& k, uint32_t ledgerSeq)
 {
     auto ttlKey = getTTLKey(k);
     LedgerTxn ltx(getApp().getLedgerTxnRoot());
@@ -1429,8 +1358,7 @@ SorobanTest::isEntryLive(LedgerKey const& k, uint32_t ledgerSeq)
     return isLive(ttlLtxe.current(), ledgerSeq);
 }
 
-ExpirationStatus
-SorobanTest::getEntryExpirationStatus(LedgerKey const& key)
+ExpirationStatus SorobanTest::getEntryExpirationStatus(LedgerKey const& key)
 {
     auto ttlKey = getTTLKey(key);
     LedgerSnapshot ls(getApp());
@@ -1454,9 +1382,8 @@ SorobanTest::getEntryExpirationStatus(LedgerKey const& key)
     return ExpirationStatus::NOT_FOUND;
 }
 
-void
-SorobanTest::invokeRestoreOp(xdr::xvector<LedgerKey> const& readWrite,
-                             int64_t expectedRefundableFeeCharged)
+void SorobanTest::invokeRestoreOp(xdr::xvector<LedgerKey> const& readWrite,
+                                  int64_t expectedRefundableFeeCharged)
 {
     SorobanResources resources;
     resources.footprint.readWrite = readWrite;
@@ -1469,10 +1396,9 @@ SorobanTest::invokeRestoreOp(xdr::xvector<LedgerKey> const& readWrite,
     invokeArchivalOp(tx, expectedRefundableFeeCharged);
 }
 
-void
-SorobanTest::invokeExtendOp(xdr::xvector<LedgerKey> const& readOnly,
-                            uint32_t extendTo,
-                            std::optional<int64_t> expectedRefundableFeeCharged)
+void SorobanTest::invokeExtendOp(
+    xdr::xvector<LedgerKey> const& readOnly, uint32_t extendTo,
+    std::optional<int64_t> expectedRefundableFeeCharged)
 {
     if (!expectedRefundableFeeCharged)
     {
@@ -1534,8 +1460,7 @@ AssetContractTestClient::AssetContractTestClient(SorobanTest& test,
 {
 }
 
-LedgerKey
-AssetContractTestClient::makeBalanceKey(AccountID const& acc)
+LedgerKey AssetContractTestClient::makeBalanceKey(AccountID const& acc)
 {
     LedgerKey balanceKey;
     if (mAsset.type() == ASSET_TYPE_NATIVE)
@@ -1569,8 +1494,7 @@ AssetContractTestClient::makeContractDataBalanceKey(SCAddress const& addr)
     return balanceKey;
 }
 
-void
-AssetContractTestClient::setLastEvent(
+void AssetContractTestClient::setLastEvent(
     TestContract::Invocation const& invocation, bool success)
 {
     if (!success)
@@ -1584,8 +1508,7 @@ AssetContractTestClient::setLastEvent(
     mLastEvent = sorobanEvents[0];
 }
 
-LedgerKey
-AssetContractTestClient::makeBalanceKey(SCAddress const& addr)
+LedgerKey AssetContractTestClient::makeBalanceKey(SCAddress const& addr)
 {
     if (addr.type() == SC_ADDRESS_TYPE_ACCOUNT)
     {
@@ -1597,16 +1520,14 @@ AssetContractTestClient::makeBalanceKey(SCAddress const& addr)
     }
 }
 
-LedgerKey
-AssetContractTestClient::makeIssuerKey(Asset const& asset)
+LedgerKey AssetContractTestClient::makeIssuerKey(Asset const& asset)
 {
     LedgerKey issuerLedgerKey(ACCOUNT);
     issuerLedgerKey.account().accountID = getIssuer(asset);
     return issuerLedgerKey;
 }
 
-int64_t
-AssetContractTestClient::getBalance(SCAddress const& addr)
+int64_t AssetContractTestClient::getBalance(SCAddress const& addr)
 {
     SCVal val(SCV_ADDRESS);
     val.address() = addr;
@@ -1616,8 +1537,7 @@ AssetContractTestClient::getBalance(SCAddress const& addr)
                : getContractBalance(mApp, mContract.getAddress(), val);
 }
 
-SorobanInvocationSpec
-AssetContractTestClient::defaultSpec() const
+SorobanInvocationSpec AssetContractTestClient::defaultSpec() const
 {
     return SorobanInvocationSpec()
         .setInstructions(2'000'000)
@@ -1625,14 +1545,12 @@ AssetContractTestClient::defaultSpec() const
         .setWriteBytes(2000);
 }
 
-TestContract const&
-AssetContractTestClient::getContract() const
+TestContract const& AssetContractTestClient::getContract() const
 {
     return mContract;
 }
 
-std::optional<ContractEvent>
-AssetContractTestClient::lastEvent() const
+std::optional<ContractEvent> AssetContractTestClient::lastEvent() const
 {
     return mLastEvent;
 }
@@ -1699,11 +1617,9 @@ AssetContractTestClient::getTransferTx(TestAccount& fromAcc,
     return tx;
 }
 
-TestContract::Invocation
-AssetContractTestClient::transferInvocation(TestAccount& fromAcc,
-                                            SCAddress const& maybeMuxedToAddr,
-                                            int64_t amount, bool& fromIsIssuer,
-                                            bool& toIsIssuer, SCAddress& toAddr)
+TestContract::Invocation AssetContractTestClient::transferInvocation(
+    TestAccount& fromAcc, SCAddress const& maybeMuxedToAddr, int64_t amount,
+    bool& fromIsIssuer, bool& toIsIssuer, SCAddress& toAddr)
 {
     SCVal fromVal(SCV_ADDRESS);
     fromVal.address() = makeAccountAddress(fromAcc.getPublicKey());
@@ -1769,10 +1685,9 @@ AssetContractTestClient::transferInvocation(TestAccount& fromAcc,
     return invocation;
 }
 
-bool
-AssetContractTestClient::transfer(TestAccount& fromAcc,
-                                  SCAddress const& maybeMuxedToAddr,
-                                  int64_t amount)
+bool AssetContractTestClient::transfer(TestAccount& fromAcc,
+                                       SCAddress const& maybeMuxedToAddr,
+                                       int64_t amount)
 {
     bool fromIsIssuer;
     bool toIsIssuer;
@@ -1794,7 +1709,6 @@ AssetContractTestClient::transfer(TestAccount& fromAcc,
     auto postTransferToBalance = getBalance(toAddr);
     if (success)
     {
-
         if (!fromIsIssuer)
         {
             int64_t expectedBalance = preTransferFromBalance - amount;
@@ -1857,9 +1771,8 @@ AssetContractTestClient::transfer(TestAccount& fromAcc,
     return success;
 }
 
-bool
-AssetContractTestClient::mint(TestAccount& admin, SCAddress const& toAddr,
-                              int64_t amount)
+bool AssetContractTestClient::mint(TestAccount& admin, SCAddress const& toAddr,
+                                   int64_t amount)
 {
     SCVal toVal(SCV_ADDRESS);
     toVal.address() = toAddr;
@@ -1893,8 +1806,7 @@ AssetContractTestClient::mint(TestAccount& admin, SCAddress const& toAddr,
     return success;
 }
 
-bool
-AssetContractTestClient::burn(TestAccount& from, int64_t amount)
+bool AssetContractTestClient::burn(TestAccount& from, int64_t amount)
 {
     auto fromAddr = makeAccountAddress(from.getPublicKey());
 
@@ -1940,9 +1852,9 @@ AssetContractTestClient::burn(TestAccount& from, int64_t amount)
     return success;
 }
 
-bool
-AssetContractTestClient::clawback(TestAccount& admin, SCAddress const& fromAddr,
-                                  int64_t amount)
+bool AssetContractTestClient::clawback(TestAccount& admin,
+                                       SCAddress const& fromAddr,
+                                       int64_t amount)
 {
     SCVal fromVal(SCV_ADDRESS);
     fromVal.address() = fromAddr;
@@ -1982,14 +1894,12 @@ ContractStorageTestClient::ContractStorageTestClient(
 {
 }
 
-TestContract&
-ContractStorageTestClient::getContract() const
+TestContract& ContractStorageTestClient::getContract() const
 {
     return mContract;
 }
 
-SorobanInvocationSpec
-ContractStorageTestClient::defaultSpecWithoutFootprint()
+SorobanInvocationSpec ContractStorageTestClient::defaultSpecWithoutFootprint()
 {
     return SorobanInvocationSpec()
         .setInstructions(4'000'000)
@@ -2016,33 +1926,29 @@ ContractStorageTestClient::writeKeySpec(std::string const& key,
         .setWriteBytes(1000);
 }
 
-uint32_t
-ContractStorageTestClient::getTTL(std::string const& key,
-                                  ContractDataDurability durability)
+uint32_t ContractStorageTestClient::getTTL(std::string const& key,
+                                           ContractDataDurability durability)
 {
     return mContract.getTest().getTTL(
         mContract.getDataKey(makeSymbolSCVal(key), durability));
 }
 
-bool
-ContractStorageTestClient::isEntryLive(std::string const& key,
-                                       ContractDataDurability durability,
-                                       uint32_t ledgerSeq)
+bool ContractStorageTestClient::isEntryLive(std::string const& key,
+                                            ContractDataDurability durability,
+                                            uint32_t ledgerSeq)
 {
     return mContract.getTest().isEntryLive(
         mContract.getDataKey(makeSymbolSCVal(key), durability), ledgerSeq);
 }
 
-ExpirationStatus
-ContractStorageTestClient::getEntryExpirationStatus(
+ExpirationStatus ContractStorageTestClient::getEntryExpirationStatus(
     std::string const& key, ContractDataDurability durability)
 {
     return mContract.getTest().getEntryExpirationStatus(
         mContract.getDataKey(makeSymbolSCVal(key), durability));
 }
 
-TestContract::Invocation
-ContractStorageTestClient::putInvocation(
+TestContract::Invocation ContractStorageTestClient::putInvocation(
     std::string const& key, ContractDataDurability durability, uint64_t val,
     std::optional<SorobanInvocationSpec> spec)
 {
@@ -2092,11 +1998,9 @@ ContractStorageTestClient::get(std::string const& key,
     return *invocation.getResultCode();
 }
 
-InvokeHostFunctionResultCode
-ContractStorageTestClient::has(std::string const& key,
-                               ContractDataDurability durability,
-                               std::optional<bool> expectHas,
-                               std::optional<SorobanInvocationSpec> spec)
+InvokeHostFunctionResultCode ContractStorageTestClient::has(
+    std::string const& key, ContractDataDurability durability,
+    std::optional<bool> expectHas, std::optional<SorobanInvocationSpec> spec)
 {
     if (!spec)
     {
@@ -2117,8 +2021,7 @@ ContractStorageTestClient::has(std::string const& key,
     return *invocation.getResultCode();
 }
 
-TestContract::Invocation
-ContractStorageTestClient::delInvocation(
+TestContract::Invocation ContractStorageTestClient::delInvocation(
     std::string const& key, ContractDataDurability durability,
     std::optional<SorobanInvocationSpec> spec)
 {
@@ -2141,7 +2044,6 @@ ContractStorageTestClient::del(std::string const& key,
                                ContractDataDurability durability,
                                std::optional<SorobanInvocationSpec> spec)
 {
-
     auto invocation = delInvocation(key, durability, spec);
     invocation.withExactNonRefundableResourceFee().invoke();
     return *invocation.getResultCode();
@@ -2187,8 +2089,7 @@ ContractStorageTestClient::resizeStorageAndExtendInvocation(
                                        *spec);
 }
 
-InvokeHostFunctionResultCode
-ContractStorageTestClient::resizeStorageAndExtend(
+InvokeHostFunctionResultCode ContractStorageTestClient::resizeStorageAndExtend(
     std::string const& key, uint32_t numKiloBytes, uint32_t thresh,
     uint32_t extendTo, std::optional<SorobanInvocationSpec> spec)
 {
@@ -2227,14 +2128,12 @@ SorobanSigner::sign(SorobanAuthorizedInvocation const& invocation) const
     return fullCredentials;
 }
 
-SCVal
-SorobanSigner::getAddressVal() const
+SCVal SorobanSigner::getAddressVal() const
 {
     return makeAddressSCVal(mAddress);
 }
 
-xdr::xvector<LedgerKey> const&
-SorobanSigner::getLedgerKeys() const
+xdr::xvector<LedgerKey> const& SorobanSigner::getLedgerKeys() const
 {
     return mKeys;
 }
@@ -2244,21 +2143,18 @@ AuthTestTreeNode::AuthTestTreeNode(SCAddress const& contract)
 {
 }
 
-AuthTestTreeNode&
-AuthTestTreeNode::add(std::vector<AuthTestTreeNode> children)
+AuthTestTreeNode& AuthTestTreeNode::add(std::vector<AuthTestTreeNode> children)
 {
     mChildren.insert(mChildren.end(), children.begin(), children.end());
     return *this;
 }
 
-void
-AuthTestTreeNode::setAddress(SCAddress const& address)
+void AuthTestTreeNode::setAddress(SCAddress const& address)
 {
     mContractAddress = address;
 }
 
-SCVal
-AuthTestTreeNode::toSCVal(int addressCount) const
+SCVal AuthTestTreeNode::toSCVal(int addressCount) const
 {
     std::vector<SCVal> children;
     for (auto const& child : mChildren)
@@ -2279,8 +2175,7 @@ AuthTestTreeNode::toSCVal(int addressCount) const
     return node;
 }
 
-SorobanAuthorizedInvocation
-AuthTestTreeNode::toAuthorizedInvocation() const
+SorobanAuthorizedInvocation AuthTestTreeNode::toAuthorizedInvocation() const
 {
     SorobanAuthorizedInvocation invocation;
     auto& function = invocation.function.contractFn();

--- a/src/transactions/test/SponsorshipTestUtils.cpp
+++ b/src/transactions/test/SponsorshipTestUtils.cpp
@@ -17,8 +17,7 @@
 using namespace stellar;
 using namespace stellar::txtest;
 
-static OperationResult
-getOperationResult(TransactionTestFramePtr tx, size_t i)
+static OperationResult getOperationResult(TransactionTestFramePtr tx, size_t i)
 {
     return tx->getResult().result.results()[i];
 }
@@ -26,8 +25,8 @@ getOperationResult(TransactionTestFramePtr tx, size_t i)
 namespace stellar
 {
 
-static void
-validateExpectedAccountV0Ext(uint32_t ledgerVersion, AccountEntry const& ae)
+static void validateExpectedAccountV0Ext(uint32_t ledgerVersion,
+                                         AccountEntry const& ae)
 {
     if (protocolVersionStartsFrom(ledgerVersion, ProtocolVersion::V_19) &&
         hasAccountEntryExtV3(ae))
@@ -41,9 +40,8 @@ validateExpectedAccountV0Ext(uint32_t ledgerVersion, AccountEntry const& ae)
     }
 }
 
-void
-checkSponsorship(AbstractLedgerTxn& ltx, LedgerKey const& lk, int leExt,
-                 AccountID const* sponsoringID)
+void checkSponsorship(AbstractLedgerTxn& ltx, LedgerKey const& lk, int leExt,
+                      AccountID const* sponsoringID)
 {
     auto ltxe = ltx.load(lk);
     auto const& le = ltxe.current();
@@ -64,10 +62,9 @@ checkSponsorship(AbstractLedgerTxn& ltx, LedgerKey const& lk, int leExt,
     }
 }
 
-void
-checkSponsorship(AbstractLedgerTxn& ltx, AccountID const& accountID,
-                 SignerKey const& signerKey, int aeExt,
-                 AccountID const* sponsoringID)
+void checkSponsorship(AbstractLedgerTxn& ltx, AccountID const& accountID,
+                      SignerKey const& signerKey, int aeExt,
+                      AccountID const* sponsoringID)
 {
     auto ltxe = loadAccount(ltx, accountID);
     auto const& ae = ltxe.current().data.account();
@@ -105,10 +102,9 @@ checkSponsorship(AbstractLedgerTxn& ltx, AccountID const& accountID,
     }
 }
 
-void
-checkSponsorship(AbstractLedgerTxn& ltx, AccountID const& acc, int leExt,
-                 AccountID const* sponsoringID, uint32_t numSubEntries,
-                 int aeExt, uint32_t numSponsoring, uint32_t numSponsored)
+void checkSponsorship(AbstractLedgerTxn& ltx, AccountID const& acc, int leExt,
+                      AccountID const* sponsoringID, uint32_t numSubEntries,
+                      int aeExt, uint32_t numSponsoring, uint32_t numSponsored)
 {
     checkSponsorship(ltx, accountKey(acc), leExt, sponsoringID);
 
@@ -133,8 +129,7 @@ checkSponsorship(AbstractLedgerTxn& ltx, AccountID const& acc, int leExt,
     }
 }
 
-void
-createSponsoredEntryButSponsorHasInsufficientBalance(
+void createSponsoredEntryButSponsorHasInsufficientBalance(
     Application& app, TestAccount& sponsoringAcc, TestAccount& sponsoredAcc,
     Operation const& op, std::function<bool(OperationResult const&)> check)
 {
@@ -162,8 +157,7 @@ createSponsoredEntryButSponsorHasInsufficientBalance(
     }
 }
 
-static uint32_t
-getNumReservesRequiredForOperation(Operation const& op)
+static uint32_t getNumReservesRequiredForOperation(Operation const& op)
 {
     if (op.body.type() == REVOKE_SPONSORSHIP &&
         op.body.revokeSponsorshipOp().type() ==
@@ -193,14 +187,11 @@ getNumReservesRequiredForOperation(Operation const& op)
     return 1;
 }
 
-static void
-createModifyAndRemoveSponsoredEntry(Application& app, TestAccount& sponsoredAcc,
-                                    Operation const& opCreate,
-                                    Operation const& opModify1,
-                                    Operation const& opModify2,
-                                    Operation const& opRemove,
-                                    RevokeSponsorshipOp const& rso,
-                                    uint32_t ledgerVersionFrom)
+static void createModifyAndRemoveSponsoredEntry(
+    Application& app, TestAccount& sponsoredAcc, Operation const& opCreate,
+    Operation const& opModify1, Operation const& opModify2,
+    Operation const& opRemove, RevokeSponsorshipOp const& rso,
+    uint32_t ledgerVersionFrom)
 {
     SECTION("create, modify, and remove sponsored entry")
     {
@@ -328,8 +319,7 @@ createModifyAndRemoveSponsoredEntry(Application& app, TestAccount& sponsoredAcc,
     }
 }
 
-void
-createModifyAndRemoveSponsoredEntry(
+void createModifyAndRemoveSponsoredEntry(
     Application& app, TestAccount& sponsoredAcc, Operation const& opCreate,
     Operation const& opModify1, Operation const& opModify2,
     Operation const& opRemove, LedgerKey const& lk, uint32_t ledgerVersionFrom)
@@ -341,13 +331,10 @@ createModifyAndRemoveSponsoredEntry(
                                         ledgerVersionFrom);
 }
 
-void
-createModifyAndRemoveSponsoredEntry(Application& app, TestAccount& sponsoredAcc,
-                                    Operation const& opCreate,
-                                    Operation const& opModify1,
-                                    Operation const& opModify2,
-                                    Operation const& opRemove,
-                                    SignerKey const& signerKey)
+void createModifyAndRemoveSponsoredEntry(
+    Application& app, TestAccount& sponsoredAcc, Operation const& opCreate,
+    Operation const& opModify1, Operation const& opModify2,
+    Operation const& opRemove, SignerKey const& signerKey)
 {
     RevokeSponsorshipOp rso(REVOKE_SPONSORSHIP_SIGNER);
     rso.signer().accountID = sponsoredAcc;
@@ -356,17 +343,15 @@ createModifyAndRemoveSponsoredEntry(Application& app, TestAccount& sponsoredAcc,
                                         opModify2, opRemove, rso, 14);
 }
 
-void
-tooManySponsoring(Application& app, TestAccount& sponsoredAcc,
-                  Operation const& successfulOp, Operation const& failOp,
-                  uint32_t reservesForSuccesfulOp)
+void tooManySponsoring(Application& app, TestAccount& sponsoredAcc,
+                       Operation const& successfulOp, Operation const& failOp,
+                       uint32_t reservesForSuccesfulOp)
 {
     tooManySponsoring(app, sponsoredAcc, sponsoredAcc, successfulOp, failOp,
                       reservesForSuccesfulOp);
 }
 
-static uint32_t
-getMinProtocolVersionForTooManyTestsFromOp(Operation const& op)
+static uint32_t getMinProtocolVersionForTooManyTestsFromOp(Operation const& op)
 {
     if (op.body.type() == CHANGE_TRUST &&
         op.body.changeTrustOp().line.type() == ASSET_TYPE_POOL_SHARE)
@@ -395,11 +380,11 @@ getMinProtocolVersionForTooManyTestsFromOp(Operation const& op)
     return 14;
 }
 
-static void
-submitTooManySponsoringTxs(Application& app, TestAccount& successfulOpAcc,
-                           TestAccount& failOpAcc,
-                           Operation const& successfulOp,
-                           Operation const& failOp)
+static void submitTooManySponsoringTxs(Application& app,
+                                       TestAccount& successfulOpAcc,
+                                       TestAccount& failOpAcc,
+                                       Operation const& successfulOp,
+                                       Operation const& failOp)
 {
     auto root = app.getRoot();
     {
@@ -436,10 +421,9 @@ submitTooManySponsoringTxs(Application& app, TestAccount& successfulOpAcc,
     }
 }
 
-void
-tooManySponsoring(Application& app, TestAccount& successfulOpAcc,
-                  TestAccount& failOpAcc, Operation const& successfulOp,
-                  Operation const& failOp, uint32_t reservesForSuccesfulOp)
+void tooManySponsoring(Application& app, TestAccount& successfulOpAcc,
+                       TestAccount& failOpAcc, Operation const& successfulOp,
+                       Operation const& failOp, uint32_t reservesForSuccesfulOp)
 {
     REQUIRE(failOp.body.type() == successfulOp.body.type());
 
@@ -547,10 +531,9 @@ tooManySponsoring(Application& app, TestAccount& successfulOpAcc,
     }
 }
 
-static void
-submitTooManyNumSubEntries(Application& app, TestAccount& testAcc,
-                           Operation const& successfulOp,
-                           Operation const& failOp)
+static void submitTooManyNumSubEntries(Application& app, TestAccount& testAcc,
+                                       Operation const& successfulOp,
+                                       Operation const& failOp)
 {
     {
         auto tx1 = transactionFrameFromOps(app.getNetworkID(), testAcc,
@@ -580,9 +563,8 @@ submitTooManyNumSubEntries(Application& app, TestAccount& testAcc,
     }
 }
 
-void
-tooManySubentries(Application& app, TestAccount& testAcc,
-                  Operation const& successfulOp, Operation const& failOp)
+void tooManySubentries(Application& app, TestAccount& testAcc,
+                       Operation const& successfulOp, Operation const& failOp)
 {
     REQUIRE(failOp.body.type() == successfulOp.body.type());
 

--- a/src/transactions/test/TransactionTestFrame.cpp
+++ b/src/transactions/test/TransactionTestFrame.cpp
@@ -30,8 +30,7 @@ TransactionTestFrame::fromTxFrame(TransactionFrameBasePtr txFrame)
         new TransactionTestFrame(txFrame));
 }
 
-bool
-TransactionTestFrame::apply(
+bool TransactionTestFrame::apply(
     AppConnector& app, AbstractLedgerTxn& ltx, TransactionMetaBuilder& meta,
     std::optional<SorobanNetworkConfig const> const& sorobanConfig,
     Hash const& sorobanBasePrngSeed)
@@ -40,34 +39,29 @@ TransactionTestFrame::apply(
                                     sorobanConfig, sorobanBasePrngSeed);
 }
 
-void
-TransactionTestFrame::clearCached() const
+void TransactionTestFrame::clearCached() const
 {
     mTransactionFrame->clearCached();
 }
 
-OperationResult&
-TransactionTestFrame::getOperationResultAt(size_t i) const
+OperationResult& TransactionTestFrame::getOperationResultAt(size_t i) const
 {
     return mTransactionTxResult->getOpResultAt(i);
 }
 
-void
-TransactionTestFrame::addSignature(SecretKey const& secretKey)
+void TransactionTestFrame::addSignature(SecretKey const& secretKey)
 {
     auto sig = SignatureUtils::sign(secretKey, getContentsHash());
     addSignature(sig);
 }
 
-void
-TransactionTestFrame::addSignature(DecoratedSignature const& signature)
+void TransactionTestFrame::addSignature(DecoratedSignature const& signature)
 {
     clearCached();
     txbridge::getSignatures(getMutableEnvelope()).push_back(signature);
 }
 
-bool
-TransactionTestFrame::apply(
+bool TransactionTestFrame::apply(
     AppConnector& app, AbstractLedgerTxn& ltx, TransactionMetaBuilder& meta,
     MutableTransactionResultBase& txResult,
     std::optional<SorobanNetworkConfig const> const& sorobanConfig,
@@ -105,12 +99,10 @@ TransactionTestFrame::checkValid(AppConnector& app, LedgerSnapshot const& ls,
                       upperBoundCloseTimeOffset, diagnostics);
 }
 
-MutableTxResultPtr
-TransactionTestFrame::checkValid(AppConnector& app, LedgerSnapshot const& ls,
-                                 SequenceNumber current,
-                                 uint64_t lowerBoundCloseTimeOffset,
-                                 uint64_t upperBoundCloseTimeOffset,
-                                 DiagnosticEventManager& diagnosticEvents) const
+MutableTxResultPtr TransactionTestFrame::checkValid(
+    AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
+    uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+    DiagnosticEventManager& diagnosticEvents) const
 {
     mTransactionTxResult = mTransactionFrame->checkValid(
         app, ls, current, lowerBoundCloseTimeOffset, upperBoundCloseTimeOffset,
@@ -118,12 +110,9 @@ TransactionTestFrame::checkValid(AppConnector& app, LedgerSnapshot const& ls,
     return mTransactionTxResult->clone();
 }
 
-bool
-TransactionTestFrame::checkValidForTesting(AppConnector& app,
-                                           AbstractLedgerTxn& ltxOuter,
-                                           SequenceNumber current,
-                                           uint64_t lowerBoundCloseTimeOffset,
-                                           uint64_t upperBoundCloseTimeOffset)
+bool TransactionTestFrame::checkValidForTesting(
+    AppConnector& app, AbstractLedgerTxn& ltxOuter, SequenceNumber current,
+    uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset)
 {
     mTransactionTxResult =
         checkValid(app, ltxOuter, current, lowerBoundCloseTimeOffset,
@@ -131,8 +120,7 @@ TransactionTestFrame::checkValidForTesting(AppConnector& app,
     return mTransactionTxResult->isSuccess();
 }
 
-bool
-TransactionTestFrame::checkSorobanResources(
+bool TransactionTestFrame::checkSorobanResources(
     SorobanNetworkConfig const& cfg, uint32_t ledgerVersion,
     DiagnosticEventManager& diagnosticEvents) const
 {
@@ -140,33 +128,28 @@ TransactionTestFrame::checkSorobanResources(
                                                     diagnosticEvents);
 }
 
-MutableTxResultPtr
-TransactionTestFrame::createTxErrorResult(
+MutableTxResultPtr TransactionTestFrame::createTxErrorResult(
     TransactionResultCode txErrorCode) const
 {
     return mTransactionFrame->createTxErrorResult(txErrorCode);
 }
 
-MutableTxResultPtr
-TransactionTestFrame::createValidationSuccessResult() const
+MutableTxResultPtr TransactionTestFrame::createValidationSuccessResult() const
 {
     return mTransactionFrame->createValidationSuccessResult();
 }
 
-TransactionEnvelope const&
-TransactionTestFrame::getEnvelope() const
+TransactionEnvelope const& TransactionTestFrame::getEnvelope() const
 {
     return mTransactionFrame->getEnvelope();
 }
 
-TransactionEnvelope&
-TransactionTestFrame::getMutableEnvelope() const
+TransactionEnvelope& TransactionTestFrame::getMutableEnvelope() const
 {
     return mTransactionFrame->getMutableEnvelope();
 }
 
-TransactionFrame const&
-TransactionTestFrame::getRawTransactionFrame() const
+TransactionFrame const& TransactionTestFrame::getRawTransactionFrame() const
 {
     auto ret =
         std::dynamic_pointer_cast<TransactionFrame const>(mTransactionFrame);
@@ -174,56 +157,48 @@ TransactionTestFrame::getRawTransactionFrame() const
     return *ret;
 }
 
-TransactionFrameBasePtr
-TransactionTestFrame::getTxFramePtr() const
+TransactionFrameBasePtr TransactionTestFrame::getTxFramePtr() const
 {
     return mTransactionFrame;
 }
 
-bool
-TransactionTestFrame::validateSorobanTxForFlooding(
+bool TransactionTestFrame::validateSorobanTxForFlooding(
     UnorderedSet<LedgerKey> const& keysToFilter) const
 {
     return mTransactionFrame->validateSorobanTxForFlooding(keysToFilter);
 }
 
-bool
-TransactionTestFrame::validateSorobanMemo() const
+bool TransactionTestFrame::validateSorobanMemo() const
 {
     return mTransactionFrame->validateSorobanMemo();
 }
 
-int64_t
-TransactionTestFrame::getFullFee() const
+int64_t TransactionTestFrame::getFullFee() const
 {
     return mTransactionFrame->getFullFee();
 }
 
-int64_t
-TransactionTestFrame::getInclusionFee() const
+int64_t TransactionTestFrame::getInclusionFee() const
 {
     return mTransactionFrame->getInclusionFee();
 }
 
-int64_t
-TransactionTestFrame::getFee(LedgerHeader const& header,
-                             std::optional<int64_t> baseFee,
-                             bool applying) const
+int64_t TransactionTestFrame::getFee(LedgerHeader const& header,
+                                     std::optional<int64_t> baseFee,
+                                     bool applying) const
 {
     return mTransactionFrame->getFee(header, baseFee, applying);
 }
 
-bool
-TransactionTestFrame::checkSignature(SignatureChecker& signatureChecker,
-                                     LedgerEntryWrapper const& account,
-                                     int32_t neededWeight) const
+bool TransactionTestFrame::checkSignature(SignatureChecker& signatureChecker,
+                                          LedgerEntryWrapper const& account,
+                                          int32_t neededWeight) const
 {
     return mTransactionFrame->checkSignature(signatureChecker, account,
                                              neededWeight);
 }
 
-bool
-TransactionTestFrame::checkOperationSignatures(
+bool TransactionTestFrame::checkOperationSignatures(
     SignatureChecker& signatureChecker, LedgerSnapshot const& ls,
     MutableTransactionResultBase* txResult) const
 {
@@ -231,8 +206,7 @@ TransactionTestFrame::checkOperationSignatures(
                                                        txResult);
 }
 
-bool
-TransactionTestFrame::checkAllTransactionSignatures(
+bool TransactionTestFrame::checkAllTransactionSignatures(
     SignatureChecker& signatureChecker, LedgerEntryWrapper const& sourceAccount,
     uint32_t ledgerVersion) const
 {
@@ -240,20 +214,17 @@ TransactionTestFrame::checkAllTransactionSignatures(
         signatureChecker, sourceAccount, ledgerVersion);
 }
 
-Hash const&
-TransactionTestFrame::getContentsHash() const
+Hash const& TransactionTestFrame::getContentsHash() const
 {
     return mTransactionFrame->getContentsHash();
 }
 
-Hash const&
-TransactionTestFrame::getFullHash() const
+Hash const& TransactionTestFrame::getFullHash() const
 {
     return mTransactionFrame->getFullHash();
 }
 
-uint32_t
-TransactionTestFrame::getNumOperations() const
+uint32_t TransactionTestFrame::getNumOperations() const
 {
     return mTransactionFrame->getNumOperations();
 }
@@ -264,46 +235,39 @@ TransactionTestFrame::getOperationFrames() const
     return mTransactionFrame->getOperationFrames();
 }
 
-Resource
-TransactionTestFrame::getResources(bool useByteLimitInClassic,
-                                   uint32_t ledgerVersion) const
+Resource TransactionTestFrame::getResources(bool useByteLimitInClassic,
+                                            uint32_t ledgerVersion) const
 {
     return mTransactionFrame->getResources(useByteLimitInClassic,
                                            ledgerVersion);
 }
 
-std::vector<Operation> const&
-TransactionTestFrame::getRawOperations() const
+std::vector<Operation> const& TransactionTestFrame::getRawOperations() const
 {
     return mTransactionFrame->getRawOperations();
 }
 
-TransactionResult const&
-TransactionTestFrame::getResult() const
+TransactionResult const& TransactionTestFrame::getResult() const
 {
     return mTransactionTxResult->getXDR();
 }
 
-TransactionResultCode
-TransactionTestFrame::getResultCode() const
+TransactionResultCode TransactionTestFrame::getResultCode() const
 {
     return mTransactionTxResult->getResultCode();
 }
 
-SequenceNumber
-TransactionTestFrame::getSeqNum() const
+SequenceNumber TransactionTestFrame::getSeqNum() const
 {
     return mTransactionFrame->getSeqNum();
 }
 
-AccountID
-TransactionTestFrame::getFeeSourceID() const
+AccountID TransactionTestFrame::getFeeSourceID() const
 {
     return mTransactionFrame->getFeeSourceID();
 }
 
-AccountID
-TransactionTestFrame::getSourceID() const
+AccountID TransactionTestFrame::getSourceID() const
 {
     return mTransactionFrame->getSourceID();
 }
@@ -314,33 +278,29 @@ TransactionTestFrame::getMinSeqNum() const
     return mTransactionFrame->getMinSeqNum();
 }
 
-Duration
-TransactionTestFrame::getMinSeqAge() const
+Duration TransactionTestFrame::getMinSeqAge() const
 {
     return mTransactionFrame->getMinSeqAge();
 }
 
-uint32
-TransactionTestFrame::getMinSeqLedgerGap() const
+uint32 TransactionTestFrame::getMinSeqLedgerGap() const
 {
     return mTransactionFrame->getMinSeqLedgerGap();
 }
 
-void
-TransactionTestFrame::insertKeysForFeeProcessing(
+void TransactionTestFrame::insertKeysForFeeProcessing(
     UnorderedSet<LedgerKey>& keys) const
 {
     mTransactionFrame->insertKeysForFeeProcessing(keys);
 }
 
-void
-TransactionTestFrame::insertKeysForTxApply(UnorderedSet<LedgerKey>& keys) const
+void TransactionTestFrame::insertKeysForTxApply(
+    UnorderedSet<LedgerKey>& keys) const
 {
     mTransactionFrame->insertKeysForTxApply(keys);
 }
 
-void
-TransactionTestFrame::preParallelApply(
+void TransactionTestFrame::preParallelApply(
     AppConnector& app, AbstractLedgerTxn& ltx, TransactionMetaBuilder& meta,
     MutableTransactionResultBase& resPayload,
     SorobanNetworkConfig const& sorobanConfig) const
@@ -349,8 +309,7 @@ TransactionTestFrame::preParallelApply(
                                         sorobanConfig);
 }
 
-ParallelTxReturnVal
-TransactionTestFrame::parallelApply(
+ParallelTxReturnVal TransactionTestFrame::parallelApply(
     AppConnector& app, ThreadParallelApplyLedgerState const& threadState,
     Config const& config, ParallelLedgerInfo const& ledgerInfo,
     MutableTransactionResultBase& resPayload, SorobanMetrics& sorobanMetrics,
@@ -369,8 +328,7 @@ TransactionTestFrame::processFeeSeqNum(AbstractLedgerTxn& ltx,
     return mTransactionTxResult->clone();
 }
 
-void
-TransactionTestFrame::processPostApply(
+void TransactionTestFrame::processPostApply(
     AppConnector& app, AbstractLedgerTxn& ltx, TransactionMetaBuilder& meta,
     MutableTransactionResultBase& txResult) const
 {
@@ -378,8 +336,7 @@ TransactionTestFrame::processPostApply(
     mTransactionTxResult = txResult.clone();
 }
 
-void
-TransactionTestFrame::processPostTxSetApply(
+void TransactionTestFrame::processPostTxSetApply(
     AppConnector& app, AbstractLedgerTxn& ltx,
     MutableTransactionResultBase& txResult,
     TxEventManager& txEventManager) const
@@ -394,20 +351,17 @@ TransactionTestFrame::toStellarMessage() const
     return mTransactionFrame->toStellarMessage();
 }
 
-bool
-TransactionTestFrame::hasDexOperations() const
+bool TransactionTestFrame::hasDexOperations() const
 {
     return mTransactionFrame->hasDexOperations();
 }
 
-bool
-TransactionTestFrame::isSoroban() const
+bool TransactionTestFrame::isSoroban() const
 {
     return mTransactionFrame->isSoroban();
 }
 
-SorobanResources const&
-TransactionTestFrame::sorobanResources() const
+SorobanResources const& TransactionTestFrame::sorobanResources() const
 {
     return mTransactionFrame->sorobanResources();
 }
@@ -418,44 +372,37 @@ TransactionTestFrame::getResourcesExt() const
     return mTransactionFrame->getResourcesExt();
 }
 
-int64
-TransactionTestFrame::declaredSorobanResourceFee() const
+int64 TransactionTestFrame::declaredSorobanResourceFee() const
 {
     return mTransactionFrame->declaredSorobanResourceFee();
 }
 
-bool
-TransactionTestFrame::XDRProvidesValidFee() const
+bool TransactionTestFrame::XDRProvidesValidFee() const
 {
     return mTransactionFrame->XDRProvidesValidFee();
 }
 
-bool
-TransactionTestFrame::isRestoreFootprintTx() const
+bool TransactionTestFrame::isRestoreFootprintTx() const
 {
     return mTransactionFrame->isRestoreFootprintTx();
 }
 
-void
-TransactionTestFrame::overrideResult(MutableTxResultPtr result)
+void TransactionTestFrame::overrideResult(MutableTxResultPtr result)
 {
     mTransactionTxResult = std::move(result);
 }
 
-void
-TransactionTestFrame::overrideResultXDR(TransactionResult const& resultXDR)
+void TransactionTestFrame::overrideResultXDR(TransactionResult const& resultXDR)
 {
     mTransactionTxResult->overrideXDR(resultXDR);
 }
 
-void
-TransactionTestFrame::overrideResultFeeCharged(int64_t feeCharged)
+void TransactionTestFrame::overrideResultFeeCharged(int64_t feeCharged)
 {
     mTransactionTxResult->overrideFeeCharged(feeCharged);
 }
 
-void
-TransactionTestFrame::withInnerTx(
+void TransactionTestFrame::withInnerTx(
     std::function<void(TransactionFrameBaseConstPtr)> fn) const
 {
     mTransactionFrame->withInnerTx(fn);

--- a/src/transactions/test/TransactionTestFrame.h
+++ b/src/transactions/test/TransactionTestFrame.h
@@ -138,15 +138,14 @@ class TransactionTestFrame : public TransactionFrameBase
     Duration getMinSeqAge() const override;
     uint32 getMinSeqLedgerGap() const override;
 
-    void
-    insertKeysForFeeProcessing(UnorderedSet<LedgerKey>& keys) const override;
+    void insertKeysForFeeProcessing(
+        UnorderedSet<LedgerKey>& keys) const override;
     void insertKeysForTxApply(UnorderedSet<LedgerKey>& keys) const override;
 
-    void
-    preParallelApply(AppConnector& app, AbstractLedgerTxn& ltx,
-                     TransactionMetaBuilder& meta,
-                     MutableTransactionResultBase& resPayload,
-                     SorobanNetworkConfig const& sorobanConfig) const override;
+    void preParallelApply(
+        AppConnector& app, AbstractLedgerTxn& ltx, TransactionMetaBuilder& meta,
+        MutableTransactionResultBase& resPayload,
+        SorobanNetworkConfig const& sorobanConfig) const override;
 
     ParallelTxReturnVal parallelApply(
         AppConnector& app, ThreadParallelApplyLedgerState const& threadState,
@@ -159,10 +158,9 @@ class TransactionTestFrame : public TransactionFrameBase
     processFeeSeqNum(AbstractLedgerTxn& ltx,
                      std::optional<int64_t> baseFee) const override;
 
-    void
-    processPostApply(AppConnector& app, AbstractLedgerTxn& ltx,
-                     TransactionMetaBuilder& meta,
-                     MutableTransactionResultBase& txResult) const override;
+    void processPostApply(
+        AppConnector& app, AbstractLedgerTxn& ltx, TransactionMetaBuilder& meta,
+        MutableTransactionResultBase& txResult) const override;
 
     void processPostTxSetApply(AppConnector& app, AbstractLedgerTxn& ltx,
                                MutableTransactionResultBase& txResult,
@@ -182,8 +180,7 @@ class TransactionTestFrame : public TransactionFrameBase
     void withInnerTx(
         std::function<void(TransactionFrameBaseConstPtr)> fn) const override;
 
-    bool
-    isTestTx() const override
+    bool isTestTx() const override
     {
         return true;
     }

--- a/src/transactions/test/TxEnvelopeTests.cpp
+++ b/src/transactions/test/TxEnvelopeTests.cpp
@@ -2591,7 +2591,6 @@ TEST_CASE_VERSIONS("soroban transaction validation", "[tx][envelope][soroban]")
                 if (i <
                     InitialSorobanNetworkConfig::TX_MAX_WRITE_LEDGER_ENTRIES)
                 {
-
                     resources.footprint.readWrite.push_back(key);
                 }
                 else

--- a/src/util/Algorithm.h
+++ b/src/util/Algorithm.h
@@ -9,8 +9,8 @@
 
 template <typename V, typename Extractor,
           typename K = typename std::result_of<Extractor(const V&)>::type>
-std::map<K, std::vector<V>>
-split(const std::vector<V>& data, Extractor extractor)
+std::map<K, std::vector<V>> split(const std::vector<V>& data,
+                                  Extractor extractor)
 {
     auto r = std::map<K, std::vector<V>>{};
     for (auto&& v : data)

--- a/src/util/Backtrace.cpp
+++ b/src/util/Backtrace.cpp
@@ -66,8 +66,7 @@ BacktraceManager::~BacktraceManager()
 namespace stellar
 {
 
-void
-printCurrentBacktrace()
+void printCurrentBacktrace()
 {
     if (!threadIsMain())
     {
@@ -151,14 +150,12 @@ printCurrentBacktrace()
 #else
 
 #ifdef _WIN32
-static size_t
-backtrace(void**, size_t)
+static size_t backtrace(void**, size_t)
 {
     return 0;
 }
 
-static char**
-backtrace_symbols(void** v, size_t n)
+static char** backtrace_symbols(void** v, size_t n)
 {
     return nullptr;
 }
@@ -172,8 +169,7 @@ namespace stellar
 
 static constexpr int MAX_SIZE = 1024;
 
-void
-printCurrentBacktrace()
+void printCurrentBacktrace()
 {
     if (!threadIsMain())
     {

--- a/src/util/BinaryFuseFilter.cpp
+++ b/src/util/BinaryFuseFilter.cpp
@@ -30,8 +30,7 @@ BinaryFuseFilter<T>::BinaryFuseFilter(
 }
 
 template <typename T>
-bool
-BinaryFuseFilter<T>::contains(LedgerKey const& key) const
+bool BinaryFuseFilter<T>::contains(LedgerKey const& key) const
 {
     SipHash24 hasher(mHashSeed.data());
     auto keybuf = xdr::xdr_to_opaque(key);
@@ -40,8 +39,7 @@ BinaryFuseFilter<T>::contains(LedgerKey const& key) const
 }
 
 template <typename T>
-bool
-BinaryFuseFilter<T>::operator==(BinaryFuseFilter<T> const& other) const
+bool BinaryFuseFilter<T>::operator==(BinaryFuseFilter<T> const& other) const
 {
     return mFilter == other.mFilter && mHashSeed == other.mHashSeed;
 }

--- a/src/util/BinaryFuseFilter.h
+++ b/src/util/BinaryFuseFilter.h
@@ -45,9 +45,7 @@ template <typename T> class BinaryFuseFilter : public NonMovableOrCopyable
 
     bool operator==(BinaryFuseFilter<T> const& other) const;
 
-    template <class Archive>
-    void
-    save(Archive& archive) const
+    template <class Archive> void save(Archive& archive) const
     {
         SerializedBinaryFuseFilter xdrFilter;
         std::copy(mHashSeed.begin(), mHashSeed.end(),
@@ -57,9 +55,7 @@ template <typename T> class BinaryFuseFilter : public NonMovableOrCopyable
         archive(xdrFilter);
     }
 
-    template <class Archive>
-    void
-    load(Archive& archive)
+    template <class Archive> void load(Archive& archive)
     {
         SerializedBinaryFuseFilter xdrFilter;
         archive(xdrFilter);

--- a/src/util/BitSet.h
+++ b/src/util/BitSet.h
@@ -40,14 +40,12 @@ class BitSet
     bitset_t mInlineBitset{nullptr, INLINE_NWORDS, INLINE_NWORDS};
     uint64_t mInlineBits[INLINE_NWORDS]{0};
 
-    bool
-    isStoredInline() const
+    bool isStoredInline() const
     {
         return mPtr == &mInlineBitset;
     }
 
-    void
-    setToEmptyAndInline()
+    void setToEmptyAndInline()
     {
         if (mPtr && !isStoredInline())
         {
@@ -61,8 +59,7 @@ class BitSet
         mInlineBitset.array = mInlineBits;
     }
 
-    void
-    ensureCapacity(size_t nBits)
+    void ensureCapacity(size_t nBits)
     {
         size_t nWords = (nBits + WORD_BITS - 1) >> WORD_BITS_LOG2;
         if (nWords <= mPtr->capacity)
@@ -77,8 +74,7 @@ class BitSet
         bitset_resize(mPtr, nWords, true);
     }
 
-    void
-    setToEmptyWithCapacity(size_t nBits)
+    void setToEmptyWithCapacity(size_t nBits)
     {
         // Equal to "setToEmptyAndInline + ensureCapacity" but with one malloc
         // rather than malloc+realloc in the case where it's not inline.
@@ -89,8 +85,7 @@ class BitSet
         }
     }
 
-    void
-    copyOther(BitSet const& other)
+    void copyOther(BitSet const& other)
     {
         // This step will also free any out-of-line bitset_t we own.
         setToEmptyAndInline();
@@ -135,64 +130,54 @@ class BitSet
     {
         copyOther(other);
     }
-    BitSet&
-    operator=(BitSet const& other)
+    BitSet& operator=(BitSet const& other)
     {
         copyOther(other);
         return *this;
     }
 
-    bool
-    operator!=(BitSet const& other) const
+    bool operator!=(BitSet const& other) const
     {
         return !((*this) == other);
     }
 
-    bool
-    operator==(BitSet const& other) const
+    bool operator==(BitSet const& other) const
     {
         return bitset_equal(mPtr, other.mPtr);
     }
 
-    bool
-    isSubsetEq(BitSet const& other) const
+    bool isSubsetEq(BitSet const& other) const
     {
         return bitset_subseteq(mPtr, other.mPtr);
     }
 
-    size_t
-    size() const
+    size_t size() const
     {
         return bitset_size_in_bits(mPtr);
     }
-    void
-    set(size_t i)
+    void set(size_t i)
     {
         ensureCapacity(i + 1);
         bitset_set(mPtr, i);
         mCountDirty = true;
     }
-    void
-    unset(size_t i)
+    void unset(size_t i)
     {
         bitset_unset(mPtr, i);
         mCountDirty = true;
     }
-    bool
-    get(size_t i) const
+    bool get(size_t i) const
     {
         return bitset_get(mPtr, i);
     }
-    void
-    clear()
+    void clear()
     {
         bitset_clear(mPtr);
         mCount = 0;
         mCountDirty = false;
     }
 
-    size_t
-    count() const
+    size_t count() const
     {
         if (mCountDirty)
         {
@@ -201,128 +186,108 @@ class BitSet
         }
         return mCount;
     }
-    bool
-    empty() const
+    bool empty() const
     {
         size_t tmp = 0;
         return !nextSet(tmp);
     }
-    size_t
-    min() const
+    size_t min() const
     {
         return bitset_minimum(mPtr);
     }
-    size_t
-    max() const
+    size_t max() const
     {
         return bitset_maximum(mPtr);
     }
 
-    void
-    inplaceUnion(BitSet const& other)
+    void inplaceUnion(BitSet const& other)
     {
         ensureCapacity(other.size());
         bitset_inplace_union(mPtr, other.mPtr);
         mCountDirty = true;
     }
-    BitSet
-    operator|(BitSet const& other) const
+    BitSet operator|(BitSet const& other) const
     {
         BitSet tmp(*this);
         tmp.inplaceUnion(other);
         return tmp;
     }
-    void
-    operator|=(BitSet const& other)
+    void operator|=(BitSet const& other)
     {
         inplaceUnion(other);
     }
 
-    void
-    inplaceIntersection(BitSet const& other)
+    void inplaceIntersection(BitSet const& other)
     {
         // We do not need to do ensureCapacity() here because
         // intersection never grows a bitset: no reallocation.
         bitset_inplace_intersection(mPtr, other.mPtr);
         mCountDirty = true;
     }
-    BitSet
-    operator&(BitSet const& other) const
+    BitSet operator&(BitSet const& other) const
     {
         BitSet tmp(*this);
         tmp.inplaceIntersection(other);
         return tmp;
     }
-    void
-    operator&=(BitSet const& other)
+    void operator&=(BitSet const& other)
     {
         inplaceIntersection(other);
     }
 
-    void
-    inplaceDifference(BitSet const& other)
+    void inplaceDifference(BitSet const& other)
     {
         // We do not need to do ensureCapacity() here because
         // difference never grows a bitset: no reallocation.
         bitset_inplace_difference(mPtr, other.mPtr);
         mCountDirty = true;
     }
-    BitSet
-    operator-(BitSet const& other) const
+    BitSet operator-(BitSet const& other) const
     {
         BitSet tmp(*this);
         tmp.inplaceDifference(other);
         return tmp;
     }
-    void
-    operator-=(BitSet const& other)
+    void operator-=(BitSet const& other)
     {
         inplaceDifference(other);
     }
 
-    void
-    inplaceSymmetricDifference(BitSet const& other)
+    void inplaceSymmetricDifference(BitSet const& other)
     {
         ensureCapacity(other.size());
         bitset_inplace_symmetric_difference(mPtr, other.mPtr);
         mCountDirty = true;
     }
-    BitSet
-    symmetricDifference(BitSet const& other) const
+    BitSet symmetricDifference(BitSet const& other) const
     {
         BitSet tmp(*this);
         tmp.inplaceSymmetricDifference(other);
         return tmp;
     }
 
-    size_t
-    unionCount(BitSet const& other) const
+    size_t unionCount(BitSet const& other) const
     {
         return bitset_union_count(mPtr, other.mPtr);
     }
-    size_t
-    intersectionCount(BitSet const& other) const
+    size_t intersectionCount(BitSet const& other) const
     {
         return bitset_intersection_count(mPtr, other.mPtr);
     }
-    size_t
-    differenceCount(BitSet const& other) const
+    size_t differenceCount(BitSet const& other) const
     {
         return bitset_difference_count(mPtr, other.mPtr);
     }
-    size_t
-    symmetricDifferenceCount(BitSet const& other) const
+    size_t symmetricDifferenceCount(BitSet const& other) const
     {
         return bitset_symmetric_difference_count(mPtr, other.mPtr);
     }
-    bool
-    nextSet(size_t& i) const
+    bool nextSet(size_t& i) const
     {
         return nextSetBit(mPtr, &i);
     }
-    void
-    streamWith(std::ostream& out,
-               std::function<void(std::ostream&, size_t)> item) const
+    void streamWith(std::ostream& out,
+                    std::function<void(std::ostream&, size_t)> item) const
     {
         out << '{';
         bool first = true;
@@ -340,8 +305,7 @@ class BitSet
         }
         out << '}';
     }
-    void
-    stream(std::ostream& out) const
+    void stream(std::ostream& out) const
     {
         streamWith(out, [](std::ostream& out, size_t i) { out << i; });
     }
@@ -350,8 +314,7 @@ class BitSet
         std::hash<uint64_t> mHasher;
 
       public:
-        size_t
-        operator()(BitSet const& bitset) const noexcept
+        size_t operator()(BitSet const& bitset) const noexcept
         {
             // Implementation taken from Boost.
             // https://www.boost.org/doc/libs/1_35_0/doc/html/boost/hash_combine_id241013.html
@@ -366,15 +329,13 @@ class BitSet
     };
 };
 
-inline std::ostream&
-operator<<(std::ostream& out, BitSet const& b)
+inline std::ostream& operator<<(std::ostream& out, BitSet const& b)
 {
     b.stream(out);
     return out;
 }
 
-inline std::string
-format_as(BitSet const& b)
+inline std::string format_as(BitSet const& b)
 {
     std::stringstream s;
     s << b;

--- a/src/util/BufferedAsioCerealOutputArchive.h
+++ b/src/util/BufferedAsioCerealOutputArchive.h
@@ -34,8 +34,7 @@ class BufferedAsioOutputArchive
     ~BufferedAsioOutputArchive() CEREAL_NOEXCEPT = default;
 
     // Writes size bytes of data to the output stream
-    void
-    saveBinary(const void* data, std::streamsize size)
+    void saveBinary(const void* data, std::streamsize size)
     {
         itsStream.writeBytes(static_cast<char const*>(data), size);
     }
@@ -71,9 +70,8 @@ inline CEREAL_ARCHIVE_RESTRICT_SINGLE_TYPE(BufferedAsioOutputArchive)
 
 // Saving binary data
 template <class T>
-inline void
-CEREAL_SAVE_FUNCTION_NAME(BufferedAsioOutputArchive& ar,
-                          BinaryData<T> const& bd)
+inline void CEREAL_SAVE_FUNCTION_NAME(BufferedAsioOutputArchive& ar,
+                                      BinaryData<T> const& bd)
 {
     ar.saveBinary(bd.data, static_cast<std::streamsize>(bd.size));
 }

--- a/src/util/DebugMetaUtils.cpp
+++ b/src/util/DebugMetaUtils.cpp
@@ -45,14 +45,12 @@ listMetaDebugFiles(std::filesystem::path const& bucketDir)
     return std::vector<std::filesystem::path>(files.begin(), files.end());
 }
 
-bool
-isDebugSegmentBoundary(uint32_t ledgerSeq)
+bool isDebugSegmentBoundary(uint32_t ledgerSeq)
 {
     return ledgerSeq % META_DEBUG_LEDGER_SEGMENT_SIZE == 0;
 }
 
-size_t
-getNumberOfDebugFilesToKeep(uint32_t numLedgers)
+size_t getNumberOfDebugFilesToKeep(uint32_t numLedgers)
 {
     size_t segLen = META_DEBUG_LEDGER_SEGMENT_SIZE;
     // Always keep an extra older file in case the newest file just got rotated,
@@ -60,8 +58,7 @@ getNumberOfDebugFilesToKeep(uint32_t numLedgers)
     return ((numLedgers + segLen - 1) / segLen) + 1;
 }
 
-std::regex
-getDebugMetaRegexForLedger(uint32_t ledgerSeq)
+std::regex getDebugMetaRegexForLedger(uint32_t ledgerSeq)
 {
     std::string const regexStr =
         fmt::format("meta-debug-{:08x}-[[:xdigit:]]+\\.xdr(\\.gz)?", ledgerSeq);

--- a/src/util/Decoder.h
+++ b/src/util/Decoder.h
@@ -24,9 +24,7 @@ inline size_t constexpr encoded_size64(size_t rawsize)
     return ((rawsize + 2) / 3 * 4);
 }
 
-template <class T>
-inline std::string
-encode_b32(T const& v)
+template <class T> inline std::string encode_b32(T const& v)
 {
     std::string res;
     res.reserve(encoded_size32(v.size() * sizeof(typename T::value_type)) + 1);
@@ -34,9 +32,7 @@ encode_b32(T const& v)
     return res;
 }
 
-template <class T>
-inline std::string
-encode_b64(T const& v)
+template <class T> inline std::string encode_b64(T const& v)
 {
     std::string res;
     res.reserve(encoded_size64(v.size() * sizeof(typename T::value_type)) + 1);
@@ -44,18 +40,14 @@ encode_b64(T const& v)
     return res;
 }
 
-template <class V, class T>
-inline void
-decode_b32(V const& v, T& out)
+template <class V, class T> inline void decode_b32(V const& v, T& out)
 {
     out.clear();
     out.reserve(v.size() * sizeof(typename T::value_type));
     bn::decode_b32(v.begin(), v.end(), std::back_inserter(out));
 }
 
-template <class V, class T>
-inline void
-decode_b64(V const& v, T& out)
+template <class V, class T> inline void decode_b64(V const& v, T& out)
 {
     out.clear();
     out.reserve(v.size() * sizeof(typename T::value_type));
@@ -63,8 +55,7 @@ decode_b64(V const& v, T& out)
 }
 
 template <class Iter1, class Iter2>
-inline void
-decode_b64(Iter1 start, Iter1 end, Iter2 out)
+inline void decode_b64(Iter1 start, Iter1 end, Iter2 out)
 {
     bn::decode_b64(start, end, out);
 }

--- a/src/util/FileSystemException.cpp
+++ b/src/util/FileSystemException.cpp
@@ -14,8 +14,7 @@ namespace stellar
 
 #ifdef _WIN32
 
-std::string
-FileSystemException::getLastErrorString()
+std::string FileSystemException::getLastErrorString()
 {
     std::string res;
 
@@ -31,8 +30,7 @@ FileSystemException::getLastErrorString()
     return res;
 }
 
-void
-FileSystemException::failWithGetLastError(std::string msg)
+void FileSystemException::failWithGetLastError(std::string msg)
 {
     failWith(msg + ", " + getLastErrorString());
 }

--- a/src/util/FileSystemException.h
+++ b/src/util/FileSystemException.h
@@ -15,14 +15,12 @@ namespace stellar
 class FileSystemException : public std::runtime_error
 {
   public:
-    static void
-    failWith(std::string msg)
+    static void failWith(std::string msg)
     {
         CLOG_FATAL(Fs, "{}", msg);
         throw FileSystemException(msg);
     }
-    static void
-    failWithErrno(std::string msg)
+    static void failWithErrno(std::string msg)
     {
         failWith(msg + std::strerror(errno));
     }

--- a/src/util/Fs.cpp
+++ b/src/util/Fs.cpp
@@ -51,8 +51,7 @@ namespace fs
 
 static std::map<std::string, HANDLE> lockMap;
 
-void
-lockFile(std::string const& path)
+void lockFile(std::string const& path)
 {
     ZoneScoped;
     std::ostringstream errmsg;
@@ -78,8 +77,7 @@ lockFile(std::string const& path)
     lockMap.insert(std::make_pair(path, h));
 }
 
-void
-unlockFile(std::string const& path)
+void unlockFile(std::string const& path)
 {
     ZoneScoped;
     auto it = lockMap.find(path);
@@ -94,8 +92,7 @@ unlockFile(std::string const& path)
     }
 }
 
-void
-flushFileChanges(native_handle_t fh)
+void flushFileChanges(native_handle_t fh)
 {
     ZoneScoped;
     if (FlushFileBuffers(fh) == FALSE)
@@ -105,8 +102,7 @@ flushFileChanges(native_handle_t fh)
     }
 }
 
-native_handle_t
-openFileToWrite(std::string const& path)
+native_handle_t openFileToWrite(std::string const& path)
 {
     ZoneScoped;
     HANDLE h = ::CreateFile(path.c_str(),
@@ -126,8 +122,7 @@ openFileToWrite(std::string const& path)
     return h;
 }
 
-FILE*
-fdOpen(native_handle_t h)
+FILE* fdOpen(native_handle_t h)
 {
     FILE* res;
     int const fd =
@@ -148,9 +143,8 @@ fdOpen(native_handle_t h)
     return res;
 }
 
-bool
-durableRename(std::string const& src, std::string const& dst,
-              std::string const& dir)
+bool durableRename(std::string const& src, std::string const& dst,
+                   std::string const& dir)
 {
     ZoneScoped;
     if (MoveFileExA(src.c_str(), dst.c_str(),
@@ -171,8 +165,7 @@ durableRename(std::string const& src, std::string const& dst,
 
 static std::map<std::string, int> lockMap;
 
-void
-lockFile(std::string const& path)
+void lockFile(std::string const& path)
 {
     ZoneScoped;
     std::ostringstream errmsg;
@@ -203,8 +196,7 @@ lockFile(std::string const& path)
     lockMap.insert(std::make_pair(path, fd));
 }
 
-void
-unlockFile(std::string const& path)
+void unlockFile(std::string const& path)
 {
     ZoneScoped;
     auto it = lockMap.find(path);
@@ -220,8 +212,7 @@ unlockFile(std::string const& path)
     }
 }
 
-void
-flushFileChanges(native_handle_t fd)
+void flushFileChanges(native_handle_t fd)
 {
     ZoneScoped;
     while (fsync(fd) == -1)
@@ -235,8 +226,7 @@ flushFileChanges(native_handle_t fd)
     }
 }
 
-native_handle_t
-openFileToWrite(std::string const& path)
+native_handle_t openFileToWrite(std::string const& path)
 {
     ZoneScoped;
     int fd;
@@ -253,9 +243,8 @@ openFileToWrite(std::string const& path)
     return fd;
 }
 
-bool
-durableRename(std::string const& src, std::string const& dst,
-              std::string const& dir)
+bool durableRename(std::string const& src, std::string const& dst,
+                   std::string const& dir)
 {
     ZoneScoped;
     std::error_code ec;
@@ -298,15 +287,13 @@ durableRename(std::string const& src, std::string const& dst,
 
 namespace stdfs = std::filesystem;
 
-bool
-exists(std::string const& name)
+bool exists(std::string const& name)
 {
     ZoneScoped;
     return stdfs::exists(stdfs::path(name));
 }
 
-bool
-mkdir(std::string const& name)
+bool mkdir(std::string const& name)
 {
     ZoneScoped;
     bool ok = stdfs::create_directory(stdfs::path(name));
@@ -315,8 +302,7 @@ mkdir(std::string const& name)
     return ok;
 }
 
-void
-deltree(std::string const& d)
+void deltree(std::string const& d)
 {
     ZoneScoped;
     stdfs::remove_all(stdfs::path(d));
@@ -342,8 +328,7 @@ findfiles(std::string const& p,
     return res;
 }
 
-bool
-mkpath(const std::string& path)
+bool mkpath(const std::string& path)
 {
     ZoneScoped;
     auto p = stdfs::path(path);
@@ -351,14 +336,12 @@ mkpath(const std::string& path)
     return stdfs::exists(p) && stdfs::is_directory(p);
 }
 
-std::string
-hexStr(uint32_t checkpointNum)
+std::string hexStr(uint32_t checkpointNum)
 {
     return fmt::format(FMT_STRING("{:08x}"), checkpointNum);
 }
 
-std::string
-hexDir(std::string const& hexStr)
+std::string hexDir(std::string const& hexStr)
 {
     static const std::regex rx(
         "([[:xdigit:]]{2})([[:xdigit:]]{2})([[:xdigit:]]{2}).*");
@@ -369,28 +352,24 @@ hexDir(std::string const& hexStr)
             std::string(sm[3]));
 }
 
-std::string
-baseName(std::string const& type, std::string const& hexStr,
-         std::string const& suffix)
+std::string baseName(std::string const& type, std::string const& hexStr,
+                     std::string const& suffix)
 {
     return type + "-" + hexStr + "." + suffix;
 }
 
-std::string
-remoteDir(std::string const& type, std::string const& hexStr)
+std::string remoteDir(std::string const& type, std::string const& hexStr)
 {
     return type + "/" + hexDir(hexStr);
 }
 
-std::string
-remoteName(std::string const& type, std::string const& hexStr,
-           std::string const& suffix)
+std::string remoteName(std::string const& type, std::string const& hexStr,
+                       std::string const& suffix)
 {
     return remoteDir(type, hexStr) + "/" + baseName(type, hexStr, suffix);
 }
 
-void
-checkGzipSuffix(std::string const& filename)
+void checkGzipSuffix(std::string const& filename)
 {
     static const std::string suf(".gz");
     if (std::filesystem::path(filename).extension().string() != suf)
@@ -399,8 +378,7 @@ checkGzipSuffix(std::string const& filename)
     }
 }
 
-void
-checkNoGzipSuffix(std::string const& filename)
+void checkNoGzipSuffix(std::string const& filename)
 {
     static const std::string suf(".gz");
     if (std::filesystem::path(filename).extension().string() == suf)
@@ -409,8 +387,7 @@ checkNoGzipSuffix(std::string const& filename)
     }
 }
 
-size_t
-size(std::ifstream& ifs)
+size_t size(std::ifstream& ifs)
 {
     ZoneScoped;
     releaseAssert(ifs.is_open());
@@ -422,8 +399,7 @@ size(std::ifstream& ifs)
     return std::max(decltype(result){0}, result);
 }
 
-size_t
-size(std::string const& filename)
+size_t size(std::string const& filename)
 {
     ZoneScoped;
     return stdfs::file_size(stdfs::path(filename));
@@ -431,8 +407,7 @@ size(std::string const& filename)
 
 #ifdef _WIN32
 
-int64_t
-getMaxHandles()
+int64_t getMaxHandles()
 {
     // on Windows, there is no limit on handles
     // only limits based on ephemeral ports, etc
@@ -440,8 +415,7 @@ getMaxHandles()
 }
 
 #else
-int64_t
-getMaxHandles()
+int64_t getMaxHandles()
 {
     struct rlimit rl;
     if (getrlimit(RLIMIT_NOFILE, &rl) == 0)
@@ -455,8 +429,7 @@ getMaxHandles()
 #endif
 
 #if defined(_WIN32)
-int64_t
-getOpenHandleCount()
+int64_t getOpenHandleCount()
 {
     HANDLE proc =
         OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, GetCurrentProcessId());
@@ -472,8 +445,7 @@ getOpenHandleCount()
     return 0;
 }
 #elif defined(__APPLE__)
-int64_t
-getOpenHandleCount()
+int64_t getOpenHandleCount()
 {
     int64_t n{0};
     for (auto const& _fd : std::filesystem::directory_iterator("/dev/fd"))
@@ -484,8 +456,7 @@ getOpenHandleCount()
     return n;
 }
 #elif defined(__linux__)
-int64_t
-getOpenHandleCount()
+int64_t getOpenHandleCount()
 {
     int64_t n{0};
     for (auto const& _fd : std::filesystem::directory_iterator("/proc/self/fd"))
@@ -496,15 +467,13 @@ getOpenHandleCount()
     return n;
 }
 #else
-int64_t
-getOpenHandleCount()
+int64_t getOpenHandleCount()
 {
     return 0;
 }
 #endif
 
-bool
-removeWithLog(std::string const& path, bool ignoreEnoent)
+bool removeWithLog(std::string const& path, bool ignoreEnoent)
 {
     if (std::remove(path.c_str()) == 0)
     {

--- a/src/util/Fs.h
+++ b/src/util/Fs.h
@@ -18,8 +18,7 @@ namespace fs
 {
 
 // An AWS EBS IOP is 256kb, so we try to write those.
-inline constexpr size_t
-bufsz()
+inline constexpr size_t bufsz()
 {
     return 0x40000;
 }

--- a/src/util/GlobalChecks.cpp
+++ b/src/util/GlobalChecks.cpp
@@ -18,14 +18,12 @@ namespace stellar
 {
 static std::thread::id mainThread = std::this_thread::get_id();
 
-bool
-threadIsMain()
+bool threadIsMain()
 {
     return mainThread == std::this_thread::get_id();
 }
 
-void
-dbgAbort()
+void dbgAbort()
 {
 #ifdef _WIN32
     DebugBreak();
@@ -34,8 +32,7 @@ dbgAbort()
 #endif
 }
 
-void
-printErrorAndAbort(const char* s1)
+void printErrorAndAbort(const char* s1)
 {
     std::fprintf(stderr, "%s\n", s1);
     std::fflush(stderr);
@@ -44,8 +41,7 @@ printErrorAndAbort(const char* s1)
     std::abort();
 }
 
-void
-printErrorAndAbort(const char* s1, const char* s2)
+void printErrorAndAbort(const char* s1, const char* s2)
 {
     std::fprintf(stderr, "%s%s\n", s1, s2);
     std::fflush(stderr);
@@ -54,8 +50,7 @@ printErrorAndAbort(const char* s1, const char* s2)
     std::abort();
 }
 
-void
-printAssertFailureAndAbort(const char* s1, const char* file, int line)
+void printAssertFailureAndAbort(const char* s1, const char* file, int line)
 {
     std::fprintf(stderr, "%s at %s:%d\n", s1, file, line);
     std::fflush(stderr);
@@ -64,8 +59,7 @@ printAssertFailureAndAbort(const char* s1, const char* file, int line)
     std::abort();
 }
 
-void
-printAssertFailureAndThrow(const char* s1, const char* file, int line)
+void printAssertFailureAndThrow(const char* s1, const char* file, int line)
 {
     std::fprintf(stderr, "%s at %s:%d\n", s1, file, line);
     std::fflush(stderr);

--- a/src/util/JitterInjection.cpp
+++ b/src/util/JitterInjection.cpp
@@ -23,8 +23,7 @@ static JitterInjector::Config gJitterConfig;
 // Track whether current thread's RNG has been initialized
 static thread_local bool gJitterRandEngineInitialized{false};
 
-void
-JitterInjector::initialize(uint32_t testSeed)
+void JitterInjector::initialize(uint32_t testSeed)
 {
     releaseAssert(threadIsMain());
 
@@ -41,21 +40,19 @@ JitterInjector::initialize(uint32_t testSeed)
                testSeed);
 }
 
-void
-JitterInjector::resetStats()
+void JitterInjector::resetStats()
 {
     sInjectionCount = 0;
     sDelayCount = 0;
 }
 
-void
-JitterInjector::configure(const Config& cfg)
+void JitterInjector::configure(const Config& cfg)
 {
     gJitterConfig = cfg;
 }
 
-bool
-JitterInjector::injectDelay(int32_t probability, uint32_t minNs, uint32_t maxNs)
+bool JitterInjector::injectDelay(int32_t probability, uint32_t minNs,
+                                 uint32_t maxNs)
 {
     // Initialize RNG on first use for this thread
     if (!gJitterRandEngineInitialized)
@@ -109,8 +106,7 @@ JitterInjector::injectDelay(int32_t probability, uint32_t minNs, uint32_t maxNs)
     return true;
 }
 
-void
-JitterInjector::yield()
+void JitterInjector::yield()
 {
     sInjectionCount++;
 

--- a/src/util/JitterInjection.h
+++ b/src/util/JitterInjection.h
@@ -90,13 +90,11 @@ class JitterInjector
     static void resetStats();
 
     // Get statistics
-    static uint64_t
-    getInjectionCount()
+    static uint64_t getInjectionCount()
     {
         return sInjectionCount;
     }
-    static uint64_t
-    getDelayCount()
+    static uint64_t getDelayCount()
     {
         return sDelayCount;
     }

--- a/src/util/LogSlowExecution.cpp
+++ b/src/util/LogSlowExecution.cpp
@@ -37,8 +37,7 @@ LogSlowExecution::~LogSlowExecution()
     }
 }
 
-std::chrono::milliseconds
-LogSlowExecution::checkElapsedTime() const
+std::chrono::milliseconds LogSlowExecution::checkElapsedTime() const
 {
     auto finish = std::chrono::system_clock::now();
     auto elapsed =

--- a/src/util/Logging.cpp
+++ b/src/util/Logging.cpp
@@ -52,8 +52,7 @@ CoutLogger::~CoutLogger()
 }
 
 #if defined(USE_SPDLOG)
-static spdlog::level::level_enum
-convert_loglevel(LogLevel level)
+static spdlog::level::level_enum convert_loglevel(LogLevel level)
 {
     auto slev = spdlog::level::info;
     switch (level)
@@ -83,8 +82,7 @@ convert_loglevel(LogLevel level)
 }
 #endif
 
-void
-Logging::init(bool truncate)
+void Logging::init(bool truncate)
 {
 #if defined(USE_SPDLOG)
     std::lock_guard<std::recursive_mutex> guard(mLogMutex);
@@ -199,8 +197,7 @@ Logging::init(bool truncate)
 #endif
 }
 
-void
-Logging::deinit()
+void Logging::deinit()
 {
 #if defined(USE_SPDLOG)
     std::lock_guard<std::recursive_mutex> guard(mLogMutex);
@@ -215,8 +212,7 @@ Logging::deinit()
 #endif
 }
 
-void
-Logging::setFmt(std::string const& peerID, bool timestamps)
+void Logging::setFmt(std::string const& peerID, bool timestamps)
 {
 #if defined(USE_SPDLOG)
     auto pattern =
@@ -231,8 +227,7 @@ Logging::setFmt(std::string const& peerID, bool timestamps)
 #endif
 }
 
-void
-Logging::setLoggingToConsole(bool console)
+void Logging::setLoggingToConsole(bool console)
 {
 #if defined(USE_SPDLOG)
     std::lock_guard<std::recursive_mutex> guard(mLogMutex);
@@ -242,8 +237,7 @@ Logging::setLoggingToConsole(bool console)
 #endif
 }
 
-void
-Logging::setLoggingToFile(std::string const& filename)
+void Logging::setLoggingToFile(std::string const& filename)
 {
 #if defined(USE_SPDLOG)
     std::lock_guard<std::recursive_mutex> guard(mLogMutex);
@@ -266,8 +260,7 @@ Logging::setLoggingToFile(std::string const& filename)
 #endif
 }
 
-void
-Logging::setLoggingColor(bool color)
+void Logging::setLoggingColor(bool color)
 {
 #if defined(USE_SPDLOG)
     std::lock_guard<std::recursive_mutex> guard(mLogMutex);
@@ -277,8 +270,7 @@ Logging::setLoggingColor(bool color)
 #endif
 }
 
-void
-Logging::setLogLevel(LogLevel level, const char* partition)
+void Logging::setLogLevel(LogLevel level, const char* partition)
 {
     std::lock_guard<std::recursive_mutex> guard(mLogMutex);
     if (partition)
@@ -305,8 +297,7 @@ Logging::setLogLevel(LogLevel level, const char* partition)
 #endif
 }
 
-LogLevel
-Logging::getLLfromString(std::string const& levelName)
+LogLevel Logging::getLLfromString(std::string const& levelName)
 {
     if (iequals(levelName, "fatal"))
     {
@@ -336,8 +327,7 @@ Logging::getLLfromString(std::string const& levelName)
     return LogLevel::LVL_INFO;
 }
 
-LogLevel
-Logging::getLogLevel(std::string const& partition)
+LogLevel Logging::getLogLevel(std::string const& partition)
 {
     std::lock_guard<std::recursive_mutex> guard(mLogMutex);
     auto p = mPartitionLogLevels.find(partition);
@@ -348,8 +338,7 @@ Logging::getLogLevel(std::string const& partition)
     return mGlobalLogLevel;
 }
 
-std::string
-Logging::getStringFromLL(LogLevel level)
+std::string Logging::getStringFromLL(LogLevel level)
 {
     switch (level)
     {
@@ -369,20 +358,17 @@ Logging::getStringFromLL(LogLevel level)
     return "????";
 }
 
-bool
-Logging::logDebug(std::string const& partition)
+bool Logging::logDebug(std::string const& partition)
 {
     return isLogLevelAtLeast(partition, LogLevel::LVL_DEBUG);
 }
 
-bool
-Logging::logTrace(std::string const& partition)
+bool Logging::logTrace(std::string const& partition)
 {
     return isLogLevelAtLeast(partition, LogLevel::LVL_TRACE);
 }
 
-bool
-Logging::isLogLevelAtLeast(std::string const& partition, LogLevel level)
+bool Logging::isLogLevelAtLeast(std::string const& partition, LogLevel level)
 {
     std::lock_guard<std::recursive_mutex> guard(mLogMutex);
     auto it = mPartitionLogLevels.find(partition);
@@ -393,8 +379,7 @@ Logging::isLogLevelAtLeast(std::string const& partition, LogLevel level)
     return mGlobalLogLevel >= level;
 }
 
-void
-Logging::rotate()
+void Logging::rotate()
 {
     std::lock_guard<std::recursive_mutex> guard(mLogMutex);
     deinit();
@@ -402,8 +387,7 @@ Logging::rotate()
 }
 
 // throws if partition name is not recognized
-std::string
-Logging::normalizePartition(std::string const& partition)
+std::string Logging::normalizePartition(std::string const& partition)
 {
     for (auto& p : kPartitionNames)
     {
@@ -433,9 +417,8 @@ std::recursive_mutex Logging::mLogMutex;
 #undef LOG_PARTITION
 #endif
 
-void
-Logging::logAtPartitionAndLevel(std::string const& partition, LogLevel level,
-                                std::string const& msg)
+void Logging::logAtPartitionAndLevel(std::string const& partition,
+                                     LogLevel level, std::string const& msg)
 {
 #if defined(USE_SPDLOG)
     auto lev = convert_loglevel(level);

--- a/src/util/Logging.h
+++ b/src/util/Logging.h
@@ -145,9 +145,7 @@ class CoutLogger
 
     ~CoutLogger();
 
-    template <typename T>
-    CoutLogger&
-    operator<<(T const& val)
+    template <typename T> CoutLogger& operator<<(T const& val)
     {
         if (mShouldLog)
         {
@@ -218,8 +216,7 @@ format_as(T const& u)
 
 namespace std::filesystem
 {
-inline std::string
-format_as(path const& p)
+inline std::string format_as(path const& p)
 {
     return p.string();
 }

--- a/src/util/Math.cpp
+++ b/src/util/Math.cpp
@@ -22,8 +22,7 @@ namespace stellar
 
 std::uniform_real_distribution<double> uniformFractionDistribution(0.0, 1.0);
 
-stellar_default_random_engine&
-getGlobalRandomEngine()
+stellar_default_random_engine& getGlobalRandomEngine()
 {
     // gRandomEngine is for main thread only.
     static stellar_default_random_engine gRandomEngine;
@@ -31,20 +30,17 @@ getGlobalRandomEngine()
     return gRandomEngine;
 }
 
-double
-rand_fraction()
+double rand_fraction()
 {
     return uniformFractionDistribution(getGlobalRandomEngine());
 }
 
-bool
-rand_flip()
+bool rand_flip()
 {
     return (getGlobalRandomEngine()() & 1);
 }
 
-double
-closest_cluster(double p, std::set<double> const& centers)
+double closest_cluster(double p, std::set<double> const& centers)
 {
     auto bestCenter = std::numeric_limits<double>::max();
     auto currDist = std::numeric_limits<double>::max();
@@ -65,8 +61,7 @@ closest_cluster(double p, std::set<double> const& centers)
     return bestCenter;
 }
 
-VirtualClock::duration
-exponentialBackoff(uint64_t n)
+VirtualClock::duration exponentialBackoff(uint64_t n)
 {
     // Cap to 512 sec or ~8 minutes
     uint64_t const MAX_EXPONENT = 9;
@@ -75,8 +70,7 @@ exponentialBackoff(uint64_t n)
     return std::chrono::seconds(rand_uniform<uint64_t>(lowerBound, upperBound));
 }
 
-std::set<double>
-k_meansPP(std::vector<double> const& points, uint32_t k)
+std::set<double> k_meansPP(std::vector<double> const& points, uint32_t k)
 {
     auto& engine = getGlobalRandomEngine();
     if (k == 0)
@@ -129,8 +123,7 @@ k_meansPP(std::vector<double> const& points, uint32_t k)
     return centroids;
 }
 
-std::set<double>
-k_means(std::vector<double> const& points, uint32_t k)
+std::set<double> k_means(std::vector<double> const& points, uint32_t k)
 {
     ZoneScoped;
     // initialize centroids with k-means++
@@ -181,8 +174,7 @@ k_means(std::vector<double> const& points, uint32_t k)
 }
 
 static unsigned int lastGlobalSeed{0};
-static void
-reinitializeAllGlobalStateWithSeedInternal(unsigned int seed)
+static void reinitializeAllGlobalStateWithSeedInternal(unsigned int seed)
 {
     lastGlobalSeed = seed;
     PubKeyUtils::clearVerifySigCache();
@@ -196,8 +188,7 @@ reinitializeAllGlobalStateWithSeedInternal(unsigned int seed)
 #endif
 }
 
-void
-initializeAllGlobalState()
+void initializeAllGlobalState()
 {
     releaseAssert(lastGlobalSeed == 0);
     auto const seed = static_cast<unsigned int>(
@@ -208,8 +199,7 @@ initializeAllGlobalState()
 }
 
 #ifdef BUILD_TESTS
-void
-reinitializeAllGlobalStateWithSeed(unsigned int seed)
+void reinitializeAllGlobalStateWithSeed(unsigned int seed)
 {
     reinitializeAllGlobalStateWithSeedInternal(seed);
     // shortHash seeded for tests
@@ -223,8 +213,7 @@ reinitializeAllGlobalStateWithSeed(unsigned int seed)
 #endif
 }
 
-unsigned int
-getLastGlobalStateSeed()
+unsigned int getLastGlobalStateSeed()
 {
     return lastGlobalSeed;
 }

--- a/src/util/Math.h
+++ b/src/util/Math.h
@@ -28,22 +28,17 @@ typedef std::minstd_rand stellar_default_random_engine;
 stellar_default_random_engine& getGlobalRandomEngine();
 
 template <typename T>
-T
-rand_uniform(T lo, T hi, stellar_default_random_engine& engine)
+T rand_uniform(T lo, T hi, stellar_default_random_engine& engine)
 {
     return stellar::uniform_int_distribution<T>(lo, hi)(engine);
 }
 
-template <typename T>
-T
-rand_uniform(T lo, T hi)
+template <typename T> T rand_uniform(T lo, T hi)
 {
     return rand_uniform<T>(lo, hi, getGlobalRandomEngine());
 }
 
-template <typename T>
-T const&
-rand_element(std::vector<T> const& v)
+template <typename T> T const& rand_element(std::vector<T> const& v)
 {
     if (v.size() == 0)
     {
@@ -52,9 +47,7 @@ rand_element(std::vector<T> const& v)
     return v.at(rand_uniform<size_t>(0, v.size() - 1));
 }
 
-template <typename T>
-T&
-rand_element(std::vector<T>& v)
+template <typename T> T& rand_element(std::vector<T>& v)
 {
     if (v.size() == 0)
     {

--- a/src/util/MetaUtils.cpp
+++ b/src/util/MetaUtils.cpp
@@ -16,8 +16,7 @@ namespace
 using namespace stellar;
 struct CmpLedgerEntryChanges
 {
-    int
-    remap(LedgerEntryChangeType let)
+    int remap(LedgerEntryChangeType let)
     {
         // order that we want is:
         // LEDGER_ENTRY_STATE, LEDGER_ENTRY_CREATED,
@@ -27,8 +26,7 @@ struct CmpLedgerEntryChanges
         return reindex[let];
     }
 
-    LedgerKey
-    getKeyFromChange(LedgerEntryChange const& change)
+    LedgerKey getKeyFromChange(LedgerEntryChange const& change)
     {
         LedgerKey res;
         switch (change.type())
@@ -52,8 +50,7 @@ struct CmpLedgerEntryChanges
         return res;
     }
 
-    bool
-    operator()(LedgerEntryChange const& l, LedgerEntryChange const& r)
+    bool operator()(LedgerEntryChange const& l, LedgerEntryChange const& r)
     {
         auto lT =
             std::make_tuple(getKeyFromChange(l), remap(l.type()), xdrSha256(l));
@@ -63,14 +60,12 @@ struct CmpLedgerEntryChanges
     }
 };
 
-void
-sortChanges(LedgerEntryChanges& c)
+void sortChanges(LedgerEntryChanges& c)
 {
     std::sort(c.begin(), c.end(), CmpLedgerEntryChanges());
 }
 
-void
-normalizeOps(xdr::xvector<OperationMeta>& oms)
+void normalizeOps(xdr::xvector<OperationMeta>& oms)
 {
     for (auto& om : oms)
     {
@@ -78,8 +73,7 @@ normalizeOps(xdr::xvector<OperationMeta>& oms)
     }
 }
 
-void
-normalizeOps(xdr::xvector<OperationMetaV2>& oms)
+void normalizeOps(xdr::xvector<OperationMetaV2>& oms)
 {
     for (auto& om : oms)
     {
@@ -91,8 +85,7 @@ normalizeOps(xdr::xvector<OperationMetaV2>& oms)
 namespace stellar
 {
 
-void
-normalizeMeta(TransactionMeta& m)
+void normalizeMeta(TransactionMeta& m)
 {
     switch (m.v())
     {
@@ -123,8 +116,7 @@ normalizeMeta(TransactionMeta& m)
     }
 }
 
-void
-normalizeMeta(LedgerCloseMeta& lcm)
+void normalizeMeta(LedgerCloseMeta& lcm)
 {
     switch (lcm.v())
     {

--- a/src/util/MetricResetter.cpp
+++ b/src/util/MetricResetter.cpp
@@ -7,32 +7,27 @@
 namespace stellar
 {
 
-void
-MetricResetter::Process(medida::Counter& counter)
+void MetricResetter::Process(medida::Counter& counter)
 {
     counter.clear();
 }
 
-void
-MetricResetter::Process(medida::Meter& meter)
+void MetricResetter::Process(medida::Meter& meter)
 {
     meter.Clear();
 }
 
-void
-MetricResetter::Process(medida::Histogram& histogram)
+void MetricResetter::Process(medida::Histogram& histogram)
 {
     histogram.Clear();
 }
 
-void
-MetricResetter::Process(medida::Timer& timer)
+void MetricResetter::Process(medida::Timer& timer)
 {
     timer.Clear();
 }
 
-void
-MetricResetter::Process(medida::Buckets& buckets)
+void MetricResetter::Process(medida::Buckets& buckets)
 {
     buckets.Clear();
 }

--- a/src/util/NonCopyable.h
+++ b/src/util/NonCopyable.h
@@ -21,7 +21,8 @@ struct NonMovable
     NonMovable& operator=(NonMovable&&) = delete;
 };
 
-struct NonMovableOrCopyable : private NonCopyable, NonMovable
+struct NonMovableOrCopyable : private NonCopyable,
+                              NonMovable
 {
     NonMovableOrCopyable() = default;
 };

--- a/src/util/ProtocolVersion.cpp
+++ b/src/util/ProtocolVersion.cpp
@@ -6,20 +6,20 @@
 
 namespace stellar
 {
-bool
-protocolVersionIsBefore(uint32_t protocolVersion, ProtocolVersion beforeVersion)
+bool protocolVersionIsBefore(uint32_t protocolVersion,
+                             ProtocolVersion beforeVersion)
 {
     return protocolVersion < static_cast<uint32_t>(beforeVersion);
 }
 
-bool
-protocolVersionStartsFrom(uint32_t protocolVersion, ProtocolVersion fromVersion)
+bool protocolVersionStartsFrom(uint32_t protocolVersion,
+                               ProtocolVersion fromVersion)
 {
     return protocolVersion >= static_cast<uint32_t>(fromVersion);
 }
 
-bool
-protocolVersionEquals(uint32_t protocolVersion, ProtocolVersion equalsVersion)
+bool protocolVersionEquals(uint32_t protocolVersion,
+                           ProtocolVersion equalsVersion)
 {
     return protocolVersion == static_cast<uint32_t>(equalsVersion);
 }

--- a/src/util/RandHasher.cpp
+++ b/src/util/RandHasher.cpp
@@ -16,8 +16,7 @@ size_t gMixer{0};
 bool gHaveInitialized{false};
 static std::mutex gInitMutex;
 
-void
-initialize()
+void initialize()
 {
     std::lock_guard<std::mutex> guard(gInitMutex);
     if (!gHaveInitialized)

--- a/src/util/RandHasher.h
+++ b/src/util/RandHasher.h
@@ -19,8 +19,7 @@ extern size_t gMixer;
 template <class T, class Hasher = std::hash<T>> class RandHasher
 {
   public:
-    size_t
-    operator()(T const& t) const
+    size_t operator()(T const& t) const
     {
         releaseAssert(randHash::gHaveInitialized);
         return Hasher()(t) ^ randHash::gMixer;

--- a/src/util/RandomEvictionCache.h
+++ b/src/util/RandomEvictionCache.h
@@ -68,8 +68,7 @@ class RandomEvictionCache : public NonMovableOrCopyable
     stellar_default_random_engine mRandEngine;
 
     // Randomly pick two elements and evict the less-recently-used one.
-    void
-    evictOne()
+    void evictOne()
     {
         size_t sz = mValuePtrs.size();
         if (sz == 0)
@@ -97,26 +96,22 @@ class RandomEvictionCache : public NonMovableOrCopyable
         mValuePtrs.reserve(maxSize + 1);
     }
 
-    void
-    seed(unsigned int seed)
+    void seed(unsigned int seed)
     {
         mRandEngine.seed(seed);
     }
 
-    size_t
-    maxSize() const
+    size_t maxSize() const
     {
         return mMaxSize;
     }
 
-    size_t
-    size() const
+    size_t size() const
     {
         return mValueMap.size();
     }
 
-    Counters const&
-    getCounters() const
+    Counters const& getCounters() const
     {
         return mCounters;
     }
@@ -124,8 +119,7 @@ class RandomEvictionCache : public NonMovableOrCopyable
     // `put` does not offer exception safety. If it throws an exception,
     // cache may be in an inconsistent state. It is, therefore,
     // client's responsibility to handle failures correctly.
-    void
-    put(K const& k, V const& v)
+    void put(K const& k, V const& v)
     {
         ++mGeneration;
         CacheValue newValue{mGeneration, v};
@@ -155,8 +149,7 @@ class RandomEvictionCache : public NonMovableOrCopyable
     }
 
     // `exists` offers strong exception safety guarantee.
-    bool
-    exists(K const& k, bool countMisses = true)
+    bool exists(K const& k, bool countMisses = true)
     {
         bool miss = (mValueMap.find(k) == mValueMap.end());
         // We do not count hits here; but we usually count misses, as exists()
@@ -173,8 +166,7 @@ class RandomEvictionCache : public NonMovableOrCopyable
     }
 
     // `clear` does not throw
-    void
-    clear()
+    void clear()
     {
         mValuePtrs.clear();
         mValueMap.clear();
@@ -182,8 +174,7 @@ class RandomEvictionCache : public NonMovableOrCopyable
 
     // `erase_if` offers basic exception safety guarantee. If it throws an
     // exception, then the cache may or may not be modified.
-    void
-    erase_if(std::function<bool(V const&)> const& f)
+    void erase_if(std::function<bool(V const&)> const& f)
     {
         for (size_t i = 0; i < mValuePtrs.size(); ++i)
         {
@@ -205,8 +196,7 @@ class RandomEvictionCache : public NonMovableOrCopyable
     // `maybeGet` offers basic exception safety guarantee.
     // Returns a pointer to the value if the key exists,
     // and returns a nullptr otherwise.
-    V*
-    maybeGet(K const& k)
+    V* maybeGet(K const& k)
     {
         auto it = mValueMap.find(k);
         if (it != mValueMap.end())
@@ -224,8 +214,7 @@ class RandomEvictionCache : public NonMovableOrCopyable
     }
 
     // `get` offers basic exception safety guarantee.
-    V&
-    get(K const& k)
+    V& get(K const& k)
     {
         V* result = maybeGet(k);
         if (result == nullptr)

--- a/src/util/Scheduler.cpp
+++ b/src/util/Scheduler.cpp
@@ -49,14 +49,12 @@ class Scheduler::ActionQueue
     {
     }
 
-    bool
-    isInIdleList() const
+    bool isInIdleList() const
     {
         return mIdlePosition != mIdleList.end();
     }
 
-    void
-    addToIdleList()
+    void addToIdleList()
     {
         releaseAssert(!isInIdleList());
         releaseAssert(isEmpty());
@@ -64,8 +62,7 @@ class Scheduler::ActionQueue
         mIdlePosition = mIdleList.begin();
     }
 
-    void
-    removeFromIdleList()
+    void removeFromIdleList()
     {
         releaseAssert(isInIdleList());
         releaseAssert(isEmpty());
@@ -73,44 +70,37 @@ class Scheduler::ActionQueue
         mIdlePosition = mIdleList.end();
     }
 
-    std::string const&
-    name() const
+    std::string const& name() const
     {
         return mName;
     }
 
-    ActionType
-    type() const
+    ActionType type() const
     {
         return mType;
     }
 
-    nsecs
-    totalService() const
+    nsecs totalService() const
     {
         return mTotalService;
     }
 
-    std::chrono::steady_clock::time_point
-    lastService() const
+    std::chrono::steady_clock::time_point lastService() const
     {
         return mLastService;
     }
 
-    size_t
-    size() const
+    size_t size() const
     {
         return mActions.size();
     }
 
-    bool
-    isEmpty() const
+    bool isEmpty() const
     {
         return mActions.empty();
     }
 
-    bool
-    isOverloaded(nsecs latencyWindow, VirtualClock::time_point now) const
+    bool isOverloaded(nsecs latencyWindow, VirtualClock::time_point now) const
     {
         if (!mActions.empty())
         {
@@ -120,8 +110,7 @@ class Scheduler::ActionQueue
         return false;
     }
 
-    size_t
-    tryTrim(nsecs latencyWindow, VirtualClock::time_point now)
+    size_t tryTrim(nsecs latencyWindow, VirtualClock::time_point now)
     {
         size_t n = 0;
         while (mType == ActionType::DROPPABLE_ACTION && !mActions.empty() &&
@@ -133,15 +122,13 @@ class Scheduler::ActionQueue
         return n;
     }
 
-    void
-    enqueue(VirtualClock& clock, Action&& action)
+    void enqueue(VirtualClock& clock, Action&& action)
     {
         auto elt = Element(clock, std::move(action));
         mActions.emplace_back(std::move(elt));
     }
 
-    void
-    runNext(VirtualClock& clock, nsecs minTotalService)
+    void runNext(VirtualClock& clock, nsecs minTotalService)
     {
         ZoneScoped;
         ZoneText(mName.c_str(), mName.size());
@@ -171,16 +158,14 @@ Scheduler::Scheduler(VirtualClock& clock,
     setOverloaded(false);
 }
 
-void
-Scheduler::trimSingleActionQueue(Qptr q, VirtualClock::time_point now)
+void Scheduler::trimSingleActionQueue(Qptr q, VirtualClock::time_point now)
 {
     size_t trimmed = q->tryTrim(mLatencyWindow, now);
     mStats.mActionsDroppedDueToOverload += trimmed;
     mSize -= trimmed;
 }
 
-void
-Scheduler::trimIdleActionQueues(VirtualClock::time_point now)
+void Scheduler::trimIdleActionQueues(VirtualClock::time_point now)
 {
     if (mIdleActionQueues.empty())
     {
@@ -195,8 +180,7 @@ Scheduler::trimIdleActionQueues(VirtualClock::time_point now)
     }
 }
 
-void
-Scheduler::shutdown()
+void Scheduler::shutdown()
 {
     if (!mIsShutdown)
     {
@@ -210,8 +194,7 @@ Scheduler::shutdown()
     }
 }
 
-void
-Scheduler::setOverloaded(bool overloaded)
+void Scheduler::setOverloaded(bool overloaded)
 {
     if (overloaded)
     {
@@ -223,8 +206,7 @@ Scheduler::setOverloaded(bool overloaded)
     }
 }
 
-void
-Scheduler::enqueue(std::string&& name, Action&& action, ActionType type)
+void Scheduler::enqueue(std::string&& name, Action&& action, ActionType type)
 {
     if (mIsShutdown)
     {
@@ -255,8 +237,7 @@ Scheduler::enqueue(std::string&& name, Action&& action, ActionType type)
     mSize += 1;
 }
 
-size_t
-Scheduler::runOne()
+size_t Scheduler::runOne()
 {
     auto start = mClock.now();
     trimIdleActionQueues(start);
@@ -326,8 +307,7 @@ Scheduler::runOne()
     }
 }
 
-std::chrono::seconds
-Scheduler::getOverloadedDuration() const
+std::chrono::seconds Scheduler::getOverloadedDuration() const
 {
     auto now = mClock.now();
     std::chrono::seconds res;
@@ -345,8 +325,7 @@ Scheduler::getOverloadedDuration() const
     return res;
 }
 
-Scheduler::ActionType
-Scheduler::currentActionType() const
+Scheduler::ActionType Scheduler::currentActionType() const
 {
     return mCurrentActionType;
 }
@@ -363,8 +342,7 @@ Scheduler::getExistingQueue(std::string const& name, ActionType type) const
     return qi->second;
 }
 
-std::string const&
-Scheduler::nextQueueToRun() const
+std::string const& Scheduler::nextQueueToRun() const
 {
     static std::string empty;
     if (mRunnableActionQueues.empty())
@@ -373,16 +351,15 @@ Scheduler::nextQueueToRun() const
     }
     return mRunnableActionQueues.top()->name();
 }
-std::chrono::nanoseconds
-Scheduler::totalService(std::string const& q, ActionType type) const
+std::chrono::nanoseconds Scheduler::totalService(std::string const& q,
+                                                 ActionType type) const
 {
     auto eq = getExistingQueue(q, type);
     releaseAssert(eq);
     return eq->totalService();
 }
 
-size_t
-Scheduler::queueLength(std::string const& q, ActionType type) const
+size_t Scheduler::queueLength(std::string const& q, ActionType type) const
 {
     auto eq = getExistingQueue(q, type);
     releaseAssert(eq);

--- a/src/util/Scheduler.h
+++ b/src/util/Scheduler.h
@@ -224,20 +224,17 @@ class Scheduler
     // overloaded)
     std::chrono::seconds getOverloadedDuration() const;
 
-    size_t
-    size() const
+    size_t size() const
     {
         return mSize;
     }
 
-    std::chrono::nanoseconds
-    maxTotalService() const
+    std::chrono::nanoseconds maxTotalService() const
     {
         return mMaxTotalService;
     }
 
-    Stats const&
-    stats() const
+    Stats const& stats() const
     {
         return mStats;
     }

--- a/src/util/SecretValue.cpp
+++ b/src/util/SecretValue.cpp
@@ -7,14 +7,12 @@
 namespace stellar
 {
 
-bool
-operator==(SecretValue const& x, SecretValue const& y)
+bool operator==(SecretValue const& x, SecretValue const& y)
 {
     return x.value == y.value;
 }
 
-bool
-operator!=(SecretValue const& x, SecretValue const& y)
+bool operator!=(SecretValue const& x, SecretValue const& y)
 {
     return !(x == y);
 }

--- a/src/util/StatusManager.cpp
+++ b/src/util/StatusManager.cpp
@@ -17,20 +17,17 @@ StatusManager::~StatusManager()
 {
 }
 
-void
-StatusManager::setStatusMessage(StatusCategory issue, std::string message)
+void StatusManager::setStatusMessage(StatusCategory issue, std::string message)
 {
     mStatusMessages[issue] = std::move(message);
 }
 
-void
-StatusManager::removeStatusMessage(StatusCategory issue)
+void StatusManager::removeStatusMessage(StatusCategory issue)
 {
     mStatusMessages.erase(issue);
 }
 
-std::string
-StatusManager::getStatusMessage(StatusCategory issue) const
+std::string StatusManager::getStatusMessage(StatusCategory issue) const
 {
     auto it = mStatusMessages.find(issue);
     if (it == mStatusMessages.end())

--- a/src/util/StatusManager.h
+++ b/src/util/StatusManager.h
@@ -39,18 +39,15 @@ class StatusManager
     void removeStatusMessage(StatusCategory issue);
     std::string getStatusMessage(StatusCategory issue) const;
 
-    const_iterator
-    begin() const
+    const_iterator begin() const
     {
         return mStatusMessages.begin();
     }
-    const_iterator
-    end() const
+    const_iterator end() const
     {
         return mStatusMessages.end();
     }
-    std::size_t
-    size() const
+    std::size_t size() const
     {
         return mStatusMessages.size();
     }

--- a/src/util/TarjanSCCCalculator.cpp
+++ b/src/util/TarjanSCCCalculator.cpp
@@ -15,8 +15,7 @@ TarjanSCCCalculator::TarjanSCCCalculator()
 {
 }
 
-void
-TarjanSCCCalculator::calculateSCCs(
+void TarjanSCCCalculator::calculateSCCs(
     size_t graphSize,
     std::function<BitSet const&(size_t)> const& getNodeSuccessors)
 {
@@ -37,8 +36,7 @@ TarjanSCCCalculator::calculateSCCs(
     }
 }
 
-void
-TarjanSCCCalculator::scc(
+void TarjanSCCCalculator::scc(
     size_t i, std::function<BitSet const&(size_t)> const& getNodeSuccessors)
 {
     auto& v = mNodes.at(i);

--- a/src/util/Thread.cpp
+++ b/src/util/Thread.cpp
@@ -19,8 +19,7 @@ namespace stellar
 
 #if defined(_WIN32)
 
-static void
-runCurrentThreadWithPriority(int priority)
+static void runCurrentThreadWithPriority(int priority)
 {
     HANDLE curThread = ::GetCurrentThread();
     BOOL ret = ::SetThreadPriority(curThread, priority);
@@ -31,22 +30,19 @@ runCurrentThreadWithPriority(int priority)
     }
 }
 
-void
-runCurrentThreadWithLowPriority()
+void runCurrentThreadWithLowPriority()
 {
     runCurrentThreadWithPriority(THREAD_PRIORITY_LOWEST);
 }
 
-void
-runCurrentThreadWithMediumPriority()
+void runCurrentThreadWithMediumPriority()
 {
     runCurrentThreadWithPriority(THREAD_PRIORITY_BELOW_NORMAL);
 }
 
 #elif defined(__linux__)
 
-static void
-runCurrentThreadWithPriority(int priority)
+static void runCurrentThreadWithPriority(int priority)
 {
     auto newNice = nice(priority);
     if (newNice != priority)
@@ -56,22 +52,19 @@ runCurrentThreadWithPriority(int priority)
     }
 }
 
-void
-runCurrentThreadWithLowPriority()
+void runCurrentThreadWithLowPriority()
 {
     runCurrentThreadWithPriority(/*LOW_PRIORITY_NICE*/ 5);
 }
 
-void
-runCurrentThreadWithMediumPriority()
+void runCurrentThreadWithMediumPriority()
 {
     runCurrentThreadWithPriority(/*MED_PRIORITY_NICE*/ 3);
 }
 
 #elif defined(__APPLE__)
 
-static void
-runCurrentThreadWithPriority(int priority)
+static void runCurrentThreadWithPriority(int priority)
 {
     // Default MacOS priority is 31 in a user-mode band from 0..63, niceing (or
     // other priority-adjustment) usually subtracts from there. Range is +/- 16,
@@ -92,26 +85,22 @@ runCurrentThreadWithPriority(int priority)
     }
 }
 
-void
-runCurrentThreadWithLowPriority()
+void runCurrentThreadWithLowPriority()
 {
     runCurrentThreadWithPriority(/*LOW_PRIORITY_NICE*/ 5);
 }
 
-void
-runCurrentThreadWithMediumPriority()
+void runCurrentThreadWithMediumPriority()
 {
     runCurrentThreadWithPriority(/*MED_PRIORITY_NICE*/ 3);
 }
 #else
 
-void
-runCurrentThreadWithLowPriority()
+void runCurrentThreadWithLowPriority()
 {
 }
 
-void
-runCurrentThreadWithMediumPriority()
+void runCurrentThreadWithMediumPriority()
 {
 }
 

--- a/src/util/Thread.h
+++ b/src/util/Thread.h
@@ -14,9 +14,7 @@ namespace stellar
 void runCurrentThreadWithLowPriority();
 void runCurrentThreadWithMediumPriority();
 
-template <typename T>
-bool
-futureIsReady(std::future<T> const& fut)
+template <typename T> bool futureIsReady(std::future<T> const& fut)
 {
     if (!fut.valid())
     {
@@ -26,9 +24,7 @@ futureIsReady(std::future<T> const& fut)
     return status == std::future_status::ready;
 }
 
-template <typename T>
-bool
-futureIsReady(std::shared_future<T> const& fut)
+template <typename T> bool futureIsReady(std::shared_future<T> const& fut)
 {
     if (!fut.valid())
     {

--- a/src/util/ThreadAnnotations.h
+++ b/src/util/ThreadAnnotations.h
@@ -141,16 +141,14 @@ class LOCKABLE Mutex : public stellar::NonMovableOrCopyable
     // Acquire/lock this mutex exclusively.  Only one thread can have exclusive
     // access at any one time.  Write operations to guarded data require an
     // exclusive lock.
-    void
-    Lock() EXCLUSIVE_LOCK_FUNCTION()
+    void Lock() EXCLUSIVE_LOCK_FUNCTION()
     {
         mMutex.lock();
     }
 
     // Release/unlock the mutex, regardless of whether it is exclusive or
     // shared.
-    void
-    Unlock() UNLOCK_FUNCTION()
+    void Unlock() UNLOCK_FUNCTION()
     {
         mMutex.unlock();
     }
@@ -186,30 +184,26 @@ class LOCKABLE SharedMutex : public stellar::NonMovableOrCopyable
   public:
     // Acquire/lock this mutex exclusively (for writing).
     // Only one thread can have exclusive access at any one time.
-    void
-    Lock() EXCLUSIVE_LOCK_FUNCTION()
+    void Lock() EXCLUSIVE_LOCK_FUNCTION()
     {
         mSharedMutex.lock();
     }
 
     // Acquire/lock this mutex for shared (read-only) access.
     // Multiple threads can acquire the mutex simultaneously for shared access.
-    void
-    LockShared() SHARED_LOCK_FUNCTION()
+    void LockShared() SHARED_LOCK_FUNCTION()
     {
         mSharedMutex.lock_shared();
     }
 
     // Release/unlock the mutex from exclusive mode.
-    void
-    Unlock() UNLOCK_FUNCTION()
+    void Unlock() UNLOCK_FUNCTION()
     {
         mSharedMutex.unlock();
     }
 
     // Release/unlock the mutex from shared mode.
-    void
-    UnlockShared() UNLOCK_FUNCTION()
+    void UnlockShared() UNLOCK_FUNCTION()
     {
         mSharedMutex.unlock_shared();
     }
@@ -245,16 +239,14 @@ class LOCKABLE RecursiveMutex : public stellar::NonMovableOrCopyable
     // Acquire/lock this mutex exclusively. The same thread may acquire the
     // mutex multiple times without blocking. The owning thread must release the
     // mutex the same number of times it was acquired.
-    void
-    Lock() EXCLUSIVE_LOCK_FUNCTION()
+    void Lock() EXCLUSIVE_LOCK_FUNCTION()
     {
         mRecursiveMutex.lock();
     }
 
     // Release/unlock the mutex. Only the owning thread can release the mutex,
     // and the mutex must be released as many times as it was acquired.
-    void
-    Unlock() UNLOCK_FUNCTION()
+    void Unlock() UNLOCK_FUNCTION()
     {
         mRecursiveMutex.unlock();
     }

--- a/src/util/Timer.cpp
+++ b/src/util/Timer.cpp
@@ -29,8 +29,7 @@ VirtualClock::VirtualClock(Mode mode)
 {
 }
 
-VirtualClock::time_point
-VirtualClock::now() const noexcept
+VirtualClock::time_point VirtualClock::now() const noexcept
 {
     if (mMode == REAL_TIME)
     {
@@ -43,8 +42,7 @@ VirtualClock::now() const noexcept
     }
 }
 
-VirtualClock::system_time_point
-VirtualClock::system_now() const noexcept
+VirtualClock::system_time_point VirtualClock::system_now() const noexcept
 {
     if (mMode == REAL_TIME)
     {
@@ -60,8 +58,7 @@ VirtualClock::system_now() const noexcept
     }
 }
 
-void
-VirtualClock::maybeSetRealtimer()
+void VirtualClock::maybeSetRealtimer()
 {
     if (mMode == REAL_TIME)
     {
@@ -83,15 +80,13 @@ VirtualClock::maybeSetRealtimer()
     }
 }
 
-bool
-VirtualClockEventCompare::operator()(shared_ptr<VirtualClockEvent> a,
-                                     shared_ptr<VirtualClockEvent> b)
+bool VirtualClockEventCompare::operator()(shared_ptr<VirtualClockEvent> a,
+                                          shared_ptr<VirtualClockEvent> b)
 {
     return *a < *b;
 }
 
-VirtualClock::time_point
-VirtualClock::next() const
+VirtualClock::time_point VirtualClock::next() const
 {
     releaseAssert(threadIsMain());
     VirtualClock::time_point least = time_point::max();
@@ -105,15 +100,13 @@ VirtualClock::next() const
     return least;
 }
 
-VirtualClock::system_time_point
-VirtualClock::from_time_t(std::time_t timet)
+VirtualClock::system_time_point VirtualClock::from_time_t(std::time_t timet)
 {
     system_time_point epoch;
     return epoch + std::chrono::seconds(timet);
 }
 
-std::time_t
-VirtualClock::to_time_t(system_time_point point)
+std::time_t VirtualClock::to_time_t(system_time_point point)
 {
     return static_cast<std::time_t>(
         std::chrono::duration_cast<std::chrono::seconds>(
@@ -122,16 +115,14 @@ VirtualClock::to_time_t(system_time_point point)
 }
 
 #ifdef _WIN32
-time_t
-timegm(struct tm* tm)
+time_t timegm(struct tm* tm)
 {
     // Timezone independent version
     return _mkgmtime(tm);
 }
 #endif
 
-std::tm
-VirtualClock::systemPointToTm(system_time_point point)
+std::tm VirtualClock::systemPointToTm(system_time_point point)
 {
     std::time_t rawtime = to_time_t(point);
     std::tm out;
@@ -146,15 +137,13 @@ VirtualClock::systemPointToTm(system_time_point point)
     return out;
 }
 
-VirtualClock::system_time_point
-VirtualClock::tmToSystemPoint(tm t)
+VirtualClock::system_time_point VirtualClock::tmToSystemPoint(tm t)
 {
     time_t tt = timegm(&t);
     return VirtualClock::system_time_point() + std::chrono::seconds(tt);
 }
 
-std::tm
-VirtualClock::isoStringToTm(std::string const& iso)
+std::tm VirtualClock::isoStringToTm(std::string const& iso)
 {
     std::tm res{};
     std::istringstream ss(iso);
@@ -166,8 +155,7 @@ VirtualClock::isoStringToTm(std::string const& iso)
     return res;
 }
 
-std::string
-VirtualClock::tmToISOString(std::tm const& tm)
+std::string VirtualClock::tmToISOString(std::tm const& tm)
 {
     char buf[sizeof("0000-00-00T00:00:00Z")];
     size_t conv = strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tm);
@@ -175,14 +163,12 @@ VirtualClock::tmToISOString(std::tm const& tm)
     return std::string(buf);
 }
 
-std::string
-VirtualClock::systemPointToISOString(system_time_point point)
+std::string VirtualClock::systemPointToISOString(system_time_point point)
 {
     return tmToISOString(systemPointToTm(point));
 }
 
-void
-VirtualClock::enqueue(shared_ptr<VirtualClockEvent> ve)
+void VirtualClock::enqueue(shared_ptr<VirtualClockEvent> ve)
 {
     if (mDestructing)
     {
@@ -193,8 +179,7 @@ VirtualClock::enqueue(shared_ptr<VirtualClockEvent> ve)
     maybeSetRealtimer();
 }
 
-void
-VirtualClock::flushCancelledEvents()
+void VirtualClock::flushCancelledEvents()
 {
     ZoneScoped;
     if (mDestructing)
@@ -230,8 +215,7 @@ VirtualClock::flushCancelledEvents()
     maybeSetRealtimer();
 }
 
-bool
-VirtualClock::cancelAllEvents()
+bool VirtualClock::cancelAllEvents()
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -247,8 +231,7 @@ VirtualClock::cancelAllEvents()
     return !wasEmpty;
 }
 
-void
-VirtualClock::shutdown()
+void VirtualClock::shutdown()
 {
     if (!isStopped())
     {
@@ -271,8 +254,7 @@ VirtualClock::shutdown()
     }
 }
 
-void
-VirtualClock::setCurrentVirtualTime(time_point t)
+void VirtualClock::setCurrentVirtualTime(time_point t)
 {
     releaseAssert(mMode == VIRTUAL_TIME);
     std::lock_guard<std::mutex> lock(mVirtualNowMutex);
@@ -281,15 +263,13 @@ VirtualClock::setCurrentVirtualTime(time_point t)
     mVirtualNow = t;
 }
 
-void
-VirtualClock::setCurrentVirtualTime(system_time_point t)
+void VirtualClock::setCurrentVirtualTime(system_time_point t)
 {
     auto offset = t.time_since_epoch();
     setCurrentVirtualTime(time_point(offset));
 }
 
-void
-VirtualClock::sleep_for(std::chrono::microseconds us)
+void VirtualClock::sleep_for(std::chrono::microseconds us)
 {
     ZoneScoped;
     if (mMode == VIRTUAL_TIME)
@@ -302,8 +282,7 @@ VirtualClock::sleep_for(std::chrono::microseconds us)
     }
 }
 
-bool
-VirtualClock::shouldYield() const
+bool VirtualClock::shouldYield() const
 {
     if (mMode == VIRTUAL_TIME)
     {
@@ -317,14 +296,13 @@ VirtualClock::shouldYield() const
     }
 }
 
-bool
-VirtualClock::isStopped()
+bool VirtualClock::isStopped()
 {
     return getIOContext().stopped();
 }
 
-static size_t
-crankStep(VirtualClock& clock, std::function<size_t()> step, size_t divisor = 1)
+static size_t crankStep(VirtualClock& clock, std::function<size_t()> step,
+                        size_t divisor = 1)
 {
     size_t eCount = 0;
     auto tLimit = clock.now() + (CRANK_TIME_SLICE / divisor);
@@ -341,8 +319,7 @@ crankStep(VirtualClock& clock, std::function<size_t()> step, size_t divisor = 1)
     return totalProgress;
 }
 
-size_t
-VirtualClock::crank(bool block)
+size_t VirtualClock::crank(bool block)
 {
     ZoneScoped;
     if (mDestructing)
@@ -427,9 +404,8 @@ VirtualClock::crank(bool block)
     return progressCount;
 }
 
-void
-VirtualClock::postAction(std::function<void()>&& f, std::string&& name,
-                         Scheduler::ActionType type)
+void VirtualClock::postAction(std::function<void()>&& f, std::string&& name,
+                              Scheduler::ActionType type)
 {
     if (isStopped())
     {
@@ -466,8 +442,7 @@ VirtualClock::postAction(std::function<void()>&& f, std::string&& name,
     }
 }
 
-size_t
-VirtualClock::getActionQueueSize() const
+size_t VirtualClock::getActionQueueSize() const
 {
     size_t pending = 0;
     {
@@ -477,20 +452,17 @@ VirtualClock::getActionQueueSize() const
     return pending + mActionScheduler->size();
 }
 
-bool
-VirtualClock::actionQueueIsOverloaded() const
+bool VirtualClock::actionQueueIsOverloaded() const
 {
     return mActionScheduler->getOverloadedDuration().count() != 0;
 }
 
-Scheduler::ActionType
-VirtualClock::currentSchedulerActionType() const
+Scheduler::ActionType VirtualClock::currentSchedulerActionType() const
 {
     return mActionScheduler->currentActionType();
 }
 
-asio::io_context&
-VirtualClock::getIOContext()
+asio::io_context& VirtualClock::getIOContext()
 {
     return mIOContext;
 }
@@ -501,8 +473,7 @@ VirtualClock::~VirtualClock()
     cancelAllEvents();
 }
 
-size_t
-VirtualClock::advanceToNow()
+size_t VirtualClock::advanceToNow()
 {
     ZoneScoped;
     if (mDestructing)
@@ -531,8 +502,7 @@ VirtualClock::advanceToNow()
     return toDispatch.size();
 }
 
-size_t
-VirtualClock::advanceToNext()
+size_t VirtualClock::advanceToNext()
 {
     if (mDestructing)
     {
@@ -564,13 +534,11 @@ VirtualClockEvent::VirtualClockEvent(
 {
 }
 
-bool
-VirtualClockEvent::getTriggered()
+bool VirtualClockEvent::getTriggered()
 {
     return mTriggered;
 }
-void
-VirtualClockEvent::trigger()
+void VirtualClockEvent::trigger()
 {
     if (!mTriggered)
     {
@@ -580,8 +548,7 @@ VirtualClockEvent::trigger()
     }
 }
 
-void
-VirtualClockEvent::cancel()
+void VirtualClockEvent::cancel()
 {
     if (!mTriggered)
     {
@@ -591,8 +558,7 @@ VirtualClockEvent::cancel()
     }
 }
 
-bool
-VirtualClockEvent::operator<(VirtualClockEvent const& other) const
+bool VirtualClockEvent::operator<(VirtualClockEvent const& other) const
 {
     // For purposes of priority queue, a timer is "less than"
     // another timer if it occurs in the future (has a higher
@@ -622,8 +588,7 @@ VirtualTimer::~VirtualTimer()
     cancel();
 }
 
-void
-VirtualTimer::cancel()
+void VirtualTimer::cancel()
 {
     if (!mCancelled)
     {
@@ -638,20 +603,17 @@ VirtualTimer::cancel()
     }
 }
 
-VirtualClock::time_point const&
-VirtualTimer::expiry_time() const
+VirtualClock::time_point const& VirtualTimer::expiry_time() const
 {
     return mExpiryTime;
 }
 
-size_t
-VirtualTimer::seq() const
+size_t VirtualTimer::seq() const
 {
     return mEvents.empty() ? 0 : mEvents.back()->mSeq + 1;
 }
 
-void
-VirtualTimer::expires_at(VirtualClock::time_point t)
+void VirtualTimer::expires_at(VirtualClock::time_point t)
 {
     ZoneScoped;
     cancel();
@@ -659,8 +621,7 @@ VirtualTimer::expires_at(VirtualClock::time_point t)
     mCancelled = false;
 }
 
-void
-VirtualTimer::expires_from_now(VirtualClock::duration d)
+void VirtualTimer::expires_from_now(VirtualClock::duration d)
 {
     ZoneScoped;
     cancel();
@@ -668,8 +629,7 @@ VirtualTimer::expires_from_now(VirtualClock::duration d)
     mCancelled = false;
 }
 
-void
-VirtualTimer::async_wait(function<void(asio::error_code)> const& fn)
+void VirtualTimer::async_wait(function<void(asio::error_code)> const& fn)
 {
     if (mClock.isStopped())
     {
@@ -685,9 +645,9 @@ VirtualTimer::async_wait(function<void(asio::error_code)> const& fn)
     }
 }
 
-void
-VirtualTimer::async_wait(std::function<void()> const& onSuccess,
-                         std::function<void(asio::error_code)> const& onFailure)
+void VirtualTimer::async_wait(
+    std::function<void()> const& onSuccess,
+    std::function<void(asio::error_code)> const& onFailure)
 {
     if (mClock.isStopped())
     {

--- a/src/util/Timer.h
+++ b/src/util/Timer.h
@@ -129,14 +129,12 @@ class VirtualClock
     void shutdown();
     bool isStopped();
 
-    Mode
-    getMode() const
+    Mode getMode() const
     {
         return mMode;
     }
 
-    void
-    newBackgroundWork()
+    void newBackgroundWork()
     {
         if (mMode == VIRTUAL_TIME)
         {
@@ -144,8 +142,7 @@ class VirtualClock
         }
     }
 
-    void
-    finishedBackgroundWork()
+    void finishedBackgroundWork()
     {
         if (mMode == VIRTUAL_TIME)
         {
@@ -288,8 +285,7 @@ class VirtualTimer : private NonMovableOrCopyable
     void expires_at(VirtualClock::time_point t);
     void expires_from_now(VirtualClock::duration d);
     template <typename R, typename P>
-    void
-    expires_from_now(std::chrono::duration<R, P> const& d)
+    void expires_from_now(std::chrono::duration<R, P> const& d)
     {
         expires_from_now(std::chrono::duration_cast<VirtualClock::duration>(d));
     }

--- a/src/util/TmpDir.cpp
+++ b/src/util/TmpDir.cpp
@@ -40,8 +40,7 @@ TmpDir::TmpDir(TmpDir&& other) : mPath(std::move(other.mPath))
 {
 }
 
-std::string const&
-TmpDir::getName() const
+std::string const& TmpDir::getName() const
 {
     return *mPath;
 }
@@ -86,8 +85,7 @@ TmpDirManager::~TmpDirManager()
     clean();
 }
 
-void
-TmpDirManager::clean()
+void TmpDirManager::clean()
 {
     ZoneScoped;
     if (fs::exists(mRoot))
@@ -97,8 +95,7 @@ TmpDirManager::clean()
     }
 }
 
-TmpDir
-TmpDirManager::tmpDir(std::string const& prefix)
+TmpDir TmpDirManager::tmpDir(std::string const& prefix)
 {
     return TmpDir(mRoot + "/" + prefix);
 }

--- a/src/util/TxResource.cpp
+++ b/src/util/TxResource.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2023 Stellar Development Foundation and contributors. Licensed
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
@@ -9,8 +8,7 @@
 namespace stellar
 {
 
-Resource
-subtractNonNegative(Resource const& lhs, Resource const& rhs)
+Resource subtractNonNegative(Resource const& lhs, Resource const& rhs)
 {
     releaseAssert(lhs.size() == rhs.size());
     auto newRes = lhs;
@@ -30,8 +28,7 @@ subtractNonNegative(Resource const& lhs, Resource const& rhs)
     return newRes;
 }
 
-bool
-anyLessThan(Resource const& lhs, Resource const& rhs)
+bool anyLessThan(Resource const& lhs, Resource const& rhs)
 {
     releaseAssert(lhs.size() == rhs.size());
     for (size_t i = 0; i < lhs.size(); i++)
@@ -45,8 +42,7 @@ anyLessThan(Resource const& lhs, Resource const& rhs)
 }
 
 // Throws if multiplication result overflows int64_t
-Resource
-multiplyByDouble(Resource const& res, double m)
+Resource multiplyByDouble(Resource const& res, double m)
 {
     auto newRes = res;
     for (auto& resource : newRes.mResources)
@@ -62,8 +58,7 @@ multiplyByDouble(Resource const& res, double m)
 }
 
 // Saturating multiply: cap at int64_t::max if result would overflow
-Resource
-saturatedMultiplyByDouble(Resource const& res, double m)
+Resource saturatedMultiplyByDouble(Resource const& res, double m)
 {
     auto newRes = res;
     for (auto& resource : newRes.mResources)
@@ -84,8 +79,8 @@ saturatedMultiplyByDouble(Resource const& res, double m)
     return newRes;
 }
 
-Resource
-bigDivideOrThrow(Resource const& res, int64_t B, int64_t C, Rounding rounding)
+Resource bigDivideOrThrow(Resource const& res, int64_t B, int64_t C,
+                          Rounding rounding)
 {
     auto newRes = res;
     for (auto& resource : newRes.mResources)
@@ -96,28 +91,24 @@ bigDivideOrThrow(Resource const& res, int64_t B, int64_t C, Rounding rounding)
     return newRes;
 }
 
-bool
-operator==(Resource const& lhs, Resource const& rhs)
+bool operator==(Resource const& lhs, Resource const& rhs)
 {
     return lhs.mResources == rhs.mResources;
 }
 
-Resource
-operator+(Resource const& lhs, Resource const& rhs)
+Resource operator+(Resource const& lhs, Resource const& rhs)
 {
     Resource result(lhs);
     return result += rhs;
 }
 
-Resource
-operator-(Resource const& lhs, Resource const& rhs)
+Resource operator-(Resource const& lhs, Resource const& rhs)
 {
     Resource result(lhs);
     return result -= rhs;
 }
 
-bool
-operator<=(Resource const& lhs, Resource const& rhs)
+bool operator<=(Resource const& lhs, Resource const& rhs)
 {
     releaseAssert(lhs.size() == rhs.size());
     for (size_t i = 0; i < lhs.size(); i++)
@@ -130,8 +121,7 @@ operator<=(Resource const& lhs, Resource const& rhs)
     return true;
 }
 
-bool
-anyGreater(Resource const& lhs, Resource const& rhs)
+bool anyGreater(Resource const& lhs, Resource const& rhs)
 {
     releaseAssert(lhs.size() == rhs.size());
     for (size_t i = 0; i < lhs.size(); i++)
@@ -145,14 +135,12 @@ anyGreater(Resource const& lhs, Resource const& rhs)
 }
 
 // All greater
-bool
-operator>(Resource const& lhs, Resource const& rhs)
+bool operator>(Resource const& lhs, Resource const& rhs)
 {
     return !(lhs <= rhs);
 }
 
-Resource&
-Resource::operator+=(Resource const& other)
+Resource& Resource::operator+=(Resource const& other)
 {
     releaseAssert(canAdd(other));
     for (size_t i = 0; i < mResources.size(); i++)
@@ -162,8 +150,7 @@ Resource::operator+=(Resource const& other)
     return *this;
 }
 
-Resource&
-Resource::operator-=(Resource const& other)
+Resource& Resource::operator-=(Resource const& other)
 {
     releaseAssert(mResources.size() == other.mResources.size());
     for (size_t i = 0; i < mResources.size(); i++)
@@ -174,8 +161,7 @@ Resource::operator-=(Resource const& other)
     return *this;
 }
 
-Resource
-limitTo(Resource const& curr, Resource const& limit)
+Resource limitTo(Resource const& curr, Resource const& limit)
 {
     releaseAssert(curr.size() == limit.size());
     Resource limited(std::vector<int64_t>(curr.size(), 0));
@@ -187,8 +173,7 @@ limitTo(Resource const& curr, Resource const& limit)
     return limited;
 }
 
-bool
-Resource::canAdd(Resource const& other) const
+bool Resource::canAdd(Resource const& other) const
 {
     releaseAssert(size() == other.size());
     for (size_t i = 0; i < size(); i++)

--- a/src/util/TxResource.h
+++ b/src/util/TxResource.h
@@ -33,8 +33,7 @@ class Resource
         WRITE_LEDGER_ENTRIES = 6
     };
 
-    static std::string
-    getStringFromType(Type type)
+    static std::string getStringFromType(Type type)
     {
         switch (type)
         {
@@ -72,28 +71,24 @@ class Resource
         mResources = std::vector<int64_t>(1, arg);
     }
 
-    bool
-    isZero() const
+    bool isZero() const
     {
         return std::all_of(mResources.begin(), mResources.end(),
                            [](int64_t x) { return x == 0; });
     }
 
-    bool
-    anyPositive() const
+    bool anyPositive() const
     {
         return std::any_of(mResources.begin(), mResources.end(),
                            [](int64_t x) { return x > 0; });
     }
 
-    size_t
-    size() const
+    size_t size() const
     {
         return mResources.size();
     }
 
-    std::string
-    toString() const
+    std::string toString() const
     {
         std::string res = "";
         for (auto const& r : mResources)
@@ -106,27 +101,23 @@ class Resource
     Resource& operator+=(Resource const& other);
     Resource& operator-=(Resource const& other);
 
-    static Resource
-    makeEmptySoroban()
+    static Resource makeEmptySoroban()
     {
         return makeEmpty(NUM_SOROBAN_TX_RESOURCES);
     }
 
-    static Resource
-    makeEmpty(size_t numRes)
+    static Resource makeEmpty(size_t numRes)
     {
         std::vector<int64_t> res(numRes, 0);
         return Resource(res);
     }
 
-    int64_t
-    getVal(Resource::Type valType) const
+    int64_t getVal(Resource::Type valType) const
     {
         return mResources.at(static_cast<size_t>(valType));
     }
 
-    void
-    setVal(Resource::Type valType, int64_t val)
+    void setVal(Resource::Type valType, int64_t val)
     {
         mResources.at(static_cast<size_t>(valType)) = val;
     }

--- a/src/util/XDRCereal.cpp
+++ b/src/util/XDRCereal.cpp
@@ -6,16 +6,14 @@
 #include "crypto/StrKey.h"
 #include "xdr/Stellar-contract.h"
 
-void
-cereal_override(cereal::JSONOutputArchive& ar, const stellar::PublicKey& s,
-                const char* field)
+void cereal_override(cereal::JSONOutputArchive& ar, const stellar::PublicKey& s,
+                     const char* field)
 {
     xdr::archive(ar, stellar::KeyUtils::toStrKey<stellar::PublicKey>(s), field);
 }
 
-void
-cereal_override(cereal::JSONOutputArchive& ar, const stellar::SCAddress& addr,
-                const char* field)
+void cereal_override(cereal::JSONOutputArchive& ar,
+                     const stellar::SCAddress& addr, const char* field)
 {
     switch (addr.type())
     {
@@ -69,9 +67,8 @@ cereal_override(cereal::JSONOutputArchive& ar, const stellar::SCAddress& addr,
     }
 }
 
-void
-cereal_override(cereal::JSONOutputArchive& ar,
-                const stellar::ConfigUpgradeSetKey& key, const char* field)
+void cereal_override(cereal::JSONOutputArchive& ar,
+                     const stellar::ConfigUpgradeSetKey& key, const char* field)
 {
     ar.setNextName(field);
     ar.startNode();
@@ -86,9 +83,9 @@ cereal_override(cereal::JSONOutputArchive& ar,
     ar.finishNode();
 }
 
-void
-cereal_override(cereal::JSONOutputArchive& ar,
-                const stellar::MuxedAccount& muxedAccount, const char* field)
+void cereal_override(cereal::JSONOutputArchive& ar,
+                     const stellar::MuxedAccount& muxedAccount,
+                     const char* field)
 {
     switch (muxedAccount.type())
     {
@@ -111,23 +108,20 @@ cereal_override(cereal::JSONOutputArchive& ar,
     }
 }
 
-void
-cerealPoolAsset(cereal::JSONOutputArchive& ar, const stellar::Asset& asset,
-                const char* field)
+void cerealPoolAsset(cereal::JSONOutputArchive& ar, const stellar::Asset& asset,
+                     const char* field)
 {
     xdr::archive(ar, std::string("INVALID"), field);
 }
 
-void
-cerealPoolAsset(cereal::JSONOutputArchive& ar,
-                const stellar::TrustLineAsset& asset, const char* field)
+void cerealPoolAsset(cereal::JSONOutputArchive& ar,
+                     const stellar::TrustLineAsset& asset, const char* field)
 {
     cereal_override(ar, asset.liquidityPoolID(), field);
 }
 
-void
-cerealPoolAsset(cereal::JSONOutputArchive& ar,
-                const stellar::ChangeTrustAsset& asset, const char* field)
+void cerealPoolAsset(cereal::JSONOutputArchive& ar,
+                     const stellar::ChangeTrustAsset& asset, const char* field)
 {
     auto const& cp = asset.liquidityPool().constantProduct();
 

--- a/src/util/XDRCereal.h
+++ b/src/util/XDRCereal.h
@@ -18,17 +18,15 @@
 using namespace std::placeholders;
 
 template <uint32_t N>
-void
-cereal_override(cereal::JSONOutputArchive& ar, const xdr::xstring<N>& s,
-                const char* field)
+void cereal_override(cereal::JSONOutputArchive& ar, const xdr::xstring<N>& s,
+                     const char* field)
 {
     xdr::archive(ar, static_cast<std::string const&>(s), field);
 }
 
 template <uint32_t N>
-void
-cereal_override(cereal::JSONOutputArchive& ar, const xdr::opaque_array<N>& s,
-                const char* field)
+void cereal_override(cereal::JSONOutputArchive& ar,
+                     const xdr::opaque_array<N>& s, const char* field)
 {
     xdr::archive(ar, stellar::binToHex(stellar::ByteSlice(s.data(), s.size())),
                  field);
@@ -67,9 +65,8 @@ cereal_override(cereal::JSONOutputArchive& ar, T const& t, const char* field)
 }
 
 template <uint32_t N>
-void
-cereal_override(cereal::JSONOutputArchive& ar, const xdr::opaque_vec<N>& s,
-                const char* field)
+void cereal_override(cereal::JSONOutputArchive& ar, const xdr::opaque_vec<N>& s,
+                     const char* field)
 {
     xdr::archive(ar, stellar::binToHex(stellar::ByteSlice(s.data(), s.size())),
                  field);
@@ -159,9 +156,8 @@ cereal_override(cereal::JSONOutputArchive& ar, const T& t, const char* field)
 }
 
 template <typename T>
-void
-cereal_override(cereal::JSONOutputArchive& ar, const xdr::pointer<T>& t,
-                const char* field)
+void cereal_override(cereal::JSONOutputArchive& ar, const xdr::pointer<T>& t,
+                     const char* field)
 {
     // We tolerate a little information-loss here collapsing *T into T for
     // the non-null case, and use JSON 'null' for the null case. This reads
@@ -188,8 +184,8 @@ namespace stellar
 {
 // If compact = true, the output string will not contain any indentation.
 template <typename T>
-std::string
-xdrToCerealString(const T& t, std::string const& name, bool compact = false)
+std::string xdrToCerealString(const T& t, std::string const& name,
+                              bool compact = false)
 {
     std::stringstream os;
 

--- a/src/util/XDRStream.h
+++ b/src/util/XDRStream.h
@@ -42,15 +42,13 @@ class XDRInputFileStream
     {
     }
 
-    void
-    close()
+    void close()
     {
         ZoneScoped;
         mIn.close();
     }
 
-    void
-    open(std::string const& filename)
+    void open(std::string const& filename)
     {
         ZoneScoped;
         mIn.open(filename, std::ifstream::binary);
@@ -67,8 +65,7 @@ class XDRInputFileStream
         mSize = fs::size(mIn);
     }
 
-    void
-    open(std::filesystem::path const& filename)
+    void open(std::filesystem::path const& filename)
     {
         open(filename.string());
     }
@@ -78,28 +75,24 @@ class XDRInputFileStream
         return mIn.good();
     }
 
-    size_t
-    size() const
+    size_t size() const
     {
         return mSize;
     }
 
-    std::streamoff
-    pos()
+    std::streamoff pos()
     {
         releaseAssertOrThrow(!mIn.fail());
         return mIn.tellg();
     }
 
-    void
-    seek(size_t pos)
+    void seek(size_t pos)
     {
         releaseAssertOrThrow(!mIn.fail());
         mIn.seekg(pos);
     }
 
-    static inline uint32_t
-    getXDRSize(char* buf)
+    static inline uint32_t getXDRSize(char* buf)
     {
         // Read 4 bytes of size, big-endian, with XDR 'continuation' bit cleared
         // (high bit of high byte).
@@ -116,9 +109,7 @@ class XDRInputFileStream
 
     // If a hasher is provided, it will be updated with the raw XDR bytes
     // read from the stream.
-    template <typename T>
-    bool
-    readOne(T& out, SHA256* hasher = nullptr)
+    template <typename T> bool readOne(T& out, SHA256* hasher = nullptr)
     {
         ZoneScoped;
         char szBuf[4];
@@ -167,8 +158,7 @@ class XDRInputFileStream
     // an `out` value for which `getBucketLedgerKey(out) == key`. It returns
     // `true` if it located such a value, or false if it failed to find one.
     template <typename T>
-    bool
-    readPage(T& out, LedgerKey const& key, size_t pageSize)
+    bool readPage(T& out, LedgerKey const& key, size_t pageSize)
     {
         ZoneScoped;
         if (mBuf.size() != pageSize)
@@ -275,8 +265,7 @@ class OutputFileStream
         }
     }
 
-    bool
-    isOpen()
+    bool isOpen()
     {
 #ifdef WIN32
         return mOut != nullptr;
@@ -285,8 +274,7 @@ class OutputFileStream
 #endif
     }
 
-    fs::native_handle_t
-    getHandle()
+    fs::native_handle_t getHandle()
     {
 #ifdef WIN32
         return mHandle;
@@ -295,8 +283,7 @@ class OutputFileStream
 #endif
     }
 
-    void
-    close()
+    void close()
     {
         ZoneScoped;
         if (!isOpen())
@@ -317,8 +304,7 @@ class OutputFileStream
 #endif
     }
 
-    void
-    fdopen(int fd)
+    void fdopen(int fd)
     {
 #ifdef WIN32
         FileSystemException::failWith(
@@ -338,8 +324,7 @@ class OutputFileStream
 #endif
     }
 
-    void
-    flush()
+    void flush()
     {
         ZoneScoped;
         if (!isOpen())
@@ -364,8 +349,7 @@ class OutputFileStream
 #endif
     }
 
-    void
-    open(std::string const& filename)
+    void open(std::string const& filename)
     {
         ZoneScoped;
         if (isOpen())
@@ -395,8 +379,7 @@ class OutputFileStream
         return isOpen();
     }
 
-    void
-    writeBytes(char const* buf, size_t const sizeBytes)
+    void writeBytes(char const* buf, size_t const sizeBytes)
     {
         ZoneScoped;
         if (!isOpen())
@@ -448,9 +431,8 @@ class XDROutputFileStream : public OutputFileStream
     }
 
     template <typename T>
-    void
-    durableWriteOne(T const& t, SHA256* hasher = nullptr,
-                    size_t* bytesPut = nullptr)
+    void durableWriteOne(T const& t, SHA256* hasher = nullptr,
+                         size_t* bytesPut = nullptr)
     {
         writeOne(t, hasher, bytesPut);
         flush();
@@ -458,8 +440,8 @@ class XDROutputFileStream : public OutputFileStream
     }
 
     template <typename T>
-    void
-    writeOne(T const& t, SHA256* hasher = nullptr, size_t* bytesPut = nullptr)
+    void writeOne(T const& t, SHA256* hasher = nullptr,
+                  size_t* bytesPut = nullptr)
     {
         ZoneScoped;
         uint32_t sz = (uint32_t)xdr::xdr_size(t);

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -12,8 +12,8 @@
 namespace stellar
 {
 // calculates A*B/C when A*B overflows 64bits
-bool
-bigDivide(int64_t& result, int64_t A, int64_t B, int64_t C, Rounding rounding)
+bool bigDivide(int64_t& result, int64_t A, int64_t B, int64_t C,
+               Rounding rounding)
 {
     bool res;
     releaseAssertOrThrow((A >= 0) && (B >= 0) && (C > 0));
@@ -28,9 +28,8 @@ bigDivide(int64_t& result, int64_t A, int64_t B, int64_t C, Rounding rounding)
     return res;
 }
 
-bool
-bigDivideUnsigned(uint64_t& result, uint64_t A, uint64_t B, uint64_t C,
-                  Rounding rounding)
+bool bigDivideUnsigned(uint64_t& result, uint64_t A, uint64_t B, uint64_t C,
+                       Rounding rounding)
 {
     releaseAssertOrThrow(C > 0);
 
@@ -44,8 +43,7 @@ bigDivideUnsigned(uint64_t& result, uint64_t A, uint64_t B, uint64_t C,
     return (x <= UINT64_MAX);
 }
 
-int64_t
-bigDivideOrThrow(int64_t A, int64_t B, int64_t C, Rounding rounding)
+int64_t bigDivideOrThrow(int64_t A, int64_t B, int64_t C, Rounding rounding)
 {
     int64_t res;
     if (!bigDivide(res, A, B, C, rounding))
@@ -55,8 +53,8 @@ bigDivideOrThrow(int64_t A, int64_t B, int64_t C, Rounding rounding)
     return res;
 }
 
-bool
-bigDivide128(int64_t& result, uint128_t const& a, int64_t B, Rounding rounding)
+bool bigDivide128(int64_t& result, uint128_t const& a, int64_t B,
+                  Rounding rounding)
 {
     releaseAssertOrThrow(B > 0);
 
@@ -70,9 +68,8 @@ bigDivide128(int64_t& result, uint128_t const& a, int64_t B, Rounding rounding)
     return res;
 }
 
-bool
-bigDivideUnsigned128(uint64_t& result, uint128_t const& a, uint64_t B,
-                     Rounding rounding)
+bool bigDivideUnsigned128(uint64_t& result, uint128_t const& a, uint64_t B,
+                          Rounding rounding)
 {
     releaseAssertOrThrow(B != 0);
 
@@ -104,8 +101,7 @@ bigDivideUnsigned128(uint64_t& result, uint128_t const& a, uint64_t B,
     return (x <= UINT64_MAX);
 }
 
-int64_t
-bigDivideOrThrow128(uint128_t const& a, int64_t B, Rounding rounding)
+int64_t bigDivideOrThrow128(uint128_t const& a, int64_t B, Rounding rounding)
 {
     int64_t res;
     if (!bigDivide128(res, a, B, rounding))
@@ -115,16 +111,14 @@ bigDivideOrThrow128(uint128_t const& a, int64_t B, Rounding rounding)
     return res;
 }
 
-uint128_t
-bigMultiplyUnsigned(uint64_t a, uint64_t b)
+uint128_t bigMultiplyUnsigned(uint64_t a, uint64_t b)
 {
     uint128_t A(a);
     uint128_t B(b);
     return A * B;
 }
 
-uint128_t
-bigMultiply(int64_t a, int64_t b)
+uint128_t bigMultiply(int64_t a, int64_t b)
 {
     releaseAssertOrThrow((a >= 0) && (b >= 0));
     return bigMultiplyUnsigned((uint64_t)a, (uint64_t)b);
@@ -214,8 +208,7 @@ bigMultiply(int64_t a, int64_t b)
 // Now that we have an algorithm to compute ceil(sqrt(R+1)) then we can simply
 // use R-1 instead of R in the definition of the sequence to compute
 // ceil(sqrt(R)). This requires handling R=0 as a special case.
-static uint64_t
-bigSquareRootCeil(uint64_t a, uint64_t b)
+static uint64_t bigSquareRootCeil(uint64_t a, uint64_t b)
 {
     // a * b = 0 is a special-case because we can't compute a * b - 1
     if (a == 0 || b == 0)
@@ -257,8 +250,7 @@ bigSquareRootCeil(uint64_t a, uint64_t b)
 }
 
 // Find x such that x * x <= a * b < (x+1) * (x+1).
-uint64_t
-bigSquareRoot(uint64_t a, uint64_t b)
+uint64_t bigSquareRoot(uint64_t a, uint64_t b)
 {
     uint64_t sqrtCeil = bigSquareRootCeil(a, b);
 
@@ -282,9 +274,8 @@ bigSquareRoot(uint64_t a, uint64_t b)
     return sqrtCeil - 1;
 }
 
-bool
-hugeDivide(int64_t& result, int32_t a, uint128_t const& B, uint128_t const& C,
-           Rounding rounding)
+bool hugeDivide(int64_t& result, int32_t a, uint128_t const& B,
+                uint128_t const& C, Rounding rounding)
 {
     uint128_t constexpr i32_max((uint32_t)INT32_MAX);
     uint128_t constexpr i64_max((uint64_t)INT64_MAX);
@@ -331,8 +322,7 @@ hugeDivide(int64_t& result, int32_t a, uint128_t const& B, uint128_t const& C,
     return false;
 }
 
-uint32_t
-doubleToClampedUint32(double d)
+uint32_t doubleToClampedUint32(double d)
 {
     // IEEE-754 doubles have 52-bit fractions, and so can perfectly represent
     // uint32_t values. Therefore, it should be safe to convert to the full

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -16,8 +16,7 @@ enum Rounding
     ROUND_UP
 };
 
-inline bool
-isRepresentableAsInt64(double d)
+inline bool isRepresentableAsInt64(double d)
 {
     // Subtle: the min value here is a power-of-two and is exactly representable
     // as a double, so any double equal-or-greater can be rounded-up to an
@@ -59,8 +58,7 @@ uint64_t bigSquareRoot(uint64_t a, uint64_t b);
 
 // Saturating multiplication: returns a * b, capped at INT64_MAX if overflow
 // would occur. Assumes both inputs are non-negative.
-inline int64_t
-saturatingMultiply(int64_t a, int64_t b)
+inline int64_t saturatingMultiply(int64_t a, int64_t b)
 {
     // Both inputs must be non-negative for this implementation
     if (a < 0 || b < 0)
@@ -84,9 +82,7 @@ saturatingMultiply(int64_t a, int64_t b)
 }
 
 // Saturating addition for unsigned ints: returns a + b, capped at type max.
-template <typename T>
-inline T
-saturatingAdd(T a, T b)
+template <typename T> inline T saturatingAdd(T a, T b)
 {
     static_assert(std::is_unsigned<T>());
     if (a > std::numeric_limits<T>::max() - b)

--- a/src/util/test/BalanceTests.cpp
+++ b/src/util/test/BalanceTests.cpp
@@ -7,9 +7,8 @@
 
 using namespace stellar;
 
-bool
-addBalance(int64_t balance, int64_t delta, int64_t resultBalance,
-           int64_t maxBalance = std::numeric_limits<int64_t>::max())
+bool addBalance(int64_t balance, int64_t delta, int64_t resultBalance,
+                int64_t maxBalance = std::numeric_limits<int64_t>::max())
 {
     auto r = stellar::addBalance(balance, delta, maxBalance);
     REQUIRE(balance == resultBalance);

--- a/src/util/test/BigDivideTests.cpp
+++ b/src/util/test/BigDivideTests.cpp
@@ -22,8 +22,7 @@ template <typename T> class BigDivideTester
     {
     }
 
-    void
-    test(P const& p, R const& downResult, R const& upResult)
+    void test(P const& p, R const& downResult, R const& upResult)
     {
         std::vector<uint64_t> values;
         for (auto v : mValues)

--- a/src/util/test/BinaryFuseTests.cpp
+++ b/src/util/test/BinaryFuseTests.cpp
@@ -20,9 +20,7 @@ static auto ledgerKeyGenerator = autocheck::such_that(
     [](LedgerKey const& k) { return k.type() != CONFIG_SETTING; },
     autocheck::generator<LedgerKey>());
 
-template <class FilterT>
-void
-testFilter(double expectedFalsePositiveRate)
+template <class FilterT> void testFilter(double expectedFalsePositiveRate)
 {
     LedgerKeySet keys;
     for (size_t size = 100; size <= 1'000'000; size *= 100)
@@ -116,7 +114,6 @@ testFilter(double expectedFalsePositiveRate)
 
 TEST_CASE("binary fuse filter", "[BinaryFuseFilter][!hide]")
 {
-
     SECTION("8 bit")
     {
         auto epsilon = 1ul << 8;

--- a/src/util/test/MetricTests.cpp
+++ b/src/util/test/MetricTests.cpp
@@ -28,8 +28,7 @@ using uniform_u64 = stellar::uniform_int_distribution<uint64_t>;
 // how much data to keep in memory when comparing datasets
 static std::chrono::seconds const sampleCutoff(60 * 5);
 
-void
-sleepTillNextBucketIfNecessary(std::chrono::seconds const& windowSize)
+void sleepTillNextBucketIfNecessary(std::chrono::seconds const& windowSize)
 {
     // Medida doesn't support any virtual clock.
     // Therefore, the following tests use the real time.
@@ -56,8 +55,7 @@ sleepTillNextBucketIfNecessary(std::chrono::seconds const& windowSize)
         std::this_thread::sleep_for(threshold / 2);
     }
 }
-void
-sleepAtLeast(std::chrono::seconds const& duration)
+void sleepAtLeast(std::chrono::seconds const& duration)
 {
     // By sleeping a shorter amount repeatedly,
     // we reduce the risk of sleeping too much.
@@ -70,8 +68,7 @@ sleepAtLeast(std::chrono::seconds const& duration)
 }
 
 // Helper for diagnostics.
-void
-printDistribution(std::vector<double> const& dist, size_t nbuckets = 10)
+void printDistribution(std::vector<double> const& dist, size_t nbuckets = 10)
 {
     // Establish bucket linear range.
     double lo = std::numeric_limits<double>::max();
@@ -136,8 +133,7 @@ struct Percentiles
             setSkewMargin(p999 * 0.075);
         }
     }
-    void
-    setFlatMargin(double m)
+    void setFlatMargin(double m)
     {
         mP50.margin(m);
         mP75.margin(m);
@@ -146,8 +142,7 @@ struct Percentiles
         mP99.margin(m);
         mP999.margin(m);
     }
-    void
-    setSkewMargin(double m)
+    void setSkewMargin(double m)
     {
         // When dealing with gamma distributions we've got quite a long tail, so
         // the p9x values all need more leeway.
@@ -158,8 +153,7 @@ struct Percentiles
         mP99.margin(m * 4);
         mP999.margin(m * 16);
     }
-    void
-    checkAgainst(medida::stats::Snapshot const& snap) const
+    void checkAgainst(medida::stats::Snapshot const& snap) const
     {
         double calc50 = snap.getMedian();
         double calc75 = snap.get75thPercentile();
@@ -243,8 +237,7 @@ class SlidingWindowTester
         mSlidingWindowSample.Seed(stellar::getGlobalRandomEngine()());
     }
     template <typename Dist, typename... Args>
-    void
-    addSamplesAtFrequency(std::chrono::milliseconds timeStep, Args... args)
+    void addSamplesAtFrequency(std::chrono::milliseconds timeStep, Args... args)
     {
         Dist dist(std::forward<Args>(args)...);
 
@@ -270,61 +263,53 @@ class SlidingWindowTester
     }
 
     // Adds 10 minutes @ 1khz of uniform samples from [low, high]
-    void
-    addUniformSamplesAtHighFrequency(uint64_t low, uint64_t high)
+    void addUniformSamplesAtHighFrequency(uint64_t low, uint64_t high)
     {
         auto freq = std::chrono::milliseconds(1);
         addSamplesAtFrequency<uniform_u64>(freq, low, high);
     }
 
     // Adds 10 minutes @ 30hz of uniform samples from [low, high]
-    void
-    addUniformSamplesAtMediumFrequency(uint64_t low, uint64_t high)
+    void addUniformSamplesAtMediumFrequency(uint64_t low, uint64_t high)
     {
         auto freq = std::chrono::milliseconds(33);
         addSamplesAtFrequency<uniform_u64>(freq, low, high);
     }
 
     // Adds 10 minutes @ 1hz of uniform samples from [low, high]
-    void
-    addUniformSamplesAtLowFrequency(uint64_t low, uint64_t high)
+    void addUniformSamplesAtLowFrequency(uint64_t low, uint64_t high)
     {
         auto freq = std::chrono::milliseconds(1000);
         addSamplesAtFrequency<uniform_u64>(freq, low, high);
     }
 
     // Adds 10 minutes @ 1khz of gamma(shape,scale) samples
-    void
-    addGammaSamplesAtHighFrequency(double shape, double scale)
+    void addGammaSamplesAtHighFrequency(double shape, double scale)
     {
         auto freq = std::chrono::milliseconds(1);
         addSamplesAtFrequency<gamma_dbl>(freq, shape, scale);
     }
 
     // Adds 10 minutes @ 30hz of gamma(shape,scale) samples
-    void
-    addGammaSamplesAtMediumFrequency(double shape, double scale)
+    void addGammaSamplesAtMediumFrequency(double shape, double scale)
     {
         auto freq = std::chrono::milliseconds(33);
         addSamplesAtFrequency<gamma_dbl>(freq, shape, scale);
     }
 
     // Adds 10 minutes @ 1hz of gamma(shape,scale) samples
-    void
-    addGammaSamplesAtLowFrequency(double shape, double scale)
+    void addGammaSamplesAtLowFrequency(double shape, double scale)
     {
         auto freq = std::chrono::milliseconds(1000);
         addSamplesAtFrequency<gamma_dbl>(freq, shape, scale);
     }
 
-    medida::stats::Snapshot
-    getSnapshot()
+    medida::stats::Snapshot getSnapshot()
     {
         return mSlidingWindowSample.MakeSnapshot();
     }
 
-    void
-    dumpData() const
+    void dumpData() const
     {
         for (auto s : mSamples)
         {
@@ -333,8 +318,7 @@ class SlidingWindowTester
         }
     }
 
-    Percentiles
-    computePercentiles(bool skewed) const
+    Percentiles computePercentiles(bool skewed) const
     {
         // dumpData();
         std::vector<double> data;
@@ -351,8 +335,7 @@ class SlidingWindowTester
                            !skewed);
     }
 
-    void
-    checkPercentiles(bool skewed)
+    void checkPercentiles(bool skewed)
     {
         auto snp = computePercentiles(skewed);
         snp.checkAgainst(getSnapshot());
@@ -365,8 +348,7 @@ class SlidingWindowTester
  *****************************************************************/
 
 template <typename Dist, typename... Args>
-medida::stats::Snapshot
-sampleFrom(Args... args)
+medida::stats::Snapshot sampleFrom(Args... args)
 {
     Dist dist(std::forward<Args>(args)...);
     std::vector<double> sample;
@@ -391,7 +373,6 @@ TEST_CASE("percentile calculation - uniform", "[percentile][medida_math]")
 
 TEST_CASE("percentile calculation - gamma", "[percentile][medida_math]")
 {
-
     auto snap = sampleFrom<gamma_dbl>(4.0, 100.0);
     gamma_4_100_pct.checkAgainst(snap);
 }
@@ -573,8 +554,7 @@ TEST_CASE("sums of nanoseconds do not overflow", "[medida_math]")
 }
 
 template <typename Dist, typename... Args>
-void
-testCKMSSample(int const count, Args... args)
+void testCKMSSample(int const count, Args... args)
 {
     auto const windowSize = std::chrono::seconds(5);
     medida::Histogram hist{medida::SamplingInterface::kCKMS, windowSize};

--- a/src/util/test/Uint128Tests.cpp
+++ b/src/util/test/Uint128Tests.cpp
@@ -24,8 +24,7 @@ using large_int::uint128_t;
 
 constexpr uint64_t full = std::numeric_limits<uint64_t>::max();
 
-uint128_t
-fromNative(unsigned __int128 const& x)
+uint128_t fromNative(unsigned __int128 const& x)
 {
     uint128_t high(uint64_t(x >> 64));
     uint128_t low(uint64_t(x & full));
@@ -33,14 +32,12 @@ fromNative(unsigned __int128 const& x)
     return (high << 64) | low;
 }
 
-unsigned __int128
-toNative(uint128_t const& x)
+unsigned __int128 toNative(uint128_t const& x)
 {
     return static_cast<unsigned __int128>(x);
 }
 
-bool
-toNative(bool x)
+bool toNative(bool x)
 {
     return x;
 }
@@ -48,8 +45,7 @@ toNative(bool x)
 struct gen128
 {
     typedef unsigned __int128 result_type;
-    result_type
-    operator()(size_t size = 0)
+    result_type operator()(size_t size = 0)
     {
         stellar::uniform_int_distribution<uint64_t> dist(1, full);
         auto a = dist(autocheck::rng());
@@ -60,8 +56,7 @@ struct gen128
 
 namespace std
 {
-std::ostream&
-operator<<(std::ostream& out, unsigned __int128 const& x)
+std::ostream& operator<<(std::ostream& out, unsigned __int128 const& x)
 {
     return out << std::hex << "0x" << uint64_t(x >> 64) << uint64_t(x);
 }

--- a/src/util/types.cpp
+++ b/src/util/types.cpp
@@ -17,8 +17,7 @@
 namespace stellar
 {
 
-LedgerKey
-LedgerEntryKey(LedgerEntry const& e)
+LedgerKey LedgerEntryKey(LedgerEntry const& e)
 {
     auto& d = e.data;
     LedgerKey k(d.type());
@@ -71,8 +70,7 @@ LedgerEntryKey(LedgerEntry const& e)
     return k;
 }
 
-bool
-isZero(uint256 const& b)
+bool isZero(uint256 const& b)
 {
     for (auto i : b)
         if (i != 0)
@@ -81,16 +79,14 @@ isZero(uint256 const& b)
     return true;
 }
 
-Hash&
-operator^=(Hash& l, Hash const& r)
+Hash& operator^=(Hash& l, Hash const& r)
 {
     std::transform(l.begin(), l.end(), r.begin(), l.begin(),
                    [](uint8_t a, uint8_t b) -> uint8_t { return a ^ b; });
     return l;
 }
 
-bool
-lessThanXored(Hash const& l, Hash const& r, Hash const& x)
+bool lessThanXored(Hash const& l, Hash const& r, Hash const& x)
 {
     Hash v1, v2;
     for (size_t i = 0; i < l.size(); i++)
@@ -102,8 +98,7 @@ lessThanXored(Hash const& l, Hash const& r, Hash const& x)
     return v1 < v2;
 }
 
-bool
-isStringValid(std::string const& str)
+bool isStringValid(std::string const& str)
 {
     for (auto c : str)
     {
@@ -115,20 +110,18 @@ isStringValid(std::string const& str)
     return true;
 }
 
-bool
-isPoolShareAssetValid(Asset const& asset, uint32_t ledgerVersion)
+bool isPoolShareAssetValid(Asset const& asset, uint32_t ledgerVersion)
 {
     throw std::runtime_error("ASSET_TYPE_POOL_SHARE is not a valid Asset type");
 }
 
-bool
-isPoolShareAssetValid(TrustLineAsset const& asset, uint32_t ledgerVersion)
+bool isPoolShareAssetValid(TrustLineAsset const& asset, uint32_t ledgerVersion)
 {
     return protocolVersionStartsFrom(ledgerVersion, ProtocolVersion::V_18);
 }
 
-bool
-isPoolShareAssetValid(ChangeTrustAsset const& asset, uint32_t ledgerVersion)
+bool isPoolShareAssetValid(ChangeTrustAsset const& asset,
+                           uint32_t ledgerVersion)
 {
     if (protocolVersionIsBefore(ledgerVersion, ProtocolVersion::V_18))
     {
@@ -141,9 +134,7 @@ isPoolShareAssetValid(ChangeTrustAsset const& asset, uint32_t ledgerVersion)
            cp.assetA < cp.assetB && cp.fee == LIQUIDITY_POOL_FEE_V18;
 }
 
-template <typename T>
-bool
-isAssetValid(T const& cur, uint32_t ledgerVersion)
+template <typename T> bool isAssetValid(T const& cur, uint32_t ledgerVersion)
 {
     if (cur.type() == ASSET_TYPE_NATIVE)
         return true;
@@ -214,8 +205,7 @@ template bool isAssetValid<Asset>(Asset const&, uint32_t);
 template bool isAssetValid<TrustLineAsset>(TrustLineAsset const&, uint32_t);
 template bool isAssetValid<ChangeTrustAsset>(ChangeTrustAsset const&, uint32_t);
 
-bool
-compareAsset(Asset const& first, Asset const& second)
+bool compareAsset(Asset const& first, Asset const& second)
 {
     if (first.type() != second.type())
         return false;
@@ -239,24 +229,21 @@ compareAsset(Asset const& first, Asset const& second)
     return false;
 }
 
-int32_t
-unsignedToSigned(uint32_t v)
+int32_t unsignedToSigned(uint32_t v)
 {
     if (v > static_cast<uint32_t>(std::numeric_limits<int32_t>::max()))
         throw std::runtime_error("unsigned-to-signed overflow");
     return static_cast<int32_t>(v);
 }
 
-int64_t
-unsignedToSigned(uint64_t v)
+int64_t unsignedToSigned(uint64_t v)
 {
     if (v > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
         throw std::runtime_error("unsigned-to-signed overflow");
     return static_cast<int64_t>(v);
 }
 
-std::string
-formatSize(size_t size)
+std::string formatSize(size_t size)
 {
     const std::vector<std::string> suffixes = {"B", "KB", "MB", "GB"};
     double dsize = static_cast<double>(size);
@@ -271,8 +258,7 @@ formatSize(size_t size)
     return fmt::format("{:.2f}{}", dsize, suffixes[i]);
 }
 
-bool
-addBalance(int64_t& balance, int64_t delta, int64_t maxBalance)
+bool addBalance(int64_t& balance, int64_t delta, int64_t maxBalance)
 {
     releaseAssertOrThrow(balance >= 0);
     releaseAssertOrThrow(maxBalance >= 0);
@@ -299,8 +285,7 @@ addBalance(int64_t& balance, int64_t delta, int64_t maxBalance)
     return true;
 }
 
-bool
-iequals(std::string const& a, std::string const& b)
+bool iequals(std::string const& a, std::string const& b)
 {
     size_t sz = a.size();
     if (b.size() != sz)
@@ -311,8 +296,7 @@ iequals(std::string const& a, std::string const& b)
     return true;
 }
 
-bool
-operator>=(Price const& a, Price const& b)
+bool operator>=(Price const& a, Price const& b)
 {
     releaseAssertOrThrow(a.n >= 0);
     releaseAssertOrThrow(a.d >= 0);
@@ -325,8 +309,7 @@ operator>=(Price const& a, Price const& b)
     return l >= r;
 }
 
-bool
-operator>(Price const& a, Price const& b)
+bool operator>(Price const& a, Price const& b)
 {
     releaseAssertOrThrow(a.n >= 0);
     releaseAssertOrThrow(a.d >= 0);
@@ -339,8 +322,7 @@ operator>(Price const& a, Price const& b)
     return l > r;
 }
 
-bool
-operator==(Price const& a, Price const& b)
+bool operator==(Price const& a, Price const& b)
 {
     return (a.n == b.n) && (a.d == b.d);
 }

--- a/src/util/types.h
+++ b/src/util/types.h
@@ -46,9 +46,7 @@ std::string formatSize(size_t size);
 template <typename T> bool isAssetValid(T const& cur, uint32_t ledgerVersion);
 
 // returns the issuer for the given asset
-template <typename T>
-AccountID
-getIssuer(T const& asset)
+template <typename T> AccountID getIssuer(T const& asset)
 {
     switch (asset.type())
     {
@@ -64,9 +62,7 @@ getIssuer(T const& asset)
     }
 }
 
-template <typename T>
-bool
-isIssuer(AccountID const& acc, T const& asset)
+template <typename T> bool isIssuer(AccountID const& acc, T const& asset)
 {
     switch (asset.type())
     {
@@ -83,8 +79,7 @@ isIssuer(AccountID const& acc, T const& asset)
 }
 
 template <uint32_t N>
-void
-assetCodeToStr(xdr::opaque_array<N> const& code, std::string& retStr)
+void assetCodeToStr(xdr::opaque_array<N> const& code, std::string& retStr)
 {
     retStr.clear();
     for (auto c : code)
@@ -98,16 +93,14 @@ assetCodeToStr(xdr::opaque_array<N> const& code, std::string& retStr)
 };
 
 template <uint32_t N>
-void
-strToAssetCode(xdr::opaque_array<N>& ret, std::string const& str)
+void strToAssetCode(xdr::opaque_array<N>& ret, std::string const& str)
 {
     ret.fill(0);
     size_t n = std::min(ret.size(), str.size());
     std::copy(str.begin(), str.begin() + n, ret.begin());
 }
 
-inline std::string
-assetToString(const Asset& asset)
+inline std::string assetToString(const Asset& asset)
 {
     auto r = std::string{};
     switch (asset.type())
@@ -128,8 +121,7 @@ assetToString(const Asset& asset)
     return r;
 };
 
-inline LedgerKey
-getBucketLedgerKey(HotArchiveBucketEntry const& be)
+inline LedgerKey getBucketLedgerKey(HotArchiveBucketEntry const& be)
 {
     switch (be.type())
     {
@@ -143,8 +135,7 @@ getBucketLedgerKey(HotArchiveBucketEntry const& be)
     }
 }
 
-inline LedgerKey
-getBucketLedgerKey(BucketEntry const& be)
+inline LedgerKey getBucketLedgerKey(BucketEntry const& be)
 {
     switch (be.type())
     {
@@ -160,9 +151,7 @@ getBucketLedgerKey(BucketEntry const& be)
 }
 
 // Round value v down to largest multiple of m, m must be power of 2
-template <typename T>
-inline T
-roundDown(T v, T m)
+template <typename T> inline T roundDown(T v, T m)
 {
     return v & ~(m - 1);
 }
@@ -180,8 +169,7 @@ bool operator==(Price const& a, Price const& b);
 // importantly are easy to accidentally misuse, we provide a few simpler
 // ascii-only functions.
 
-inline bool
-isAsciiAlphaNumeric(char c)
+inline bool isAsciiAlphaNumeric(char c)
 {
     unsigned char uc = static_cast<unsigned char>(c);
     if ('a' <= uc && uc <= 'z')
@@ -193,15 +181,13 @@ isAsciiAlphaNumeric(char c)
     return false;
 }
 
-inline bool
-isAsciiNonControl(char c)
+inline bool isAsciiNonControl(char c)
 {
     unsigned char uc = static_cast<unsigned char>(c);
     return (0x1f < uc && uc < 0x7F);
 }
 
-inline char
-toAsciiLower(char c)
+inline char toAsciiLower(char c)
 {
     unsigned char uc = static_cast<unsigned char>(c);
     if ('A' <= uc && uc <= 'Z')

--- a/src/util/xdrquery/XDRFieldResolver.h
+++ b/src/util/xdrquery/XDRFieldResolver.h
@@ -35,15 +35,13 @@ struct XDRFieldResolver
     {
     }
 
-    ResultType const&
-    getResult()
+    ResultType const& getResult()
     {
         releaseAssert(!mValidate);
         return mResult;
     }
 
-    bool
-    isValid() const
+    bool isValid() const
     {
         releaseAssert(mValidate);
         return mPathIter == mFieldPath.end();
@@ -158,8 +156,7 @@ struct XDRFieldResolver
     }
 
     template <uint32_t N>
-    void
-    operator()(xstring<N> const& t, char const* fieldName)
+    void operator()(xstring<N> const& t, char const* fieldName)
     {
         if (checkLeafField(fieldName))
         {
@@ -168,8 +165,7 @@ struct XDRFieldResolver
     }
 
     template <uint32_t N>
-    void
-    operator()(xdr::opaque_vec<N> const& v, char const* fieldName)
+    void operator()(xdr::opaque_vec<N> const& v, char const* fieldName)
     {
         if (checkLeafField(fieldName))
         {
@@ -178,8 +174,7 @@ struct XDRFieldResolver
     }
 
     template <uint32_t N>
-    void
-    operator()(xdr::opaque_array<N> const& v, char const* fieldName)
+    void operator()(xdr::opaque_array<N> const& v, char const* fieldName)
     {
         if (checkLeafField(fieldName))
         {
@@ -188,8 +183,7 @@ struct XDRFieldResolver
     }
 
     template <typename T>
-    void
-    operator()(xdr::pointer<T> const& ptr, char const* fieldName)
+    void operator()(xdr::pointer<T> const& ptr, char const* fieldName)
     {
         if (ptr)
         {
@@ -278,15 +272,13 @@ struct XDRFieldResolver
     }
 
   private:
-    bool
-    matchFieldToPath(char const* fieldName) const
+    bool matchFieldToPath(char const* fieldName) const
     {
         return fieldName != nullptr && mPathIter != mFieldPath.end() &&
                *mPathIter == fieldName;
     }
 
-    bool
-    checkLeafField(char const* fieldName)
+    bool checkLeafField(char const* fieldName)
     {
         if (!matchFieldToPath(fieldName))
         {
@@ -302,8 +294,7 @@ struct XDRFieldResolver
         return true;
     }
 
-    bool
-    checkMaybeLeafField(char const* fieldName, bool& isLeaf)
+    bool checkMaybeLeafField(char const* fieldName, bool& isLeaf)
     {
         if (!matchFieldToPath(fieldName))
         {
@@ -312,8 +303,7 @@ struct XDRFieldResolver
         return ++mPathIter != mFieldPath.end();
     }
 
-    void
-    processString(std::string const& s, char const* fieldName)
+    void processString(std::string const& s, char const* fieldName)
     {
         if (checkLeafField(fieldName))
         {
@@ -321,14 +311,12 @@ struct XDRFieldResolver
         }
     }
 
-    void
-    processPoolAsset(Asset const& asset)
+    void processPoolAsset(Asset const& asset)
     {
         throw std::runtime_error("Unexpected asset type for the pool asset.");
     }
 
-    void
-    processPoolAsset(TrustLineAsset const& asset)
+    void processPoolAsset(TrustLineAsset const& asset)
     {
         (*this)(asset.liquidityPoolID(), "liquidityPoolID");
     }
@@ -399,8 +387,8 @@ struct XDRFieldResolver
 //     `liquidityPoolID` for the pool shares)
 //   - Fixed size byte arrays are represented by the hex strings
 template <typename T>
-ResultType
-getXDRField(T const& xdrMessage, std::vector<std::string> const& fieldPath)
+ResultType getXDRField(T const& xdrMessage,
+                       std::vector<std::string> const& fieldPath)
 {
     internal::XDRFieldResolver resolver(fieldPath, false);
     xdr::xdr_argpack_archive(resolver, xdrMessage);
@@ -410,9 +398,8 @@ getXDRField(T const& xdrMessage, std::vector<std::string> const& fieldPath)
 // Like `getXDRField`, but throws XDRQueryError when path is not present in XDR
 // message (accounting for all the union variants and optional fields).
 template <typename T>
-ResultType
-getXDRFieldValidated(T const& xdrMessage,
-                     std::vector<std::string> const& fieldPath)
+ResultType getXDRFieldValidated(T const& xdrMessage,
+                                std::vector<std::string> const& fieldPath)
 {
     internal::XDRFieldResolver validator(fieldPath, true);
     xdr::xdr_argpack_archive(validator, xdrMessage);
@@ -431,9 +418,8 @@ namespace xdr
 template <> struct archive_adapter<xdrquery::internal::XDRFieldResolver>
 {
     template <typename T>
-    static void
-    apply(xdrquery::internal::XDRFieldResolver& ar, T&& t,
-          char const* fieldName)
+    static void apply(xdrquery::internal::XDRFieldResolver& ar, T&& t,
+                      char const* fieldName)
     {
         ar(std::forward<T>(t), fieldName);
     }

--- a/src/util/xdrquery/XDRQuery.cpp
+++ b/src/util/xdrquery/XDRQuery.cpp
@@ -17,8 +17,7 @@ XDRFieldExtractor::XDRFieldExtractor(std::string const& query,
 {
 }
 
-std::vector<std::string>
-XDRFieldExtractor::getColumnNames() const
+std::vector<std::string> XDRFieldExtractor::getColumnNames() const
 {
     return mFieldList->getColumnNames();
 }
@@ -34,8 +33,7 @@ XDRAccumulator::getAccumulators() const
     return mAccumulatorList->getAccumulators();
 }
 
-uint32_t
-noTtlGetter(LedgerKey const&)
+uint32_t noTtlGetter(LedgerKey const&)
 {
     throw std::runtime_error("TTLGetter not available");
 }

--- a/src/util/xdrquery/XDRQuery.h
+++ b/src/util/xdrquery/XDRQuery.h
@@ -42,14 +42,12 @@ class TypedDynamicXDRGetterResolver : public DynamicXDRGetter
         return getXDRField(mXdrMessage, fieldPath);
     }
 
-    uint64_t
-    getSize() const override
+    uint64_t getSize() const override
     {
         return xdr::xdr_size(mXdrMessage);
     }
 
-    uint32_t
-    getLiveUntilLedger() const override
+    uint32_t getLiveUntilLedger() const override
     {
         // XDR getter is implemented in generic fashion as it can normally work
         // for any XDR message. TTL getter is a special case because TTL is
@@ -98,9 +96,7 @@ class XDRMatcher
   public:
     XDRMatcher(std::string const& query, TTLGetter ttlGetter = noTtlGetter);
 
-    template <typename T>
-    bool
-    matchXDR(T const& xdrMessage)
+    template <typename T> bool matchXDR(T const& xdrMessage)
     {
         // Lazily parse the query in order to simplify exception handling as we
         // might throw XDRQueryError both during query parsing and query
@@ -138,8 +134,7 @@ class XDRFieldExtractor
                       TTLGetter ttlGetter = noTtlGetter);
 
     template <typename T>
-    std::vector<ResultType>
-    extractFields(T const& xdrMessage)
+    std::vector<ResultType> extractFields(T const& xdrMessage)
     {
         // Lazily parse the query in order to simplify exception handling as we
         // might throw XDRQueryError both during query parsing and query
@@ -180,9 +175,7 @@ class XDRAccumulator
   public:
     XDRAccumulator(std::string const& query, TTLGetter ttlGetter = noTtlGetter);
 
-    template <typename T>
-    void
-    addEntry(T const& xdrMessage)
+    template <typename T> void addEntry(T const& xdrMessage)
     {
         // Lazily parse the query in order to simplify exception handling as we
         // might throw XDRQueryError both during query parsing and query

--- a/src/util/xdrquery/XDRQueryEval.cpp
+++ b/src/util/xdrquery/XDRQueryEval.cpp
@@ -8,38 +8,31 @@
 
 namespace xdrquery
 {
-bool
-NullField::operator==(NullField other) const
+bool NullField::operator==(NullField other) const
 {
     return operationNotSupported();
 }
-bool
-NullField::operator!=(NullField other) const
+bool NullField::operator!=(NullField other) const
 {
     return operationNotSupported();
 }
-bool
-NullField::operator<(NullField other) const
+bool NullField::operator<(NullField other) const
 {
     return operationNotSupported();
 }
-bool
-NullField::operator<=(NullField other) const
+bool NullField::operator<=(NullField other) const
 {
     return operationNotSupported();
 }
-bool
-NullField::operator>(NullField other) const
+bool NullField::operator>(NullField other) const
 {
     return operationNotSupported();
 }
-bool
-NullField::operator>=(NullField other) const
+bool NullField::operator>=(NullField other) const
 {
     return operationNotSupported();
 }
-bool
-NullField::operationNotSupported() const
+bool NullField::operationNotSupported() const
 {
     throw std::runtime_error("Null fields should not be compared directly.");
     return false;
@@ -54,21 +47,18 @@ LiteralNode::LiteralNode(LiteralNodeType valueType, std::string const& val)
     }
 }
 
-ResultType
-LiteralNode::eval(DynamicXDRGetter const& xdrGetter) const
+ResultType LiteralNode::eval(DynamicXDRGetter const& xdrGetter) const
 {
     return mValue;
 }
 
-EvalNodeType
-LiteralNode::getType() const
+EvalNodeType LiteralNode::getType() const
 {
     return EvalNodeType::LITERAL;
 }
 
-void
-LiteralNode::resolveIntType(ResultValueType const& columnValue,
-                            std::string const& columnName) const
+void LiteralNode::resolveIntType(ResultValueType const& columnValue,
+                                 std::string const& columnName) const
 {
     if (std::holds_alternative<std::string>(columnValue))
     {
@@ -129,62 +119,52 @@ FieldNode::FieldNode(std::string const& initField)
     mFieldPath.push_back(initField);
 }
 
-ResultType
-FieldNode::eval(DynamicXDRGetter const& xdrGetter) const
+ResultType FieldNode::eval(DynamicXDRGetter const& xdrGetter) const
 {
     return xdrGetter.getField(mFieldPath);
 }
 
-EvalNodeType
-FieldNode::getType() const
+EvalNodeType FieldNode::getType() const
 {
     return EvalNodeType::COLUMN;
 }
 
-std::string
-FieldNode::getName() const
+std::string FieldNode::getName() const
 {
     return fmt::to_string(fmt::join(mFieldPath, "."));
 }
 
-ResultType
-EntrySizeNode::eval(DynamicXDRGetter const& xdrGetter) const
+ResultType EntrySizeNode::eval(DynamicXDRGetter const& xdrGetter) const
 {
     return xdrGetter.getSize();
 }
 
-EvalNodeType
-EntrySizeNode::getType() const
+EvalNodeType EntrySizeNode::getType() const
 {
     return EvalNodeType::COLUMN;
 }
 
-std::string
-EntrySizeNode::getName() const
+std::string EntrySizeNode::getName() const
 {
     return "entry_size";
 }
 
-ResultType
-TTLNode::eval(DynamicXDRGetter const& xdrGetter) const
+ResultType TTLNode::eval(DynamicXDRGetter const& xdrGetter) const
 {
     return xdrGetter.getLiveUntilLedger();
 }
 
-EvalNodeType
-TTLNode::getType() const
+EvalNodeType TTLNode::getType() const
 {
     return EvalNodeType::COLUMN;
 }
 
-std::string
-TTLNode::getName() const
+std::string TTLNode::getName() const
 {
     return "ttl";
 }
 
-ResultType
-BoolEvalNode::eval(DynamicXDRGetter const& xdrGetter) const
+ResultType BoolEvalNode::eval(DynamicXDRGetter const& xdrGetter) const
 {
     return evalBool(xdrGetter);
 }
@@ -196,8 +176,7 @@ BoolOpNode::BoolOpNode(BoolOpNodeType nodeType,
 {
 }
 
-bool
-BoolOpNode::evalBool(DynamicXDRGetter const& xdrGetter) const
+bool BoolOpNode::evalBool(DynamicXDRGetter const& xdrGetter) const
 {
     switch (mType)
     {
@@ -208,8 +187,7 @@ BoolOpNode::evalBool(DynamicXDRGetter const& xdrGetter) const
     }
 }
 
-EvalNodeType
-BoolOpNode::getType() const
+EvalNodeType BoolOpNode::getType() const
 {
     return EvalNodeType();
 }
@@ -245,8 +223,7 @@ ComparisonNode::ComparisonNode(ComparisonNodeType nodeType,
     }
 }
 
-bool
-ComparisonNode::evalBool(DynamicXDRGetter const& xdrGetter) const
+bool ComparisonNode::evalBool(DynamicXDRGetter const& xdrGetter) const
 {
     auto leftType = mLeft->getType();
     auto leftVal = mLeft->eval(xdrGetter);
@@ -307,14 +284,12 @@ ComparisonNode::evalBool(DynamicXDRGetter const& xdrGetter) const
     }
 }
 
-EvalNodeType
-ComparisonNode::getType() const
+EvalNodeType ComparisonNode::getType() const
 {
     return EvalNodeType::COMPARISON_OP;
 }
 
-bool
-ComparisonNode::compareNullFields(bool leftIsNull, bool rightIsNull) const
+bool ComparisonNode::compareNullFields(bool leftIsNull, bool rightIsNull) const
 {
     switch (mType)
     {
@@ -352,8 +327,7 @@ Accumulator::Accumulator(AccumulatorType nodeType,
     }
 }
 
-void
-Accumulator::addEntry(DynamicXDRGetter const& xdrGetter)
+void Accumulator::addEntry(DynamicXDRGetter const& xdrGetter)
 {
     ResultType columnValue;
     if (mType != AccumulatorType::COUNT)
@@ -404,8 +378,7 @@ Accumulator::addEntry(DynamicXDRGetter const& xdrGetter)
     }
 }
 
-AccumulatorResultType
-Accumulator::getValue() const
+AccumulatorResultType Accumulator::getValue() const
 {
     if (mType == AccumulatorType::COUNT)
     {
@@ -422,8 +395,7 @@ Accumulator::getValue() const
     return mValue;
 }
 
-std::string
-Accumulator::getName() const
+std::string Accumulator::getName() const
 {
     switch (mType)
     {
@@ -441,14 +413,12 @@ AccumulatorList::AccumulatorList(std::shared_ptr<Accumulator> accumulator)
     mAccumulators.emplace_back(accumulator);
 }
 
-void
-AccumulatorList::addAccumulator(std::shared_ptr<Accumulator> accumulator)
+void AccumulatorList::addAccumulator(std::shared_ptr<Accumulator> accumulator)
 {
     mAccumulators.emplace_back(accumulator);
 }
 
-void
-AccumulatorList::addEntry(DynamicXDRGetter const& xdrGetter) const
+void AccumulatorList::addEntry(DynamicXDRGetter const& xdrGetter) const
 {
     for (auto const& accumulator : mAccumulators)
     {
@@ -467,8 +437,7 @@ ColumnList::ColumnList(std::shared_ptr<ColumnNode> column)
     mColumns.emplace_back(column);
 }
 
-void
-ColumnList::addColumn(std::shared_ptr<ColumnNode> column)
+void ColumnList::addColumn(std::shared_ptr<ColumnNode> column)
 {
     mColumns.emplace_back(column);
 }
@@ -485,8 +454,7 @@ ColumnList::getValues(DynamicXDRGetter const& xdrGetter) const
     return res;
 }
 
-std::vector<std::string>
-ColumnList::getColumnNames() const
+std::vector<std::string> ColumnList::getColumnNames() const
 {
     std::vector<std::string> names;
     names.reserve(mColumns.size());
@@ -497,14 +465,12 @@ ColumnList::getColumnNames() const
     return names;
 }
 
-inline std::string
-format_as(const NullField&)
+inline std::string format_as(const NullField&)
 {
     return "<notset>";
 }
 
-std::string
-resultToString(ResultValueType const& result)
+std::string resultToString(ResultValueType const& result)
 {
     return std::visit([](auto&& v) { return fmt::to_string(v); }, result);
 }

--- a/src/util/xdrquery/test/XDRQueryTests.cpp
+++ b/src/util/xdrquery/test/XDRQueryTests.cpp
@@ -15,8 +15,7 @@ namespace
 {
 using namespace stellar;
 
-LedgerEntry
-makeAccountEntry(int64_t balance)
+LedgerEntry makeAccountEntry(int64_t balance)
 {
     LedgerEntry accountEntry;
     accountEntry.data.type(ACCOUNT);
@@ -38,8 +37,7 @@ makeAccountEntry(int64_t balance)
     return accountEntry;
 }
 
-LedgerEntry
-makeOfferEntry(std::string const& assetName)
+LedgerEntry makeOfferEntry(std::string const& assetName)
 {
     LedgerEntry offerEntry;
     offerEntry.data.type(OFFER);
@@ -64,8 +62,7 @@ makeOfferEntry(std::string const& assetName)
 }
 
 template <typename VariantT>
-void
-compareVariants(VariantT const& v1, VariantT const& v2)
+void compareVariants(VariantT const& v1, VariantT const& v2)
 {
     REQUIRE(v1.index() == v2.index());
     std::visit(

--- a/src/work/BasicWork.cpp
+++ b/src/work/BasicWork.cpp
@@ -47,8 +47,7 @@ BasicWork::~BasicWork()
     releaseAssert(isDone() || mState == InternalState::PENDING || isAborting());
 }
 
-void
-BasicWork::resetWaitingTimer()
+void BasicWork::resetWaitingTimer()
 {
     if (mWaitingTimer)
     {
@@ -57,8 +56,7 @@ BasicWork::resetWaitingTimer()
     }
 }
 
-void
-BasicWork::shutdown()
+void BasicWork::shutdown()
 {
     CLOG_TRACE(Work, "Shutting down: {}", getName());
     if (!isDone())
@@ -70,14 +68,12 @@ BasicWork::shutdown()
     }
 }
 
-std::string const&
-BasicWork::getName() const
+std::string const& BasicWork::getName() const
 {
     return mName;
 }
 
-std::string
-BasicWork::getStatus() const
+std::string BasicWork::getStatus() const
 {
     // Work is in `WAITING` state when retrying
     auto state = mRetryTimer ? InternalState::RETRYING : mState.load();
@@ -109,15 +105,13 @@ BasicWork::getStatus() const
     }
 }
 
-bool
-BasicWork::isDone() const
+bool BasicWork::isDone() const
 {
     return mState == InternalState::SUCCESS ||
            mState == InternalState::FAILURE || mState == InternalState::ABORTED;
 }
 
-std::string
-BasicWork::stateName(InternalState st)
+std::string BasicWork::stateName(InternalState st)
 {
     switch (st)
     {
@@ -142,8 +136,7 @@ BasicWork::stateName(InternalState st)
     }
 }
 
-void
-BasicWork::reset()
+void BasicWork::reset()
 {
     CLOG_TRACE(Work, "resetting {}", getName());
 
@@ -156,8 +149,7 @@ BasicWork::reset()
     onReset();
 }
 
-void
-BasicWork::startWork(std::function<void()> notificationCallback)
+void BasicWork::startWork(std::function<void()> notificationCallback)
 {
     CLOG_TRACE(Work, "Starting {}", getName());
 
@@ -172,8 +164,7 @@ BasicWork::startWork(std::function<void()> notificationCallback)
     releaseAssert(mRetries == 0);
 }
 
-void
-BasicWork::waitForRetry()
+void BasicWork::waitForRetry()
 {
     if (mRetryTimer)
     {
@@ -208,28 +199,23 @@ BasicWork::waitForRetry()
     });
 }
 
-void
-BasicWork::onReset()
+void BasicWork::onReset()
 {
 }
 
-void
-BasicWork::onSuccess()
+void BasicWork::onSuccess()
 {
 }
 
-void
-BasicWork::onFailureRetry()
+void BasicWork::onFailureRetry()
 {
 }
 
-void
-BasicWork::onFailureRaise()
+void BasicWork::onFailureRaise()
 {
 }
 
-BasicWork::State
-BasicWork::getState() const
+BasicWork::State BasicWork::getState() const
 {
     switch (mState)
     {
@@ -251,8 +237,7 @@ BasicWork::getState() const
     }
 }
 
-void
-BasicWork::setState(InternalState st)
+void BasicWork::setState(InternalState st)
 {
     if (st == InternalState::FAILURE && (mRetries < mMaxRetries))
     {
@@ -301,8 +286,7 @@ BasicWork::setState(InternalState st)
     }
 }
 
-void
-BasicWork::wakeUp(std::function<void()> innerCallback)
+void BasicWork::wakeUp(std::function<void()> innerCallback)
 {
     // Work should not be waking up in terminal state
     // Work should not be interrupted when retrying or destructing
@@ -345,8 +329,7 @@ BasicWork::wakeSelfUpCallback(std::function<void()> innerCallback)
     return callback;
 }
 
-void
-BasicWork::setupWaitingCallback(std::chrono::milliseconds wakeUpIn)
+void BasicWork::setupWaitingCallback(std::chrono::milliseconds wakeUpIn)
 {
     // Work must be running to schedule a timer
     releaseAssert(mState == BasicWork::InternalState::RUNNING);
@@ -367,8 +350,7 @@ BasicWork::setupWaitingCallback(std::chrono::milliseconds wakeUpIn)
                               &VirtualTimer::onFailureNoop);
 }
 
-void
-BasicWork::crankWork()
+void BasicWork::crankWork()
 {
     ZoneScoped;
     releaseAssert(!isDone() && mState != InternalState::WAITING);
@@ -389,14 +371,12 @@ BasicWork::crankWork()
     setState(nextState);
 }
 
-VirtualClock::duration
-BasicWork::getRetryDelay() const
+VirtualClock::duration BasicWork::getRetryDelay() const
 {
     return exponentialBackoff(uint64_t(mRetries));
 }
 
-uint64_t
-BasicWork::getRetryETA() const
+uint64_t BasicWork::getRetryETA() const
 {
     if (!mRetryTimer)
     {
@@ -412,8 +392,7 @@ BasicWork::getRetryETA() const
     return secs.count();
 }
 
-void
-BasicWork::assertValidTransition(Transition const& t) const
+void BasicWork::assertValidTransition(Transition const& t) const
 {
     if (ALLOWED_TRANSITIONS.find(t) == ALLOWED_TRANSITIONS.end())
     {
@@ -423,8 +402,7 @@ BasicWork::assertValidTransition(Transition const& t) const
     }
 }
 
-BasicWork::InternalState
-BasicWork::getInternalState(State s) const
+BasicWork::InternalState BasicWork::getInternalState(State s) const
 {
     switch (s)
     {

--- a/src/work/BasicWork.h
+++ b/src/work/BasicWork.h
@@ -156,8 +156,7 @@ class BasicWork : public std::enable_shared_from_this<BasicWork>,
     // internal state of work.
     virtual void shutdown();
 
-    bool
-    isAborting() const
+    bool isAborting() const
     {
         return mState == InternalState::ABORTING;
     }

--- a/src/work/BatchWork.cpp
+++ b/src/work/BatchWork.cpp
@@ -16,15 +16,13 @@ BatchWork::BatchWork(Application& app, std::string name)
 {
 }
 
-void
-BatchWork::doReset()
+void BatchWork::doReset()
 {
     mBatch.clear();
     resetIter();
 }
 
-BasicWork::State
-BatchWork::doWork()
+BasicWork::State BatchWork::doWork()
 {
     ZoneScoped;
     if (anyChildRaiseFailure())
@@ -61,8 +59,7 @@ BatchWork::doWork()
     return State::WORK_RUNNING;
 }
 
-void
-BatchWork::addMoreWorkIfNeeded()
+void BatchWork::addMoreWorkIfNeeded()
 {
     ZoneScoped;
     if (isAborting())

--- a/src/work/BatchWork.h
+++ b/src/work/BatchWork.h
@@ -26,8 +26,7 @@ class BatchWork : public Work
     BatchWork(Application& app, std::string name);
     ~BatchWork() = default;
 
-    size_t
-    getNumWorksInBatch() const
+    size_t getNumWorksInBatch() const
     {
         return mBatch.size();
     }

--- a/src/work/ConditionalWork.cpp
+++ b/src/work/ConditionalWork.cpp
@@ -32,8 +32,7 @@ ConditionalWork::ConditionalWork(Application& app, std::string name,
     }
 }
 
-BasicWork::State
-ConditionalWork::onRun()
+BasicWork::State ConditionalWork::onRun()
 {
     ZoneScoped;
     if (mWorkStarted)
@@ -61,8 +60,7 @@ ConditionalWork::onRun()
     }
 }
 
-void
-ConditionalWork::shutdown()
+void ConditionalWork::shutdown()
 {
     ZoneScoped;
     if (mWorkStarted)
@@ -72,8 +70,7 @@ ConditionalWork::shutdown()
     BasicWork::shutdown();
 }
 
-bool
-ConditionalWork::onAbort()
+bool ConditionalWork::onAbort()
 {
     ZoneScoped;
     if (mWorkStarted && !mConditionedWork->isDone())
@@ -84,14 +81,12 @@ ConditionalWork::onAbort()
     return true;
 }
 
-void
-ConditionalWork::onReset()
+void ConditionalWork::onReset()
 {
     mWorkStarted = false;
 }
 
-std::string
-ConditionalWork::getStatus() const
+std::string ConditionalWork::getStatus() const
 {
     return fmt::format(FMT_STRING("{}{}"),
                        mWorkStarted ? "" : "Waiting before starting ",

--- a/src/work/Work.cpp
+++ b/src/work/Work.cpp
@@ -25,8 +25,7 @@ Work::~Work()
     }
 }
 
-std::string
-Work::getStatus() const
+std::string Work::getStatus() const
 {
     auto status = BasicWork::getStatus();
     if (mTotalChildren)
@@ -37,16 +36,14 @@ Work::getStatus() const
     return status;
 }
 
-void
-Work::shutdown()
+void Work::shutdown()
 {
     ZoneScoped;
     shutdownChildren();
     BasicWork::shutdown();
 }
 
-BasicWork::State
-Work::onRun()
+BasicWork::State Work::onRun()
 {
     ZoneScoped;
     if (mAbortChildrenButNotSelf)
@@ -85,8 +82,7 @@ Work::onRun()
     }
 }
 
-bool
-Work::onAbort()
+bool Work::onAbort()
 {
     ZoneScoped;
     auto child = yieldNextRunningChild();
@@ -103,18 +99,15 @@ Work::onAbort()
     }
 }
 
-void
-Work::onFailureRaise()
+void Work::onFailureRaise()
 {
 }
 
-void
-Work::onFailureRetry()
+void Work::onFailureRetry()
 {
 }
 
-void
-Work::shutdownChildren()
+void Work::shutdownChildren()
 {
     // Shutdown any children that are still running
     for (auto const& c : mChildren)
@@ -126,8 +119,7 @@ Work::shutdownChildren()
     }
 }
 
-void
-Work::onReset()
+void Work::onReset()
 {
     ZoneScoped;
     clearChildren();
@@ -135,13 +127,11 @@ Work::onReset()
     doReset();
 }
 
-void
-Work::doReset()
+void Work::doReset()
 {
 }
 
-void
-Work::clearChildren()
+void Work::clearChildren()
 {
     ZoneScoped;
     releaseAssert(allChildrenDone());
@@ -150,8 +140,7 @@ Work::clearChildren()
     mNextChild = mChildren.begin();
 }
 
-void
-Work::addChild(std::shared_ptr<BasicWork> child)
+void Work::addChild(std::shared_ptr<BasicWork> child)
 {
     bool resetIter = !hasChildren();
     mChildren.push_back(child);
@@ -162,46 +151,39 @@ Work::addChild(std::shared_ptr<BasicWork> child)
     }
 }
 
-bool
-Work::allChildrenSuccessful() const
+bool Work::allChildrenSuccessful() const
 {
     return WorkUtils::allSuccessful(mChildren);
 }
 
-bool
-Work::allChildrenDone() const
+bool Work::allChildrenDone() const
 {
     return std::all_of(
         mChildren.begin(), mChildren.end(),
         [](std::shared_ptr<BasicWork> const& w) { return w->isDone(); });
 }
 
-bool
-Work::anyChildRunning() const
+bool Work::anyChildRunning() const
 {
     return WorkUtils::anyRunning(mChildren);
 }
 
-bool
-Work::hasChildren() const
+bool Work::hasChildren() const
 {
     return !mChildren.empty();
 }
 
-bool
-Work::anyChildRaiseFailure() const
+bool Work::anyChildRaiseFailure() const
 {
     return WorkUtils::anyFailed(mChildren);
 }
 
-BasicWork::State
-Work::checkChildrenStatus() const
+BasicWork::State Work::checkChildrenStatus() const
 {
     return WorkUtils::getWorkStatus(mChildren);
 }
 
-std::shared_ptr<BasicWork>
-Work::yieldNextRunningChild()
+std::shared_ptr<BasicWork> Work::yieldNextRunningChild()
 {
     while (mNextChild != mChildren.end())
     {
@@ -228,8 +210,7 @@ Work::yieldNextRunningChild()
 namespace WorkUtils
 {
 
-bool
-allSuccessful(std::list<std::shared_ptr<BasicWork>> const& works)
+bool allSuccessful(std::list<std::shared_ptr<BasicWork>> const& works)
 {
     return std::all_of(
         works.begin(), works.end(), [](std::shared_ptr<BasicWork> w) {
@@ -237,8 +218,7 @@ allSuccessful(std::list<std::shared_ptr<BasicWork>> const& works)
         });
 }
 
-bool
-anyFailed(std::list<std::shared_ptr<BasicWork>> const& works)
+bool anyFailed(std::list<std::shared_ptr<BasicWork>> const& works)
 {
     return std::any_of(
         works.begin(), works.end(), [](std::shared_ptr<BasicWork> w) {
@@ -246,8 +226,7 @@ anyFailed(std::list<std::shared_ptr<BasicWork>> const& works)
         });
 }
 
-bool
-anyRunning(std::list<std::shared_ptr<BasicWork>> const& works)
+bool anyRunning(std::list<std::shared_ptr<BasicWork>> const& works)
 {
     return std::any_of(
         works.begin(), works.end(), [](std::shared_ptr<BasicWork> w) {

--- a/src/work/Work.h
+++ b/src/work/Work.h
@@ -59,8 +59,7 @@ class Work : public BasicWork
     // Thus, `addWork` should be used to create Work (then the parent holds
     // the reference).
     template <typename T, typename... Args>
-    std::shared_ptr<T>
-    addWork(Args&&... args)
+    std::shared_ptr<T> addWork(Args&&... args)
     {
         return addWorkWithCallback<T>(nullptr, std::forward<Args>(args)...);
     }
@@ -70,8 +69,8 @@ class Work : public BasicWork
     // callback may be passed in, in case anything else needs to be done after
     // waking up.
     template <typename T, typename... Args>
-    std::shared_ptr<T>
-    addWorkWithCallback(std::function<void()> cb, Args&&... args)
+    std::shared_ptr<T> addWorkWithCallback(std::function<void()> cb,
+                                           Args&&... args)
     {
         if (isAborting())
         {
@@ -94,8 +93,7 @@ class Work : public BasicWork
     // which will wire up callbacks / start running the child. The parent's
     // onRun method should only return WORK_WAITING if it observes an _existing_
     // child running or waiting.
-    void
-    addWork(std::function<void()> cb, std::shared_ptr<BasicWork> child)
+    void addWork(std::function<void()> cb, std::shared_ptr<BasicWork> child)
     {
         addChild(child);
         auto wakeSelf = wakeSelfUpCallback(cb);

--- a/src/work/WorkScheduler.cpp
+++ b/src/work/WorkScheduler.cpp
@@ -22,8 +22,7 @@ WorkScheduler::~WorkScheduler()
 {
 }
 
-std::shared_ptr<WorkScheduler>
-WorkScheduler::create(Application& app)
+std::shared_ptr<WorkScheduler> WorkScheduler::create(Application& app)
 {
     auto work = std::shared_ptr<WorkScheduler>(new WorkScheduler(app));
     work->startWork(nullptr);
@@ -31,8 +30,7 @@ WorkScheduler::create(Application& app)
     return work;
 };
 
-BasicWork::State
-WorkScheduler::doWork()
+BasicWork::State WorkScheduler::doWork()
 {
     if (anyChildRunning())
     {
@@ -41,8 +39,7 @@ WorkScheduler::doWork()
     return State::WORK_WAITING;
 }
 
-void
-WorkScheduler::scheduleOne(std::weak_ptr<WorkScheduler> weak)
+void WorkScheduler::scheduleOne(std::weak_ptr<WorkScheduler> weak)
 {
     auto self = weak.lock();
     if (!self || self->mScheduled)
@@ -76,8 +73,7 @@ WorkScheduler::scheduleOne(std::weak_ptr<WorkScheduler> weak)
         "WorkScheduler");
 }
 
-void
-WorkScheduler::shutdown()
+void WorkScheduler::shutdown()
 {
     if (isDone())
     {

--- a/src/work/WorkScheduler.h
+++ b/src/work/WorkScheduler.h
@@ -29,8 +29,7 @@ class WorkScheduler : public Work
     static std::shared_ptr<WorkScheduler> create(Application& app);
 
     template <typename T, typename... Args>
-    std::shared_ptr<T>
-    executeWork(Args&&... args)
+    std::shared_ptr<T> executeWork(Args&&... args)
     {
         auto work = scheduleWork<T>(std::forward<Args>(args)...);
         auto& clock = mApp.getClock();
@@ -44,8 +43,7 @@ class WorkScheduler : public Work
     // Returns a work that's been scheduled, or nullptr if the WorkScheduler
     // is aborting.
     template <typename T, typename... Args>
-    std::shared_ptr<T>
-    scheduleWork(Args&&... args)
+    std::shared_ptr<T> scheduleWork(Args&&... args)
     {
         if (isAborting() || isDone())
         {

--- a/src/work/WorkSequence.cpp
+++ b/src/work/WorkSequence.cpp
@@ -20,8 +20,7 @@ WorkSequence::WorkSequence(Application& app, std::string name,
 {
 }
 
-BasicWork::State
-WorkSequence::onRun()
+BasicWork::State WorkSequence::onRun()
 {
     ZoneScoped;
     if (mNextInSequence == mSequenceOfWork.end())
@@ -57,8 +56,7 @@ WorkSequence::onRun()
     return State::WORK_RUNNING;
 }
 
-bool
-WorkSequence::onAbort()
+bool WorkSequence::onAbort()
 {
     ZoneScoped;
     if (mCurrentExecuting && !mCurrentExecuting->isDone())
@@ -70,8 +68,7 @@ WorkSequence::onAbort()
     return true;
 }
 
-void
-WorkSequence::onReset()
+void WorkSequence::onReset()
 {
     ZoneScoped;
     releaseAssert(std::all_of(
@@ -81,8 +78,7 @@ WorkSequence::onReset()
     mCurrentExecuting.reset();
 }
 
-std::string
-WorkSequence::getStatus() const
+std::string WorkSequence::getStatus() const
 {
     if (!isDone() && mNextInSequence != mSequenceOfWork.end())
     {
@@ -91,8 +87,7 @@ WorkSequence::getStatus() const
     return BasicWork::getStatus();
 }
 
-void
-WorkSequence::shutdown()
+void WorkSequence::shutdown()
 {
     ZoneScoped;
     if (mCurrentExecuting)

--- a/src/work/WorkWithCallback.cpp
+++ b/src/work/WorkWithCallback.cpp
@@ -21,8 +21,7 @@ WorkWithCallback::WorkWithCallback(
     }
 }
 
-BasicWork::State
-WorkWithCallback::onRun()
+BasicWork::State WorkWithCallback::onRun()
 {
     bool res;
     try

--- a/src/work/WorkWithCallback.h
+++ b/src/work/WorkWithCallback.h
@@ -18,8 +18,7 @@ class WorkWithCallback : public BasicWork
 
   protected:
     BasicWork::State onRun() override;
-    bool
-    onAbort() override
+    bool onAbort() override
     {
         return true;
     };

--- a/src/work/test/WorkTests.cpp
+++ b/src/work/test/WorkTests.cpp
@@ -41,15 +41,13 @@ class TestBasicWork : public BasicWork
     {
     }
 
-    void
-    forceWakeUp()
+    void forceWakeUp()
     {
         wakeUp();
     }
 
   protected:
-    BasicWork::State
-    onRun() override
+    BasicWork::State onRun() override
     {
         CLOG_DEBUG(Work, "Running {}", getName());
         mRunningCount++;
@@ -61,34 +59,29 @@ class TestBasicWork : public BasicWork
         return mShouldFail ? State::WORK_FAILURE : State::WORK_SUCCESS;
     }
 
-    bool
-    onAbort() override
+    bool onAbort() override
     {
         CLOG_DEBUG(Work, "Aborting {}", getName());
         ++mAbortCount;
         return true;
     }
 
-    void
-    onSuccess() override
+    void onSuccess() override
     {
         ++mSuccessCount;
     }
 
-    void
-    onFailureRaise() override
+    void onFailureRaise() override
     {
         ++mFailureCount;
     }
 
-    void
-    onFailureRetry() override
+    void onFailureRetry() override
     {
         ++mRetryCount;
     }
 
-    void
-    onReset() override
+    void onReset() override
     {
         mCount = mNumSteps;
     }
@@ -108,8 +101,7 @@ class TestWaitingWork : public TestBasicWork
     }
 
   protected:
-    BasicWork::State
-    onRun() override
+    BasicWork::State onRun() override
     {
         ++mRunningCount;
         if (--mCount > 0)
@@ -122,8 +114,7 @@ class TestWaitingWork : public TestBasicWork
         return BasicWork::State::WORK_SUCCESS;
     }
 
-    void
-    wakeUp(std::function<void()> innerCallback) override
+    void wakeUp(std::function<void()> innerCallback) override
     {
         ++mWakeUpCount;
         TestBasicWork::wakeUp(innerCallback);
@@ -288,34 +279,29 @@ class TestWork : public Work
     {
     }
 
-    BasicWork::State
-    doWork() override
+    BasicWork::State doWork() override
     {
         ++mRunningCount;
         return checkChildrenStatus();
     }
 
     template <typename T, typename... Args>
-    std::shared_ptr<T>
-    addTestWork(Args&&... args)
+    std::shared_ptr<T> addTestWork(Args&&... args)
     {
         return addWork<T>(std::forward<Args>(args)...);
     }
 
-    void
-    onSuccess() override
+    void onSuccess() override
     {
         mSuccessCount++;
     }
 
-    void
-    onFailureRaise() override
+    void onFailureRaise() override
     {
         mFailureCount++;
     }
 
-    void
-    onFailureRetry() override
+    void onFailureRetry() override
     {
         mRetryCount++;
     }
@@ -562,14 +548,12 @@ class TestRunCommandWork : public RunCommandWork
     }
     ~TestRunCommandWork() override = default;
 
-    CommandInfo
-    getCommand() override
+    CommandInfo getCommand() override
     {
         return CommandInfo{mCommand, std::string()};
     }
 
-    BasicWork::State
-    onRun() override
+    BasicWork::State onRun() override
     {
         return RunCommandWork::onRun();
     }
@@ -787,20 +771,17 @@ class TestBatchWork : public BatchWork
     }
 
   protected:
-    bool
-    hasNext() const override
+    bool hasNext() const override
     {
         return mCount < mTotalWorks;
     }
 
-    void
-    resetIter() override
+    void resetIter() override
     {
         mCount = 0;
     }
 
-    std::shared_ptr<BasicWork>
-    yieldMoreWork() override
+    std::shared_ptr<BasicWork> yieldMoreWork() override
     {
         // Last work will fail
         bool fail = mCount == mTotalWorks - 1 && mShouldFail;
@@ -868,8 +849,7 @@ class TestBatchWorkCondition : public TestBatchWork
     TestBatchWorkCondition(Application& app, std::string const& name)
         : TestBatchWork(app, name) {};
 
-    std::shared_ptr<BasicWork>
-    yieldMoreWork() override
+    std::shared_ptr<BasicWork> yieldMoreWork() override
     {
         auto w = std::make_shared<TestBasicWork>(
             mApp, fmt::format("child-{:d}", mCount++));


### PR DESCRIPTION
### what
Remove deprecated [clang-format20 style options](https://releases.llvm.org/20.1.0/tools/clang/docs/ClangFormatStyleOptions.html) and improve readability.

One more change here is to set `BreakAfterReturnType: ExceptShortType` which puts the return type in the same line as the definition with break after return type based on PenaltyReturnTypeOnItsOwnLine setting.
`Example:`
```
class A {
  int f() { return 0; };
};
int f();
int f() { return 1; }
int LongName::
    AnotherLongName();
```
### why
1. Keeping .clang-format config file up to date by removing deprecated options. 
2. Changes look more readable with reduced lines of code with return type on the same line. If a line gets too long, PenaltyReturnTypeOnItsOwnLine setting of 60 would break the line after return type. 

NOTE: Counter proposal in https://github.com/stellar/stellar-core/pull/5061