### PR TITLE
Refactored ParallelTxReturnVal

### DIFF
--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -2282,9 +2282,9 @@ LedgerManagerImpl::applyThread(
             app, *threadState, config, ledgerInfo, txBundle.getResPayload(),
             getSorobanMetrics(), txSubSeed, txBundle.getEffects());
 
-        if (res.getSuccess())
+        if (res)
         {
-            threadState->commitChangesFromSuccessfulTx(res, txBundle);
+            threadState->commitChangesFromSuccessfulTx(*res, txBundle);
         }
         else
         {

--- a/src/transactions/ExtendFootprintTTLOpFrame.cpp
+++ b/src/transactions/ExtendFootprintTTLOpFrame.cpp
@@ -253,20 +253,14 @@ class ExtendFootprintTTLParallelApplyHelper
         return true;
     }
 
-    ParallelTxReturnVal
-    takeSuccess()
+    std::optional<ParallelTxSuccessVal>
+    takeResult(bool success)
     {
-        return mTxState.takeSuccess();
-    }
-
-    ParallelTxReturnVal
-    takeFailure()
-    {
-        return mTxState.takeFailure();
+        return mTxState.takeResult(success);
     }
 };
 
-ParallelTxReturnVal
+std::optional<ParallelTxSuccessVal>
 ExtendFootprintTTLOpFrame::doParallelApply(
     AppConnector& app, ThreadParallelApplyLedgerState const& threadState,
     Config const& appConfig, Hash const& _txPrngSeed,
@@ -281,14 +275,7 @@ ExtendFootprintTTLOpFrame::doParallelApply(
                                   PARALLEL_SOROBAN_PHASE_PROTOCOL_VERSION));
     ExtendFootprintTTLParallelApplyHelper helper(
         app, threadState, ledgerInfo, res, refundableFeeTracker, opMeta, *this);
-    if (helper.apply())
-    {
-        return helper.takeSuccess();
-    }
-    else
-    {
-        return helper.takeFailure();
-    }
+    return helper.takeResult(helper.apply());
 }
 
 bool

--- a/src/transactions/ExtendFootprintTTLOpFrame.h
+++ b/src/transactions/ExtendFootprintTTLOpFrame.h
@@ -40,7 +40,7 @@ class ExtendFootprintTTLOpFrame : public OperationFrame
     bool doCheckValid(uint32_t ledgerVersion,
                       OperationResult& res) const override;
 
-    ParallelTxReturnVal
+    std::optional<ParallelTxSuccessVal>
     doParallelApply(AppConnector& app,
                     ThreadParallelApplyLedgerState const& threadState,
                     Config const& appConfig, Hash const& txPrngSeed,

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -118,7 +118,7 @@ FeeBumpTransactionFrame::preParallelApply(
     }
 }
 
-ParallelTxReturnVal
+std::optional<ParallelTxSuccessVal>
 FeeBumpTransactionFrame::parallelApply(
     AppConnector& app, ThreadParallelApplyLedgerState const& threadState,
     Config const& config, ParallelLedgerInfo const& ledgerInfo,
@@ -132,10 +132,9 @@ FeeBumpTransactionFrame::parallelApply(
         // Note that even after updateResult is called here, feeCharged will not
         // be accurate for Soroban transactions until
         // FeeBumpTransactionFrame::processPostApply is called.
-        auto res = mInnerTx->parallelApply(app, threadState, config, ledgerInfo,
-                                           txResult, sorobanMetrics, txPrngSeed,
-                                           effects);
-        return res;
+        return mInnerTx->parallelApply(app, threadState, config, ledgerInfo,
+                                       txResult, sorobanMetrics, txPrngSeed,
+                                       effects);
     }
     catch (std::exception& e)
     {

--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -87,7 +87,7 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
                      MutableTransactionResultBase& txResult,
                      SorobanNetworkConfig const& sorobanConfig) const override;
 
-    ParallelTxReturnVal parallelApply(
+    std::optional<ParallelTxSuccessVal> parallelApply(
         AppConnector& app, ThreadParallelApplyLedgerState const& threadState,
         Config const& config, ParallelLedgerInfo const& ledgerInfo,
         MutableTransactionResultBase& resPayload,

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -1197,17 +1197,10 @@ class InvokeHostFunctionParallelApplyHelper
         }
     }
 
-    ParallelTxReturnVal
-    takeResults(bool applySucceeded)
+    std::optional<ParallelTxSuccessVal>
+    takeResult(bool success)
     {
-        if (applySucceeded)
-        {
-            return mTxState.takeSuccess();
-        }
-        else
-        {
-            return mTxState.takeFailure();
-        }
+        return mTxState.takeResult(success);
     }
 };
 
@@ -1256,7 +1249,7 @@ InvokeHostFunctionOpFrame::doApply(AppConnector& app, AbstractLedgerTxn& ltx,
         "InvokeHostFunctionOpFrame may only be applied via doApplyForSoroban");
 }
 
