### PR TITLE
Decrease the max entry TTL to ~4 weeks for testnet.

### DIFF
--- a/soroban-settings/testnet_settings_upgrade.json
+++ b/soroban-settings/testnet_settings_upgrade.json
@@ -764,7 +764,7 @@
     },
     {
       "state_archival": {
-        "max_entry_ttl": 3110400,
+        "max_entry_ttl": 483840,
         "min_temporary_ttl": 720,
         "min_persistent_ttl": 120960,
         "persistent_rent_rate_denominator": "1215",


### PR DESCRIPTION
# Description

There is a lot of contract prototyping going on in testnet which results in rather fast in-memory state growth, which is unbounded as the fees are meaningless for testnet. With the max extension reduced it won't be possible to keep state on-chain without actively using and bumping it, which hopefully should get most of the outdated prototypes to expire rather quickly.

This might result in some contracts failing on testnet if a temporary entry is being extended for more than allowed by the network limit. However, it's not clear if this is going to actually affect anyone, as the temporary entries are either very short-lived, or have TTL that is configured by the respective call (like allowance or signature TTL), which should be easy to workaround in testing. If this proves to be an issue, we'll need to add a separate configuration setting for the temp entry maximum TTL.

This is to be used with the next testnet reset that happens very soon; it wouldn't affect testnet currently.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
