### PR TITLE
Disable lumen invariant in test that pushes new accounts directly into the bucket list

### DIFF
--- a/src/overlay/test/FloodTests.cpp
+++ b/src/overlay/test/FloodTests.cpp
@@ -198,6 +198,11 @@ TEST_CASE("Flooding", "[flood][overlay][acceptance]")
             // adjust delayed tx flooding and how often to pull
             cfg.FLOOD_TX_PERIOD_MS = 10;
             cfg.FLOOD_DEMAND_PERIOD_MS = std::chrono::milliseconds(10);
+
+            // Disable ConservationOfLumens because this test pushes accounts
+            // directly into the bucket list.
+            cfg.INVARIANT_CHECKS = {
+                "(?!EventsAreConsistentWithEntryDiffs|ConservationOfLumens).*"};
             return cfg;
         };
         SECTION("core")
@@ -224,6 +229,11 @@ TEST_CASE("Flooding", "[flood][overlay][acceptance]")
                 // While there's no strict requirement for batching,
                 // it seems more useful to test more realistic settings.
                 cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE = 1000;
+
+                // Disable ConservationOfLumens because this test pushes
+                // accounts directly into the bucket list.
+                cfg.INVARIANT_CHECKS = {"(?!EventsAreConsistentWithEntryDiffs|"
+                                        "ConservationOfLumens).*"};
                 return cfg;
             };
             SECTION("pull mode with 2 nodes")


### PR DESCRIPTION
# Description

This fixes an acceptance test failure.


<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
