### PR TITLE
Fix some missing durable writes in CheckpointBuilder

### DIFF
--- a/src/history/CheckpointBuilder.cpp
+++ b/src/history/CheckpointBuilder.cpp
@@ -170,8 +170,7 @@ CheckpointBuilder::appendLedgerHeader(LedgerHeader const& header,
     LedgerHeaderHistoryEntry lhe;
     lhe.header = header;
     lhe.hash = xdrSha256(header);
-    mLedgerHeaders->writeOne(lhe);
-    mLedgerHeaders->flush();
+    mLedgerHeaders->durableWriteOne(lhe);
 }
 
 uint32_t
@@ -286,7 +285,7 @@ CheckpointBuilder::cleanup(uint32_t lcl)
                                   ft.localPath_nogz_dirty(), lcl);
                         break;
                     }
-                    out.writeOne(entry);
+                    out.durableWriteOne(entry);
                 }
                 catch (xdr::xdr_runtime_error const& e)
                 {


### PR DESCRIPTION
This is just a v25.0.1-targeting variant of #5080 