### PR TITLE
Drop prepared statement cache

### DIFF
--- a/src/catchup/CatchupWork.cpp
+++ b/src/catchup/CatchupWork.cpp
@@ -495,8 +495,6 @@ CatchupWork::runCatchupStep()
                 // will unnecessarily rebuild the ledger but the buckets are
                 // persistently available locally so it will return us to the
                 // correct state.
-                mApp.getDatabase().clearPreparedStatementCache(
-                    mApp.getDatabase().getSession());
                 auto& ps = mApp.getPersistentState();
                 ps.clearRebuildForOfferTable();
             }

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1391,9 +1391,6 @@ LedgerManagerImpl::advanceLedgerStateAndPublish(
     }
 #endif
 
-    mApp.getDatabase().clearPreparedStatementCache(
-        mApp.getDatabase().getSession());
-
     // Perform LCL->appliedLedgerState transition on the _main_ thread, and kick
     // off publishing, cleanup bucket files, notify herder to trigger next
     // ledger.

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -2933,11 +2933,6 @@ LedgerTxnRoot::Impl::commitChild(EntryIterator iter,
         // but maybe we would like one?
         TracyPlot("ledger.entry.commit", counter);
 
-        // NB: we want to clear the prepared statement cache _before_
-        // committing; on postgres this doesn't matter but on SQLite the passive
-        // WAL-auto-checkpointing-at-commit behaviour will starve if there are
-        // still prepared statements open at commit time.
-        mApp.getDatabase().clearPreparedStatementCache(getSession());
         ZoneNamedN(commitZone, "SOCI commit", true);
         mTransaction->commit();
     }
@@ -3681,7 +3676,6 @@ LedgerTxnRoot::Impl::rollbackChild() noexcept
             mTransaction.reset();
             if (mSession)
             {
-                mApp.getDatabase().clearPreparedStatementCache(*mSession);
                 mSession.reset();
             }
         }

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -282,8 +282,6 @@ class LedgerTxn::Impl
 
     // getDeltaVotes has the basic exception safety guarantee. If it throws an
     // exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
     // - the entry cache may be, but is not guaranteed to be, cleared.
     std::map<AccountID, int64_t> getDeltaVotes() const;
 
@@ -346,8 +344,6 @@ class LedgerTxn::Impl
 
     // create has the basic exception safety guarantee. If it throws an
     // exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
     // - the entry cache may be, but is not guaranteed to be, cleared.
     LedgerTxnEntry create(LedgerTxn& self, InternalLedgerEntry const& entry);
 
@@ -359,36 +355,26 @@ class LedgerTxn::Impl
 
     // erase has the basic exception safety guarantee. If it throws an
     // exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
     // - the entry cache may be, but is not guaranteed to be, cleared.
     void erase(InternalLedgerKey const& key);
 
     // markRestoredFromHotArchive has the basic exception safety guarantee. If
     // it throws an exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
     void markRestoredFromHotArchive(LedgerEntry const& ledgerEntry,
                                     LedgerEntry const& ttlEntry);
 
     // restoreFromLiveBucketList has the basic exception safety guarantee. If it
     // throws an exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
     LedgerTxnEntry restoreFromLiveBucketList(LedgerTxn& self,
                                              LedgerEntry const& entry,
                                              uint32_t ttl);
 
     // getAllOffers has the basic exception safety guarantee. If it throws an
     // exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified.
     UnorderedMap<LedgerKey, LedgerEntry> getAllOffers();
 
     // getBestOffer has the basic exception safety guarantee. If it throws an
     // exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
     // - the entry cache may be, but is not guaranteed to be, modified or even
     //   cleared
     // - the best offers cache may be, but is not guaranteed to be, modified or
@@ -403,29 +389,20 @@ class LedgerTxn::Impl
 
     // getChanges has the basic exception safety guarantee. If it throws an
     // exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
     // - the entry cache may be, but is not guaranteed to be, cleared.
     LedgerEntryChanges getChanges();
 
     // getDelta has the basic exception safety guarantee. If it throws an
     // exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
     // - the entry cache may be, but is not guaranteed to be, cleared.
     LedgerTxnDelta getDelta();
 
