### PR TITLE
Minor improvements to publishing

### DIFF
--- a/src/history/CheckpointBuilder.h
+++ b/src/history/CheckpointBuilder.h
@@ -57,9 +57,11 @@ class CheckpointBuilder
     std::unique_ptr<XDROutputFileStream> mLedgerHeaders;
     bool mOpen{false};
     bool mStartupValidationComplete{false};
-    bool mPublishWasDisabled{false};
+    // Skip building this checkpoint if it can't be completed.
+    // This may happen if a node enabled publishing mid-checkpoint.
+    bool mSkipFirstCheckpointSinceItIsIncomplete{false};
 
-    bool ensureOpen(uint32_t ledgerSeq);
+    void ensureOpen(uint32_t ledgerSeq);
 
   public:
     CheckpointBuilder(Application& app);
@@ -82,5 +84,11 @@ class CheckpointBuilder
     // Finalize checkpoint by renaming all temporary files to their canonical
     // names. No-op if files are already rotated.
     void checkpointComplete(uint32_t checkpoint);
+
+    bool
+    skipIncompleteFirstCheckpointSinceRestart() const
+    {
+        return mSkipFirstCheckpointSinceItIsIncomplete;
+    }
 };
 }

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -316,6 +316,14 @@ HistoryManagerImpl::maybeQueueHistoryCheckpoint(uint32_t lcl,
         return false;
     }
 
+    if (mCheckpointBuilder.skipIncompleteFirstCheckpointSinceRestart())
+    {
+        CLOG_INFO(
+            History,
+            "Skipping incomplete checkpoint, publish was previously disabled");
+        return false;
+    }
+
     queueCurrentHistory(lcl, ledgerVers);
     return true;
 }


### PR DESCRIPTION
Small follow up to #5081 to better handle some edge cases
- Move the exception about potentially corrupt checkpoints further down the recovery function to capture all possible recovery failures.
- Handle cases where publishing was enabled mid-checkpoint: skip publishing of the incomplete file, start publishing on the _next_ checkpoint.