### PR TITLE
Clear prepared statements cache at the end of catchup

### DIFF
--- a/src/catchup/CatchupWork.cpp
+++ b/src/catchup/CatchupWork.cpp
@@ -495,6 +495,8 @@ CatchupWork::runCatchupStep()
                 // will unnecessarily rebuild the ledger but the buckets are
                 // persistently available locally so it will return us to the
                 // correct state.
+                mApp.getDatabase().clearPreparedStatementCache(
+                    mApp.getDatabase().getSession());
                 auto& ps = mApp.getPersistentState();
                 ps.clearRebuildForOfferTable();
             }


### PR DESCRIPTION
Reason we didn't run into this previously was because LedgerTxn always clears prepared statements cache on commit/rollback. in `setLastClosedLedger` we were lucky to call LedgerTxn prior to `clearRebuildForOfferTable`, which cleared the cache. With the switch to multiple DB sessions, we now need to explicitly clean up main session prepared statement cache on startup when we setup state. 