### PR TITLE
Fix race on startup with HTTP server

### DIFF
--- a/src/bucket/BucketSnapshotManager.cpp
+++ b/src/bucket/BucketSnapshotManager.cpp
@@ -155,6 +155,14 @@ BucketSnapshotManager::maybeCopyLiveAndHotArchiveSnapshots(
     }
 }
 
+std::pair<SearchableSnapshotConstPtr, SearchableHotArchiveSnapshotConstPtr>
+BucketSnapshotManager::copySearchableBucketListSnapshots() const
+{
+    SharedLockShared guard(mSnapshotMutex);
+    return {copySearchableLiveBucketListSnapshot(guard),
+            copySearchableHotArchiveBucketListSnapshot(guard)};
+}
+
 void
 BucketSnapshotManager::updateCurrentSnapshot(
     LiveBucketList const& liveBL, HotArchiveBucketList const& hotArchiveBL,

--- a/src/bucket/BucketSnapshotManager.h
+++ b/src/bucket/BucketSnapshotManager.h
@@ -121,5 +121,10 @@ class BucketSnapshotManager : NonMovableOrCopyable
         SearchableSnapshotConstPtr& liveSnapshot,
         SearchableHotArchiveSnapshotConstPtr& hotArchiveSnapshot)
         LOCKS_EXCLUDED(mSnapshotMutex);
+
+    // Copy both live and hot archive snapshots atomically under a single lock.
+    // This guarantees both snapshots are from the same ledger.
+    std::pair<SearchableSnapshotConstPtr, SearchableHotArchiveSnapshotConstPtr>
+    copySearchableBucketListSnapshots() const LOCKS_EXCLUDED(mSnapshotMutex);
 };
 }

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -20,6 +20,7 @@
 #include "transactions/TransactionFrame.h"
 #include "util/XDRStream.h"
 #include "xdr/Stellar-ledger.h"
+#include <atomic>
 #include <filesystem>
 #include <optional>
 #include <string>
@@ -415,7 +416,7 @@ class LedgerManagerImpl : public LedgerManager
                                     ApplicableTxSetFrame const& txSet,
                                     Config const& config);
 
-    State mState;
+    std::atomic<State> mState;
 
 #ifdef BUILD_TESTS
     std::vector<TransactionMetaFrame> mLastLedgerTxMeta;

--- a/src/main/AppConnector.cpp
+++ b/src/main/AppConnector.cpp
@@ -194,6 +194,24 @@ AppConnector::maybeCopySearchableBucketListSnapshot(
         .maybeCopySearchableBucketListSnapshot(snapshot);
 }
 
