### PR TITLE
Fix lower bound for testnet maxEntryTTL and add logging

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -83,8 +83,8 @@ then parse the path of log files, bucket directory, and SQL DB. All these fields
 - Prequisites - `stellar-xdr` and `stellar-core`
 - Description - This is a script to help with the [Soroban Settings Upgrade](../docs/software/soroban-settings.md). It's important to be aware of how the underlying process works
 in case the script has some issues, so please read through that doc before attempting to use this script. This script should be run from the directory that contains your stellar-core binary. This script also queries the SDF Horizon for the sequence number of the account, so if the SDF Horizon instance is unavailable, then you'll need to provide the account's sequence number manually.
-- Usage - Ex. `sh ../scripts/settings-helper.sh SCSQHJIUGUGTH2P4K6AOFTEW4HUMI2BRTUBBDDXMQ4FLHXCX25W3PGBJ testnet ../soroban-settings/testnet_settings_phase2.json`. The first argument is the secret key of the source account that will be used for the transactions to set up the upgrade, the second argument is the network passphrase, and the third is 
-the path to the JSON file with the proposed settings.
+- Usage - Ex. `sh ../scripts/settings-helper.sh SCSQHJIUGUGTH2P4K6AOFTEW4HUMI2BRTUBBDDXMQ4FLHXCX25W3PGBJ testnet ../soroban-settings/testnet_settings_phase2.json 100`. The first argument is the secret key of the source account that will be used for the transactions to set up the upgrade, the second argument is the network passphrase, the third is 
+the path to the JSON file with the proposed settings, and the fourth is any additional resource fee you want to add to your transactions.
 
 ### Histogram Generator
 - Name - `HistogramGenerator.py`

--- a/soroban-settings/testnet_settings_upgrade.json
+++ b/soroban-settings/testnet_settings_upgrade.json
@@ -764,7 +764,7 @@
     },
     {
       "state_archival": {
-        "max_entry_ttl": 483840,
+        "max_entry_ttl": 1054080,
         "min_temporary_ttl": 720,
         "min_persistent_ttl": 120960,
         "persistent_rent_rate_denominator": "1215",

--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -1493,6 +1493,8 @@ ConfigUpgradeSetFrame::isValidForApply() const
                                                              mLedgerVersion) ||
             SorobanNetworkConfig::isNonUpgradeableConfigSettingEntry(cfg))
         {
+            CLOG_DEBUG(Herder, "Got bad ConfigSettingEntry {}",
+                       xdrToCerealString(cfg, "cfg"));
             return Upgrades::UpgradeValidity::INVALID;
         }
     }


### PR DESCRIPTION
# Description

We have a lower bound on the maxEntryTTL of 1,054,080 ledgers, so the value in the testnet file is too low.

We also need to reduce https://github.com/stellar/stellar-core/blob/72182e1408a38d10e3119a06550f047c246ef90f/src/ledger/NetworkConfig.h#L42, but I'll open an issue for that. 



# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