-ParallelTxReturnVal
+std::optional<ParallelTxSuccessVal>
 InvokeHostFunctionOpFrame::doParallelApply(
     AppConnector& app, ThreadParallelApplyLedgerState const& threadState,
     Config const& appConfig, Hash const& txPrngSeed,
@@ -1275,8 +1268,7 @@ InvokeHostFunctionOpFrame::doParallelApply(
         app, threadState, ledgerInfo, txPrngSeed, res, refundableFeeTracker,
         opMeta, *this);
 
-    bool success = helper.apply();
-    return helper.takeResults(success);
+    return helper.takeResult(helper.apply());
 }
 
 bool

--- a/src/transactions/InvokeHostFunctionOpFrame.h
+++ b/src/transactions/InvokeHostFunctionOpFrame.h
@@ -55,7 +55,7 @@ class InvokeHostFunctionOpFrame : public OperationFrame
     bool doCheckValid(uint32_t ledgerVersion,
                       OperationResult& res) const override;
 
-    ParallelTxReturnVal
+    std::optional<ParallelTxSuccessVal>
     doParallelApply(AppConnector& app,
                     ThreadParallelApplyLedgerState const& threadState,
                     Config const& appConfig, Hash const& txPrngSeed,

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -172,7 +172,7 @@ OperationFrame::apply(
     return applyRes;
 }
 
-ParallelTxReturnVal
+std::optional<ParallelTxSuccessVal>
 OperationFrame::parallelApply(
     AppConnector& app, ThreadParallelApplyLedgerState const& threadState,
     Config const& config, ParallelLedgerInfo const& ledgerInfo,
@@ -188,7 +188,7 @@ OperationFrame::parallelApply(
                            sorobanMetrics, res, refundableFeeTracker, opMeta);
 }
 
-ParallelTxReturnVal
+std::optional<ParallelTxSuccessVal>
 OperationFrame::doParallelApply(
     AppConnector& app, ThreadParallelApplyLedgerState const& threadState,
     Config const& appConfig, Hash const& txPrngSeed,

--- a/src/transactions/OperationFrame.h
+++ b/src/transactions/OperationFrame.h
@@ -58,7 +58,7 @@ class OperationFrame
                          OperationResult& res,
                          OperationMetaBuilder& opMeta) const = 0;
 
-    virtual ParallelTxReturnVal
+    virtual std::optional<ParallelTxSuccessVal>
     doParallelApply(AppConnector& app,
                     ThreadParallelApplyLedgerState const& threadState,
                     Config const& config, Hash const& txPrngSeed,
@@ -108,7 +108,8 @@ class OperationFrame
                std::optional<RefundableFeeTracker>& refundableFeeTracker,
                OperationMetaBuilder& opMeta) const;
 
-    ParallelTxReturnVal parallelApply(
+    // Returns std::nullopt if operation fails.
+    std::optional<ParallelTxSuccessVal> parallelApply(
         AppConnector& app, ThreadParallelApplyLedgerState const& threadState,
         Config const& config, ParallelLedgerInfo const& ledgerInfo,
         SorobanMetrics& sorobanMetrics, OperationResult& res,

--- a/src/transactions/ParallelApplyUtils.h
+++ b/src/transactions/ParallelApplyUtils.h
@@ -160,11 +160,11 @@ class ThreadParallelApplyLedgerState
     OptionalEntryT getLiveEntryOpt(LedgerKey const& key) const;
     bool entryWasRestored(LedgerKey const& key) const;
 
-    void setEffectsDeltaFromSuccessfulTx(ParallelTxReturnVal const& res,
+    void setEffectsDeltaFromSuccessfulTx(ParallelTxSuccessVal const& res,
                                          ParallelLedgerInfo const& ledgerInfo,
                                          TxEffects& effects) const;
 
-    void commitChangesFromSuccessfulTx(ParallelTxReturnVal const& res,
+    void commitChangesFromSuccessfulTx(ParallelTxSuccessVal const& res,
                                        TxBundle const& txBundle);
 
     // The snapshot ledger sequence number is one less than the
@@ -325,8 +325,7 @@ class TxParallelApplyLedgerState
                                   LedgerEntry const& entry,
                                   LedgerKey const& ttlKey,
                                   LedgerEntry const& ttlEntry);
-    ParallelTxReturnVal takeSuccess();
-    ParallelTxReturnVal takeFailure();
+    std::optional<ParallelTxSuccessVal> takeResult(bool success);
     uint32_t getSnapshotLedgerSeq() const;
 };
 

--- a/src/transactions/RestoreFootprintOpFrame.cpp
+++ b/src/transactions/RestoreFootprintOpFrame.cpp
@@ -352,17 +352,10 @@ class RestoreFootprintParallelApplyHelper
         }
     }
 
-    ParallelTxReturnVal
-    takeResults(bool applySucceeded)
+    std::optional<ParallelTxSuccessVal>
+    takeResult(bool success)
     {
-        if (applySucceeded)
-        {
-            return mTxState.takeSuccess();
-        }
-        else
-        {
-            return mTxState.takeFailure();
-        }
+        return mTxState.takeResult(success);
     }
 };
 
