### PR TITLE
Remove master from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
   merge_group:
   push:
     branches:
-      - master
       - prod
       - testnet
       - acceptance-test-pass


### PR DESCRIPTION
This change removes `master` from the set of branches that trigger `build.yml` workflow runs.

The reason is that we currently build twice: once during the merge queue run, and once when master moves. Even though master is going to move to the exact same revision that the merge queue just tested.

We do this on the off chance that master moved for some other reason (eg. someone did a force push).

We try to _inhibit_ double-execution of CI by maintaining a somewhat fragile "which rev did we just test" file in the cache volume. But for this to work, cache volume hits have to be 100%, and they're presently nowhere near that. Every time there's a miss it will cost us an extra run.

This PR proposes to remove `master` entirely and assume that 99.99% of the time nobody will ever force push to master, and if they _do_ they can also just manually run the CI action, it's just another button you can push. The odds that this will really be a problem in practice are very low and if it ever happened the very worst case would be that the next merge would notice it. IMO the savings in pointless re-executions are worth that (extremely small) risk.