### PR TITLE
Switch to tcmalloc

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -67,6 +67,7 @@ To install Postgresql, follow instructions from the [Postgresql download page](h
 - `clang-format-20` (for `make format` to work)
 - `sed` and `perl`
 - `libunwind-dev`
+- `libgoogle-perftools-dev` (Linux only, for tcmalloc memory allocator)
 - Rust toolchain (see [Installing Rust](#installing-rust) subsection)
   - `cargo` >= 1.74
   - `rust` >= 1.74
@@ -118,7 +119,7 @@ sudo apt install gcc-14 g++-14
 ```zsh
 # common packages
 sudo apt-get update
-sudo apt-get install git build-essential pkg-config autoconf automake libtool bison flex libpq-dev libunwind-dev parallel sed perl
+sudo apt-get install git build-essential pkg-config autoconf automake libtool bison flex libpq-dev libunwind-dev libgoogle-perftools-dev parallel sed perl
 # if using clang
 sudo apt-get -y install clang-20 llvm-20
 # clang with libc++

--- a/configure.ac
+++ b/configure.ac
@@ -338,6 +338,31 @@ if test x"$enable_postgres" != xno; then
 fi
 AM_CONDITIONAL(USE_POSTGRES, [test -n "$have_postgres"])
 
+# tcmalloc_minimal - enabled by default on Linux for improved memory allocation performance
+# Disabled when using sanitizers (asan, memcheck, tsan) as they replace malloc
+unset have_tcmalloc
+if test "x$enable_asan" = "xyes" -o "x$enable_memcheck" = "xyes" -o "x$enable_threadsanitizer" = "xyes"; then
+    AC_MSG_NOTICE([tcmalloc disabled due to sanitizer being enabled])
+else
+    case "${host_os}" in
+        linux*)
+            PKG_CHECK_MODULES(libtcmalloc, [libtcmalloc_minimal >= 2.0], [
+                have_tcmalloc=1
+                AC_DEFINE([USE_TCMALLOC], [1], [Define to 1 if using tcmalloc])
+                AC_MSG_NOTICE([tcmalloc_minimal found and will be used])
+            ], [
+                AC_MSG_ERROR([tcmalloc_minimal not found. Install libgoogle-perftools-dev])
+            ])
+            ;;
+        *)
+            AC_MSG_NOTICE([tcmalloc is only used on Linux, skipping])
+            ;;
+    esac
+fi
+AM_CONDITIONAL(USE_TCMALLOC, [test -n "$have_tcmalloc"])
+AC_SUBST(libtcmalloc_CFLAGS)
+AC_SUBST(libtcmalloc_LIBS)
+
 AC_ARG_ENABLE(tests,
     AS_HELP_STRING([--disable-tests],
         [Disable building test suite]))

--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get -y install iproute2 procps lsb-release \
                        git build-essential pkg-config autoconf automake libtool \
-                       bison flex sed perl libpq-dev parallel libunwind-20-dev \
+                       bison flex sed perl libpq-dev parallel libunwind-20-dev libgoogle-perftools-dev \
                        clang-20 libc++abi-20-dev libc++-20-dev libclang-rt-20-dev \
                        postgresql curl
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -74,7 +74,8 @@ endif
 
 stellar_core_LDADD = $(soci_LIBS) $(libmedida_LIBS)		\
 	$(top_builddir)/lib/lib3rdparty.a $(sqlite3_LIBS)	\
-	$(libpq_LIBS) $(xdrpp_LIBS) $(libsodium_LIBS) $(libunwind_LIBS)
+	$(libpq_LIBS) $(xdrpp_LIBS) $(libsodium_LIBS) $(libunwind_LIBS) \
+	$(libtcmalloc_LIBS)
 
 TESTDATA_DIR = testdata
 TEST_FILES = $(TESTDATA_DIR)/stellar-core_example.cfg $(TESTDATA_DIR)/stellar-core_standalone.cfg \

--- a/src/util/TcmallocConfig.cpp
+++ b/src/util/TcmallocConfig.cpp
@@ -1,0 +1,47 @@
+// Copyright 2026 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "config.h"
+
+#ifdef USE_TCMALLOC
+#include <gperftools/malloc_extension.h>
+
+namespace
+{
+// Configure tcmalloc parameters at startup using a constructor attribute.
+// This runs before main() to ensure optimal allocator settings from the start.
+//
+// Parameters:
+// - Release rate 10.0: Aggressively return memory to OS (default is 1.0)
+//   Whenever core makes a large allocation (in-memory soroban state, module
+//   cache, Bucket indexes), it is almost always on startup or in a background
+//   thread. Allocation speed is not critical for these larger allocations, so
+//   we free memory aggressively.
+// - Max thread cache 512MB: Allow larger per-thread caches for high-throughput
+//   The most commonly allocated objects are around ~1KB BucketEntry/LedgerEntry
+//   and are routinely allocated from multiple threads. We allocate large
+//   per-thread caches to reduce contention.
+// - Large alloc threshold 10GB: Functionally disable allocation related logs
+//   for performance, since we don't read stderr and have lots of other
+//   telemetry.
+__attribute__((constructor)) void
+initTcmallocConfig()
+{
+    MallocExtension* ext = MallocExtension::instance();
+    if (ext)
+    {
+        // TCMALLOC_RELEASE_RATE=10.0
+        ext->SetMemoryReleaseRate(10.0);
+
+        // TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES=536870912 (512MB)
+        ext->SetNumericProperty("tcmalloc.max_total_thread_cache_bytes",
+                                536870912);
+
+        // TCMALLOC_LARGE_ALLOC_REPORT_THRESHOLD=10737418240 (10GB)
+        ext->SetNumericProperty("tcmalloc.large_alloc_report_threshold",
+                                10737418240ULL);
+    }
+}
+} // namespace
+#endif // USE_TCMALLOC


### PR DESCRIPTION
# Description

Switches core grom glibc allocator to tcmalloc.

After adding the state snapshot invariant, we've seen nodes with it enabled get OOM killed. This was due to an issue with glibc memory arenas. TLDR: we'd make a large allocation on thread A (the in-memory snapshot copy), pass it over to thread B, then have thread B free the allocation. In glibc, there is a per-thread memory arena. Each allocation made by a thread takes capacity from this arena. The issue is, whatever thread frees an allocation gets the capacity added back to its own arena regardless of the original allocating thread. This means that the snapshot invariant copy allocation caused us to "drain" memory from the apply thread, resulting in the apply thread continually requesting more heap until we get OOM killed. For more info, [check out this blog](https://blog.cloudflare.com/the-effect-of-switching-to-tcmalloc-on-rocksdb-memory-use/). 

The solution is to switch to an allocator more friendly to our multithreaded allocation pattern. After testing mimalloc, jemalloc, glibc, and tcmalloc, I've landed on tcmalloc as our winner.

[tcmalloc is developed by Google](https://github.com/google/tcmalloc), packaged in default Ubuntu repos, and is quite stable. It's memory overhead and runtime performance are both excellent for our use case. In order to test Resident Set Size (RSS, or allocator memory overhead), I've been running different allocator setting over the last couple days on test-core-003. After tuning tcmalloc, I've seen a memory decrease of about 40%, from 7.5 GB to 5 GB. Surprisingly, I've also seen a very significant runtime improvement.

In a multithreaded, high throughput environment (measured  by indexing the BucketList in parallel), we see the following allocation measurements:

```
glibc:

median: 69 ns
mean: 680 ns
total allocation time during Bucket Indexing: 313 ms
```

```
tcmalloc (with settings from this PR)

median: 22 ns
mean: 178 ns
total allocation time during Bucket Indexing: 82.4 ms
```

Deallocation time is omitted, as it is basically the same for both. The key takeway is that tcmalloc is faster on the mdeian case, but also much more consistent due to better handling of thread contention.

To test more realistic patterns, I ran catchup on 200 ledgers starting from 60757320 locally on my laptop. tcmalloc resulted in an 11% reduction of total apply time compared to glibc:

<img width="899" height="429" alt="image" src="https://github.com/user-attachments/assets/9a5c1935-b602-4c4f-863d-13ffeeccdbdf" />


I also tested max-sac-tps test on `user-dev-001`. I tested with 4 threads, batch size of 1, with disk writes counting towards overall apply time. tcmalloc consistently showed ~18% improvement in apply time and overall max sac TPS (from 6400 -> 7680 TPS). This seems like a pretty significant and easy win!

I don't think CI will pass, as we need to add a new dependency to our build. It looks like we have to create the runner with the new dependency inside namespace directly, so maybe @graydon can help out with this. I'm also not sure if I correctly changed the build system, especially with the way I've set up the config options. In my testing I was just linking everything directly, and the actual compile time changes are AI generated, so some help would be appreciated.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