+void
+AppConnector::maybeCopyLiveAndHotArchiveSnapshots(
+    SearchableSnapshotConstPtr& liveSnapshot,
+    SearchableHotArchiveSnapshotConstPtr& hotArchiveSnapshot)
+{
+    mApp.getBucketManager()
+        .getBucketSnapshotManager()
+        .maybeCopyLiveAndHotArchiveSnapshots(liveSnapshot, hotArchiveSnapshot);
+}
+
+std::pair<SearchableSnapshotConstPtr, SearchableHotArchiveSnapshotConstPtr>
+AppConnector::copySearchableBucketListSnapshots()
+{
+    return mApp.getBucketManager()
+        .getBucketSnapshotManager()
+        .copySearchableBucketListSnapshots();
+}
+
 SearchableSnapshotConstPtr&
 AppConnector::getOverlayThreadSnapshot()
 {

--- a/src/main/AppConnector.h
+++ b/src/main/AppConnector.h
@@ -81,6 +81,13 @@ class AppConnector
     void
     maybeCopySearchableBucketListSnapshot(SearchableSnapshotConstPtr& snapshot);
 
+    void maybeCopyLiveAndHotArchiveSnapshots(
+        SearchableSnapshotConstPtr& liveSnapshot,
+        SearchableHotArchiveSnapshotConstPtr& hotArchiveSnapshot);
+
+    std::pair<SearchableSnapshotConstPtr, SearchableHotArchiveSnapshotConstPtr>
+    copySearchableBucketListSnapshots();
+
     // Get a snapshot of ledger state for use by the overlay thread only. Must
     // only be called from the overlay thread.
     SearchableSnapshotConstPtr& getOverlayThreadSnapshot();

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -807,6 +807,9 @@ ApplicationImpl::start()
 
     mLedgerManager->loadLastKnownLedger();
 
+    // LCL is now loaded; unblock HTTP endpoints that were gated during boot.
+    mCommandHandler->setReady();
+
     // Check if we're already on protocol V_24 or later and enable Rust Dalek
     auto const& lcl = mLedgerManager->getLastClosedLedgerHeader();
     if (protocolVersionStartsFrom(lcl.header.ledgerVersion,

--- a/src/main/CommandHandler.h
+++ b/src/main/CommandHandler.h
@@ -7,6 +7,7 @@
 #include "lib/http/server.hpp"
 #include "main/QueryServer.h"
 #include "util/ProtocolVersion.h"
+#include <atomic>
 #include <map>
 #include <memory>
 #include <string>
@@ -28,6 +29,7 @@ class CommandHandler
     Application& mApp;
     std::unique_ptr<http::server::server> mServer;
     std::unique_ptr<QueryServer> mQueryServer;
+    std::atomic<bool> mIsReady{false};
 
     void addRoute(std::string const& name, HandlerRoute route);
 
@@ -44,6 +46,11 @@ class CommandHandler
     CommandHandler(Application& app);
 
     void shutdown();
+
+    // Called when ledger state is loaded. Once set, all HTTP
+    // endpoints become available. Before this, safeRouter returns a generic
+    // "core is booting" response for every request.
+    void setReady();
 
     std::string manualCmd(std::string const& cmd);
 
@@ -75,9 +82,6 @@ class CommandHandler
     void stopSurveyCollecting(std::string const& params, std::string& retStr);
     void surveyTopologyTimeSliced(std::string const& params,
                                   std::string& retStr);
-
-    // Checks if stellar-core is booted and throws an exception if not.
-    void checkBooted() const;
 
 #ifdef BUILD_TESTS
     void generateLoad(std::string const& params, std::string& retStr);

--- a/src/main/test/QueryServerTests.cpp
+++ b/src/main/test/QueryServerTests.cpp
@@ -42,11 +42,10 @@ TEST_CASE("getledgerentry", "[queryserver]")
     // Query Server is disabled by default in cfg. Instead of enabling it, we're
     // going to manage a version here manually so we can directly call functions
     // and avoid sending network requests.
-    auto qServer = std::make_unique<QueryServer>(
-        "127.0.0.1", 0,
-        1, // maxClient
-        2, // threadPoolSize
-        app->getBucketManager().getBucketSnapshotManager(), true);
+    auto qServer = std::make_unique<QueryServer>("127.0.0.1", 0,
+                                                 1, // maxClient
+                                                 2, // threadPoolSize
+                                                 app->getAppConnector(), true);
 
     std::unordered_map<LedgerKey, LedgerEntry> liveEntryMap;
 


### PR DESCRIPTION
# Description

Resolves #5099

This PR adds a check to HTTP endpoints and exits early if core is not in the correct state to service the endpoint. I've audited the endpoints and divided them into three categories:

- Ledger State Dependent Endpoints (i.e. anything with a LedgerHeader or BucketList dependency). Here, we check that LedgerManager is not in `LM_BOOTING_STATE` such that there is some valid LCL state to query. These endpoints include:
   - /tx
   - /sorobaninfo
   - /upgrades
   - /dumpproposedsettings
   - /self-check
   - /maintenance
   - /getledgerentryraw
   - /getledgerentry
   - /info
  
- Herder Dependent Endpoints. These don't need ledger state, but require overlay and herder to be initialized:
   - /peers
   - /connect
   - /droppeer
   - /bans
   - /unban
   - /quorum
   - /scp
   - /stopsurvey
   - /getsurveyresult
   - /startsurveycollecting
   - /stopsurveycollecting
   - /surveytopologytimesliced

- No dependencies. These include all test-only endpoints for simplicity, as well as diagnostic info that should probably always be live, such as /metrics and /ll.

I thought about just delaying starting the endpoint (like the comment initially mentioned), but given the current length of our startup time, we need endpoints like /metrics available at a minimum. It is also probably better from a consumer view for captive-core to reply with a "not ready" status instead of less graceful errors.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
