### PR TITLE
Fix build without tests.

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -760,6 +760,7 @@ exit /b 0
     <ClCompile Include="..\..\src\util\LogSlowExecution.cpp" />
     <ClCompile Include="..\..\src\util\RandHasher.cpp" />
     <ClCompile Include="..\..\src\util\Scheduler.cpp" />
+    <ClCompile Include="..\..\src\util\SimpleTimer.cpp" />
     <ClCompile Include="..\..\src\util\test\BinaryFuseTests.cpp" />
     <ClCompile Include="..\..\src\util\test\MetricTests.cpp" />
     <ClCompile Include="..\..\src\util\test\SchedulerTests.cpp" />
@@ -1178,6 +1179,7 @@ exit /b 0
     <ClInclude Include="..\..\src\util\numeric128.h" />
     <ClInclude Include="..\..\src\util\RandHasher.h" />
     <ClInclude Include="..\..\src\util\Scheduler.h" />
+    <ClInclude Include="..\..\src\util\SimpleTimer.h" />
     <ClInclude Include="..\..\src\util\TxResource.h" />
     <ClInclude Include="..\..\src\util\UnorderedMap.h" />
     <ClInclude Include="..\..\src\util\UnorderedSet.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1429,6 +1429,9 @@
     <ClCompile Include="..\..\src\invariant\ArchivedStateConsistency.cpp">
       <Filter>invariant</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\util\SimpleTimer.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\util\cpptoml.h">
@@ -2535,6 +2538,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\invariant\ArchivedStateConsistency.h">
       <Filter>invariant</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\SimpleTimer.h">
+      <Filter>util</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -10,15 +10,17 @@
 #include "herder/Herder.h"
 #include "history/HistoryArchive.h"
 #include "main/StellarCoreVersion.h"
+#include "overlay/OverlayManager.h"
 #include "scp/LocalNode.h"
 #include "scp/QuorumSetUtils.h"
-#include "simulation/ApplyLoad.h"
 #include "util/Fs.h"
 #include "util/GlobalChecks.h"
 #include "util/Logging.h"
-
-#include "overlay/OverlayManager.h"
 #include "util/UnorderedSet.h"
+#ifdef BUILD_TESTS
+#include "simulation/ApplyLoad.h"
+#endif
+
 #include <fmt/chrono.h>
 #include <fmt/format.h>
 #include <functional>
@@ -1583,6 +1585,7 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                      LOADGEN_INSTRUCTIONS_DISTRIBUTION_FOR_TESTING =
                          readIntArray<uint32_t>(item);
                  }},
+#ifdef BUILD_TESTS
                 {"APPLY_LOAD_DATA_ENTRY_SIZE",
                  [&]() {
                      APPLY_LOAD_DATA_ENTRY_SIZE = readInt<uint32_t>(item);
@@ -1768,6 +1771,7 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                  }},
                 {"APPLY_LOAD_TIME_WRITES",
                  [&]() { APPLY_LOAD_TIME_WRITES = readBool(item); }},
+#endif // BUILD_TESTS
                 {"GENESIS_TEST_ACCOUNT_COUNT",
                  [&]() {
                      GENESIS_TEST_ACCOUNT_COUNT = readInt<uint32_t>(item, 0);

--- a/src/simulation/test/LoadGeneratorTests.cpp
+++ b/src/simulation/test/LoadGeneratorTests.cpp
@@ -777,8 +777,8 @@ TEST_CASE("Multi-byte payment transactions are valid", "[loadgen]")
     uint32_t constexpr baseSize = 148;
     uint32_t constexpr opSize = 56;
     uint32_t constexpr frameSize = baseSize + opSize * 3;
-    Simulation::pointer simulation =
-        Topologies::pair(Simulation::OVER_LOOPBACK, networkID, [](int i) {
+    Simulation::pointer simulation = Topologies::pair(
+        Simulation::OVER_LOOPBACK, networkID, [frameSize](int i) {
             auto cfg = getTestConfig(i);
             cfg.ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING = true;
             cfg.LOADGEN_BYTE_COUNT_FOR_TESTING = {frameSize};

--- a/src/util/Backtrace.cpp
+++ b/src/util/Backtrace.cpp
@@ -3,7 +3,6 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "util/Backtrace.h"
-#include "config.h"
 #include "util/GlobalChecks.h"
 #include <cstdio>
 #include <cstdlib>

--- a/src/util/SimpleTimer.cpp
+++ b/src/util/SimpleTimer.cpp
@@ -40,7 +40,7 @@ SimpleTimer::count() const
 void
 SimpleTimer::Update(std::chrono::nanoseconds d)
 {
-    auto converted = d / mDurationUnit;
+    int64_t converted = d / mDurationUnit;
     mSum.inc(converted);
     mSampleCount.inc(1);
     {


### PR DESCRIPTION
# Description

Fix build without tests.

I'm not sure how this worked before, but we had a few unguarded test-only methods that now finally started to actually cause compilation errors.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
