### PR TITLE
cache, check and short-circuit on reused last-tested-commit in namespace cache volumes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,60 +18,85 @@ jobs:
 
   complete:
     if: always()
-    needs: [fmt, cargo-deny, rust-check-git-rev-deps, build-linux, build-mac]
+    needs: [static-checks, build-linux, build-mac]
     runs-on:
       - namespace-profile-noble-24-04-stellar-core-x64-small
-      - nscloud-cache-exp-do-not-commit
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
       run: exit 1
 
-  fmt:
+  static-checks:
     runs-on:
-      - namespace-profile-noble-24-04-stellar-core-x64-small
-      - nscloud-cache-exp-do-not-commit
+      - namespace-profile-noble-24-04-stellar-core-x64-small;overrides.cache-tag=config-static-checks
     steps:
       - uses: namespacelabs/nscloud-checkout-action@v7
         with:
           fetch-depth: 1
           submodules: recursive
-      - run: rustup component add rustfmt
-      - run: rustup update
-      - run: cargo fmt --all --check
 
-  cargo-deny:
-    runs-on:
-      - namespace-profile-noble-24-04-stellar-core-x64-small
-      - nscloud-cache-exp-do-not-commit
-    strategy:
-      matrix:
-        checks:
-          - advisories
-          - bans licenses sources
-    # Prevent sudden announcement of a new advisory from failing ci:
-    continue-on-error: ${{ matrix.checks == 'advisories' }}
-    steps:
-      - uses: namespacelabs/nscloud-checkout-action@v7
+      - name: Configure Namespace cache volume
+        uses: namespacelabs/nscloud-cache-action@v1
         with:
-          fetch-depth: 1
-          submodules: recursive
-      - uses: EmbarkStudios/cargo-deny-action@8d73959fce1cdc8989f23fdf03bec6ae6a6576ef
+          path: |
+            ~/.cargo
+            build-static-checks
+
+      - name: Check if commit already tested
+        id: check-last-tested-commit
+        run: |
+          LAST_TESTED_COMMIT_SHA_FILE="build-static-checks/.last-tested-commit-sha"
+          if [ -f "$LAST_TESTED_COMMIT_SHA_FILE" ] && [ "$(cat "$LAST_TESTED_COMMIT_SHA_FILE")" = "${{ github.sha }}" ]; then
+            echo "Commit ${{ github.sha }} already tested successfully, skipping build"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Install rustup
+        if: steps.check-last-tested-commit.outputs.skip != 'true'
+        run: ./install-rust.sh
+
+      - name: Update rustup
+        if: steps.check-last-tested-commit.outputs.skip != 'true'
+        run: rustup update
+
+      - name: Install rustfmt
+        if: steps.check-last-tested-commit.outputs.skip != 'true'
+        run: rustup component add rustfmt
+
+      - name: Check git rev deps
+        if: steps.check-last-tested-commit.outputs.skip != 'true'
+        uses: stellar/actions/rust-check-git-rev-deps@main
+
+      - name: Check formatting
+        if: steps.check-last-tested-commit.outputs.skip != 'true'
+        run: cargo fmt --all --check
+
+      - name: Check cargo-deny advisories
+        if: steps.check-last-tested-commit.outputs.skip != 'true'
+        # Prevent sudden announcement of a new advisory from failing ci:
+        continue-on-error: true
+        uses: EmbarkStudios/cargo-deny-action@8d73959fce1cdc8989f23fdf03bec6ae6a6576ef
         with:
-          command: check ${{ matrix.checks }}
+          command: check advisories
           # leave arguments empty so we don't test --all-features
           # which will see conflicting env versions
           arguments:
 
-  rust-check-git-rev-deps:
-    runs-on:
-      - namespace-profile-noble-24-04-stellar-core-x64-small
-      - nscloud-cache-exp-do-not-commit
-    steps:
-      - uses: namespacelabs/nscloud-checkout-action@v7
+      - name: Check cargo-deny bans licenses sources
+        if: steps.check-last-tested-commit.outputs.skip != 'true'
+        uses: EmbarkStudios/cargo-deny-action@8d73959fce1cdc8989f23fdf03bec6ae6a6576ef
         with:
-          fetch-depth: 1
-          submodules: recursive
-      - uses: stellar/actions/rust-check-git-rev-deps@main
+          command: check bans licenses sources
+          # leave arguments empty so we don't test --all-features
+          # which will see conflicting env versions
+          arguments:
+
+      - name: Record successful test commit
+        if: ${{ success() && steps.check-last-tested-commit.outputs.skip != 'true' }}
+        run: |
+          mkdir -p build-static-checks
+          echo "${{ github.sha }}" > "build-static-checks/.last-tested-commit-sha"
 
   build-linux:
     runs-on:
@@ -83,7 +108,7 @@ jobs:
         protocol: ["current", "next"]
     steps:
       - name: Fix kernel mmap rnd bits
-        # Asan in llvm provided in some ubuntus is incompatible with
+        # Asan in llvm provided in some ubuntu versions is incompatible with
         # high-entropy ASLR in much newer kernels that GitHub runners are
         # using leading to random crashes: https://reviews.llvm.org/D148280
         run: sudo sysctl vm.mmap_rnd_bits=28
@@ -112,11 +137,11 @@ jobs:
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: install rustup
+      - name: Install rustup
         if: steps.check-last-tested-commit.outputs.skip != 'true'
         run: ./install-rust.sh
 
-      - name: install rustup components
+      - name: Install rustup components
         if: steps.check-last-tested-commit.outputs.skip != 'true'
         run: rustup component add rustfmt
 
@@ -164,7 +189,7 @@ jobs:
           ./ci-build.sh --use-temp-db --protocol ${{ matrix.protocol }}
 
       - name: Record successful test commit
-        if: steps.check-last-tested-commit.outputs.skip != 'true'
+        if: ${{ success() && steps.check-last-tested-commit.outputs.skip != 'true' }}
         run: |
           echo "${{ github.sha }}" > "build-${{matrix.toolchain}}-${{matrix.protocol}}/.last-tested-commit-sha"
 
@@ -197,14 +222,14 @@ jobs:
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: install prerequisites and uninstall brew rust, add rustup
+      - name: Install prerequisites and uninstall brew rust, add rustup
         if: steps.check-last-tested-commit.outputs.skip != 'true'
         run: |
           brew install libsodium libtool autoconf automake pkg-config libpq openssl parallel ccache bison gnu-sed perl coreutils
           brew uninstall rust rustup
           brew install rustup
 
-      - name: install rustup components
+      - name: Install rustup components
         if: steps.check-last-tested-commit.outputs.skip != 'true'
         run: |
           rustup-init -y
@@ -251,6 +276,6 @@ jobs:
           ./ci-build.sh --disable-postgres --protocol current
 
       - name: Record successful test commit
-        if: steps.check-last-tested-commit.outputs.skip != 'true'
+        if: ${{ success() && steps.check-last-tested-commit.outputs.skip != 'true' }}
         run: |
           echo "${{ github.sha }}" > "build-clang-current/.last-tested-commit-sha"


### PR DESCRIPTION
This should (if we get our cache volume hit rate to anything reasonable) prevent double-executions (where we run once on the merge queue and then _immediately again_ once master advances to the merge queue commit) from happening on the majority of our runners.

I also merged the miscellaneous static checks into a single job to cut down on the number of parallel instances and caches we populate. sequential execution of these checks will be fine -- they all run quickly anyways and are dominated by instance setup time.