### PR TITLE
Add quickstart CI workflows for pull requests

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -1,0 +1,47 @@
+name: Quickstart
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: stellar/quickstart/.github/workflows/build.yml@main
+    with:
+      images: |
+        [
+          {
+            "tag": "testing-with-pr",
+            "inherit": "testing",
+            "config": {
+              "horizon_skip_protocol_version_check": true
+            },
+            "deps": [
+              { "name": "core", "repo": "${{ github.event.pull_request.head.repo.full_name }}", "ref": "${{ github.event.pull_request.head.sha }}", "options": { "configure_flags": "--disable-tests" } }
+            ]
+          },
+          {
+            "tag": "nightly-with-pr",
+            "inherit": "nightly",
+            "config": {
+              "horizon_skip_protocol_version_check": true
+            },
+            "deps": [
+              { "name": "core", "repo": "${{ github.event.pull_request.head.repo.full_name }}", "ref": "${{ github.event.pull_request.head.sha }}", "options": { "configure_flags": "--disable-tests" } }
+            ]
+          },
+          {
+            "tag": "nightly-next-with-pr",
+            "inherit": "nightly-next",
+            "config": {
+              "horizon_skip_protocol_version_check": true
+            },
+            "deps": [
+              { "name": "core", "repo": "${{ github.event.pull_request.head.repo.full_name }}", "ref": "${{ github.event.pull_request.head.sha }}", "options": { "configure_flags": "--disable-tests" } }
+            ]
+          }
+        ]
+      archs: '["amd64"]'


### PR DESCRIPTION
# Description

Add three GitHub Actions workflows that build and test quickstart images on pull requests. Each workflow targets a different base image: testing, nightly, and nightly-next. The workflows build stellar-core from the PR branch and run quickstart built-in tests that check that the network is up, and other software components are ingesting and syncing, and that someone can do some payments (this happens via friendbot).

This change is an experiment to see if we get useful feedback about potential breakages to other downstream systems earlier in the development life cycle. The workflows only target pull requests and not push because the quick start repository already runs nightly builds of all software components' default branches.

The intent with running this on pull requests is that the repo does have long-lived pull requests from time to time. The goal is to give developers working on Stellar Core earlier feedback if changes they're making are likely to break downstream systems.

Failures in these builds, should not block merges. As we figure out how to best tune the build an to evaluate if it's value, if failures occur, they can be ignored, but would appreciate a comment in [this slack channel](https://stellarfoundation.slack.com/archives/C09AY3FHCN6).

The protocol default version config parameter in the change will be able to disappear after:
- https://github.com/stellar/quickstart/pull/859

There is no issue for this change, but it was discussed prior [here](https://stellarfoundation.slack.com/archives/C09AY3FHCN6/p1764674707236829).

cc @sisuresh @anupsdf 

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [ ] ~Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)~
- [ ] ~Compiles~
- [ ] ~Ran all tests~
- [ ] ~If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)~
