### PR TITLE
Ensure expired entries are never modified by LedgerTxn

### DIFF
--- a/src/bucket/BucketSnapshot.cpp
+++ b/src/bucket/BucketSnapshot.cpp
@@ -226,6 +226,11 @@ LiveBucketSnapshot::scanForEviction(
 
     auto processQueue = [&]() {
         auto loadResult = populateLoadedEntries(
+            // Note: load from a stale snapshot here. Expired entries should
+            // never be modified by the ltx, unless they're getting restored.
+            // `resolveBackgroundEviction` checks that entries loaded from the
+            // snapshot are indeed not touched by the ltx, so it should be safe
+            // to evict these candidates.
             keysToSearch, bl.loadKeys(keysToSearch, "eviction"));
         for (auto& e : maybeEvictQueue)
         {

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -2819,7 +2819,7 @@ LedgerManagerImpl::finalizeLedgerTxnChanges(
     {
         {
             auto sorobanConfig = SorobanNetworkConfig::loadFromLedger(ltx);
-            auto keys = ltx.getAllTTLKeysWithoutSealing();
+            auto keys = ltx.getAllKeysWithoutSealing();
             LedgerTxn ltxEvictions(ltx);
             auto evictedState =
                 mApp.getBucketManager().resolveBackgroundEvictionScan(

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -1674,21 +1674,23 @@ LedgerTxn::Impl::getRestoredLiveBucketListKeys() const
 }
 
 LedgerKeySet
-LedgerTxn::getAllTTLKeysWithoutSealing() const
+LedgerTxn::getAllKeysWithoutSealing() const
 {
-    return getImpl()->getAllTTLKeysWithoutSealing();
+    return getImpl()->getAllKeysWithoutSealing();
 }
 
 LedgerKeySet
-LedgerTxn::Impl::getAllTTLKeysWithoutSealing() const
+LedgerTxn::Impl::getAllKeysWithoutSealing() const
 {
-    abortIfWrongThread("getAllTTLKeysWithoutSealing");
+    abortIfWrongThread("getAllKeysWithoutSealing");
     throwIfNotExactConsistency();
     LedgerKeySet result;
+    // Subtle: mEntry contains only *modified* entries in this LedgerTxn.
+    // Callers rely on this — for example, to enforce that expired entries
+    // (which cannot be modified) are never present here.
     for (auto const& [k, v] : mEntry)
     {
-        if (k.type() == InternalLedgerEntryType::LEDGER_ENTRY &&
-            k.ledgerKey().type() == TTL)
+        if (k.type() == InternalLedgerEntryType::LEDGER_ENTRY)
         {
             result.emplace(k.ledgerKey());
         }

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -672,7 +672,7 @@ class AbstractLedgerTxn : public AbstractLedgerTxnParent
     // Returns all TTL keys that have been modified (create, update, and
     // delete), but does not cause the AbstractLedgerTxn or update last
     // modified.
-    virtual LedgerKeySet getAllTTLKeysWithoutSealing() const = 0;
+    virtual LedgerKeySet getAllKeysWithoutSealing() const = 0;
 
     // forAllWorstBestOffers allows a parent AbstractLedgerTxn to process the
     // worst best offers (an offer is a worst best offer if every better offer
@@ -806,7 +806,7 @@ class LedgerTxn : public AbstractLedgerTxn
     void getAllEntries(std::vector<LedgerEntry>& initEntries,
                        std::vector<LedgerEntry>& liveEntries,
                        std::vector<LedgerKey>& deadEntries) override;
-    LedgerKeySet getAllTTLKeysWithoutSealing() const override;
+    LedgerKeySet getAllKeysWithoutSealing() const override;
 
     UnorderedMap<LedgerKey, LedgerEntry>
     getRestoredHotArchiveKeys() const override;

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -457,7 +457,7 @@ class LedgerTxn::Impl
     UnorderedMap<LedgerKey, LedgerEntry> getRestoredHotArchiveKeys() const;
     UnorderedMap<LedgerKey, LedgerEntry> getRestoredLiveBucketListKeys() const;
 
-    LedgerKeySet getAllTTLKeysWithoutSealing() const;
+    LedgerKeySet getAllKeysWithoutSealing() const;
 
     // getNewestVersion has the basic exception safety guarantee. If it throws
     // an exception, then

--- a/src/transactions/TransactionMeta.cpp
+++ b/src/transactions/TransactionMeta.cpp
@@ -371,7 +371,7 @@ OperationMetaBuilder::setLedgerChanges(AbstractLedgerTxn& opLtx,
     // subset of the restored key maps.
     UnorderedMap<LedgerKey, LedgerEntry> opRestoredLiveBucketListKeys{};
     auto allRestoredLiveBucketListKeys = opLtx.getRestoredLiveBucketListKeys();
-    auto opModifiedTTLKeys = opLtx.getAllTTLKeysWithoutSealing();
+    auto opModifiedKeys = opLtx.getAllKeysWithoutSealing();
     if (mOp.getOperation().body.type() == OperationType::RESTORE_FOOTPRINT)
     {
         for (auto const& [key, entry] : allRestoredLiveBucketListKeys)
@@ -379,7 +379,7 @@ OperationMetaBuilder::setLedgerChanges(AbstractLedgerTxn& opLtx,
             if (isSorobanEntry(key))
             {
                 auto ttlKey = getTTLKey(key);
-                if (opModifiedTTLKeys.find(ttlKey) != opModifiedTTLKeys.end())
+                if (opModifiedKeys.find(ttlKey) != opModifiedKeys.end())
                 {
                     opRestoredLiveBucketListKeys[key] = entry;
                     opRestoredLiveBucketListKeys[ttlKey] =


### PR DESCRIPTION
Resolves https://github.com/stellar/stellar-core-internal/issues/399

After some experimentation, I ended up implementing Nico's proposal to verify that eviction candidates are never touched by the ltx, unless their TTLs are modified. That's quite a bit better performance-wise, since we don't need to do any additional loads. Also added some comments about mEntry assumptions (getAllKeysWithoutSealing relies on mEntry to determine which entries have been modified).

One thing I'm not certain about is what to do in case eviction candidates _were_ illegally modified. That would be a bug, but I'm not sure it's worth crashing core in this case. Of course, not evicting them is also not ideal. Looking for inputs here.