### PR TITLE
Handle background exceptions gracefully

### DIFF
--- a/src/invariant/InvariantManagerImpl.cpp
+++ b/src/invariant/InvariantManagerImpl.cpp
@@ -20,6 +20,7 @@
 #include "main/Application.h"
 #include "main/ErrorMessages.h"
 #include "medida/counter.h"
+#include "util/GlobalChecks.h"
 #include "util/Logging.h"
 #include "util/MetricsRegistry.h"
 #include "util/ProtocolVersion.h"
@@ -342,15 +343,25 @@ InvariantManagerImpl::runStateSnapshotInvariant(
     auto reset =
         gsl::finally([this]() { mStateSnapshotInvariantRunning = false; });
 
-    for (auto const& invariant : mEnabled)
+    try
     {
-        auto result = invariant->checkSnapshot(liveSnapshot, hotArchiveSnapshot,
-                                               inMemorySnapshot, isStopping);
-        if (!result.empty())
+        for (auto const& invariant : mEnabled)
         {
-            auto ledgerSeq = liveSnapshot->getLedgerSeq();
-            onInvariantFailure(invariant, result, ledgerSeq);
+            auto result = invariant->checkSnapshot(
+                liveSnapshot, hotArchiveSnapshot, inMemorySnapshot, isStopping);
+            if (!result.empty())
+            {
+                auto ledgerSeq = liveSnapshot->getLedgerSeq();
+                onInvariantFailure(invariant, result, ledgerSeq);
+            }
         }
+    }
+    catch (std::exception const& e)
+    {
+        // Snapshot-based invariants run in a background thread. Abort on
+        // failure to match the behavior of strict invariants on the main
+        // thread.
+        printErrorAndAbort("Exception in state snapshot invariant: ", e.what());
     }
 }
 

--- a/src/invariant/test/ConservationOfLumensTests.cpp
+++ b/src/invariant/test/ConservationOfLumensTests.cpp
@@ -307,16 +307,14 @@ TEST_CASE("Inflation changes are consistent",
     }
 }
 
-// This test ensures that the invariant is called in the right path,
-// while the next test corrups the bucket list and calls into the invariant
-// directly.
+// This test validates that the ConservationOfLumens invariant correctly detects
+// when totalCoins doesn't match the actual balance in buckets.
 TEST_CASE(
     "ConservationOfLumens snapshot invariant validates corrupted total lumens",
     "[invariant][conservationoflumens]")
 {
     auto cfg = getTestConfig();
     cfg.INVARIANT_CHECKS = {"ConservationOfLumens"};
-    cfg.INVARIANT_EXTRA_CHECKS = true;
 
     SorobanTest test(cfg);
 
@@ -346,7 +344,7 @@ TEST_CASE(
     }
 
     // Now, manually modify totalCoins to be inconsistent. The invariant should
-    // trigger.
+    // detect the mismatch.
     {
         {
             LedgerTxn ltx(app.getLedgerTxnRoot());
@@ -361,11 +359,16 @@ TEST_CASE(
         auto& inMemoryState =
             app.getLedgerManager().getInMemorySorobanStateForTesting();
 
-        REQUIRE_THROWS_AS(app.getInvariantManager().runStateSnapshotInvariant(
-                              ledgerState->getBucketSnapshot(),
-                              ledgerState->getHotArchiveSnapshot(),
-                              inMemoryState, []() { return false; }),
-                          InvariantDoesNotHold);
+        Asset native(ASSET_TYPE_NATIVE);
+        auto lumenInfo = getAssetContractInfo(native, app.getNetworkID());
+        ConservationOfLumens invariant(lumenInfo);
+        auto result =
+            invariant.checkSnapshot(ledgerState->getBucketSnapshot(),
+                                    ledgerState->getHotArchiveSnapshot(),
+                                    inMemoryState, []() { return false; });
+        REQUIRE_FALSE(result.empty());
+        REQUIRE(result.find("Total native asset supply mismatch") !=
+                std::string::npos);
     }
 }
 
@@ -455,18 +458,21 @@ TEST_CASE("ConservationOfLumens snapshot invariant detects bucket corruption",
 
         BucketTestUtils::closeLedger(*app);
 
-        app->getInvariantManager().enableInvariant("ConservationOfLumens");
-
         auto ledgerState =
             app->getLedgerManager().getLastClosedLedgerStateForTesting();
         auto& inMemoryState =
             app->getLedgerManager().getInMemorySorobanStateForTesting();
 
-        REQUIRE_THROWS_AS(app->getInvariantManager().runStateSnapshotInvariant(
-                              ledgerState->getBucketSnapshot(),
-                              ledgerState->getHotArchiveSnapshot(),
-                              inMemoryState, []() { return false; }),
-                          InvariantDoesNotHold);
+        Asset native(ASSET_TYPE_NATIVE);
+        auto lumenInfo = getAssetContractInfo(native, app->getNetworkID());
+        ConservationOfLumens invariant(lumenInfo);
+        auto result =
+            invariant.checkSnapshot(ledgerState->getBucketSnapshot(),
+                                    ledgerState->getHotArchiveSnapshot(),
+                                    inMemoryState, []() { return false; });
+        REQUIRE_FALSE(result.empty());
+        REQUIRE(result.find("Total native asset supply mismatch") !=
+                std::string::npos);
     }
 
     SECTION("Invariant handles shadowing correctly")
@@ -602,12 +608,16 @@ TEST_CASE("ConservationOfLumens snapshot invariant detects bucket corruption",
             auto& inMemoryState =
                 app->getLedgerManager().getInMemorySorobanStateForTesting();
 
-            REQUIRE_THROWS_AS(
-                app->getInvariantManager().runStateSnapshotInvariant(
-                    ledgerState->getBucketSnapshot(),
-                    ledgerState->getHotArchiveSnapshot(), inMemoryState,
-                    []() { return false; }),
-                InvariantDoesNotHold);
+            Asset native(ASSET_TYPE_NATIVE);
+            auto lumenInfo = getAssetContractInfo(native, app->getNetworkID());
+            ConservationOfLumens invariant(lumenInfo);
+            auto result =
+                invariant.checkSnapshot(ledgerState->getBucketSnapshot(),
+                                        ledgerState->getHotArchiveSnapshot(),
+                                        inMemoryState, []() { return false; });
+            REQUIRE_FALSE(result.empty());
+            REQUIRE(result.find("Total native asset supply mismatch") !=
+                    std::string::npos);
         }
     }
 }


### PR DESCRIPTION
# Description

Currently, if a background thread throws, we don't properly go through graceful shutdown. This gracefully handles background exceptions.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
