### PR TITLE
Enable background tx signature verification by default

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -269,11 +269,11 @@ BACKGROUND_OVERLAY_PROCESSING = true
 # performance on multicore machines. Note that this is not compatible with SQLite.
 EXPERIMENTAL_PARALLEL_LEDGER_APPLY = false
 
-# EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION (bool) default false
+# BACKGROUND_TX_SIG_VERIFICATION (bool) default true
 # Check signatures in the background for transactions received
 # over the network. Does nothing if `BACKGROUND_OVERLAY_PROCESSING` is not
-# also enabled. (experimental)
-EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION = false
+# also enabled.
+BACKGROUND_TX_SIG_VERIFICATION = true
 
 # PREFERRED_PEERS (list of strings) default is empty
 # These are IP:port strings that this server will add to its DB of peers.

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -3273,7 +3273,7 @@ TEST_CASE("overlay parallel processing", "[herder][parallel]")
             Topologies::core(4, 1, Simulation::OVER_TCP, networkID, [](int i) {
                 auto cfg = getTestConfig(i);
                 cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE = 100;
-                cfg.EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION = true;
+                cfg.BACKGROUND_TX_SIG_VERIFICATION = true;
                 cfg.GENESIS_TEST_ACCOUNT_COUNT = 100;
                 return cfg;
             });
@@ -3384,7 +3384,7 @@ TEST_CASE("randomized parallel features with jitter injection",
                         auto cfg = getTestConfig(i, Config::TESTDB_POSTGRESQL);
                         cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE = 1000;
                         // Enable ALL parallel features
-                        cfg.EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION = true;
+                        cfg.BACKGROUND_TX_SIG_VERIFICATION = true;
                         cfg.EXPERIMENTAL_PARALLEL_LEDGER_APPLY = true;
                         cfg.BACKGROUND_OVERLAY_PROCESSING = true;
                         cfg.GENESIS_TEST_ACCOUNT_COUNT = 1000;
@@ -3404,7 +3404,7 @@ TEST_CASE("randomized parallel features with jitter injection",
                         auto cfg = getTestConfig(i);
                         cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE = 1000;
                         // Enable ALL parallel features
-                        cfg.EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION = true;
+                        cfg.BACKGROUND_TX_SIG_VERIFICATION = true;
                         cfg.EXPERIMENTAL_PARALLEL_LEDGER_APPLY = false;
                         cfg.BACKGROUND_OVERLAY_PROCESSING = true;
                         cfg.GENESIS_TEST_ACCOUNT_COUNT = 1000;

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -171,7 +171,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     BACKGROUND_OVERLAY_PROCESSING = true;
     EXPERIMENTAL_PARALLEL_LEDGER_APPLY = false;
     DISABLE_SOROBAN_METRICS_FOR_TESTING = false;
-    EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION = false;
+    BACKGROUND_TX_SIG_VERIFICATION = true;
     BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT = 14; // 2^14 == 16 kb
     BUCKETLIST_DB_INDEX_CUTOFF = 20;             // 20 mb
     BUCKETLIST_DB_MEMORY_FOR_CACHING = 0;
@@ -1120,9 +1120,13 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                  }},
                 {"EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION",
                  [&]() {
-                     EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION =
-                         readBool(item);
+                     CLOG_WARNING(Overlay,
+                                  "EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION "
+                                  "has been renamed. Please use "
+                                  "BACKGROUND_TX_SIG_VERIFICATION instead.");
                  }},
+                {"BACKGROUND_TX_SIG_VERIFICATION",
+                 [&]() { BACKGROUND_TX_SIG_VERIFICATION = readBool(item); }},
                 {"ARTIFICIALLY_DELAY_LEDGER_CLOSE_FOR_TESTING",
                  [&]() {
                      ARTIFICIALLY_DELAY_LEDGER_CLOSE_FOR_TESTING =

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -534,8 +534,8 @@ class Config : public std::enable_shared_from_this<Config>
 
     // Check signatures in the background for transactions received
     // over the network. Does nothing if `BACKGROUND_OVERLAY_PROCESSING` is not
-    // also enabled. (experimental)
-    bool EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION;
+    // also enabled.
+    bool BACKGROUND_TX_SIG_VERIFICATION;
 
     // When set to true, BucketListDB indexes are persisted on-disk so that the
     // BucketList does not need to be reindexed on startup. Defaults to true.

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -63,7 +63,7 @@ void
 populateSignatureCache(AppConnector& app, TransactionFrameBaseConstPtr tx)
 {
     ZoneScoped;
-    releaseAssert(app.getConfig().EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION &&
+    releaseAssert(app.getConfig().BACKGROUND_TX_SIG_VERIFICATION &&
                   app.threadIsType(Application::ThreadType::OVERLAY));
 
     auto& snapshot = app.getOverlayThreadSnapshot();
@@ -184,9 +184,9 @@ CapacityTrackedMessage::CapacityTrackedMessage(std::weak_ptr<Peer> peer,
 
     // Whether to check transaction signatures in the background, adding them to
     // the signature cache in the process.
-    bool const checkTxSig = self->mAppConnector.getConfig()
-                                .EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION &&
-                            self->useBackgroundThread();
+    bool const checkTxSig =
+        self->mAppConnector.getConfig().BACKGROUND_TX_SIG_VERIFICATION &&
+        self->useBackgroundThread();
 
     if (mMsg.type() == TRANSACTION)
     {

--- a/src/overlay/test/OverlayTests.cpp
+++ b/src/overlay/test/OverlayTests.cpp
@@ -3096,7 +3096,7 @@ TEST_CASE("background signature verification with missing account",
         Simulation::OVER_TCP, networkID, [](int i) {
             Config cfg = getTestConfig(i);
             cfg.BACKGROUND_OVERLAY_PROCESSING = true;
-            cfg.EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION = true;
+            cfg.BACKGROUND_TX_SIG_VERIFICATION = true;
             return cfg;
         });
 
@@ -3166,7 +3166,7 @@ TEST_CASE("populateSignatureCache tests", "[overlay]")
     // Common test setup
     VirtualClock clock;
     Config cfg = getTestConfig();
-    cfg.EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION = true;
+    cfg.BACKGROUND_TX_SIG_VERIFICATION = true;
     auto app = createTestApplication(clock, cfg);
 
     constexpr int64_t INITIAL_BALANCE = 10000000000;


### PR DESCRIPTION
Closes stellar/stellar-core-internal#377

This change drops the `EXPERIMENTAL` prefix from the background transaction signature verification configuration option and enables it by default.

I also used the new jitter injection framework to insert jitter around the transaction signature cache operations (specifically around aquiring locks) and verified that all tests passed with injected jitter.