### PR TITLE
Add metric for eviction scan duration

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -205,6 +205,8 @@ state-archival.eviction.bytes-scanned     | counter   | number of bytes that evi
 state-archival.eviction.entries-evicted   | counter   | number of entries that have been evicted
 state-archival.eviction.incomplete-scan   | counter   | number of buckets that were too large to be fully scanned for eviction
 state-archival.eviction.period            | counter   | number of ledgers to complete an eviction scan
+state-archival.eviction.blocking-time     | timer     | time spent on eviction on the main thread
+state-archival.eviction.background-time   | timer     | time spent in the background scanning entries to find evictable entries
 soroban.host-fn-op.read-entry                | meter     | number of entries accessed (read or modified) during the `InvokeHostFunctionOp`
 soroban.host-fn-op.write-entry               | meter     | number of entries modified during the `InvokeHostFunctionOp`
 soroban.host-fn-op.read-key-byte             | meter     | number of `LedgerKey` bytes in entries accessed (read or modified) during the `InvokeHostFunctionOp`

--- a/src/bucket/BucketListBase.h
+++ b/src/bucket/BucketListBase.h
@@ -348,7 +348,7 @@ class Application;
 class Bucket;
 struct BucketEntryCounters;
 class Config;
-struct EvictionCounters;
+struct EvictionMetrics;
 struct InflationWinner;
 
 namespace testutil

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -120,7 +120,7 @@ class BucketManager : NonMovableOrCopyable
     medida::Meter& mCacheMissMeter;
     medida::Counter& mLiveBucketIndexCacheEntries;
     medida::Counter& mLiveBucketIndexCacheBytes;
-    EvictionCounters mBucketListEvictionCounters;
+    EvictionMetrics mBucketListEvictionMetrics;
     MergeCounters mLiveMergeCounters;
     MergeCounters mHotArchiveMergeCounters;
     std::shared_ptr<EvictionStatistics> mEvictionStatistics{};

--- a/src/bucket/BucketUtils.h
+++ b/src/bucket/BucketUtils.h
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <list>
 #include <map>
+#include <medida/timer.h>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -149,15 +150,17 @@ struct EvictedStateVectors
     std::vector<LedgerEntry> archivedEntries;
 };
 
-struct EvictionCounters
+struct EvictionMetrics
 {
     medida::Counter& entriesEvicted;
     medida::Counter& bytesScannedForEviction;
     medida::Counter& incompleteBucketScan;
     medida::Counter& evictionCyclePeriod;
     medida::Counter& averageEvictedEntryAge;
+    medida::Timer& blockingTime;
+    medida::Timer& backgroundTime;
 
-    EvictionCounters(AppConnector& app);
+    EvictionMetrics(AppConnector& app);
 };
 
 class EvictionStatistics
@@ -177,7 +180,7 @@ class EvictionStatistics
     void recordEvictedEntry(uint64_t age);
 
     void submitMetricsAndRestartCycle(uint32_t currLedgerSeq,
-                                      EvictionCounters& counters);
+                                      EvictionMetrics& metrics);
 };
 
 // Enum for more granular LedgerEntry types for Bucket metric reporting.

--- a/src/bucket/LiveBucketList.cpp
+++ b/src/bucket/LiveBucketList.cpp
@@ -115,7 +115,7 @@ bool
 LiveBucketList::updateEvictionIterAndRecordStats(
     EvictionIterator& iter, EvictionIterator startIter,
     uint32_t configFirstScanLevel, uint32_t ledgerSeq,
-    std::shared_ptr<EvictionStatistics> stats, EvictionCounters& counters)
+    std::shared_ptr<EvictionStatistics> stats, EvictionMetrics& metrics)
 {
     releaseAssert(stats);
 
@@ -140,7 +140,7 @@ LiveBucketList::updateEvictionIterAndRecordStats(
             iter.bucketListLevel = configFirstScanLevel;
 
             // Record then reset metrics at beginning of new eviction cycle
-            stats->submitMetricsAndRestartCycle(ledgerSeq, counters);
+            stats->submitMetricsAndRestartCycle(ledgerSeq, metrics);
         }
     }
 
