### PR TITLE
Consistently use `toStellarValue`

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -703,7 +703,7 @@ HerderImpl::checkCloseTime(SCPEnvelope const& envelope, bool enforceRecent)
     // returns true if one of the values is valid
     auto checkCTHelper = [&](std::vector<Value> const& values) {
         return std::any_of(values.begin(), values.end(), [&](Value const& e) {
-            auto r = scpD.toStellarValue(e, sv);
+            auto r = toStellarValue(e, sv);
             // sv must be after cutoff
             r = r && sv.closeTime >= ctCutoff;
             if (r)
@@ -2080,7 +2080,7 @@ HerderImpl::persistSCPState(uint64 slot)
         latestEnvs.emplace_back(e);
 
         // saves transaction sets referred by the statement
-        for (auto const& h : getTxSetHashes(e))
+        for (auto const& h : getValidatedTxSetHashes(e))
         {
             auto txSet = mPendingEnvelopes.getTxSet(h);
             if (txSet && !mApp.getPersistentState().hasTxSet(h))
@@ -2385,7 +2385,7 @@ HerderImpl::purgeOldPersistedTxSets()
                 xdr::xdr_from_opaque(buffer, scpState);
                 for (auto const& e : scpState.v1().scpEnvelopes)
                 {
-                    for (auto const& hash : getTxSetHashes(e))
+                    for (auto const& hash : getValidatedTxSetHashes(e))
                     {
                         hashesToDelete.erase(hash);
                     }

--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -121,10 +121,6 @@ class HerderSCPDriver : public SCPDriver
 
     std::optional<VirtualClock::time_point> getPrepareStart(uint64_t slotIndex);
 
-    // converts a Value into a StellarValue
-    // returns false on error
-    bool toStellarValue(Value const& v, StellarValue& sv);
-
     // validate close time as much as possible
     bool checkCloseTime(uint64_t slotIndex, uint64_t lastCloseTime,
                         StellarValue const& b) const;

--- a/src/herder/HerderUtils.h
+++ b/src/herder/HerderUtils.h
@@ -17,9 +17,23 @@ struct SCPEnvelope;
 struct SCPStatement;
 struct StellarValue;
 
-std::vector<Hash> getTxSetHashes(SCPEnvelope const& envelope);
+// converts a Value into a StellarValue
+// returns false on error
+bool toStellarValue(Value const& v, StellarValue& sv);
 
-std::vector<StellarValue> getStellarValues(SCPStatement const& envelope);
+// Extract the transaction set hashes present in `envelope`.
+// Returns nullopt if any of the values in the envelope cannot be parsed.
+std::optional<std::vector<Hash>> getTxSetHashes(SCPEnvelope const& envelope);
+
+// Like `getTxSetHashes`, but throws if any of the values in the envelope cannot
+// be parsed. Use only when it shouldn't be possible for the envelope to contain
+// values that cannot be parsed.
+std::vector<Hash> getValidatedTxSetHashes(SCPEnvelope const& envelope);
+
+// Extract the values present in `envelope`.
+// Returns nullopt if any of the values in the envelope cannot be parsed.
+std::optional<std::vector<StellarValue>>
+getStellarValues(SCPStatement const& envelope);
 
 std::string toShortString(std::optional<Config> const& cfg, NodeID const& id);
 

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -268,7 +268,12 @@ PendingEnvelopes::isNodeDefinitelyInQuorum(NodeID const& node)
 static std::string
 txSetsToStr(SCPEnvelope const& envelope)
 {
-    auto hashes = getTxSetHashes(envelope);
+    auto maybeHashes = getTxSetHashes(envelope);
+    if (!maybeHashes.has_value())
+    {
+        return "[invalid]";
+    }
+    auto const& hashes = maybeHashes.value();
     UnorderedSet<Hash> hashesSet(hashes.begin(), hashes.end());
     std::string res = "[";
     for (auto const& s : hashesSet)
@@ -292,7 +297,15 @@ PendingEnvelopes::recvSCPEnvelope(SCPEnvelope const& envelope)
         return Herder::ENVELOPE_STATUS_DISCARDED;
     }
 
-    auto const& values = getStellarValues(envelope.statement);
+    auto const maybeValues = getStellarValues(envelope.statement);
+    if (!maybeValues.has_value())
+    {
+        CLOG_TRACE(Herder, "Dropping envelope from {} (invalid values)",
+                   mApp.getConfig().toShortString(nodeID));
+        return Herder::ENVELOPE_STATUS_DISCARDED;
+    }
+
+    auto const& values = maybeValues.value();
     if (std::any_of(values.begin(), values.end(), [](auto const& value) {
             return value.ext.v() != STELLAR_VALUE_SIGNED;
         }))
@@ -475,7 +488,9 @@ PendingEnvelopes::recordReceivedCost(SCPEnvelope const& env)
     size_t totalReceivedBytes = 0;
     totalReceivedBytes += xdr::xdr_argpack_size(env);
 
-    for (auto const& v : getStellarValues(env.statement))
+    auto const maybeValues = getStellarValues(env.statement);
+    releaseAssert(maybeValues.has_value());
+    for (auto const& v : maybeValues.value())
     {
         size_t txSetSize = 0;
         if (mValueSizeCache.exists(v.txSetHash))
@@ -559,7 +574,7 @@ PendingEnvelopes::isFullyFetched(SCPEnvelope const& envelope)
         return false;
     }
 
-    auto txSetHashes = getTxSetHashes(envelope);
+    auto txSetHashes = getValidatedTxSetHashes(envelope);
     return std::all_of(std::begin(txSetHashes), std::end(txSetHashes),
                        [&](Hash const& txSetHash) {
                            return getKnownTxSet(txSetHash, 0, false);
@@ -579,7 +594,7 @@ PendingEnvelopes::startFetch(SCPEnvelope const& envelope)
         needSomething = true;
     }
 
-    for (auto const& h2 : getTxSetHashes(envelope))
+    for (auto const& h2 : getValidatedTxSetHashes(envelope))
     {
         if (!getKnownTxSet(h2, 0, false))
         {
@@ -603,7 +618,7 @@ PendingEnvelopes::stopFetch(SCPEnvelope const& envelope)
     Hash h = Slot::getCompanionQuorumSetHashFromStatement(envelope.statement);
     mQuorumSetFetcher.stopFetch(h, envelope);
 
-    for (auto const& h2 : getTxSetHashes(envelope))
+    for (auto const& h2 : getValidatedTxSetHashes(envelope))
     {
         mTxSetFetcher.stopFetch(h2, envelope);
     }
@@ -620,7 +635,7 @@ PendingEnvelopes::touchFetchCache(SCPEnvelope const& envelope)
         Slot::getCompanionQuorumSetHashFromStatement(envelope.statement);
     getKnownQSet(qsetHash, true);
 
-    for (auto const& h : getTxSetHashes(envelope))
+    for (auto const& h : getValidatedTxSetHashes(envelope))
     {
         getKnownTxSet(h, envelope.statement.slotIndex, true);
     }

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -2559,7 +2559,7 @@ TEST_CASE("SCP State", "[herder]")
                 }
                 for (auto const& msg : msgs)
                 {
-                    for (auto const& h : getTxSetHashes(msg))
+                    for (auto const& h : getValidatedTxSetHashes(msg))
                     {
                         REQUIRE(herder.getPendingEnvelopes().getTxSet(h));
                         REQUIRE(app->getPersistentState().hasTxSet(h));
@@ -3721,8 +3721,8 @@ getValidatorExternalizeMessages(Application& app, uint32_t start, uint32_t end)
             {
                 StellarValue sv;
                 auto& pe = herder.getPendingEnvelopes();
-                herder.getHerderSCPDriver().toStellarValue(
-                    env.statement.pledges.externalize().commit.value, sv);
+                toStellarValue(env.statement.pledges.externalize().commit.value,
+                               sv);
                 auto txset = pe.getTxSet(sv.txSetHash);
                 REQUIRE(txset);
                 validatorSCPMessages[seq] =


### PR DESCRIPTION
This change refactors the codebase to consistently use `toStellarValue` over various other one-off methods of working with values.