@@ -373,7 +366,7 @@ RestoreFootprintOpFrame::isOpSupported(LedgerHeader const& header) const
                                      SOROBAN_PROTOCOL_VERSION);
 }
 
-ParallelTxReturnVal
+std::optional<ParallelTxSuccessVal>
 RestoreFootprintOpFrame::doParallelApply(
     AppConnector& app, ThreadParallelApplyLedgerState const& threadState,
     Config const& appConfig, Hash const& txPrngSeed,
@@ -389,8 +382,7 @@ RestoreFootprintOpFrame::doParallelApply(
     releaseAssertOrThrow(refundableFeeTracker);
     RestoreFootprintParallelApplyHelper helper(
         app, threadState, ledgerInfo, res, refundableFeeTracker, opMeta, *this);
-    bool success = helper.apply();
-    return helper.takeResults(success);
+    return helper.takeResult(helper.apply());
 }
 
 bool

--- a/src/transactions/RestoreFootprintOpFrame.h
+++ b/src/transactions/RestoreFootprintOpFrame.h
@@ -39,7 +39,7 @@ class RestoreFootprintOpFrame : public OperationFrame
     bool doCheckValid(uint32_t ledgerVersion,
                       OperationResult& res) const override;
 
-    ParallelTxReturnVal
+    std::optional<ParallelTxSuccessVal>
     doParallelApply(AppConnector& app,
                     ThreadParallelApplyLedgerState const& threadState,
                     Config const& appConfig, Hash const& txPrngSeed,

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -290,7 +290,7 @@ class TransactionFrame : public TransactionFrameBase
                      MutableTransactionResultBase& txResult,
                      SorobanNetworkConfig const& sorobanConfig) const override;
 
-    ParallelTxReturnVal parallelApply(
+    std::optional<ParallelTxSuccessVal> parallelApply(
         AppConnector& app, ThreadParallelApplyLedgerState const& threadState,
         Config const& config, ParallelLedgerInfo const& ledgerInfo,
         MutableTransactionResultBase& resPayload,

--- a/src/transactions/TransactionMeta.cpp
+++ b/src/transactions/TransactionMeta.cpp
@@ -403,7 +403,7 @@ OperationMetaBuilder::setLedgerChanges(AbstractLedgerTxn& opLtx,
 void
 OperationMetaBuilder::setLedgerChangesFromSuccessfulOp(
     ThreadParallelApplyLedgerState const& threadState,
-    ParallelTxReturnVal const& res, uint32_t ledgerSeq)
+    ParallelTxSuccessVal const& res, uint32_t ledgerSeq)
 {
     ZoneScoped;
     if (!mEnabled)

--- a/src/transactions/TransactionMeta.h
+++ b/src/transactions/TransactionMeta.h
@@ -26,7 +26,7 @@ class OperationMetaBuilder
     // thread state and return value maps to track entry changes.
     void setLedgerChangesFromSuccessfulOp(
         ThreadParallelApplyLedgerState const& threadState,
-        ParallelTxReturnVal const& res, uint32_t ledgerSeq);
+        ParallelTxSuccessVal const& res, uint32_t ledgerSeq);
 
     // Sets the return value for a Soroban operation.
     void setSorobanReturnValue(SCVal const& val);

--- a/src/transactions/test/TransactionTestFrame.cpp
+++ b/src/transactions/test/TransactionTestFrame.cpp
@@ -349,7 +349,7 @@ TransactionTestFrame::preParallelApply(
                                         sorobanConfig);
 }
 
-ParallelTxReturnVal
+std::optional<ParallelTxSuccessVal>
 TransactionTestFrame::parallelApply(
     AppConnector& app, ThreadParallelApplyLedgerState const& threadState,
     Config const& config, ParallelLedgerInfo const& ledgerInfo,

--- a/src/transactions/test/TransactionTestFrame.h
+++ b/src/transactions/test/TransactionTestFrame.h
@@ -148,7 +148,7 @@ class TransactionTestFrame : public TransactionFrameBase
                      MutableTransactionResultBase& resPayload,
                      SorobanNetworkConfig const& sorobanConfig) const override;
 
-    ParallelTxReturnVal parallelApply(
+    std::optional<ParallelTxSuccessVal> parallelApply(
         AppConnector& app, ThreadParallelApplyLedgerState const& threadState,
         Config const& config, ParallelLedgerInfo const& ledgerInfo,
         MutableTransactionResultBase& resPayload,


### PR DESCRIPTION
# Description

Resolves #5084

Simplifies `ParallelTxReturnVal` on failed TXs by returning a std::nullopt instead of a weird, half baked version of the return val.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