@@ -158,7 +158,7 @@ void
 LiveBucketList::checkIfEvictionScanIsStuck(EvictionIterator const& evictionIter,
                                            uint32_t scanSize,
                                            std::shared_ptr<LiveBucket const> b,
-                                           EvictionCounters& counters)
+                                           EvictionMetrics& metrics)
 {
     // Check to see if we can finish scanning the new bucket before it
     // receives an update
@@ -168,7 +168,7 @@ LiveBucketList::checkIfEvictionScanIsStuck(EvictionIterator const& evictionIter,
     {
         CLOG_WARNING(Bucket,
                      "Bucket too large for current eviction scan size.");
-        counters.incompleteBucketScan.inc();
+        metrics.incompleteBucketScan.inc();
     }
 }
 }

--- a/src/bucket/LiveBucketList.h
+++ b/src/bucket/LiveBucketList.h
@@ -31,12 +31,12 @@ class LiveBucketList : public BucketListBase<LiveBucket>
     static bool updateEvictionIterAndRecordStats(
         EvictionIterator& iter, EvictionIterator startIter,
         uint32_t configFirstScanLevel, uint32_t ledgerSeq,
-        std::shared_ptr<EvictionStatistics> stats, EvictionCounters& counters);
+        std::shared_ptr<EvictionStatistics> stats, EvictionMetrics& metrics);
 
     static void checkIfEvictionScanIsStuck(EvictionIterator const& evictionIter,
                                            uint32_t scanSize,
                                            std::shared_ptr<LiveBucket const> b,
-                                           EvictionCounters& counters);
+                                           EvictionMetrics& metrics);
 
     // Add a batch of initial (created), live (updated) and dead entries to the
     // bucketlist, representing the entries effected by closing

--- a/src/bucket/SearchableBucketList.cpp
+++ b/src/bucket/SearchableBucketList.cpp
@@ -15,9 +15,9 @@ namespace stellar
 {
 std::unique_ptr<EvictionResultCandidates>
 SearchableLiveBucketListSnapshot::scanForEviction(
-    uint32_t ledgerSeq, EvictionCounters& counters,
-    EvictionIterator evictionIter, std::shared_ptr<EvictionStatistics> stats,
-    StateArchivalSettings const& sas, uint32_t ledgerVers) const
+    uint32_t ledgerSeq, EvictionMetrics& metrics, EvictionIterator evictionIter,
+    std::shared_ptr<EvictionStatistics> stats, StateArchivalSettings const& sas,
+    uint32_t ledgerVers) const
 {
     releaseAssert(mSnapshot);
     releaseAssert(stats);
@@ -55,7 +55,7 @@ SearchableLiveBucketListSnapshot::scanForEviction(
     {
         auto const& b = getBucketFromIter(evictionIter);
         LiveBucketList::checkIfEvictionScanIsStuck(
-            evictionIter, sas.evictionScanSize, b.getRawBucket(), counters);
+            evictionIter, sas.evictionScanSize, b.getRawBucket(), metrics);
 
         // If we scan scanSize before hitting bucket EOF, exit early
         if (b.scanForEviction(evictionIter, scanSize, ledgerSeq,
@@ -68,7 +68,7 @@ SearchableLiveBucketListSnapshot::scanForEviction(
         // If we return back to the Bucket we started at, exit
         if (LiveBucketList::updateEvictionIterAndRecordStats(
                 evictionIter, startIter, sas.startingEvictionScanLevel,
-                ledgerSeq, stats, counters))
+                ledgerSeq, stats, metrics))
         {
             break;
         }

--- a/src/bucket/SearchableBucketList.h
+++ b/src/bucket/SearchableBucketList.h
@@ -30,7 +30,7 @@ class SearchableLiveBucketListSnapshot
              std::string const& label) const;
 
     std::unique_ptr<EvictionResultCandidates> scanForEviction(
-        uint32_t ledgerSeq, EvictionCounters& counters, EvictionIterator iter,
+        uint32_t ledgerSeq, EvictionMetrics& metrics, EvictionIterator iter,
         std::shared_ptr<EvictionStatistics> stats,
         StateArchivalSettings const& sas, uint32_t ledgerVers) const;
 


### PR DESCRIPTION
Resolves stellar/stellar-core-internal#400. Adds a metric tracking eviction scan duration. (Doesn't add a metric for percentage of available time for bucket merges or evictions since these are basically a constant division we could just do in Grafana)