### PR TITLE
Update references from old go repo

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,7 +6,7 @@ These are instructions for building stellar-core from source.
 For a potentially quicker set up, the following projects could be good alternatives:
 
 * stellar-core in a [docker container](https://github.com/stellar/docker-stellar-core)
-* stellar-core and [horizon](https://github.com/stellar/go/tree/master/services/horizon) in a [docker container](https://github.com/stellar/docker-stellar-core-horizon)
+* stellar-core and [horizon](https://github.com/stellar/stellar-horizon) in a [docker container](https://github.com/stellar/quickstart)
 * pre-compiled [packages](https://github.com/stellar/packages)
 
 ## Which version to run?

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -89,7 +89,7 @@ synthetic traffic.
 
 ### Playing with history
 
-You can interact with history archives with [stellar-archivist](https://github.com/stellar/go/tree/master/tools/stellar-archivist).
+You can interact with history archives with [stellar-archivist](https://github.com/stellar/go-stellar-sdk/tree/main/tools/stellar-archivist).
 
 #### Command line catchup
 


### PR DESCRIPTION
# Description

Repos that house horizon and stellar-archivist have been restructured and/or renamed. Updating references here to account for that.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
