### PR TITLE
Update testnet instruction limits to 600M

### DIFF
--- a/soroban-settings/testnet_settings_upgrade.json
+++ b/soroban-settings/testnet_settings_upgrade.json
@@ -5,8 +5,8 @@
     },
     {
       "contract_compute_v0": {
-        "ledger_max_instructions": "100000000",
-        "tx_max_instructions": "100000000",
+        "ledger_max_instructions": "600000000",
+        "tx_max_instructions": "600000000",
         "fee_rate_per_instructions_increment": "25",
         "tx_memory_limit": 41943040
       }


### PR DESCRIPTION
Increase ledger_max_instructions and tx_max_instructions to 600000000 to support higher computational throughput on testnet.


# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
