### PR TITLE
Copy the snapshot before passing it to background eviction scan

### DIFF
--- a/src/bucket/BucketListSnapshotBase.cpp
+++ b/src/bucket/BucketListSnapshotBase.cpp
@@ -181,11 +181,9 @@ BucketLevelSnapshot<BucketT>::BucketLevelSnapshot(
 
 template <class BucketT>
 SearchableBucketListSnapshotBase<BucketT>::SearchableBucketListSnapshotBase(
-    BucketSnapshotManager const& snapshotManager, AppConnector const& app,
-    SnapshotPtrT<BucketT>&& snapshot,
+    AppConnector const& app, SnapshotPtrT<BucketT>&& snapshot,
     std::map<uint32_t, SnapshotPtrT<BucketT>>&& historicalSnapshots)
-    : mSnapshotManager(snapshotManager)
-    , mSnapshot(std::move(snapshot))
+    : mSnapshot(std::move(snapshot))
     , mHistoricalSnapshots(std::move(historicalSnapshots))
     , mAppConnector(app)
     , mBulkLoadMeter(app.getMetrics().NewMeter(

--- a/src/bucket/BucketListSnapshotBase.h
+++ b/src/bucket/BucketListSnapshotBase.h
@@ -82,8 +82,6 @@ class SearchableBucketListSnapshotBase : public NonMovableOrCopyable
   protected:
     virtual ~SearchableBucketListSnapshotBase() = 0;
 
-    BucketSnapshotManager const& mSnapshotManager;
-
     // Snapshot managed by SnapshotManager
     SnapshotPtrT<BucketT> mSnapshot{};
     std::map<uint32_t, SnapshotPtrT<BucketT>> mHistoricalSnapshots;
@@ -104,7 +102,6 @@ class SearchableBucketListSnapshotBase : public NonMovableOrCopyable
     medida::Meter& mBloomLookups;
 
     SearchableBucketListSnapshotBase(
-        BucketSnapshotManager const& snapshotManager,
         AppConnector const& appConnector, SnapshotPtrT<BucketT>&& snapshot,
         std::map<uint32_t, SnapshotPtrT<BucketT>>&& historicalSnapshots);
 
@@ -136,6 +133,18 @@ class SearchableBucketListSnapshotBase : public NonMovableOrCopyable
     }
 
     LedgerHeader const& getLedgerHeader() const;
+
+    BucketListSnapshot<BucketT> const&
+    getSnapshot() const
+    {
+        return *mSnapshot;
+    }
+
+    std::map<uint32_t, SnapshotPtrT<BucketT>> const&
+    getHistoricalSnapshots() const
+    {
+        return mHistoricalSnapshots;
+    }
 
     // Loads inKeys from the specified historical snapshot. Returns
     // load_result_vec if the snapshot for the given ledger is

--- a/src/bucket/BucketSnapshotManager.cpp
+++ b/src/bucket/BucketSnapshotManager.cpp
@@ -76,10 +76,23 @@ BucketSnapshotManager::copySearchableLiveBucketListSnapshot(
     // Can't use std::make_shared due to private constructor
     return std::shared_ptr<SearchableLiveBucketListSnapshot>(
         new SearchableLiveBucketListSnapshot(
-            *this, mAppConnector,
+            mAppConnector,
             std::make_unique<BucketListSnapshot<LiveBucket>>(
                 *mCurrLiveSnapshot),
             copyHistoricalSnapshots(mLiveHistoricalSnapshots)));
+}
+
+SearchableSnapshotConstPtr
+BucketSnapshotManager::copySearchableLiveBucketListSnapshot(
+    SearchableSnapshotConstPtr const& snapshot)
+{
+    // Can't use std::make_shared due to private constructor
+    return std::shared_ptr<SearchableLiveBucketListSnapshot>(
+        new SearchableLiveBucketListSnapshot(
+            snapshot->mAppConnector,
+            std::make_unique<BucketListSnapshot<LiveBucket>>(
+                snapshot->getSnapshot()),
+            copyHistoricalSnapshots(snapshot->getHistoricalSnapshots())));
 }
 
 SearchableHotArchiveSnapshotConstPtr
@@ -90,7 +103,7 @@ BucketSnapshotManager::copySearchableHotArchiveBucketListSnapshot(
     // Can't use std::make_shared due to private constructor
     return std::shared_ptr<SearchableHotArchiveBucketListSnapshot>(
         new SearchableHotArchiveBucketListSnapshot(
-            *this, mAppConnector,
+            mAppConnector,
             std::make_unique<BucketListSnapshot<HotArchiveBucket>>(
                 *mCurrHotArchiveSnapshot),
             copyHistoricalSnapshots(mHotArchiveHistoricalSnapshots)));

--- a/src/bucket/BucketSnapshotManager.h
+++ b/src/bucket/BucketSnapshotManager.h
@@ -83,6 +83,10 @@ class BucketSnapshotManager : NonMovableOrCopyable
     SearchableSnapshotConstPtr copySearchableLiveBucketListSnapshot() const
         LOCKS_EXCLUDED(mSnapshotMutex);
 
+    // Create a deep copy from an existing searchable snapshot
+    static SearchableSnapshotConstPtr copySearchableLiveBucketListSnapshot(
+        SearchableSnapshotConstPtr const& snapshot);
+
     // Copy the most recent snapshot for the hot archive bucket list
     SearchableHotArchiveSnapshotConstPtr
     copySearchableHotArchiveBucketListSnapshot() const

--- a/src/bucket/SearchableBucketList.cpp
+++ b/src/bucket/SearchableBucketList.cpp
@@ -240,22 +240,18 @@ SearchableLiveBucketListSnapshot::loadKeys(
 }
 
 SearchableLiveBucketListSnapshot::SearchableLiveBucketListSnapshot(
-    BucketSnapshotManager const& snapshotManager,
     AppConnector const& appConnector, SnapshotPtrT<LiveBucket>&& snapshot,
     std::map<uint32_t, SnapshotPtrT<LiveBucket>>&& historicalSnapshots)
     : SearchableBucketListSnapshotBase<LiveBucket>(
-          snapshotManager, appConnector, std::move(snapshot),
-          std::move(historicalSnapshots))
+          appConnector, std::move(snapshot), std::move(historicalSnapshots))
 {
 }
 
 SearchableHotArchiveBucketListSnapshot::SearchableHotArchiveBucketListSnapshot(
-    BucketSnapshotManager const& snapshotManager,
     AppConnector const& appConnector, SnapshotPtrT<HotArchiveBucket>&& snapshot,
     std::map<uint32_t, SnapshotPtrT<HotArchiveBucket>>&& historicalSnapshots)
     : SearchableBucketListSnapshotBase<HotArchiveBucket>(
-          snapshotManager, appConnector, std::move(snapshot),
-          std::move(historicalSnapshots))
+          appConnector, std::move(snapshot), std::move(historicalSnapshots))
 {
 }
 

--- a/src/bucket/SearchableBucketList.h
+++ b/src/bucket/SearchableBucketList.h
@@ -14,7 +14,6 @@ class SearchableLiveBucketListSnapshot
     : public SearchableBucketListSnapshotBase<LiveBucket>
 {
     SearchableLiveBucketListSnapshot(
-        BucketSnapshotManager const& snapshotManager,
         AppConnector const& appConnector, SnapshotPtrT<LiveBucket>&& snapshot,
         std::map<uint32_t, SnapshotPtrT<LiveBucket>>&& historicalSnapshots);
 
@@ -42,13 +41,16 @@ class SearchableLiveBucketListSnapshot
     friend SearchableSnapshotConstPtr
     BucketSnapshotManager::copySearchableLiveBucketListSnapshot(
         SharedLockShared const& guard) const;
+
+    friend SearchableSnapshotConstPtr
+    BucketSnapshotManager::copySearchableLiveBucketListSnapshot(
+        SearchableSnapshotConstPtr const& snapshot);
 };
 
 class SearchableHotArchiveBucketListSnapshot
     : public SearchableBucketListSnapshotBase<HotArchiveBucket>
 {
     SearchableHotArchiveBucketListSnapshot(
-        BucketSnapshotManager const& snapshotManager,
         AppConnector const& appConnector,
         SnapshotPtrT<HotArchiveBucket>&& snapshot,
         std::map<uint32_t, SnapshotPtrT<HotArchiveBucket>>&&

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1781,9 +1781,14 @@ LedgerManagerImpl::applyLedger(LedgerCloseData const& ledgerData,
                 .header.ledgerVersion,
             SOROBAN_PROTOCOL_VERSION))
     {
+        // Copy the snapshot directly from `appliedLedgerState`, which holds
+        // the latest committed state, to avoid relying on
+        // BucketSnapshotManager.
+        auto latestSnapshot =
+            BucketSnapshotManager::copySearchableLiveBucketListSnapshot(
+                appliedLedgerState->getBucketSnapshot());
         mApp.getBucketManager().startBackgroundEvictionScan(
-            appliedLedgerState->getBucketSnapshot(),
-            appliedLedgerState->getSorobanConfig());
+            latestSnapshot, appliedLedgerState->getSorobanConfig());
     }
 
     // At this point, we've committed all changes to the Apply State for this


### PR DESCRIPTION
Fix a bug introduced in https://github.com/stellar/stellar-core/pull/5029, where we re-use the same immutable snapshot in the eviction scan instead of making a deep copy first. Hardening of this interface will be done as part of https://github.com/stellar/stellar-core/issues/5067.