-    // getOffersByAccountAndAsset has the basic exception safety guarantee. If
-    // it throws an exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
+    // getOffersByAccountAndAsset has the basic exception safety guarantee.
     UnorderedMap<LedgerKey, LedgerEntry>
     getOffersByAccountAndAsset(AccountID const& account, Asset const& asset);
 
     // getPoolShareTrustLinesByAccountAndAsset has the basic exception safety
     // guarantee. If it throws an exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
     // - the entry cache may be, but is not guaranteed to be, modified.
     UnorderedMap<LedgerKey, LedgerEntry>
     getPoolShareTrustLinesByAccountAndAsset(AccountID const& account,
@@ -434,17 +411,11 @@ class LedgerTxn::Impl
     // getHeader does not throw
     LedgerHeader const& getHeader() const;
 
-    // getInflationWinners has the basic exception safety guarantee. If it
-    // throws an exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
+    // getInflationWinners has the basic exception safety guarantee.
     std::vector<InflationWinner> getInflationWinners(size_t maxWinners,
                                                      int64_t minBalance);
 
-    // queryInflationWinners has the basic exception safety guarantee. If it
-    // throws an exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
+    // queryInflationWinners has the basic exception safety guarantee.
     std::vector<InflationWinner> queryInflationWinners(size_t maxWinners,
                                                        int64_t minBalance);
 
@@ -461,24 +432,18 @@ class LedgerTxn::Impl
 
     // getNewestVersion has the basic exception safety guarantee. If it throws
     // an exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
     // - the entry cache may be, but is not guaranteed to be, cleared.
     std::shared_ptr<InternalLedgerEntry const>
     getNewestVersion(InternalLedgerKey const& key) const;
 
     // getNewestVersionBelowRoot has the basic exception safety guarantee. If it
     // throws an exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
     // - the entry cache may be, but is not guaranteed to be, cleared.
     std::pair<bool, std::shared_ptr<InternalLedgerEntry const> const>
     getNewestVersionBelowRoot(InternalLedgerKey const& key) const;
 
     // load has the basic exception safety guarantee. If it throws an exception,
     // then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
     // - the entry cache may be, but is not guaranteed to be, cleared.
     LedgerTxnEntry load(LedgerTxn& self, InternalLedgerKey const& key);
 
@@ -496,16 +461,12 @@ class LedgerTxn::Impl
 
     // loadAllOffers has the basic exception safety guarantee. If it throws an
     // exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
     // - the entry cache may be, but is not guaranteed to be, cleared.
     std::map<AccountID, std::vector<LedgerTxnEntry>>
     loadAllOffers(LedgerTxn& self);
 
     // loadBestOffer has the basic exception safety guarantee. If it throws an
     // exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
     // - the entry cache may be, but is not guaranteed to be, modified or even
     //   cleared
     // - the best offers cache may be, but is not guaranteed to be, modified or
@@ -518,8 +479,6 @@ class LedgerTxn::Impl
 
     // loadOffersByAccountAndAsset has the basic exception safety guarantee. If
     // it throws an exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
     // - the entry cache may be, but is not guaranteed to be, cleared.
     std::vector<LedgerTxnEntry>
     loadOffersByAccountAndAsset(LedgerTxn& self, AccountID const& accountID,
@@ -527,16 +486,12 @@ class LedgerTxn::Impl
 
     // loadPoolShareTrustLinesByAccountAndAsset has the basic exception safety
     // guarantee. If it throws an exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
     // - the entry cache may be, but is not guaranteed to be, modified.
     std::vector<LedgerTxnEntry> loadPoolShareTrustLinesByAccountAndAsset(
         LedgerTxn& self, AccountID const& account, Asset const& asset);
 
     // loadWithoutRecord has the basic exception safety guarantee. If it throws
     // an exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
     // - the entry cache may be, but is not guaranteed to be, cleared.
     ConstLedgerTxnEntry loadWithoutRecord(LedgerTxn& self,
                                           InternalLedgerKey const& key);
@@ -770,16 +725,11 @@ class LedgerTxnRoot::Impl
     void resetForFuzzer();
 #endif // BUILD_TESTS
 
-    // getAllOffers has the basic exception safety guarantee. If it throws an
-    // exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified.
+    // getAllOffers has the basic exception safety guarantee.
     UnorderedMap<LedgerKey, LedgerEntry> getAllOffers();
 
     // getBestOffer has the basic exception safety guarantee. If it throws an
     // exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
     // - the entry cache may be, but is not guaranteed to be, modified or even
     //   cleared
     // - the best offers cache may be, but is not guaranteed to be, modified or
@@ -788,17 +738,12 @@ class LedgerTxnRoot::Impl
     getBestOffer(Asset const& buying, Asset const& selling,
                  OfferDescriptor const* worseThan);
 
-    // getOffersByAccountAndAsset has the basic exception safety guarantee. If
-    // it throws an exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
+    // getOffersByAccountAndAsset has the basic exception safety guarantee.
     UnorderedMap<LedgerKey, LedgerEntry>
     getOffersByAccountAndAsset(AccountID const& account, Asset const& asset);
 
     // getPoolShareTrustLinesByAccountAndAsset has the basic exception safety
-    // guarantee. If it throws an exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
+    // guarantee.
     UnorderedMap<LedgerKey, LedgerEntry>
     getPoolShareTrustLinesByAccountAndAsset(AccountID const& account,
                                             Asset const& asset);
@@ -806,17 +751,12 @@ class LedgerTxnRoot::Impl
     // getHeader does not throw
     LedgerHeader const& getHeader() const;
 
-    // getInflationWinners has the basic exception safety guarantee. If it
-    // throws an exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
+    // getInflationWinners has the basic exception safety guarantee.
     std::vector<InflationWinner> getInflationWinners(size_t maxWinners,
                                                      int64_t minBalance);
 
     // getNewestVersion has the basic exception safety guarantee. If it throws
     // an exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
     // - the entry cache may be, but is not guaranteed to be, cleared.
     std::shared_ptr<InternalLedgerEntry const>
     getNewestVersion(InternalLedgerKey const& key) const;

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -212,8 +212,6 @@ maybeRebuildLedger(Application& app, bool applyBuckets)
     auto& ps = app.getPersistentState();
     if (ps.shouldRebuildForOfferTable())
     {
-        app.getDatabase().clearPreparedStatementCache(
-            app.getDatabase().getSession());
         soci::transaction tx(app.getDatabase().getRawSession());
         LOG_INFO(DEFAULT_LOG, "Dropping offers");
         app.getLedgerTxnRoot().dropOffers();
@@ -235,8 +233,6 @@ maybeRebuildLedger(Application& app, bool applyBuckets)
         LOG_INFO(DEFAULT_LOG, "Successfully rebuilt ledger tables");
     }
 
-    app.getDatabase().clearPreparedStatementCache(
-        app.getDatabase().getSession());
     ps.clearRebuildForOfferTable();
 }
 

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -898,8 +898,6 @@ resetTxInternalState(Application& app)
     app.getLedgerTxnRoot().resetForFuzzer();
     app.getInvariantManager().resetForFuzzer();
 #endif // BUILD_TESTS
-    app.getDatabase().clearPreparedStatementCache(
-        app.getDatabase().getSession());
 }
 
 // FuzzTransactionFrame is a specialized TransactionFrame that includes


### PR DESCRIPTION
With recent bugs like #5093 I realized prepared statements at this point cause more harm than good. We've moved to BucketListDB as a backend a while ago, removed SQL from publishing completely, and now the use of SQL in the codebase is minimal. In addition, for the remaining SQL bits like offers, we do batch load/inserts. The lack of consistent clearing discipline as described in https://github.com/stellar/stellar-core/issues/1591 makes this even harder to think about. On pubnet infra, it looks like we're executing 30-50 queries per second, which is fairly low. This PR removes prepared statement caching completely. I'm currently doing a perf evaluation of this change, but we can probably merge it and if needed, bring back caching for subsystems that could benefit from it. 