### PR TITLE
Modernize Codebase Using C++20 Features

### DIFF
--- a/src/bucket/BucketBase.cpp
+++ b/src/bucket/BucketBase.cpp
@@ -31,9 +31,9 @@
 namespace stellar
 {
 
-template <IsBucketType BucketT, class IndexT>
-IndexT const&
-BucketBase<BucketT, IndexT>::getIndex() const
+template <IsBucketType BucketT>
+BucketBase<BucketT>::IndexT const&
+BucketBase<BucketT>::getIndex() const
 {
     ZoneScoped;
     releaseAssertOrThrow(!mFilename.empty());
@@ -41,25 +41,24 @@ BucketBase<BucketT, IndexT>::getIndex() const
     return *mIndex;
 }
 
-template <IsBucketType BucketT, class IndexT>
+template <IsBucketType BucketT>
 bool
-BucketBase<BucketT, IndexT>::isIndexed() const
+BucketBase<BucketT>::isIndexed() const
 {
     return static_cast<bool>(std::atomic_load(&mIndex));
 }
 
-template <IsBucketType BucketT, class IndexT>
+template <IsBucketType BucketT>
 void
-BucketBase<BucketT, IndexT>::setIndex(std::shared_ptr<IndexT const> index)
+BucketBase<BucketT>::setIndex(std::shared_ptr<IndexT const> index)
 {
     releaseAssertOrThrow(!isIndexed());
     std::atomic_store(&mIndex, std::move(index));
 }
 
-template <IsBucketType BucketT, class IndexT>
-BucketBase<BucketT, IndexT>::BucketBase(std::string const& filename,
-                                        Hash const& hash,
-                                        std::shared_ptr<IndexT const>&& index)
+template <IsBucketType BucketT>
+BucketBase<BucketT>::BucketBase(std::string const& filename, Hash const& hash,
+                                std::shared_ptr<IndexT const>&& index)
     : mFilename(filename), mHash(hash), mIndex(std::move(index))
 {
     releaseAssert(filename.empty() || fs::exists(filename));
@@ -71,35 +70,34 @@ BucketBase<BucketT, IndexT>::BucketBase(std::string const& filename,
     }
 }
 
-template <IsBucketType BucketT, class IndexT>
-BucketBase<BucketT, IndexT>::BucketBase()
+template <IsBucketType BucketT> BucketBase<BucketT>::BucketBase()
 {
 }
 
-template <IsBucketType BucketT, class IndexT>
+template <IsBucketType BucketT>
 Hash const&
-BucketBase<BucketT, IndexT>::getHash() const
+BucketBase<BucketT>::getHash() const
 {
     return mHash;
 }
 
-template <IsBucketType BucketT, class IndexT>
+template <IsBucketType BucketT>
 std::filesystem::path const&
-BucketBase<BucketT, IndexT>::getFilename() const
+BucketBase<BucketT>::getFilename() const
 {
     return mFilename;
 }
 
-template <IsBucketType BucketT, class IndexT>
+template <IsBucketType BucketT>
 size_t
-BucketBase<BucketT, IndexT>::getSize() const
+BucketBase<BucketT>::getSize() const
 {
     return mSize;
 }
 
-template <IsBucketType BucketT, class IndexT>
+template <IsBucketType BucketT>
 bool
-BucketBase<BucketT, IndexT>::isEmpty() const
+BucketBase<BucketT>::isEmpty() const
 {
     if (mFilename.empty() || isZero(mHash))
     {
@@ -110,17 +108,16 @@ BucketBase<BucketT, IndexT>::isEmpty() const
     return false;
 }
 
-template <IsBucketType BucketT, class IndexT>
+template <IsBucketType BucketT>
 void
-BucketBase<BucketT, IndexT>::freeIndex()
+BucketBase<BucketT>::freeIndex()
 {
     std::atomic_store(&mIndex, std::shared_ptr<IndexT const>{});
 }
 
-template <IsBucketType BucketT, class IndexT>
+template <IsBucketType BucketT>
 std::string
-BucketBase<BucketT, IndexT>::randomFileName(std::string const& tmpDir,
-                                            std::string ext)
+BucketBase<BucketT>::randomFileName(std::string const& tmpDir, std::string ext)
 {
     ZoneScoped;
     for (;;)
@@ -135,16 +132,16 @@ BucketBase<BucketT, IndexT>::randomFileName(std::string const& tmpDir,
     }
 }
 
-template <IsBucketType BucketT, class IndexT>
+template <IsBucketType BucketT>
 std::string
-BucketBase<BucketT, IndexT>::randomBucketName(std::string const& tmpDir)
+BucketBase<BucketT>::randomBucketName(std::string const& tmpDir)
 {
     return randomFileName(tmpDir, ".xdr");
 }
 
-template <IsBucketType BucketT, class IndexT>
+template <IsBucketType BucketT>
 std::string
-BucketBase<BucketT, IndexT>::randomBucketIndexName(std::string const& tmpDir)
+BucketBase<BucketT>::randomBucketIndexName(std::string const& tmpDir)
 {
     return randomFileName(tmpDir, ".index");
 }
@@ -182,7 +179,7 @@ BucketBase<BucketT, IndexT>::randomBucketIndexName(std::string const& tmpDir)
 // and shadowing protocol simultaneously, the moment the first new-protocol
 // bucket enters the youngest level. At least one new bucket is in every merge's
 // shadows from then on in, so they all upgrade (and preserve lifecycle events).
-template <IsBucketType BucketT, class IndexT>
+template <IsBucketType BucketT>
 static void
 calculateMergeProtocolVersion(
     MergeCounters& mc, uint32_t maxProtocolVersion,
@@ -237,8 +234,7 @@ calculateMergeProtocolVersion(
 // side, or entries that compare non-equal. In all these cases we just
 // take the lesser (or existing) entry and advance only one iterator,
 // not scrutinizing the entry type further.
-template <IsBucketType BucketT, class IndexT, typename InputSource,
-          typename... ShadowParams>
+template <IsBucketType BucketT, typename InputSource, typename... ShadowParams>
 static bool
 mergeCasesWithDefaultAcceptance(
     BucketEntryIdCmp<BucketT> const& cmp, MergeCounters& mc,
@@ -282,12 +278,13 @@ mergeCasesWithDefaultAcceptance(
     return false;
 }
 
-template <IsBucketType BucketT, class IndexT>
+template <IsBucketType BucketT>
 template <typename InputSource, typename PutFuncT, typename... ShadowParams>
 void
-BucketBase<BucketT, IndexT>::mergeInternal(
-    BucketManager& bucketManager, InputSource& inputSource, PutFuncT putFunc,
-    uint32_t protocolVersion, MergeCounters& mc, ShadowParams&&... shadowParams)
+BucketBase<BucketT>::mergeInternal(BucketManager& bucketManager,
+                                   InputSource& inputSource, PutFuncT putFunc,
+                                   uint32_t protocolVersion, MergeCounters& mc,
+                                   ShadowParams&&... shadowParams)
 {
     BucketEntryIdCmp<BucketT> cmp;
     size_t iter = 0;
@@ -325,7 +322,7 @@ BucketBase<BucketT, IndexT>::mergeInternal(
 #endif
         }
 
-        if (!mergeCasesWithDefaultAcceptance<BucketT, IndexT, InputSource>(
+        if (!mergeCasesWithDefaultAcceptance<BucketT, InputSource>(
                 cmp, mc, inputSource, putFunc, protocolVersion,
                 shadowParams...))
         {
@@ -335,15 +332,15 @@ BucketBase<BucketT, IndexT>::mergeInternal(
     }
 }
 
-template <IsBucketType BucketT, class IndexT>
+template <IsBucketType BucketT>
 std::shared_ptr<BucketT>
-BucketBase<BucketT, IndexT>::merge(
-    BucketManager& bucketManager, uint32_t maxProtocolVersion,
-    std::shared_ptr<BucketT> const& oldBucket,
-    std::shared_ptr<BucketT> const& newBucket,
-    std::vector<std::shared_ptr<BucketT>> const& shadows,
-    bool keepTombstoneEntries, bool countMergeEvents, asio::io_context& ctx,
-    bool doFsync)
+BucketBase<BucketT>::merge(BucketManager& bucketManager,
+                           uint32_t maxProtocolVersion,
+                           std::shared_ptr<BucketT> const& oldBucket,
+                           std::shared_ptr<BucketT> const& newBucket,
+                           std::vector<std::shared_ptr<BucketT>> const& shadows,
+                           bool keepTombstoneEntries, bool countMergeEvents,
+                           asio::io_context& ctx, bool doFsync)
 {
     ZoneScoped;
     // This is the key operation in the scheme: merging two (read-only)
@@ -361,9 +358,9 @@ BucketBase<BucketT, IndexT>::merge(
 
     uint32_t protocolVersion;
     bool keepShadowedLifecycleEntries = true;
-    calculateMergeProtocolVersion<BucketT, IndexT>(
-        mc, maxProtocolVersion, oi, ni, shadowIterators, protocolVersion,
-        keepShadowedLifecycleEntries);
+    calculateMergeProtocolVersion<BucketT>(mc, maxProtocolVersion, oi, ni,
+                                           shadowIterators, protocolVersion,
+                                           keepShadowedLifecycleEntries);
 
     auto timer = bucketManager.getMergeTimer().TimeScope();
     BucketMetadata meta;
@@ -423,21 +420,23 @@ BucketBase<BucketT, IndexT>::merge(
     return out.getBucket(bucketManager, &mk);
 }
 
-template void BucketBase<LiveBucket, LiveBucket::IndexT>::mergeInternal<
+template void BucketBase<LiveBucket>::mergeInternal<
     MemoryMergeInput<LiveBucket>, std::function<void(BucketEntry const&)>,
     std::vector<BucketInputIterator<LiveBucket>>&, bool&>(
     BucketManager&, MemoryMergeInput<LiveBucket>&,
     std::function<void(BucketEntry const&)>, uint32_t, MergeCounters&,
     std::vector<BucketInputIterator<LiveBucket>>&, bool&);
 
-template void
-BucketBase<HotArchiveBucket, HotArchiveBucket::IndexT>::mergeInternal<
+template void BucketBase<HotArchiveBucket>::mergeInternal<
     MemoryMergeInput<HotArchiveBucket>,
     std::function<void(HotArchiveBucketEntry const&)>>(
     BucketManager&, MemoryMergeInput<HotArchiveBucket>&,
     std::function<void(HotArchiveBucketEntry const&)>, uint32_t,
     MergeCounters&);
 
-template class BucketBase<LiveBucket, LiveBucket::IndexT>;
-template class BucketBase<HotArchiveBucket, HotArchiveBucket::IndexT>;
+template class BucketBase<LiveBucket>;
+static_assert(std::same_as<BucketBase<LiveBucket>::IndexT, LiveBucket::IndexT>);
+template class BucketBase<HotArchiveBucket>;
+static_assert(std::same_as<BucketBase<HotArchiveBucket>::IndexT,
+                           HotArchiveBucket::IndexT>);
 }

--- a/src/bucket/BucketBase.cpp
+++ b/src/bucket/BucketBase.cpp
@@ -31,7 +31,7 @@
 namespace stellar
 {
 
-template <class BucketT, class IndexT>
+template <IsBucketType BucketT, class IndexT>
 IndexT const&
 BucketBase<BucketT, IndexT>::getIndex() const
 {
@@ -41,14 +41,14 @@ BucketBase<BucketT, IndexT>::getIndex() const
     return *mIndex;
 }
 
-template <class BucketT, class IndexT>
+template <IsBucketType BucketT, class IndexT>
 bool
 BucketBase<BucketT, IndexT>::isIndexed() const
 {
     return static_cast<bool>(std::atomic_load(&mIndex));
 }
 
-template <class BucketT, class IndexT>
+template <IsBucketType BucketT, class IndexT>
 void
 BucketBase<BucketT, IndexT>::setIndex(std::shared_ptr<IndexT const> index)
 {
@@ -56,7 +56,7 @@ BucketBase<BucketT, IndexT>::setIndex(std::shared_ptr<IndexT const> index)
     std::atomic_store(&mIndex, std::move(index));
 }
 
-template <class BucketT, class IndexT>
+template <IsBucketType BucketT, class IndexT>
 BucketBase<BucketT, IndexT>::BucketBase(std::string const& filename,
                                         Hash const& hash,
                                         std::shared_ptr<IndexT const>&& index)
@@ -71,32 +71,33 @@ BucketBase<BucketT, IndexT>::BucketBase(std::string const& filename,
     }
 }
 
-template <class BucketT, class IndexT> BucketBase<BucketT, IndexT>::BucketBase()
+template <IsBucketType BucketT, class IndexT>
+BucketBase<BucketT, IndexT>::BucketBase()
 {
 }
 
-template <class BucketT, class IndexT>
+template <IsBucketType BucketT, class IndexT>
 Hash const&
 BucketBase<BucketT, IndexT>::getHash() const
 {
     return mHash;
 }
 
-template <class BucketT, class IndexT>
+template <IsBucketType BucketT, class IndexT>
 std::filesystem::path const&
 BucketBase<BucketT, IndexT>::getFilename() const
 {
     return mFilename;
 }
 
-template <class BucketT, class IndexT>
+template <IsBucketType BucketT, class IndexT>
 size_t
 BucketBase<BucketT, IndexT>::getSize() const
 {
     return mSize;
 }
 
-template <class BucketT, class IndexT>
+template <IsBucketType BucketT, class IndexT>
 bool
 BucketBase<BucketT, IndexT>::isEmpty() const
 {
@@ -109,14 +110,14 @@ BucketBase<BucketT, IndexT>::isEmpty() const
     return false;
 }
 
-template <class BucketT, class IndexT>
+template <IsBucketType BucketT, class IndexT>
 void
 BucketBase<BucketT, IndexT>::freeIndex()
 {
     std::atomic_store(&mIndex, std::shared_ptr<IndexT const>{});
 }
 
-template <class BucketT, class IndexT>
+template <IsBucketType BucketT, class IndexT>
 std::string
 BucketBase<BucketT, IndexT>::randomFileName(std::string const& tmpDir,
                                             std::string ext)
@@ -134,14 +135,14 @@ BucketBase<BucketT, IndexT>::randomFileName(std::string const& tmpDir,
     }
 }
 
-template <class BucketT, class IndexT>
+template <IsBucketType BucketT, class IndexT>
 std::string
 BucketBase<BucketT, IndexT>::randomBucketName(std::string const& tmpDir)
 {
     return randomFileName(tmpDir, ".xdr");
 }
 
-template <class BucketT, class IndexT>
+template <IsBucketType BucketT, class IndexT>
 std::string
 BucketBase<BucketT, IndexT>::randomBucketIndexName(std::string const& tmpDir)
 {
@@ -181,7 +182,7 @@ BucketBase<BucketT, IndexT>::randomBucketIndexName(std::string const& tmpDir)
 // and shadowing protocol simultaneously, the moment the first new-protocol
 // bucket enters the youngest level. At least one new bucket is in every merge's
 // shadows from then on in, so they all upgrade (and preserve lifecycle events).
-template <class BucketT, class IndexT>
+template <IsBucketType BucketT, class IndexT>
 static void
 calculateMergeProtocolVersion(
     MergeCounters& mc, uint32_t maxProtocolVersion,
@@ -236,7 +237,7 @@ calculateMergeProtocolVersion(
 // side, or entries that compare non-equal. In all these cases we just
 // take the lesser (or existing) entry and advance only one iterator,
 // not scrutinizing the entry type further.
-template <class BucketT, class IndexT, typename InputSource,
+template <IsBucketType BucketT, class IndexT, typename InputSource,
           typename... ShadowParams>
 static bool
 mergeCasesWithDefaultAcceptance(
@@ -245,8 +246,6 @@ mergeCasesWithDefaultAcceptance(
     std::function<void(typename BucketT::EntryT const&)> putFunc,
     uint32_t protocolVersion, ShadowParams&&... shadowParams)
 {
-    BUCKET_TYPE_ASSERT(BucketT);
-
     // Either of:
     //
     //   - Out of new entries.
@@ -283,7 +282,7 @@ mergeCasesWithDefaultAcceptance(
     return false;
 }
 
-template <class BucketT, class IndexT>
+template <IsBucketType BucketT, class IndexT>
 template <typename InputSource, typename PutFuncT, typename... ShadowParams>
 void
 BucketBase<BucketT, IndexT>::mergeInternal(
@@ -336,7 +335,7 @@ BucketBase<BucketT, IndexT>::mergeInternal(
     }
 }
 
-template <class BucketT, class IndexT>
+template <IsBucketType BucketT, class IndexT>
 std::shared_ptr<BucketT>
 BucketBase<BucketT, IndexT>::merge(
     BucketManager& bucketManager, uint32_t maxProtocolVersion,
@@ -346,8 +345,6 @@ BucketBase<BucketT, IndexT>::merge(
     bool keepTombstoneEntries, bool countMergeEvents, asio::io_context& ctx,
     bool doFsync)
 {
-    BUCKET_TYPE_ASSERT(BucketT);
-
     ZoneScoped;
     // This is the key operation in the scheme: merging two (read-only)
     // buckets together into a new 3rd bucket, while calculating its hash,

--- a/src/bucket/BucketBase.cpp
+++ b/src/bucket/BucketBase.cpp
@@ -435,8 +435,5 @@ template void BucketBase<HotArchiveBucket>::mergeInternal<
     MergeCounters&);
 
 template class BucketBase<LiveBucket>;
-static_assert(std::same_as<BucketBase<LiveBucket>::IndexT, LiveBucket::IndexT>);
 template class BucketBase<HotArchiveBucket>;
-static_assert(std::same_as<BucketBase<HotArchiveBucket>::IndexT,
-                           HotArchiveBucket::IndexT>);
 }

--- a/src/bucket/BucketBase.h
+++ b/src/bucket/BucketBase.h
@@ -54,20 +54,14 @@ class LiveBucket;
 class LiveBucketIndex;
 class HotArchiveBucketIndex;
 
-template <IsBucketType BucketT, class IndexT>
-class BucketBase : public NonMovableOrCopyable
+template <IsBucketType BucketT> class BucketBase : public NonMovableOrCopyable
 {
+  public:
     // Because of the CRTP design with derived Bucket classes, this base class
-    // does not have direct access to BucketT::IndexT, so we take two templates
-    // and make this assert.
-    static_assert(
-        std::is_same_v<
-            IndexT,
-            std::conditional_t<
-                std::is_same_v<BucketT, LiveBucket>, LiveBucketIndex,
-                std::conditional_t<std::is_same_v<BucketT, HotArchiveBucket>,
-                                   HotArchiveBucketIndex, void>>>,
-        "IndexT must match BucketT::IndexT");
+    // does not have direct access to BucketT::IndexT, so we hardcode the
+    // index types
+    using IndexT = std::conditional_t<std::is_same_v<BucketT, LiveBucket>,
+                                      LiveBucketIndex, HotArchiveBucketIndex>;
 
   protected:
     std::filesystem::path const mFilename;

--- a/src/bucket/BucketBase.h
+++ b/src/bucket/BucketBase.h
@@ -20,7 +20,7 @@ class io_context;
 namespace stellar
 {
 
-template <class BucketT> class SearchableBucketListSnapshot;
+template <IsBucketType BucketT> class SearchableBucketListSnapshot;
 
 /**
  * Bucket is an immutable container for a sorted set of "Entries" (object ID,
@@ -54,11 +54,9 @@ class LiveBucket;
 class LiveBucketIndex;
 class HotArchiveBucketIndex;
 
-template <class BucketT, class IndexT>
+template <IsBucketType BucketT, class IndexT>
 class BucketBase : public NonMovableOrCopyable
 {
-    BUCKET_TYPE_ASSERT(BucketT);
-
     // Because of the CRTP design with derived Bucket classes, this base class
     // does not have direct access to BucketT::IndexT, so we take two templates
     // and make this assert.
@@ -202,6 +200,6 @@ class BucketBase : public NonMovableOrCopyable
 
 #endif // BUILD_TESTS
 
-    template <class T> friend class SearchableBucketListSnapshot;
+    template <IsBucketType T> friend class SearchableBucketListSnapshot;
 };
 }

--- a/src/bucket/BucketIndexUtils.cpp
+++ b/src/bucket/BucketIndexUtils.cpp
@@ -27,13 +27,11 @@ getPageSizeFromConfig(Config const& cfg)
     return 1UL << cfg.BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT;
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 std::shared_ptr<typename BucketT::IndexT const>
 createIndex(BucketManager& bm, std::filesystem::path const& filename,
             Hash const& hash, asio::io_context& ctx, SHA256* hasher)
 {
-    BUCKET_TYPE_ASSERT(BucketT);
-
     ZoneScoped;
     releaseAssertOrThrow(!filename.empty());
 
@@ -50,7 +48,7 @@ createIndex(BucketManager& bm, std::filesystem::path const& filename,
     }
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 std::shared_ptr<typename BucketT::IndexT const>
 loadIndex(BucketManager const& bm, std::filesystem::path const& filename,
           std::size_t fileSize)

--- a/src/bucket/BucketIndexUtils.h
+++ b/src/bucket/BucketIndexUtils.h
@@ -100,7 +100,7 @@ std::streamoff getPageSizeFromConfig(Config const& cfg);
 // DiskIndex or InMemoryIndex depending on config and Bucket size.
 // Note: Constructor does not initialize the cache for live bucket indexes,
 // as this must be done when the Bucket is being added to the BucketList
-template <class BucketT>
+template <IsBucketType BucketT>
 std::shared_ptr<typename BucketT::IndexT const>
 createIndex(BucketManager& bm, std::filesystem::path const& filename,
             Hash const& hash, asio::io_context& ctx, SHA256* hasher);
@@ -109,7 +109,7 @@ createIndex(BucketManager& bm, std::filesystem::path const& filename,
 // index does not have expected version or pageSize, return null
 // Note: Constructor does not initialize the cache for live bucket indexes,
 // as this must be done when the Bucket is being added to the BucketList
-template <class BucketT>
+template <IsBucketType BucketT>
 std::shared_ptr<typename BucketT::IndexT const>
 loadIndex(BucketManager const& bm, std::filesystem::path const& filename,
           std::size_t fileSize);

--- a/src/bucket/BucketInputIterator.cpp
+++ b/src/bucket/BucketInputIterator.cpp
@@ -15,7 +15,7 @@ namespace stellar
  * Helper class that reads from the file underlying a bucket, keeping the bucket
  * alive for the duration of its existence.
  */
-template <typename BucketT>
+template <IsBucketType BucketT>
 void
 BucketInputIterator<BucketT>::loadEntry()
 {
@@ -84,47 +84,48 @@ BucketInputIterator<BucketT>::loadEntry()
     }
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 std::streamoff
 BucketInputIterator<BucketT>::pos()
 {
     return mIn.pos();
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 size_t
 BucketInputIterator<BucketT>::size() const
 {
     return mIn.size();
 }
 
-template <typename BucketT> BucketInputIterator<BucketT>::operator bool() const
+template <IsBucketType BucketT>
+BucketInputIterator<BucketT>::operator bool() const
 {
     return mEntryPtr != nullptr;
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 typename BucketT::EntryT const&
 BucketInputIterator<BucketT>::operator*()
 {
     return *mEntryPtr;
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 bool
 BucketInputIterator<BucketT>::seenMetadata() const
 {
     return mSeenMetadata;
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 BucketMetadata const&
 BucketInputIterator<BucketT>::getMetadata() const
 {
     return mMetadata;
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 BucketInputIterator<BucketT>::BucketInputIterator(
     std::shared_ptr<BucketT const> bucket)
     : mBucket(bucket), mEntryPtr(nullptr), mSeenMetadata(false)
@@ -145,12 +146,13 @@ BucketInputIterator<BucketT>::BucketInputIterator(
     }
 }
 
-template <typename BucketT> BucketInputIterator<BucketT>::~BucketInputIterator()
+template <IsBucketType BucketT>
+BucketInputIterator<BucketT>::~BucketInputIterator()
 {
     mIn.close();
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 BucketInputIterator<BucketT>&
 BucketInputIterator<BucketT>::operator++()
 {
@@ -165,7 +167,7 @@ BucketInputIterator<BucketT>::operator++()
     return *this;
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 void
 BucketInputIterator<BucketT>::seek(std::streamoff offset)
 {

--- a/src/bucket/BucketInputIterator.h
+++ b/src/bucket/BucketInputIterator.h
@@ -17,9 +17,8 @@ class LiveBucket;
 class HotArchiveBucket;
 
 // Helper class that reads through the entries in a bucket.
-template <typename BucketT> class BucketInputIterator
+template <IsBucketType BucketT> class BucketInputIterator
 {
-    BUCKET_TYPE_ASSERT(BucketT);
 
     std::shared_ptr<BucketT const> mBucket;
 

--- a/src/bucket/BucketListBase.cpp
+++ b/src/bucket/BucketListBase.cpp
@@ -22,7 +22,7 @@
 namespace stellar
 {
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 BucketLevel<BucketT>::BucketLevel(uint32_t i)
     : mLevel(i)
     , mNextCurr(FutureBucket<BucketT>())
@@ -31,7 +31,7 @@ BucketLevel<BucketT>::BucketLevel(uint32_t i)
 {
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 uint256
 BucketLevel<BucketT>::getHash() const
 {
@@ -41,7 +41,7 @@ BucketLevel<BucketT>::getHash() const
     return hsh.finish();
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 FutureBucket<BucketT> const&
 BucketLevel<BucketT>::getNext() const
 {
@@ -49,7 +49,7 @@ BucketLevel<BucketT>::getNext() const
     return std::get<FutureBucket<BucketT>>(mNextCurr);
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 FutureBucket<BucketT>&
 BucketLevel<BucketT>::getNext()
 {
@@ -57,7 +57,7 @@ BucketLevel<BucketT>::getNext()
     return std::get<FutureBucket<BucketT>>(mNextCurr);
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 void
 BucketLevel<BucketT>::setNext(FutureBucket<BucketT> const& fb)
 {
@@ -65,7 +65,7 @@ BucketLevel<BucketT>::setNext(FutureBucket<BucketT> const& fb)
     mNextCurr = fb;
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 void
 BucketLevel<BucketT>::setNextInMemory(std::shared_ptr<BucketT>&& bucket)
 {
@@ -73,28 +73,28 @@ BucketLevel<BucketT>::setNextInMemory(std::shared_ptr<BucketT>&& bucket)
     mNextCurr = std::move(bucket);
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 void
 BucketLevel<BucketT>::clearNext()
 {
     mNextCurr = FutureBucket<BucketT>();
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 std::shared_ptr<BucketT>
 BucketLevel<BucketT>::getCurr() const
 {
     return mCurr;
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 std::shared_ptr<BucketT>
 BucketLevel<BucketT>::getSnap() const
 {
     return mSnap;
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 void
 BucketLevel<BucketT>::setCurr(std::shared_ptr<BucketT> b)
 {
@@ -102,11 +102,11 @@ BucketLevel<BucketT>::setCurr(std::shared_ptr<BucketT> b)
     mCurr = b;
 }
 
-template <typename BucketT> BucketListBase<BucketT>::~BucketListBase()
+template <IsBucketType BucketT> BucketListBase<BucketT>::~BucketListBase()
 {
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 bool
 BucketListBase<BucketT>::shouldMergeWithEmptyCurr(uint32_t ledger,
                                                   uint32_t level)
@@ -135,7 +135,7 @@ BucketListBase<BucketT>::shouldMergeWithEmptyCurr(uint32_t ledger,
     return false;
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 void
 BucketLevel<BucketT>::setSnap(std::shared_ptr<BucketT> b)
 {
@@ -143,28 +143,28 @@ BucketLevel<BucketT>::setSnap(std::shared_ptr<BucketT> b)
     mSnap = b;
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 bool
 BucketLevel<BucketT>::hasInMemoryMerge() const
 {
     return std::holds_alternative<std::shared_ptr<BucketT>>(mNextCurr);
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 bool
 BucketLevel<BucketT>::hasFutureBucketMerge() const
 {
     return std::holds_alternative<FutureBucket<BucketT>>(mNextCurr);
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 bool
 BucketLevel<BucketT>::hasInProgressMerge() const
 {
     return hasInMemoryMerge() || getNext().isMerging();
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 void
 BucketLevel<BucketT>::commit()
 {
@@ -287,7 +287,7 @@ BucketLevel<HotArchiveBucket>::prepareFirstLevel(
 // ----------------------------------------------------------------------------------------
 // ...
 // clang-format on
-template <typename BucketT>
+template <IsBucketType BucketT>
 void
 BucketLevel<BucketT>::prepare(
     Application& app, uint32_t currLedger, uint32_t currLedgerProtocol,
@@ -315,7 +315,7 @@ BucketLevel<BucketT>::prepare(
     releaseAssert(getNext().isMerging());
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 std::shared_ptr<BucketT>
 BucketLevel<BucketT>::snap()
 {
@@ -356,7 +356,7 @@ operator uint32_t() const
 // levelSize(8)  =  262144=0x040000
 // levelSize(9)  = 1048576=0x100000
 // levelSize(10) = 4194304=0x400000
-template <typename BucketT>
+template <IsBucketType BucketT>
 uint32_t
 BucketListBase<BucketT>::levelSize(uint32_t level)
 {
@@ -379,14 +379,14 @@ BucketListBase<BucketT>::levelSize(uint32_t level)
 // levelHalf(8)  =  131072=0x020000
 // levelHalf(9)  =  524288=0x080000
 // levelHalf(10) = 2097152=0x200000
-template <typename BucketT>
+template <IsBucketType BucketT>
 uint32_t
 BucketListBase<BucketT>::levelHalf(uint32_t level)
 {
     return levelSize(level) >> 1;
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 uint32_t
 BucketListBase<BucketT>::sizeOfCurr(uint32_t ledger, uint32_t level)
 {
@@ -436,7 +436,7 @@ BucketListBase<BucketT>::sizeOfCurr(uint32_t ledger, uint32_t level)
     }
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 uint32_t
 BucketListBase<BucketT>::sizeOfSnap(uint32_t ledger, uint32_t level)
 {
@@ -463,7 +463,7 @@ BucketListBase<BucketT>::sizeOfSnap(uint32_t ledger, uint32_t level)
     }
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 uint32_t
 BucketListBase<BucketT>::oldestLedgerInCurr(uint32_t ledger, uint32_t level)
 {
@@ -484,7 +484,7 @@ BucketListBase<BucketT>::oldestLedgerInCurr(uint32_t ledger, uint32_t level)
     return count + 1;
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 uint32_t
 BucketListBase<BucketT>::oldestLedgerInSnap(uint32_t ledger, uint32_t level)
 {
@@ -504,7 +504,7 @@ BucketListBase<BucketT>::oldestLedgerInSnap(uint32_t ledger, uint32_t level)
     return count + 1;
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 uint256
 BucketListBase<BucketT>::getHash() const
 {
@@ -536,7 +536,7 @@ BucketListBase<BucketT>::getHash() const
 //
 // clang-format on
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 bool
 BucketListBase<BucketT>::levelShouldSpill(uint32_t ledger, uint32_t level)
 {
@@ -555,7 +555,7 @@ BucketListBase<BucketT>::levelShouldSpill(uint32_t ledger, uint32_t level)
 // spill frequency of the level below.
 // incoming_spill_frequency(i) = 2^(2i - 1) for i > 0
 // incoming_spill_frequency(0) = 1
-template <typename BucketT>
+template <IsBucketType BucketT>
 uint32_t
 BucketListBase<BucketT>::bucketUpdatePeriod(uint32_t level, bool isCurr)
 {
@@ -574,21 +574,21 @@ BucketListBase<BucketT>::bucketUpdatePeriod(uint32_t level, bool isCurr)
     return 1u << (2 * level - 1);
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 bool
 BucketListBase<BucketT>::keepTombstoneEntries(uint32_t level)
 {
     return level < BucketListBase<BucketT>::kNumLevels - 1;
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 BucketLevel<BucketT> const&
 BucketListBase<BucketT>::getLevel(uint32_t i) const
 {
     return mLevels.at(i);
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 BucketLevel<BucketT>&
 BucketListBase<BucketT>::getLevel(uint32_t i)
 {
@@ -596,7 +596,7 @@ BucketListBase<BucketT>::getLevel(uint32_t i)
 }
 
 #ifdef BUILD_TESTS
-template <typename BucketT>
+template <IsBucketType BucketT>
 void
 BucketListBase<BucketT>::resolveAllFutures()
 {
@@ -611,7 +611,7 @@ BucketListBase<BucketT>::resolveAllFutures()
 }
 #endif
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 void
 BucketListBase<BucketT>::resolveAnyReadyFutures()
 {
@@ -625,7 +625,7 @@ BucketListBase<BucketT>::resolveAnyReadyFutures()
     }
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 bool
 BucketListBase<BucketT>::futuresAllResolved(uint32_t maxLevel) const
 {
@@ -642,7 +642,7 @@ BucketListBase<BucketT>::futuresAllResolved(uint32_t maxLevel) const
     return true;
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 uint32_t
 BucketListBase<BucketT>::getMaxMergeLevel(uint32_t currLedger) const
 {
@@ -657,7 +657,7 @@ BucketListBase<BucketT>::getMaxMergeLevel(uint32_t currLedger) const
     return i;
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 uint64_t
 BucketListBase<BucketT>::getSize() const
 {
@@ -678,7 +678,7 @@ BucketListBase<BucketT>::getSize() const
     return sum;
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 template <typename... VectorT>
 void
 BucketListBase<BucketT>::addBatchInternal(Application& app, uint32_t currLedger,
@@ -796,7 +796,7 @@ BucketListBase<BucketT>::addBatchInternal(Application& app, uint32_t currLedger,
     }
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 void
 BucketListBase<BucketT>::restartMerges(Application& app,
                                        uint32_t maxProtocolVersion,
@@ -870,7 +870,7 @@ BucketListBase<BucketT>::restartMerges(Application& app,
     }
 }
 
-template <typename BucketT> BucketListBase<BucketT>::BucketListBase()
+template <IsBucketType BucketT> BucketListBase<BucketT>::BucketListBase()
 {
     for (uint32_t i = 0; i < kNumLevels; ++i)
     {

--- a/src/bucket/BucketListBase.h
+++ b/src/bucket/BucketListBase.h
@@ -353,13 +353,11 @@ struct InflationWinner;
 
 namespace testutil
 {
-template <class BucketT> class BucketListDepthModifier;
+template <IsBucketType BucketT> class BucketListDepthModifier;
 }
 
-template <class BucketT> class BucketLevel
+template <IsBucketType BucketT> class BucketLevel
 {
-    BUCKET_TYPE_ASSERT(BucketT);
-
     uint32_t mLevel;
     // Variant to hold either a FutureBucket (for async merges) or a
     // shared_ptr<BucketT> (for in-memory merges)
@@ -417,7 +415,8 @@ class BucketListDepth
 
     operator uint32_t() const;
 
-    template <class BucketT> friend class testutil::BucketListDepthModifier;
+    template <IsBucketType BucketT>
+    friend class testutil::BucketListDepthModifier;
 };
 
 // While every BucketList shares the same high level structure wrt to spill
@@ -426,10 +425,8 @@ class BucketListDepth
 // entry level. This abstract base class defines the shared structure of all
 // BucketLists. It must be extended for each specific BucketList type, where the
 // template parameter BucketT refers to the underlying Bucket type.
-template <class BucketT> class BucketListBase
+template <IsBucketType BucketT> class BucketListBase
 {
-    BUCKET_TYPE_ASSERT(BucketT);
-
   protected:
     std::vector<BucketLevel<BucketT>> mLevels;
 

--- a/src/bucket/BucketListSnapshot.cpp
+++ b/src/bucket/BucketListSnapshot.cpp
@@ -24,13 +24,13 @@ namespace stellar
 // BucketListSnapshotData
 //
 
-template <class BucketT>
+template <IsBucketType BucketT>
 BucketListSnapshotData<BucketT>::Level::Level(BucketLevel<BucketT> const& level)
     : curr(level.getCurr()), snap(level.getSnap())
 {
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 BucketListSnapshotData<BucketT>::Level::Level(
     std::shared_ptr<BucketT const> currBucket,
     std::shared_ptr<BucketT const> snapBucket)
@@ -38,7 +38,7 @@ BucketListSnapshotData<BucketT>::Level::Level(
 {
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 BucketListSnapshotData<BucketT>::BucketListSnapshotData(
     BucketListBase<BucketT> const& bl)
     : levels([&bl]() {
@@ -57,7 +57,7 @@ BucketListSnapshotData<BucketT>::BucketListSnapshotData(
 // SearchableBucketListSnapshot
 //
 
-template <class BucketT>
+template <IsBucketType BucketT>
 SearchableBucketListSnapshot<BucketT>::SearchableBucketListSnapshot(
     MetricsRegistry& metrics,
     std::shared_ptr<BucketListSnapshotData<BucketT> const> data,
@@ -81,7 +81,7 @@ SearchableBucketListSnapshot<BucketT>::SearchableBucketListSnapshot(
     }
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 SearchableBucketListSnapshot<BucketT>::SearchableBucketListSnapshot(
     SearchableBucketListSnapshot const& other)
     : mData(other.mData)
@@ -95,7 +95,7 @@ SearchableBucketListSnapshot<BucketT>::SearchableBucketListSnapshot(
 {
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 SearchableBucketListSnapshot<BucketT>&
 SearchableBucketListSnapshot<BucketT>::operator=(
     SearchableBucketListSnapshot const& other)
@@ -116,7 +116,7 @@ SearchableBucketListSnapshot<BucketT>::operator=(
 
 // File streams are fairly expensive to create, so they are lazily created and
 // stored in mStreams.
-template <class BucketT>
+template <IsBucketType BucketT>
 XDRInputFileStream&
 SearchableBucketListSnapshot<BucketT>::getStream(
     std::shared_ptr<BucketT const> const& bucket) const
@@ -135,7 +135,7 @@ SearchableBucketListSnapshot<BucketT>::getStream(
 // Loads an entry from the bucket file at the given offset. Returns a pair of
 // (entry, bloomMiss) where bloomMiss is true if the bloom filter indicated the
 // key might exist but it wasn't actually found (a false positive).
-template <class BucketT>
+template <IsBucketType BucketT>
 std::pair<std::shared_ptr<typename BucketT::EntryT const>, bool>
 SearchableBucketListSnapshot<BucketT>::getEntryAtOffset(
     std::shared_ptr<BucketT const> const& bucket, LedgerKey const& k,
@@ -166,7 +166,7 @@ SearchableBucketListSnapshot<BucketT>::getEntryAtOffset(
 // Looks up a single key in a bucket using its index. Returns (entry, bloomMiss)
 // where entry is nullptr if not found, and bloomMiss indicates a bloom filter
 // false positive (key appeared to exist but wasn't actually in the bucket).
-template <class BucketT>
+template <IsBucketType BucketT>
 std::pair<std::shared_ptr<typename BucketT::EntryT const>, bool>
 SearchableBucketListSnapshot<BucketT>::getBucketEntry(
     std::shared_ptr<BucketT const> const& bucket, LedgerKey const& k) const
@@ -205,7 +205,7 @@ SearchableBucketListSnapshot<BucketT>::getBucketEntry(
 // remove it from keys so that later buckets do not load shadowed entries. If we
 // don't find the entry, we keep it in keys so it will be searched for in lower
 // levels.
-template <class BucketT>
+template <IsBucketType BucketT>
 void
 SearchableBucketListSnapshot<BucketT>::loadKeysFromBucket(
     std::shared_ptr<BucketT const> const& bucket,
@@ -276,7 +276,7 @@ SearchableBucketListSnapshot<BucketT>::loadKeysFromBucket(
     }
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 template <typename Func>
 void
 SearchableBucketListSnapshot<BucketT>::loopAllBuckets(
@@ -301,7 +301,7 @@ SearchableBucketListSnapshot<BucketT>::loopAllBuckets(
     }
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 template <typename Func>
 void
 SearchableBucketListSnapshot<BucketT>::loopAllBuckets(Func&& f) const
@@ -310,7 +310,7 @@ SearchableBucketListSnapshot<BucketT>::loopAllBuckets(Func&& f) const
     loopAllBuckets(std::forward<Func>(f), *mData);
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 std::shared_ptr<typename BucketT::LoadT const>
 SearchableBucketListSnapshot<BucketT>::load(LedgerKey const& k) const
 {
@@ -345,7 +345,7 @@ SearchableBucketListSnapshot<BucketT>::load(LedgerKey const& k) const
     return result;
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 std::optional<std::vector<typename BucketT::LoadT>>
 SearchableBucketListSnapshot<BucketT>::loadKeysInternal(
     std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys,
@@ -381,7 +381,7 @@ SearchableBucketListSnapshot<BucketT>::loadKeysInternal(
     return entries;
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 std::optional<std::vector<typename BucketT::LoadT>>
 SearchableBucketListSnapshot<BucketT>::loadKeysFromLedger(
     std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys,
@@ -390,7 +390,7 @@ SearchableBucketListSnapshot<BucketT>::loadKeysFromLedger(
     return loadKeysInternal(inKeys, ledgerSeq);
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 medida::Timer&
 SearchableBucketListSnapshot<BucketT>::getBulkLoadTimer(
     std::string const& label, size_t numEntries) const
@@ -411,14 +411,14 @@ SearchableBucketListSnapshot<BucketT>::getBulkLoadTimer(
     return iter->second.get();
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 std::shared_ptr<BucketListSnapshotData<BucketT> const> const&
 SearchableBucketListSnapshot<BucketT>::getSnapshotData() const
 {
     return mData;
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 std::map<uint32_t,
          std::shared_ptr<BucketListSnapshotData<BucketT> const>> const&
 SearchableBucketListSnapshot<BucketT>::getHistoricalSnapshots() const

--- a/src/bucket/BucketListSnapshot.h
+++ b/src/bucket/BucketListSnapshot.h
@@ -39,18 +39,16 @@ struct EvictionResultEntry;
 struct InflationWinner;
 struct StateArchivalSettings;
 class EvictionStatistics;
-template <class BucketT> class BucketListBase;
-template <class BucketT> class BucketLevel;
+template <IsBucketType BucketT> class BucketListBase;
+template <IsBucketType BucketT> class BucketLevel;
 class ImmutableLedgerData;
 class ImmutableLedgerView;
 
 // BucketListSnapshotData holds the immutable bucket references that can be
 // safely shared across threads. It contains only bucket pointers and no
 // metadata (headers, sequence numbers, etc.) or mutable state (file streams).
-template <class BucketT> struct BucketListSnapshotData
+template <IsBucketType BucketT> struct BucketListSnapshotData
 {
-    BUCKET_TYPE_ASSERT(BucketT);
-
     struct Level
     {
         std::shared_ptr<BucketT const> const curr;
@@ -74,10 +72,8 @@ template <class BucketT> struct BucketListSnapshotData
 // - A single snapshot instance must only be used by one thread at a time.
 // - The underlying snapshot data (shared via shared_ptr) is immutable and
 //   can be safely shared.
-template <class BucketT> class SearchableBucketListSnapshot
+template <IsBucketType BucketT> class SearchableBucketListSnapshot
 {
-    BUCKET_TYPE_ASSERT(BucketT);
-
   protected:
     // Shared immutable snapshot data
     std::shared_ptr<BucketListSnapshotData<BucketT> const> mData;

--- a/src/bucket/BucketManager.cpp
+++ b/src/bucket/BucketManager.cpp
@@ -319,20 +319,18 @@ BucketManager::getMergeTimer()
     return mBucketSnapMerge;
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 medida::Meter&
 BucketManager::getBloomMissMeter() const
 {
-    BUCKET_TYPE_ASSERT(BucketT);
     return mAppConnector.getMetrics().NewMeter(
         {BucketT::METRIC_STRING, "bloom", "misses"}, "bloom");
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 medida::Meter&
 BucketManager::getBloomLookupMeter() const
 {
-    BUCKET_TYPE_ASSERT(BucketT);
     return mAppConnector.getMetrics().NewMeter(
         {BucketT::METRIC_STRING, "bloom", "lookups"}, "bloom");
 }
@@ -472,7 +470,7 @@ BucketManager::adoptFileAsBucket(
         mHotArchiveBucketFutures, std::move(inMemoryState));
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 std::shared_ptr<BucketT>
 BucketManager::adoptFileAsBucketInternal(
     std::string const& filename, uint256 const& hash, MergeKey* mergeKey,
@@ -480,7 +478,6 @@ BucketManager::adoptFileAsBucketInternal(
     BucketMapT<BucketT>& bucketMap, FutureMapT<BucketT>& futureMap,
     std::unique_ptr<std::vector<BucketEntry>> inMemoryState)
 {
-    BUCKET_TYPE_ASSERT(BucketT);
     ZoneScoped;
 
     if (mergeKey)
@@ -576,13 +573,11 @@ BucketManager::noteEmptyMergeOutput<HotArchiveBucket>(MergeKey const& mergeKey)
     noteEmptyMergeOutputInternal(mergeKey, mHotArchiveBucketFutures);
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 void
 BucketManager::noteEmptyMergeOutputInternal(MergeKey const& mergeKey,
                                             FutureMapT<BucketT>& futureMap)
 {
-    BUCKET_TYPE_ASSERT(BucketT);
-
     // We _do_ want to remove the mergeKey from mLiveFutures, both so that that
     // map does not grow without bound and more importantly so that we drop the
     // refcount on the input buckets so they get GC'ed from the bucket dir.
@@ -612,12 +607,11 @@ BucketManager::getBucketIfExists(uint256 const& hash)
     return getBucketIfExistsInternal(hash, mSharedHotArchiveBuckets);
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 std::shared_ptr<BucketT>
 BucketManager::getBucketIfExistsInternal(
     uint256 const& hash, BucketMapT<BucketT> const& bucketMap) const
 {
-    BUCKET_TYPE_ASSERT(BucketT);
     ZoneScoped;
     auto i = bucketMap.find(hash);
     if (i != bucketMap.end())
@@ -647,12 +641,11 @@ BucketManager::getBucketByHash(uint256 const& hash)
     return getBucketByHashInternal(hash, mSharedHotArchiveBuckets);
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 std::shared_ptr<BucketT>
 BucketManager::getBucketByHashInternal(uint256 const& hash,
                                        BucketMapT<BucketT>& bucketMap)
 {
-    BUCKET_TYPE_ASSERT(BucketT);
     ZoneScoped;
     if (isZero(hash))
     {
@@ -698,12 +691,11 @@ BucketManager::getMergeFuture(MergeKey const& key)
     return getMergeFutureInternal(key, mHotArchiveBucketFutures);
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 std::shared_future<std::shared_ptr<BucketT>>
 BucketManager::getMergeFutureInternal(MergeKey const& key,
                                       FutureMapT<BucketT>& futureMap)
 {
-    BUCKET_TYPE_ASSERT(BucketT);
     ZoneScoped;
     MergeCounters mc;
     auto i = futureMap.find(key);
@@ -763,13 +755,12 @@ BucketManager::putMergeFuture(
     putMergeFutureInternal(key, future, mHotArchiveBucketFutures);
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 void
 BucketManager::putMergeFutureInternal(
     MergeKey const& key, std::shared_future<std::shared_ptr<BucketT>> future,
     FutureMapT<BucketT>& futureMap)
 {
-    BUCKET_TYPE_ASSERT(BucketT);
     ZoneScoped;
     CLOG_TRACE(
         Bucket,
@@ -1133,7 +1124,7 @@ BucketManager::snapshotLedger(LedgerHeader& currentHeader)
     calculateSkipValues(currentHeader);
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 void
 BucketManager::maybeSetIndex(
     std::shared_ptr<BucketT> b,
@@ -1510,7 +1501,7 @@ loadEntriesFromHotArchiveBucket(std::shared_ptr<HotArchiveBucket> b,
               b->getSize(), name, ms, formatSize(bytesPerSec));
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 std::map<LedgerKey, LedgerEntry>
 BucketManager::loadCompleteBucketListStateHelper(
     std::vector<HistoryStateBucket<BucketT>> const& buckets,
@@ -1588,7 +1579,7 @@ BucketManager::mergeBuckets(asio::io_context& ctx,
     return out.getBucket(*this);
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 static bool
 visitBucketEntries(bool visitShadowedEntries, std::shared_ptr<BucketT const> b,
                    std::string const& name, std::optional<uint32_t> minLedger,

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -67,10 +67,10 @@ struct HistoryArchiveState;
  */
 class BucketManager : NonMovableOrCopyable
 {
-    template <class BucketT>
+    template <IsBucketType BucketT>
     using BucketMapT = std::map<Hash, std::shared_ptr<BucketT>>;
 
-    template <class BucketT>
+    template <IsBucketType BucketT>
     using FutureMapT =
         UnorderedMap<MergeKey, std::shared_future<std::shared_ptr<BucketT>>>;
 
@@ -156,7 +156,7 @@ class BucketManager : NonMovableOrCopyable
 
     void updateSharedBucketSize();
 
-    template <class BucketT>
+    template <IsBucketType BucketT>
     std::shared_ptr<BucketT> adoptFileAsBucketInternal(
         std::string const& filename, uint256 const& hash, MergeKey* mergeKey,
         std::shared_ptr<typename BucketT::IndexT const> index,
@@ -164,36 +164,36 @@ class BucketManager : NonMovableOrCopyable
         std::unique_ptr<std::vector<BucketEntry>> inMemoryState)
         REQUIRES(mBucketMutex);
 
-    template <class BucketT>
+    template <IsBucketType BucketT>
     std::shared_ptr<BucketT>
     getBucketByHashInternal(uint256 const& hash, BucketMapT<BucketT>& bucketMap)
         REQUIRES(mBucketMutex);
-    template <class BucketT>
+    template <IsBucketType BucketT>
     std::shared_ptr<BucketT>
     getBucketIfExistsInternal(uint256 const& hash,
                               BucketMapT<BucketT> const& bucketMap) const
         REQUIRES(mBucketMutex);
 
-    template <class BucketT>
+    template <IsBucketType BucketT>
     std::shared_future<std::shared_ptr<BucketT>>
     getMergeFutureInternal(MergeKey const& key, FutureMapT<BucketT>& futureMap)
         REQUIRES(mBucketMutex);
 
-    template <class BucketT>
+    template <IsBucketType BucketT>
     void
     putMergeFutureInternal(MergeKey const& key,
                            std::shared_future<std::shared_ptr<BucketT>> future,
                            FutureMapT<BucketT>& futureMap)
         REQUIRES(mBucketMutex);
 
-    template <class BucketT>
+    template <IsBucketType BucketT>
     void noteEmptyMergeOutputInternal(MergeKey const& mergeKey,
                                       FutureMapT<BucketT>& futureMap)
         REQUIRES(mBucketMutex);
 
     void reportLiveBucketIndexCacheMetrics();
 
-    template <class BucketT>
+    template <IsBucketType BucketT>
     std::map<LedgerKey, LedgerEntry> loadCompleteBucketListStateHelper(
         std::vector<HistoryStateBucket<BucketT>> const& buckets,
         std::function<void(std::shared_ptr<BucketT>, std::string const&,
@@ -236,15 +236,16 @@ class BucketManager : NonMovableOrCopyable
 
     medida::Timer& getMergeTimer();
 
-    template <class BucketT> medida::Meter& getBloomMissMeter() const;
-    template <class BucketT> medida::Meter& getBloomLookupMeter() const;
+    template <IsBucketType BucketT> medida::Meter& getBloomMissMeter() const;
+    template <IsBucketType BucketT> medida::Meter& getBloomLookupMeter() const;
     medida::Meter& getCacheHitMeter() const;
     medida::Meter& getCacheMissMeter() const;
 
     // Reading and writing the merge counters is done in bulk, and takes a lock
     // briefly; this can be done from any thread.
-    template <class BucketT> MergeCounters readMergeCounters();
-    template <class BucketT> void incrMergeCounters(MergeCounters const& delta);
+    template <IsBucketType BucketT> MergeCounters readMergeCounters();
+    template <IsBucketType BucketT>
+    void incrMergeCounters(MergeCounters const& delta);
 
     // Get a reference to a persistent bucket (in the BucketManager's bucket
     // directory), from the BucketManager's shared bucket-set.
@@ -257,7 +258,7 @@ class BucketManager : NonMovableOrCopyable
     // This method is mostly-threadsafe -- assuming you don't destruct the
     // BucketManager mid-call -- and is intended to be called from both main and
     // worker threads. Very carefully.
-    template <class BucketT>
+    template <IsBucketType BucketT>
     std::shared_ptr<BucketT> adoptFileAsBucket(
         std::string const& filename, uint256 const& hash, MergeKey* mergeKey,
         std::shared_ptr<typename BucketT::IndexT const> index,
@@ -269,16 +270,16 @@ class BucketManager : NonMovableOrCopyable
     // doesn't correspond to a file on disk; the method forgets about the
     // `FutureBucket` associated with the in-progress merge, allowing the merge
     // inputs to be GC'ed.
-    template <class BucketT>
+    template <IsBucketType BucketT>
     void noteEmptyMergeOutput(MergeKey const& mergeKey);
 
     // Returns a bucket by hash if it exists and is currently managed by the
     // bucket list.
-    template <class BucketT>
+    template <IsBucketType BucketT>
     std::shared_ptr<BucketT> getBucketIfExists(uint256 const& hash);
 
     // Return a bucket by hash if we have it, else return nullptr.
-    template <class BucketT>
+    template <IsBucketType BucketT>
     std::shared_ptr<BucketT> getBucketByHash(uint256 const& hash);
 
     // Get a reference to a merge-future that's either running (or finished
@@ -286,7 +287,7 @@ class BucketManager : NonMovableOrCopyable
     // merges and/or a set of records mapping merge inputs to outputs and the
     // set of outputs held in the BucketManager. Returns an invalid future if no
     // such future can be found or synthesized.
-    template <class BucketT>
+    template <IsBucketType BucketT>
     std::shared_future<std::shared_ptr<BucketT>>
     getMergeFuture(MergeKey const& key);
 
@@ -295,7 +296,7 @@ class BucketManager : NonMovableOrCopyable
     // There is no corresponding entry-removal API: the std::shared_future will
     // be removed from the map when the merge completes and the output file is
     // adopted.
-    template <class BucketT>
+    template <IsBucketType BucketT>
     void putMergeFuture(MergeKey const& key,
                         std::shared_future<std::shared_ptr<BucketT>> future);
 
@@ -331,7 +332,7 @@ class BucketManager : NonMovableOrCopyable
     // for each bucket. However, during startup there are race conditions where
     // a bucket may be indexed twice. If there is an index race, set index with
     // this function, otherwise use BucketBase::setIndex().
-    template <class BucketT>
+    template <IsBucketType BucketT>
     void maybeSetIndex(std::shared_ptr<BucketT> b,
                        std::shared_ptr<typename BucketT::IndexT const> index);
 

--- a/src/bucket/BucketMergeAdapter.h
+++ b/src/bucket/BucketMergeAdapter.h
@@ -14,7 +14,7 @@ namespace stellar
 // These classes provide wrappers around the inputs to a BucketMerge, namely
 // either BucketInputIterators for file based merges, or a vector of bucket
 // entries for in-memory merges.
-template <class BucketT> class MergeInput
+template <IsBucketType BucketT> class MergeInput
 {
   public:
     // Check if we're done - both iterators are exhausted
@@ -39,7 +39,8 @@ template <class BucketT> class MergeInput
     virtual ~MergeInput() = default;
 };
 
-template <class BucketT> class FileMergeInput : public MergeInput<BucketT>
+template <IsBucketType BucketT>
+class FileMergeInput : public MergeInput<BucketT>
 {
   private:
     BucketInputIterator<BucketT>& mOldIter;
@@ -103,7 +104,8 @@ template <class BucketT> class FileMergeInput : public MergeInput<BucketT>
     }
 };
 
-template <class BucketT> class MemoryMergeInput : public MergeInput<BucketT>
+template <IsBucketType BucketT>
+class MemoryMergeInput : public MergeInput<BucketT>
 {
   private:
     std::vector<typename BucketT::EntryT> const& mOldEntries;

--- a/src/bucket/BucketOutputIterator.cpp
+++ b/src/bucket/BucketOutputIterator.cpp
@@ -21,7 +21,7 @@ namespace stellar
  * Helper class that points to an output tempfile. Absorbs BucketEntries and
  * hashes them while writing to either destination. Produces a Bucket when done.
  */
-template <typename BucketT>
+template <IsBucketType BucketT>
 BucketOutputIterator<BucketT>::BucketOutputIterator(std::string const& tmpDir,
                                                     bool keepTombstoneEntries,
                                                     BucketMetadata const& meta,
@@ -73,7 +73,7 @@ BucketOutputIterator<BucketT>::BucketOutputIterator(std::string const& tmpDir,
     }
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 void
 BucketOutputIterator<BucketT>::put(typename BucketT::EntryT const& e)
 {
@@ -164,7 +164,7 @@ BucketOutputIterator<BucketT>::put(typename BucketT::EntryT const& e)
     *mBuf = e;
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 std::shared_ptr<BucketT>
 BucketOutputIterator<BucketT>::getBucket(
     BucketManager& bucketManager, MergeKey* mergeKey,

--- a/src/bucket/BucketOutputIterator.h
+++ b/src/bucket/BucketOutputIterator.h
@@ -20,10 +20,8 @@ class BucketManager;
 
 // Helper class that writes new elements to a file and returns a bucket
 // when finished.
-template <typename BucketT> class BucketOutputIterator
+template <IsBucketType BucketT> class BucketOutputIterator
 {
-    BUCKET_TYPE_ASSERT(BucketT);
-
   protected:
     std::filesystem::path mFilename;
     XDROutputFileStream mOut;

--- a/src/bucket/BucketUtils.cpp
+++ b/src/bucket/BucketUtils.cpp
@@ -322,7 +322,7 @@ isBucketMetaEntry<LiveBucket>(LiveBucket::EntryT const& be)
     return be.type() == METAENTRY;
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 void
 BucketEntryCounters::count(typename BucketT::EntryT const& be)
 {

--- a/src/bucket/BucketUtils.h
+++ b/src/bucket/BucketUtils.h
@@ -30,10 +30,9 @@ class HotArchiveBucket;
 class SearchableLiveBucketListSnapshot;
 class SearchableHotArchiveBucketListSnapshot;
 
-#define BUCKET_TYPE_ASSERT(BucketT) \
-    static_assert(std::is_same_v<BucketT, LiveBucket> || \
-                      std::is_same_v<BucketT, HotArchiveBucket>, \
-                  "BucketT must be a Bucket type")
+template <class T>
+concept IsBucketType =
+    std::same_as<T, LiveBucket> || std::same_as<T, HotArchiveBucket>;
 
 // A fine-grained merge-operation-counter structure for tracking various
 // events during merges. These are not medida counters because we do not
@@ -199,7 +198,8 @@ struct BucketEntryCounters
     std::map<LedgerEntryTypeAndDurability, size_t> entryTypeCounts;
     std::map<LedgerEntryTypeAndDurability, size_t> entryTypeSizes;
 
-    template <class BucketT> void count(typename BucketT::EntryT const& be);
+    template <IsBucketType BucketT>
+    void count(typename BucketT::EntryT const& be);
     BucketEntryCounters& operator+=(BucketEntryCounters const& other);
     bool operator==(BucketEntryCounters const& other) const;
     bool operator!=(BucketEntryCounters const& other) const;
@@ -215,10 +215,10 @@ struct BucketEntryCounters
     BucketEntryCounters();
 };
 
-template <class BucketT>
+template <IsBucketType BucketT>
 bool isBucketMetaEntry(typename BucketT::EntryT const& be);
 
-template <class BucketT>
+template <IsBucketType BucketT>
 LedgerEntryTypeAndDurability
 bucketEntryToLedgerEntryAndDurabilityType(typename BucketT::EntryT const& be);
 std::string toString(LedgerEntryTypeAndDurability let);

--- a/src/bucket/DiskIndex.cpp
+++ b/src/bucket/DiskIndex.cpp
@@ -56,7 +56,7 @@ upper_bound_pred(LedgerKey const& key, RangeIndex::value_type const& indexEntry)
 }
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 std::pair<IndexReturnT, typename DiskIndex<BucketT>::IterT>
 DiskIndex<BucketT>::scan(IterT start, LedgerKey const& k) const
 {
@@ -85,7 +85,7 @@ DiskIndex<BucketT>::scan(IterT start, LedgerKey const& k) const
     }
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 std::optional<std::pair<std::streamoff, std::streamoff>>
 DiskIndex<BucketT>::getOffsetBounds(LedgerKey const& lowerBound,
                                     LedgerKey const& upperBound) const
@@ -116,7 +116,7 @@ DiskIndex<BucketT>::getOffsetBounds(LedgerKey const& lowerBound,
     return std::make_pair(startOff, endOff);
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 std::optional<std::pair<std::streamoff, std::streamoff>>
 DiskIndex<BucketT>::getRangeForType(LedgerEntryType type) const
 {
@@ -129,7 +129,7 @@ DiskIndex<BucketT>::getRangeForType(LedgerEntryType type) const
     return std::nullopt;
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 DiskIndex<BucketT>::DiskIndex(BucketManager& bm,
                               std::filesystem::path const& filename,
                               std::streamoff pageSize, Hash const& hash,
@@ -268,7 +268,7 @@ DiskIndex<BucketT>::DiskIndex(BucketManager& bm,
     }
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 template <class Archive>
 DiskIndex<BucketT>::DiskIndex(Archive& ar, BucketManager const& bm,
                               std::streamoff pageSize)
@@ -289,7 +289,7 @@ DiskIndex<BucketT>::DiskIndex(Archive& ar, BucketManager const& bm,
     }
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 void
 DiskIndex<BucketT>::saveToDisk(BucketManager& bm, Hash const& hash,
                                asio::io_context& ctx) const
@@ -340,7 +340,7 @@ DiskIndex<BucketT>::saveToDisk(BucketManager& bm, Hash const& hash,
     }
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 void
 DiskIndex<BucketT>::markBloomMiss() const
 {
@@ -348,7 +348,7 @@ DiskIndex<BucketT>::markBloomMiss() const
 }
 
 #ifdef BUILD_TESTS
-template <class BucketT>
+template <IsBucketType BucketT>
 bool
 DiskIndex<BucketT>::operator==(DiskIndex<BucketT> const& in) const
 {

--- a/src/bucket/DiskIndex.h
+++ b/src/bucket/DiskIndex.h
@@ -67,9 +67,8 @@ using RangeIndex = std::vector<std::pair<RangeEntry, std::streamoff>>;
 // random eviction cache for partial caching, and a range based index + binary
 // fuse filter for disk lookups. Creating this index is expensive, so we persist
 // it to disk. We do not persist the random eviction cache.
-template <class BucketT> class DiskIndex : public NonMovableOrCopyable
+template <IsBucketType BucketT> class DiskIndex : public NonMovableOrCopyable
 {
-    BUCKET_TYPE_ASSERT(BucketT);
 
     // Fields from here are persisted on disk. Cereal doesn't like templates so
     // we define an inner struct to hold all serializable fields.

--- a/src/bucket/DiskIndex.h
+++ b/src/bucket/DiskIndex.h
@@ -15,6 +15,7 @@
 #include <cereal/types/memory.hpp>
 #include <cereal/types/vector.hpp>
 
+#include <concepts>
 #include <filesystem>
 #include <memory>
 
@@ -179,14 +180,13 @@ template <IsBucketType BucketT> class DiskIndex : public NonMovableOrCopyable
         ar(version, pageSize);
     }
 
-    // This messy template makes is such that this function is only defined
+    // This concept template makes it such that this function is only defined
     // when BucketT == LiveBucket
-    template <int..., typename T = BucketT,
-              std::enable_if_t<std::is_same_v<T, LiveBucket>, bool> = true>
+    template <typename T = BucketT>
+        requires std::same_as<T, BucketT> && std::same_as<T, LiveBucket>
     AssetPoolIDMap const&
     getAssetPoolIDMap() const
     {
-        static_assert(std::is_same_v<T, LiveBucket>);
         releaseAssert(mData.assetToPoolID);
         return *mData.assetToPoolID;
     }

--- a/src/bucket/DiskIndex.h
+++ b/src/bucket/DiskIndex.h
@@ -180,12 +180,9 @@ template <IsBucketType BucketT> class DiskIndex : public NonMovableOrCopyable
         ar(version, pageSize);
     }
 
-    // This concept template makes it such that this function is only defined
-    // when BucketT == LiveBucket
-    template <typename T = BucketT>
-        requires std::same_as<T, BucketT> && std::same_as<T, LiveBucket>
     AssetPoolIDMap const&
     getAssetPoolIDMap() const
+        requires std::same_as<BucketT, LiveBucket>
     {
         releaseAssert(mData.assetToPoolID);
         return *mData.assetToPoolID;

--- a/src/bucket/FutureBucket.cpp
+++ b/src/bucket/FutureBucket.cpp
@@ -32,7 +32,7 @@
 
 namespace stellar
 {
-template <class BucketT>
+template <IsBucketType BucketT>
 FutureBucket<BucketT>::FutureBucket(
     Application& app, std::shared_ptr<BucketT> const& curr,
     std::shared_ptr<BucketT> const& snap,
@@ -82,7 +82,7 @@ FutureBucket<BucketT>::FutureBucket(
     startMerge(app, maxProtocolVersion, countMergeEvents, level);
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 void
 FutureBucket<BucketT>::setLiveOutput(std::shared_ptr<BucketT> output)
 {
@@ -93,14 +93,14 @@ FutureBucket<BucketT>::setLiveOutput(std::shared_ptr<BucketT> output)
     checkState();
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 static void
 checkHashEq(std::shared_ptr<BucketT> const& b, std::string const& h)
 {
     releaseAssert(b->getHash() == hexToBin256(h));
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 void
 FutureBucket<BucketT>::checkHashesMatch() const
 {
@@ -135,7 +135,7 @@ FutureBucket<BucketT>::checkHashesMatch() const
  * the different hash-only states are mutually exclusive with each other and
  * with live values.
  */
-template <class BucketT>
+template <IsBucketType BucketT>
 void
 FutureBucket<BucketT>::checkState() const
 {
@@ -196,7 +196,7 @@ FutureBucket<BucketT>::checkState() const
     }
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 void
 FutureBucket<BucketT>::clearInputs()
 {
@@ -209,7 +209,7 @@ FutureBucket<BucketT>::clearInputs()
     mInputCurrBucketHash.clear();
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 void
 FutureBucket<BucketT>::clearOutput()
 {
@@ -220,7 +220,7 @@ FutureBucket<BucketT>::clearOutput()
     mOutputBucket.reset();
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 void
 FutureBucket<BucketT>::clear()
 {
@@ -229,35 +229,35 @@ FutureBucket<BucketT>::clear()
     clearOutput();
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 bool
 FutureBucket<BucketT>::isLive() const
 {
     return (mState == FB_LIVE_INPUTS || mState == FB_LIVE_OUTPUT);
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 bool
 FutureBucket<BucketT>::isMerging() const
 {
     return mState == FB_LIVE_INPUTS;
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 bool
 FutureBucket<BucketT>::hasHashes() const
 {
     return (mState == FB_HASH_INPUTS || mState == FB_HASH_OUTPUT);
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 bool
 FutureBucket<BucketT>::isClear() const
 {
     return mState == FB_CLEAR;
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 bool
 FutureBucket<BucketT>::mergeComplete() const
 {
@@ -271,7 +271,7 @@ FutureBucket<BucketT>::mergeComplete() const
     return futureIsReady(mOutputBucketFuture);
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 std::shared_ptr<BucketT>
 FutureBucket<BucketT>::resolve()
 {
@@ -303,7 +303,7 @@ FutureBucket<BucketT>::resolve()
     return mOutputBucket;
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 bool
 FutureBucket<BucketT>::hasOutputHash() const
 {
@@ -315,7 +315,7 @@ FutureBucket<BucketT>::hasOutputHash() const
     return false;
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 std::string const&
 FutureBucket<BucketT>::getOutputHash() const
 {
@@ -324,7 +324,7 @@ FutureBucket<BucketT>::getOutputHash() const
     return mOutputBucketHash;
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 static std::chrono::seconds
 getAvailableTimeForMerge(Application& app, uint32_t level)
 {
@@ -342,7 +342,7 @@ getAvailableTimeForMerge(Application& app, uint32_t level)
     return closeTime;
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 void
 FutureBucket<BucketT>::startMerge(Application& app, uint32_t maxProtocolVersion,
                                   bool countMergeEvents, uint32_t level)
@@ -460,7 +460,7 @@ FutureBucket<BucketT>::startMerge(Application& app, uint32_t maxProtocolVersion,
     checkState();
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 void
 FutureBucket<BucketT>::makeLive(Application& app, uint32_t maxProtocolVersion,
                                 uint32_t level)
@@ -499,7 +499,7 @@ FutureBucket<BucketT>::makeLive(Application& app, uint32_t maxProtocolVersion,
     }
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 std::vector<std::string>
 FutureBucket<BucketT>::getHashes() const
 {

--- a/src/bucket/FutureBucket.h
+++ b/src/bucket/FutureBucket.h
@@ -34,9 +34,8 @@ class HotArchiveBucket;
  * the bottom of closeLedger; and the HistoryManager, when storing and
  * retrieving HistoryArchiveStates.
  */
-template <class BucketT> class FutureBucket
+template <IsBucketType BucketT> class FutureBucket
 {
-    BUCKET_TYPE_ASSERT(BucketT);
 
     // There are two lifecycles of a FutureBucket:
     //

--- a/src/bucket/HotArchiveBucket.h
+++ b/src/bucket/HotArchiveBucket.h
@@ -13,8 +13,8 @@ namespace stellar
 {
 
 class HotArchiveBucket;
-template <typename T> class BucketOutputIterator;
-template <typename T> class BucketInputIterator;
+template <IsBucketType T> class BucketOutputIterator;
+template <IsBucketType T> class BucketInputIterator;
 
 typedef BucketInputIterator<HotArchiveBucket> HotArchiveBucketInputIterator;
 typedef BucketOutputIterator<HotArchiveBucket> HotArchiveBucketOutputIterator;

--- a/src/bucket/HotArchiveBucket.h
+++ b/src/bucket/HotArchiveBucket.h
@@ -23,9 +23,8 @@ typedef BucketOutputIterator<HotArchiveBucket> HotArchiveBucketOutputIterator;
  * Hot Archive Buckets are used by the HotBucketList to store recently evicted
  * entries. They contain entries of type HotArchiveBucketEntry.
  */
-class HotArchiveBucket
-    : public BucketBase<HotArchiveBucket, HotArchiveBucketIndex>,
-      public std::enable_shared_from_this<HotArchiveBucket>
+class HotArchiveBucket : public BucketBase<HotArchiveBucket>,
+                         public std::enable_shared_from_this<HotArchiveBucket>
 {
   public:
     // Entry type that this bucket stores

--- a/src/bucket/HotArchiveBucket.h
+++ b/src/bucket/HotArchiveBucket.h
@@ -33,8 +33,6 @@ class HotArchiveBucket : public BucketBase<HotArchiveBucket>,
     // Entry type returned by loadKeys
     using LoadT = HotArchiveBucketEntry;
 
-    using IndexT = HotArchiveBucketIndex;
-
     static inline constexpr char const* METRIC_STRING =
         "bucketlistDB-hotArchive";
 

--- a/src/bucket/LedgerCmp.h
+++ b/src/bucket/LedgerCmp.h
@@ -128,10 +128,8 @@ struct LedgerEntryIdCmp
  * LedgerEntries (ignoring their hashes, as the LedgerEntryIdCmp ignores their
  * bodies).
  */
-template <typename BucketT> struct BucketEntryIdCmp
+template <IsBucketType BucketT> struct BucketEntryIdCmp
 {
-    BUCKET_TYPE_ASSERT(BucketT);
-
     bool
     compareHotArchive(HotArchiveBucketEntry const& a,
                       HotArchiveBucketEntry const& b) const

--- a/src/bucket/LiveBucket.h
+++ b/src/bucket/LiveBucket.h
@@ -19,8 +19,8 @@ class AbstractLedgerTxn;
 class Application;
 class EvictionStatistics;
 class LiveBucket;
-template <typename T> class BucketOutputIterator;
-template <typename T> class BucketInputIterator;
+template <IsBucketType T> class BucketOutputIterator;
+template <IsBucketType T> class BucketInputIterator;
 
 typedef BucketOutputIterator<LiveBucket> LiveBucketOutputIterator;
 typedef BucketInputIterator<LiveBucket> LiveBucketInputIterator;

--- a/src/bucket/LiveBucket.h
+++ b/src/bucket/LiveBucket.h
@@ -29,7 +29,7 @@ typedef BucketInputIterator<LiveBucket> LiveBucketInputIterator;
  * Live Buckets are used by the LiveBucketList to store the current canonical
  * state of the ledger. They contain entries of type BucketEntry.
  */
-class LiveBucket : public BucketBase<LiveBucket, LiveBucketIndex>,
+class LiveBucket : public BucketBase<LiveBucket>,
                    public std::enable_shared_from_this<LiveBucket>
 {
     // Stores all BucketEntries (except METAENTRY) in the same order that they

--- a/src/bucket/LiveBucket.h
+++ b/src/bucket/LiveBucket.h
@@ -45,8 +45,6 @@ class LiveBucket : public BucketBase<LiveBucket>,
     // Entry type returned by loadKeys
     using LoadT = LedgerEntry;
 
-    using IndexT = LiveBucketIndex;
-
     static inline constexpr char const* METRIC_STRING = "bucketlistDB-live";
 
     LiveBucket();

--- a/src/bucket/test/BucketTestUtils.cpp
+++ b/src/bucket/test/BucketTestUtils.cpp
@@ -161,7 +161,7 @@ EntryCounts<HotArchiveBucket>::EntryCounts(
     }
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 size_t
 countEntries(std::shared_ptr<BucketT> bucket)
 {

--- a/src/bucket/test/BucketTestUtils.h
+++ b/src/bucket/test/BucketTestUtils.h
@@ -29,10 +29,8 @@ uint32_t getAppLedgerVersion(std::shared_ptr<Application> app);
 void for_versions_with_differing_bucket_logic(
     Config const& cfg, std::function<void(Config const&)> const& f);
 
-template <class BucketT> struct EntryCounts
+template <IsBucketType BucketT> struct EntryCounts
 {
-    BUCKET_TYPE_ASSERT(BucketT);
-
     size_t nMeta{0};
     size_t nInitOrArchived{0};
     size_t nLive{0};
@@ -51,7 +49,8 @@ template <class BucketT> struct EntryCounts
     EntryCounts(std::shared_ptr<BucketT> bucket);
 };
 
-template <class BucketT> size_t countEntries(std::shared_ptr<BucketT> bucket);
+template <IsBucketType BucketT>
+size_t countEntries(std::shared_ptr<BucketT> bucket);
 
 Hash closeLedger(Application& app, std::optional<SecretKey> skToSignValue,
                  xdr::xvector<UpgradeType, 6> upgrades = emptyUpgradeSteps);

--- a/src/catchup/ApplyBucketsWork.h
+++ b/src/catchup/ApplyBucketsWork.h
@@ -14,7 +14,7 @@ namespace stellar
 class AssumeStateWork;
 class LiveBucketList;
 class Bucket;
-template <class BucketT> class IndexBucketsWork;
+template <IsBucketType BucketT> class IndexBucketsWork;
 class LiveBucket;
 struct HistoryArchiveState;
 struct LedgerHeaderHistoryEntry;

--- a/src/catchup/IndexBucketsWork.cpp
+++ b/src/catchup/IndexBucketsWork.cpp
@@ -13,14 +13,14 @@
 
 namespace stellar
 {
-template <class BucketT>
+template <IsBucketType BucketT>
 IndexBucketsWork<BucketT>::IndexWork::IndexWork(Application& app,
                                                 std::shared_ptr<BucketT> b)
     : BasicWork(app, "index-work", BasicWork::RETRY_NEVER), mBucket(b)
 {
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 BasicWork::State
 IndexBucketsWork<BucketT>::IndexWork::onRun()
 {
@@ -32,21 +32,21 @@ IndexBucketsWork<BucketT>::IndexWork::onRun()
     return mState;
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 bool
 IndexBucketsWork<BucketT>::IndexWork::onAbort()
 {
     return true;
 };
 
-template <class BucketT>
+template <IsBucketType BucketT>
 void
 IndexBucketsWork<BucketT>::IndexWork::onReset()
 {
     mState = BasicWork::State::WORK_WAITING;
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 void
 IndexBucketsWork<BucketT>::IndexWork::postWork()
 {
@@ -131,14 +131,14 @@ IndexBucketsWork<BucketT>::IndexWork::postWork()
         "IndexWork: starting in background");
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 IndexBucketsWork<BucketT>::IndexBucketsWork(
     Application& app, std::vector<std::shared_ptr<BucketT>> const& buckets)
     : Work(app, "index-bucketList", BasicWork::RETRY_NEVER), mBuckets(buckets)
 {
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 BasicWork::State
 IndexBucketsWork<BucketT>::doWork()
 {
@@ -150,14 +150,14 @@ IndexBucketsWork<BucketT>::doWork()
     return checkChildrenStatus();
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 void
 IndexBucketsWork<BucketT>::doReset()
 {
     mWorkSpawned = false;
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 void
 IndexBucketsWork<BucketT>::spawnWork()
 {

--- a/src/catchup/IndexBucketsWork.h
+++ b/src/catchup/IndexBucketsWork.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "bucket/BucketUtils.h"
 #include "work/BasicWork.h"
 #include "work/Work.h"
 #include <memory>
@@ -15,7 +16,7 @@ class Bucket;
 class LiveBucketIndex;
 class BucketManager;
 
-template <class BucketT> class IndexBucketsWork : public Work
+template <IsBucketType BucketT> class IndexBucketsWork : public Work
 {
     class IndexWork : public BasicWork
     {

--- a/src/crypto/KeyUtils.h
+++ b/src/crypto/KeyUtils.h
@@ -10,6 +10,7 @@
 
 #include <sodium.h>
 
+#include <concepts>
 #include <string>
 
 namespace stellar
@@ -43,7 +44,11 @@ namespace KeyUtils
 {
 
 template <typename T>
-typename std::enable_if<!std::is_same<T, SecretKey>::value, std::string>::type
+concept IsKeyType = std::same_as<T, PublicKey> || std::same_as<T, SignerKey> ||
+                    std::same_as<T, SecretKey>;
+
+template <IsKeyType T>
+std::string
 toStrKey(T const& key)
 {
     return strKey::toStrKey(KeyFunctions<T>::toKeyVersion(key.type()),
@@ -51,23 +56,29 @@ toStrKey(T const& key)
         .value;
 }
 
-template <typename T>
-typename std::enable_if<std::is_same<T, SecretKey>::value, SecretValue>::type
+// We use a template on this to avoid needing SecretKey's declaration to be
+// visible in this file. The subsumption rules allow this overload to be
+// selected for SecretKey over the general `toStrKey`.
+template <IsKeyType T>
+    requires std::same_as<T, SecretKey>
+SecretValue
 toStrKey(T const& key)
 {
     return strKey::toStrKey(KeyFunctions<T>::toKeyVersion(key.type()),
                             KeyFunctions<T>::getKeyValue(key));
 }
 
-template <typename T>
-typename std::enable_if<!std::is_same<T, SecretKey>::value, std::string>::type
+template <IsKeyType T>
+std::string
 toShortString(T const& key)
 {
     return toStrKey(key).substr(0, 5);
 }
 
-template <typename T>
-typename std::enable_if<std::is_same<T, SecretKey>::value, SecretValue>::type
+// We require a template here for the same reason as in toStrKey (above)
+template <IsKeyType T>
+    requires std::same_as<T, SecretKey>
+SecretValue
 toShortString(T const& key)
 {
     return SecretValue{toStrKey(key).value.substr(0, 5)};
@@ -81,7 +92,7 @@ struct InvalidStrKey : public std::invalid_argument
     using std::invalid_argument::invalid_argument;
 };
 
-template <typename T>
+template <IsKeyType T>
 T
 fromStrKey(std::string const& s)
 {

--- a/src/crypto/XDRHasher.h
+++ b/src/crypto/XDRHasher.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <concepts>
 #include <xdrpp/endian.h>
 #include <xdrpp/marshal.h>
 
@@ -57,8 +58,9 @@ template <typename Derived> struct XDRHasher
         }
     }
     template <typename T>
-    typename std::enable_if<std::is_same<
-        std::uint32_t, typename xdr::xdr_traits<T>::uint_type>::value>::type
+        requires std::same_as<std::uint32_t,
+                              typename xdr::xdr_traits<T>::uint_type>
+    void
     operator()(T t)
     {
         auto u = xdr::swap32le(xdr::xdr_traits<T>::to_uint(t));
@@ -66,8 +68,9 @@ template <typename Derived> struct XDRHasher
     }
 
     template <typename T>
-    typename std::enable_if<std::is_same<
-        std::uint64_t, typename xdr::xdr_traits<T>::uint_type>::value>::type
+        requires std::same_as<std::uint64_t,
+                              typename xdr::xdr_traits<T>::uint_type>
+    void
     operator()(T t)
     {
         auto u = xdr::swap64le(xdr::xdr_traits<T>::to_uint(t));
@@ -75,7 +78,8 @@ template <typename Derived> struct XDRHasher
     }
 
     template <typename T>
-    typename std::enable_if<xdr::xdr_traits<T>::is_bytes>::type
+        requires xdr::xdr_traits<T>::is_bytes
+    void
     operator()(T const& t)
     {
         size_t len = t.size();
@@ -95,8 +99,9 @@ template <typename Derived> struct XDRHasher
     }
 
     template <typename T>
-    typename std::enable_if<xdr::xdr_traits<T>::is_class ||
-                            xdr::xdr_traits<T>::is_container>::type
+        requires xdr::xdr_traits<T>::is_class ||
+                 xdr::xdr_traits<T>::is_container
+    void
     operator()(T const& t)
     {
         xdr::xdr_traits<T>::save(*this, t);

--- a/src/history/FileTransferInfo.h
+++ b/src/history/FileTransferInfo.h
@@ -37,13 +37,12 @@ class FileTransferInfo
     std::string getLocalDir(TmpDir const& localRoot) const;
 
   public:
-    template <typename BucketT>
+    template <IsBucketType BucketT>
     FileTransferInfo(BucketT const& bucket)
         : mType(FileType::HISTORY_FILE_TYPE_BUCKET)
         , mHexDigits(binToHex(bucket.getHash()))
         , mLocalPath(bucket.getFilename().string())
     {
-        BUCKET_TYPE_ASSERT(BucketT);
     }
 
     FileTransferInfo(TmpDir const& snapDir, FileType const& snapType,

--- a/src/history/HistoryArchive.h
+++ b/src/history/HistoryArchive.h
@@ -34,9 +34,8 @@ namespace stellar
 
 class Application;
 
-template <class BucketT> struct HistoryStateBucket
+template <IsBucketType BucketT> struct HistoryStateBucket
 {
-    BUCKET_TYPE_ASSERT(BucketT);
     using bucket_type = BucketT;
     std::string curr;
 

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -144,7 +144,7 @@ RealGenesisTmpDirHistoryConfigurator::configure(Config& mCfg,
     return mCfg;
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 BucketOutputIteratorForTesting<BucketT>::BucketOutputIteratorForTesting(
     std::string const& tmpDir, uint32_t protocolVersion, MergeCounters& mc,
     asio::io_context& ctx)
@@ -154,7 +154,7 @@ BucketOutputIteratorForTesting<BucketT>::BucketOutputIteratorForTesting(
 {
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 std::pair<std::string, uint256>
 BucketOutputIteratorForTesting<BucketT>::writeTmpTestBucket()
 {
@@ -202,11 +202,10 @@ TestBucketGenerator::TestBucketGenerator(
         mApp.getTmpDirManager().tmpDir("tmp-bucket-generator"));
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 std::string
 TestBucketGenerator::generateBucket(TestBucketState state)
 {
-    BUCKET_TYPE_ASSERT(BucketT);
 
     uint256 hash = HashUtils::pseudoRandomForTesting();
     if (state == TestBucketState::FILE_NOT_UPLOADED)

--- a/src/history/test/HistoryTestsUtils.h
+++ b/src/history/test/HistoryTestsUtils.h
@@ -50,7 +50,7 @@ enum class TestBucketState
 
 class HistoryConfigurator;
 class TestBucketGenerator;
-template <typename BucketT> class BucketOutputIteratorForTesting;
+template <IsBucketType BucketT> class BucketOutputIteratorForTesting;
 struct CatchupPerformedWork;
 
 class HistoryConfigurator : NonCopyable
@@ -102,11 +102,9 @@ class RealGenesisTmpDirHistoryConfigurator : public TmpDirHistoryConfigurator
     Config& configure(Config& cfg, bool writable) const override;
 };
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 class BucketOutputIteratorForTesting : public BucketOutputIterator<BucketT>
 {
-    BUCKET_TYPE_ASSERT(BucketT);
-
     size_t const NUM_ITEMS_PER_BUCKET = 5;
 
   public:
@@ -127,7 +125,7 @@ class TestBucketGenerator
     TestBucketGenerator(Application& app,
                         std::shared_ptr<HistoryArchive> archive);
 
-    template <typename BucketT>
+    template <IsBucketType BucketT>
     std::string generateBucket(
         TestBucketState desiredState = TestBucketState::CONTENTS_AND_HASH_OK);
 };

--- a/src/historywork/DownloadBucketsWork.cpp
+++ b/src/historywork/DownloadBucketsWork.cpp
@@ -71,7 +71,7 @@ DownloadBucketsWork::resetIter()
     mHotBucketsState.nextIter = mHotBucketsState.hashes.begin();
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 void
 DownloadBucketsWork::onSuccessCb(Application& app, FileTransferInfo const& ft,
                                  std::string const& hash, int currId,
@@ -103,7 +103,7 @@ DownloadBucketsWork::onSuccessCb(Application& app, FileTransferInfo const& ft,
     state.buckets[hash] = b;
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 std::pair<std::shared_ptr<BasicWork>, std::function<bool(Application&)>>
 DownloadBucketsWork::prepareWorkForBucketType(
     std::string const& hash, FileTransferInfo const& ft,

--- a/src/historywork/DownloadBucketsWork.h
+++ b/src/historywork/DownloadBucketsWork.h
@@ -19,7 +19,7 @@ class FileTransferInfo;
 class DownloadBucketsWork : public BatchWork
 {
     // Wrapper around state associated with each BucketList
-    template <typename BucketT> struct BucketState
+    template <IsBucketType BucketT> struct BucketState
     {
         // Must hold mutex when accessing buckets
         std::map<std::string, std::shared_ptr<BucketT>>& buckets;
@@ -51,14 +51,14 @@ class DownloadBucketsWork : public BatchWork
     TmpDir const& mDownloadDir;
     std::shared_ptr<HistoryArchive> mArchive;
 
-    template <typename BucketT>
+    template <IsBucketType BucketT>
     static void onSuccessCb(Application& app, FileTransferInfo const& ft,
                             std::string const& hash, int currId,
                             BucketState<BucketT>& state);
 
     // Helper function returns pair of verifyBucketWork and a callback to adopt
     // the verified BucketList.
-    template <typename BucketT>
+    template <IsBucketType BucketT>
     std::pair<std::shared_ptr<BasicWork>, std::function<bool(Application&)>>
     prepareWorkForBucketType(std::string const& hash,
                              FileTransferInfo const& ft,

--- a/src/historywork/VerifyBucketWork.cpp
+++ b/src/historywork/VerifyBucketWork.cpp
@@ -21,7 +21,7 @@
 namespace stellar
 {
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 VerifyBucketWork<BucketT>::VerifyBucketWork(
     Application& app, std::string const& bucketFile, uint256 const& hash,
     std::shared_ptr<typename BucketT::IndexT const>& index,
@@ -34,7 +34,7 @@ VerifyBucketWork<BucketT>::VerifyBucketWork(
 {
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 BasicWork::State
 VerifyBucketWork<BucketT>::onRun()
 {
@@ -52,7 +52,7 @@ VerifyBucketWork<BucketT>::onRun()
     return State::WORK_WAITING;
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 void
 VerifyBucketWork<BucketT>::spawnVerifier()
 {
@@ -151,7 +151,7 @@ VerifyBucketWork<BucketT>::spawnVerifier()
         "VerifyBucket: start in background");
 }
 
-template <typename BucketT>
+template <IsBucketType BucketT>
 void
 VerifyBucketWork<BucketT>::onFailureRaise()
 {

--- a/src/historywork/VerifyBucketWork.h
+++ b/src/historywork/VerifyBucketWork.h
@@ -20,10 +20,8 @@ class LiveBucketIndex;
 
 class Bucket;
 
-template <typename BucketT> class VerifyBucketWork : public BasicWork
+template <IsBucketType BucketT> class VerifyBucketWork : public BasicWork
 {
-    BUCKET_TYPE_ASSERT(BucketT);
-
     std::string mBucketFile;
     uint256 mHash;
     bool mDone{false};

--- a/src/invariant/test/InvariantTests.cpp
+++ b/src/invariant/test/InvariantTests.cpp
@@ -664,13 +664,13 @@ TEST_CASE("BucketList state consistency invariant", "[invariant]")
         else
         {
             auto it = modifiedState.mContractDataEntries.begin();
-            auto const& entryData = it->get();
+            auto const& entryData = *it;
             LedgerEntry modifiedEntry = *entryData.ledgerEntry;
             modifiedEntry.lastModifiedLedgerSeq += 100;
             auto ttlData = entryData.ttlData;
             modifiedState.mContractDataEntries.erase(it);
             modifiedState.mContractDataEntries.emplace(
-                InternalContractDataMapEntry(modifiedEntry, ttlData));
+                std::make_shared<LedgerEntry const>(modifiedEntry), ttlData);
         }
 
         auto result =
@@ -711,7 +711,7 @@ TEST_CASE("BucketList state consistency invariant", "[invariant]")
                 createContractDataWithTTL(PERSISTENT, 1000);
             TTLData ttlData(extraTTL.data.ttl().liveUntilLedgerSeq, 1);
             modifiedState.mContractDataEntries.emplace(
-                InternalContractDataMapEntry(extraEntry, ttlData));
+                std::make_shared<LedgerEntry const>(extraEntry), ttlData);
         }
 
         auto result =
@@ -736,13 +736,13 @@ TEST_CASE("BucketList state consistency invariant", "[invariant]")
 
         // Corrupt TTL of an entry in the cache
         auto it = modifiedState.mContractDataEntries.begin();
-        auto const& entryData = it->get();
+        auto const& entryData = *it;
         LedgerEntry entryCopy = *entryData.ledgerEntry;
 
         TTLData wrongTTL(42, 1);
         modifiedState.mContractDataEntries.erase(it);
         modifiedState.mContractDataEntries.emplace(
-            InternalContractDataMapEntry(entryCopy, wrongTTL));
+            std::make_shared<LedgerEntry const>(entryCopy), wrongTTL);
 
         auto result =
             invariant.checkSnapshot(makeSnap(), modifiedState, noopIsStopping);

--- a/src/ledger/ImmutableLedgerView.cpp
+++ b/src/ledger/ImmutableLedgerView.cpp
@@ -227,7 +227,7 @@ namespace
 // Build the next historical snapshot map by copying the previous map,
 // evicting the oldest entry if at capacity, and inserting the previous
 // state's current snapshot keyed by its ledger sequence number.
-template <class BucketT>
+template <IsBucketType BucketT>
 auto
 rotateHistorical(
     std::shared_ptr<BucketListSnapshotData<BucketT> const> const& prevData,

--- a/src/ledger/InMemorySorobanState.cpp
+++ b/src/ledger/InMemorySorobanState.cpp
@@ -367,11 +367,13 @@ InMemorySorobanState::InMemorySorobanState(InMemorySorobanState const& other)
     , mContractCodeStateSize(other.mContractCodeStateSize)
     , mContractDataStateSize(other.mContractDataStateSize)
 {
-    // InternalContractDataMapEntry has an explicit copy constructor that
-    // deep-copies via clone(), so we can just use emplace.
+    // ContractDataMapEntryT uses shared_ptr, so we must explicitly deep-copy
+    // each LedgerEntry.
     for (auto const& entry : other.mContractDataEntries)
     {
-        mContractDataEntries.emplace(entry);
+        mContractDataEntries.emplace(
+            std::make_shared<LedgerEntry const>(*entry.ledgerEntry),
+            entry.ttlData);
     }
 
     // ContractCodeMapEntryT uses shared_ptr, so we must explicitly deep-copy

--- a/src/ledger/InMemorySorobanState.cpp
+++ b/src/ledger/InMemorySorobanState.cpp
@@ -51,15 +51,12 @@ TTLData::isDefault() const
 
 void
 InMemorySorobanState::updateContractDataTTL(
-    std::unordered_set<InternalContractDataMapEntry,
-                       InternalContractDataEntryHash>::iterator dataIt,
-    TTLData newTtlData)
+    InternalContractDataMap::iterator dataIt, TTLData newTtlData)
 {
     // Since entries are immutable, we must erase and re-insert
-    auto ledgerEntryPtr = dataIt->get().ledgerEntry;
+    auto ledgerEntryPtr = dataIt->ledgerEntry;
     mContractDataEntries.erase(dataIt);
-    mContractDataEntries.emplace(
-        InternalContractDataMapEntry(std::move(ledgerEntryPtr), newTtlData));
+    mContractDataEntries.emplace(std::move(ledgerEntryPtr), newTtlData);
 }
 
 void
@@ -73,7 +70,7 @@ InMemorySorobanState::updateTTL(LedgerEntry const& ttlEntry)
 
     // TTL updates can apply to either ContractData or ContractCode entries.
     // First check if this TTL belongs to a stored ContractData entry.
-    auto dataIt = mContractDataEntries.find(InternalContractDataMapEntry(lk));
+    auto dataIt = mContractDataEntries.find(lk);
     if (dataIt != mContractDataEntries.end())
     {
         updateContractDataTTL(dataIt, newTtlData);
@@ -95,19 +92,19 @@ InMemorySorobanState::updateContractData(LedgerEntry const& ledgerEntry)
 
     // Entry must already exist since this is an update
     auto lk = LedgerEntryKey(ledgerEntry);
-    auto dataIt = mContractDataEntries.find(InternalContractDataMapEntry(lk));
+    auto dataIt = mContractDataEntries.find(lk);
     releaseAssertOrThrow(dataIt != mContractDataEntries.end());
-    releaseAssertOrThrow(dataIt->get().ledgerEntry != nullptr);
+    releaseAssertOrThrow(dataIt->ledgerEntry != nullptr);
 
-    uint32_t oldSize = xdr::xdr_size(*dataIt->get().ledgerEntry);
+    uint32_t oldSize = xdr::xdr_size(*dataIt->ledgerEntry);
     uint32_t newSize = xdr::xdr_size(ledgerEntry);
     updateStateSizeOnEntryUpdate(oldSize, newSize, /*isContractCode=*/false);
 
     // Preserve the existing TTL while updating the data
-    auto preservedTTL = dataIt->get().ttlData;
+    auto preservedTTL = dataIt->ttlData;
     mContractDataEntries.erase(dataIt);
     mContractDataEntries.emplace(
-        InternalContractDataMapEntry(ledgerEntry, preservedTTL));
+        std::make_shared<LedgerEntry const>(ledgerEntry), preservedTTL);
 }
 
 void
@@ -116,8 +113,7 @@ InMemorySorobanState::createContractDataEntry(LedgerEntry const& ledgerEntry)
     releaseAssertOrThrow(ledgerEntry.data.type() == CONTRACT_DATA);
 
     // Verify entry doesn't already exist
-    auto dataIt = mContractDataEntries.find(
-        InternalContractDataMapEntry(LedgerEntryKey(ledgerEntry)));
+    auto dataIt = mContractDataEntries.find(ledgerEntry);
     releaseAssertOrThrow(dataIt == mContractDataEntries.end());
 
     // Check if we've already seen this entry's TTL (can happen during
@@ -138,7 +134,7 @@ InMemorySorobanState::createContractDataEntry(LedgerEntry const& ledgerEntry)
     updateStateSizeOnEntryUpdate(0, xdr::xdr_size(ledgerEntry),
                                  /*isContractCode=*/false);
     mContractDataEntries.emplace(
-        InternalContractDataMapEntry(ledgerEntry, ttlData));
+        std::make_shared<LedgerEntry const>(ledgerEntry), ttlData);
 }
 
 bool
@@ -159,12 +155,12 @@ InMemorySorobanState::createTTL(LedgerEntry const& ttlEntry)
 
     // Check if the corresponding ContractData entry already exists
     // (can happen during initialization when entries arrive out of order)
-    auto dataIt = mContractDataEntries.find(InternalContractDataMapEntry(lk));
+    auto dataIt = mContractDataEntries.find(lk);
     if (dataIt != mContractDataEntries.end())
     {
         // ContractData exists but has no TTL yet - update it
         // Verify TTL hasn't been set yet (should be default initialized)
-        releaseAssertOrThrow(dataIt->get().ttlData.isDefault());
+        releaseAssertOrThrow(dataIt->ttlData.isDefault());
         updateContractDataTTL(dataIt, newTtlData);
     }
     else
@@ -192,11 +188,10 @@ void
 InMemorySorobanState::deleteContractData(LedgerKey const& ledgerKey)
 {
     releaseAssertOrThrow(ledgerKey.type() == CONTRACT_DATA);
-    auto it =
-        mContractDataEntries.find(InternalContractDataMapEntry(ledgerKey));
+    auto it = mContractDataEntries.find(ledgerKey);
     releaseAssertOrThrow(it != mContractDataEntries.end());
-    releaseAssertOrThrow(it->get().ledgerEntry != nullptr);
-    updateStateSizeOnEntryUpdate(xdr::xdr_size(*it->get().ledgerEntry), 0,
+    releaseAssertOrThrow(it->ledgerEntry != nullptr);
+    updateStateSizeOnEntryUpdate(xdr::xdr_size(*it->ledgerEntry), 0,
                                  /*isContractCode=*/false);
     mContractDataEntries.erase(it);
 }
@@ -208,13 +203,12 @@ InMemorySorobanState::get(LedgerKey const& ledgerKey) const
     {
     case CONTRACT_DATA:
     {
-        auto it =
-            mContractDataEntries.find(InternalContractDataMapEntry(ledgerKey));
+        auto it = mContractDataEntries.find(ledgerKey);
         if (it == mContractDataEntries.end())
         {
             return nullptr;
         }
-        return it->get().ledgerEntry;
+        return it->ledgerEntry;
     }
     case CONTRACT_CODE:
     {
@@ -327,14 +321,13 @@ InMemorySorobanState::hasTTL(LedgerKey const& ledgerKey) const
     }
 
     // Check if this is a ContractData TTL (stored with the data)
-    auto dataIt =
-        mContractDataEntries.find(InternalContractDataMapEntry(ledgerKey));
+    auto dataIt = mContractDataEntries.find(ledgerKey);
     if (dataIt != mContractDataEntries.end())
     {
         // Only return true if TTL has been set (non-zero)
         // During initialization, entries may exist with default constructed
         // TTLs
-        return !dataIt->get().ttlData.isDefault();
+        return !dataIt->ttlData.isDefault();
     }
 
     // Check if this is a ContractCode TTL (stored with the code)
@@ -427,11 +420,10 @@ InMemorySorobanState::getTTL(LedgerKey const& ledgerKey) const
 
     // Since the TTL key is the hash of the associated LedgerKey, we don't know
     // which map it could belong in, so check both.
-    auto dataIt =
-        mContractDataEntries.find(InternalContractDataMapEntry(ledgerKey));
+    auto dataIt = mContractDataEntries.find(ledgerKey);
     if (dataIt != mContractDataEntries.end())
     {
-        return constructTTLEntry(dataIt->get().ttlData);
+        return constructTTLEntry(dataIt->ttlData);
     }
 
     auto codeIt = mContractCodeEntries.find(ledgerKey.ttl().keyHash);

--- a/src/ledger/InMemorySorobanState.cpp
+++ b/src/ledger/InMemorySorobanState.cpp
@@ -70,7 +70,7 @@ InMemorySorobanState::updateTTL(LedgerEntry const& ttlEntry)
 
     // TTL updates can apply to either ContractData or ContractCode entries.
     // First check if this TTL belongs to a stored ContractData entry.
-    auto dataIt = mContractDataEntries.find(lk);
+    auto dataIt = mContractDataEntries.find(InternalContractDataMapProbe{lk});
     if (dataIt != mContractDataEntries.end())
     {
         updateContractDataTTL(dataIt, newTtlData);
@@ -92,7 +92,7 @@ InMemorySorobanState::updateContractData(LedgerEntry const& ledgerEntry)
 
     // Entry must already exist since this is an update
     auto lk = LedgerEntryKey(ledgerEntry);
-    auto dataIt = mContractDataEntries.find(lk);
+    auto dataIt = mContractDataEntries.find(InternalContractDataMapProbe{lk});
     releaseAssertOrThrow(dataIt != mContractDataEntries.end());
     releaseAssertOrThrow(dataIt->ledgerEntry != nullptr);
 
@@ -113,7 +113,8 @@ InMemorySorobanState::createContractDataEntry(LedgerEntry const& ledgerEntry)
     releaseAssertOrThrow(ledgerEntry.data.type() == CONTRACT_DATA);
 
     // Verify entry doesn't already exist
-    auto dataIt = mContractDataEntries.find(ledgerEntry);
+    auto dataIt =
+        mContractDataEntries.find(InternalContractDataMapProbe{ledgerEntry});
     releaseAssertOrThrow(dataIt == mContractDataEntries.end());
 
     // Check if we've already seen this entry's TTL (can happen during
@@ -155,7 +156,7 @@ InMemorySorobanState::createTTL(LedgerEntry const& ttlEntry)
 
     // Check if the corresponding ContractData entry already exists
     // (can happen during initialization when entries arrive out of order)
-    auto dataIt = mContractDataEntries.find(lk);
+    auto dataIt = mContractDataEntries.find(InternalContractDataMapProbe{lk});
     if (dataIt != mContractDataEntries.end())
     {
         // ContractData exists but has no TTL yet - update it
@@ -188,7 +189,8 @@ void
 InMemorySorobanState::deleteContractData(LedgerKey const& ledgerKey)
 {
     releaseAssertOrThrow(ledgerKey.type() == CONTRACT_DATA);
-    auto it = mContractDataEntries.find(ledgerKey);
+    auto it =
+        mContractDataEntries.find(InternalContractDataMapProbe{ledgerKey});
     releaseAssertOrThrow(it != mContractDataEntries.end());
     releaseAssertOrThrow(it->ledgerEntry != nullptr);
     updateStateSizeOnEntryUpdate(xdr::xdr_size(*it->ledgerEntry), 0,
@@ -203,7 +205,8 @@ InMemorySorobanState::get(LedgerKey const& ledgerKey) const
     {
     case CONTRACT_DATA:
     {
-        auto it = mContractDataEntries.find(ledgerKey);
+        auto it =
+            mContractDataEntries.find(InternalContractDataMapProbe{ledgerKey});
         if (it == mContractDataEntries.end())
         {
             return nullptr;
@@ -321,7 +324,8 @@ InMemorySorobanState::hasTTL(LedgerKey const& ledgerKey) const
     }
 
     // Check if this is a ContractData TTL (stored with the data)
-    auto dataIt = mContractDataEntries.find(ledgerKey);
+    auto dataIt =
+        mContractDataEntries.find(InternalContractDataMapProbe{ledgerKey});
     if (dataIt != mContractDataEntries.end())
     {
         // Only return true if TTL has been set (non-zero)
@@ -422,7 +426,8 @@ InMemorySorobanState::getTTL(LedgerKey const& ledgerKey) const
 
     // Since the TTL key is the hash of the associated LedgerKey, we don't know
     // which map it could belong in, so check both.
-    auto dataIt = mContractDataEntries.find(ledgerKey);
+    auto dataIt =
+        mContractDataEntries.find(InternalContractDataMapProbe{ledgerKey});
     if (dataIt != mContractDataEntries.end())
     {
         return constructTTLEntry(dataIt->ttlData);

--- a/src/ledger/InMemorySorobanState.h
+++ b/src/ledger/InMemorySorobanState.h
@@ -79,17 +79,11 @@ struct ContractCodeMapEntryT
     }
 };
 
-// InternalContractDataMapEntry provides a memory-efficient map
-// implementation.
+// InternalContractDataMap provides a memory-efficient map implementation.
 //
 // Soroban keys can be quite large (often dominating LedgerEntry size), so
 // storing them twice in a traditional key-value map would be wasteful. Instead,
 // we use std::unordered_set since LedgerEntry contains both key and value data.
-//
-// Since C++17's unordered_set doesn't support heterogeneous lookup (searching
-// with a different type than stored), we use polymorphism to enable key-only
-// lookups without constructing full entries. This will be simplified when we
-// upgrade to C++20.
 //
 // We index entries by their TTL key (SHA256 hash of the ContractData key)
 // rather than the full ContractData key. This lets us look up both ContractData
@@ -97,191 +91,68 @@ struct ContractCodeMapEntryT
 //
 // Logical map structure:
 //     TTLKey -> <std::shared_ptr<LedgerEntry>, liveUntilLedgerSeq>
-//
-class InternalContractDataMapEntry
+using InternalContractDataMap =
+    std::unordered_set<ContractDataMapEntryT,
+                       struct InternalContractDataEntryHash,
+                       struct InternalContractDataEntryEqual>;
+
+inline Hash
+getInternalContractDataMapHash(ContractDataMapEntryT const& entry)
 {
-  private:
-    // Abstract base class for polymorphic entry handling.
-    // This allows QueryKey and ValueEntry to be used interchangeably in the
-    // set.
-    struct AbstractEntry
+    return getTTLKey(LedgerEntryKey(*entry.ledgerEntry)).ttl().keyHash;
+}
+
+inline Hash
+getInternalContractDataMapHash(LedgerEntry const& entry)
+{
+    return getTTLKey(LedgerEntryKey(entry)).ttl().keyHash;
+}
+
+inline Hash
+getInternalContractDataMapHash(LedgerKey const& key)
+{
+    if (key.type() == CONTRACT_DATA)
     {
-        virtual ~AbstractEntry() = default;
-
-        // Returns the TTL key (SHA256 hash) that indexes this entry.
-        // For ContractData entries, this is getTTLKey(ledgerKey).ttl().keyHash
-        // For TTL queries, this is directly the keyHash from the TTL key
-        virtual uint256 copyKey() const = 0;
-
-        // Computes hash for unordered_set storage.
-        // Note: This returns size_t for STL compatibility, not the uint256 key
-        virtual size_t hash() const = 0;
-
-        // Returns the stored data. Only valid for ValueEntry instances.
-        virtual ContractDataMapEntryT const& get() const = 0;
-
-        // Creates a deep copy of this entry. Required for copy constructor.
-        virtual std::unique_ptr<AbstractEntry> clone() const = 0;
-
-        // Equality comparison based on TTL keys
-        virtual bool
-        operator==(AbstractEntry const& other) const
-        {
-            return copyKey() == other.copyKey();
-        }
-    };
-
-    // ValueEntry stores actual ContractData entries in the map.
-    // Contains both the LedgerEntry and its TTL information.
-    struct ValueEntry : public AbstractEntry
-    {
-      private:
-        ContractDataMapEntryT entry;
-
-      public:
-        ValueEntry(std::shared_ptr<LedgerEntry const>&& ledgerEntry,
-                   TTLData ttlData)
-            : entry(std::move(ledgerEntry), ttlData)
-        {
-        }
-
-        uint256
-        copyKey() const override
-        {
-            auto ttlKey = getTTLKey(LedgerEntryKey(*entry.ledgerEntry));
-            return ttlKey.ttl().keyHash;
-        }
-
-        size_t
-        hash() const override
-        {
-            return std::hash<uint256>{}(copyKey());
-        }
-
-        ContractDataMapEntryT const&
-        get() const override
-        {
-            return entry;
-        }
-
-        std::unique_ptr<AbstractEntry>
-        clone() const override
-        {
-            return std::make_unique<ValueEntry>(
-                std::make_shared<LedgerEntry const>(*entry.ledgerEntry),
-                entry.ttlData);
-        }
-    };
-
-    // QueryKey is a lightweight key-only entry used for map lookups.
-    struct QueryKey : public AbstractEntry
-    {
-      private:
-        uint256 const ledgerKeyHash;
-
-      public:
-        explicit QueryKey(uint256 const& ledgerKeyHash)
-            : ledgerKeyHash(ledgerKeyHash)
-        {
-        }
-
-        uint256
-        copyKey() const override
-        {
-            return ledgerKeyHash;
-        }
-
-        size_t
-        hash() const override
-        {
-            return std::hash<uint256>{}(ledgerKeyHash);
-        }
-
-        // Should never be called - QueryKey is only for lookups
-        ContractDataMapEntryT const&
-        get() const override
-        {
-            throw std::runtime_error(
-                "QueryKey::get() called - this is a logic error");
-        }
-
-        std::unique_ptr<AbstractEntry>
-        clone() const override
-        {
-            return std::make_unique<QueryKey>(ledgerKeyHash);
-        }
-    };
-
-    std::unique_ptr<AbstractEntry> impl;
-
-  public:
-    // Copy constructor - required for InMemorySorobanState copy constructor.
-    InternalContractDataMapEntry(InternalContractDataMapEntry const& other)
-        : impl(other.impl->clone())
-    {
+        auto ttlKey = getTTLKey(key);
+        return ttlKey.ttl().keyHash;
     }
-
-    // Creates a ValueEntry from a LedgerEntry (copies the entry)
-    InternalContractDataMapEntry(LedgerEntry const& ledgerEntry,
-                                 TTLData ttlData)
-        : impl(std::make_unique<ValueEntry>(
-              std::make_shared<LedgerEntry const>(ledgerEntry), ttlData))
+    else if (key.type() == TTL)
     {
+        return key.ttl().keyHash;
     }
-
-    // Creates a ValueEntry from a shared_ptr (avoids copying)
-    InternalContractDataMapEntry(
-        std::shared_ptr<LedgerEntry const>&& ledgerEntry, TTLData ttlData)
-        : impl(std::make_unique<ValueEntry>(std::move(ledgerEntry), ttlData))
+    else
     {
+        throw std::runtime_error(
+            "Invalid ledger key type for contract data map entry hash");
     }
+}
 
-    // Creates a QueryKey for lookups. Accepts both CONTRACT_DATA and TTL keys.
-    // For CONTRACT_DATA keys, converts to TTL key hash.
-    // For TTL keys, uses the hash directly.
-    explicit InternalContractDataMapEntry(LedgerKey const& ledgerKey)
-    {
-        if (ledgerKey.type() == CONTRACT_DATA)
-        {
-            auto ttlKey = getTTLKey(ledgerKey);
-            impl = std::make_unique<QueryKey>(ttlKey.ttl().keyHash);
-        }
-        else if (ledgerKey.type() == TTL)
-        {
-            impl = std::make_unique<QueryKey>(ledgerKey.ttl().keyHash);
-        }
-        else
-        {
-            throw std::runtime_error(
-                "Invalid ledger key type for contract data map entry");
-        }
-    }
-
-    size_t
-    hash() const
-    {
-        return impl->hash();
-    }
-
-    bool
-    operator==(InternalContractDataMapEntry const& other) const
-    {
-        return impl->operator==(*other.impl);
-    }
-
-    ContractDataMapEntryT const&
-    get() const
-    {
-        return impl->get();
-    }
-};
+template <typename T>
+concept IsInternalContractDataMapType =
+    std::same_as<T, ContractDataMapEntryT> || std::same_as<T, LedgerEntry> ||
+    std::same_as<T, LedgerKey>;
 
 struct InternalContractDataEntryHash
 {
+    using is_transparent = void;
+
     size_t
-    operator()(InternalContractDataMapEntry const& entry) const
+    operator()(IsInternalContractDataMapType auto const& entry) const
     {
-        return entry.hash();
+        return std::hash<uint256>()(getInternalContractDataMapHash(entry));
+    }
+};
+
+struct InternalContractDataEntryEqual
+{
+    using is_transparent = void;
+
+    bool
+    operator()(IsInternalContractDataMapType auto const& lhs,
+               IsInternalContractDataMapType auto const& rhs) const
+    {
+        return getInternalContractDataMapHash(lhs) ==
+               getInternalContractDataMapHash(rhs);
     }
 };
 
@@ -312,9 +183,7 @@ class InMemorySorobanState
 
     // Primary storage for ContractData entries with embedded TTL information.
     // Uses unordered_set with custom entries to save memory vs traditional map.
-    std::unordered_set<InternalContractDataMapEntry,
-                       InternalContractDataEntryHash>
-        mContractDataEntries;
+    InternalContractDataMap mContractDataEntries;
 
     // Storage for ContractCode entries. Maps from TTL key hash to entry, ttl
     // struct. Unlike ContractData, we use a map here because the key size is
@@ -340,10 +209,8 @@ class InMemorySorobanState
 
     // Helper to update an existing ContractData entry's TTL without changing
     // data
-    void updateContractDataTTL(
-        std::unordered_set<InternalContractDataMapEntry,
-                           InternalContractDataEntryHash>::iterator dataIt,
-        TTLData newTtlData);
+    void updateContractDataTTL(InternalContractDataMap::iterator dataIt,
+                               TTLData newTtlData);
 
     // Should be called after initialization/updates finish to check consistency
     // invariants.

--- a/src/ledger/InMemorySorobanState.h
+++ b/src/ledger/InMemorySorobanState.h
@@ -79,22 +79,40 @@ struct ContractCodeMapEntryT
     }
 };
 
-// InternalContractDataMap provides a memory-efficient map implementation.
-//
-// Soroban keys can be quite large (often dominating LedgerEntry size), so
-// storing them twice in a traditional key-value map would be wasteful. Instead,
-// we use std::unordered_set since LedgerEntry contains both key and value data.
-//
-// We index entries by their TTL key (SHA256 hash of the ContractData key)
-// rather than the full ContractData key. This lets us look up both ContractData
-// entries and their TTLs with one index.
-//
-// Logical map structure:
-//     TTLKey -> <std::shared_ptr<LedgerEntry>, liveUntilLedgerSeq>
-using InternalContractDataMap =
-    std::unordered_set<ContractDataMapEntryT,
-                       struct InternalContractDataEntryHash,
-                       struct InternalContractDataEntryEqual>;
+// Lookup probe for InternalContractDataMap that carries a precomputed digest.
+struct InternalContractDataMapProbe
+{
+    Hash const keyHash;
+
+    static Hash
+    getTTLHash(LedgerKey const& key)
+    {
+        if (key.type() == CONTRACT_DATA)
+        {
+            auto ttlKey = getTTLKey(key);
+            return ttlKey.ttl().keyHash;
+        }
+        else if (key.type() == TTL)
+        {
+            return key.ttl().keyHash;
+        }
+        else
+        {
+            throw std::runtime_error(
+                "Invalid ledger key type for contract data map entry hash");
+        }
+    }
+
+    explicit InternalContractDataMapProbe(LedgerKey const& key)
+        : keyHash(getTTLHash(key))
+    {
+    }
+
+    explicit InternalContractDataMapProbe(LedgerEntry const& entry)
+        : keyHash(getTTLHash(LedgerEntryKey(entry)))
+    {
+    }
+};
 
 inline Hash
 getInternalContractDataMapHash(ContractDataMapEntryT const& entry)
@@ -103,34 +121,15 @@ getInternalContractDataMapHash(ContractDataMapEntryT const& entry)
 }
 
 inline Hash
-getInternalContractDataMapHash(LedgerEntry const& entry)
+getInternalContractDataMapHash(InternalContractDataMapProbe const& entry)
 {
-    return getTTLKey(LedgerEntryKey(entry)).ttl().keyHash;
-}
-
-inline Hash
-getInternalContractDataMapHash(LedgerKey const& key)
-{
-    if (key.type() == CONTRACT_DATA)
-    {
-        auto ttlKey = getTTLKey(key);
-        return ttlKey.ttl().keyHash;
-    }
-    else if (key.type() == TTL)
-    {
-        return key.ttl().keyHash;
-    }
-    else
-    {
-        throw std::runtime_error(
-            "Invalid ledger key type for contract data map entry hash");
-    }
+    return entry.keyHash;
 }
 
 template <typename T>
 concept IsInternalContractDataMapType =
-    std::same_as<T, ContractDataMapEntryT> || std::same_as<T, LedgerEntry> ||
-    std::same_as<T, LedgerKey>;
+    std::same_as<T, ContractDataMapEntryT> ||
+    std::same_as<T, InternalContractDataMapProbe>;
 
 struct InternalContractDataEntryHash
 {
@@ -155,6 +154,22 @@ struct InternalContractDataEntryEqual
                getInternalContractDataMapHash(rhs);
     }
 };
+
+// InternalContractDataMap provides a memory-efficient map implementation.
+//
+// Soroban keys can be quite large (often dominating LedgerEntry size), so
+// storing them twice in a traditional key-value map would be wasteful. Instead,
+// we use std::unordered_set since LedgerEntry contains both key and value data.
+//
+// We index entries by their TTL key (SHA256 hash of the ContractData key)
+// rather than the full ContractData key. This lets us look up both ContractData
+// entries and their TTLs with one index.
+//
+// Logical map structure:
+//     TTLKey -> <std::shared_ptr<LedgerEntry>, liveUntilLedgerSeq>
+using InternalContractDataMap =
+    std::unordered_set<ContractDataMapEntryT, InternalContractDataEntryHash,
+                       InternalContractDataEntryEqual>;
 
 // InMemorySorobanState provides an efficient in-memory map for Soroban contract
 // state.

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -19,6 +19,7 @@
 #include "util/SecretManager.h"
 #include "util/UnorderedSet.h"
 
+#include <concepts>
 #include <fmt/chrono.h>
 #include <fmt/format.h>
 #include <functional>
@@ -467,8 +468,8 @@ readArray(ConfigItem const& item)
     return result;
 }
 
-template <typename T>
-std::enable_if_t<std::is_signed_v<T>, T>
+template <std::signed_integral T>
+T
 castInt(int64_t v, std::string const& name, T min, T max)
 {
     if (v < min || v > max)
@@ -478,8 +479,8 @@ castInt(int64_t v, std::string const& name, T min, T max)
     return static_cast<T>(v);
 }
 
-template <typename T>
-std::enable_if_t<std::is_unsigned_v<T>, T>
+template <std::unsigned_integral T>
+T
 castInt(int64_t v, std::string const& name, T min, T max)
 {
     if (v < 0)

--- a/src/test/TestUtils.cpp
+++ b/src/test/TestUtils.cpp
@@ -141,14 +141,14 @@ computeMultiplier(LedgerEntry const& le)
     }
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 BucketListDepthModifier<BucketT>::BucketListDepthModifier(uint32_t newDepth)
     : mPrevDepth(BucketListBase<BucketT>::kNumLevels)
 {
     BucketListBase<BucketT>::kNumLevels = newDepth;
 }
 
-template <class BucketT>
+template <IsBucketType BucketT>
 BucketListDepthModifier<BucketT>::~BucketListDepthModifier()
 {
     BucketListBase<BucketT>::kNumLevels = mPrevDepth;

--- a/src/test/TestUtils.h
+++ b/src/test/TestUtils.h
@@ -11,6 +11,7 @@
 #include "ledger/LedgerManagerImpl.h"
 #include "main/ApplicationImpl.h"
 #include "util/ProtocolVersion.h"
+#include <concepts>
 #include <type_traits>
 
 namespace stellar
@@ -81,9 +82,8 @@ class TestApplication : public ApplicationImpl
     std::unique_ptr<InvariantManager> createInvariantManager() override;
 };
 
-template <typename T = TestApplication, typename... Args,
-          typename = typename std::enable_if<
-              std::is_base_of<TestApplication, T>::value>::type>
+template <typename T = TestApplication, typename... Args>
+    requires std::derived_from<T, TestApplication>
 std::shared_ptr<T>
 createTestApplication(VirtualClock& clock, Config const& cfg, Args&&... args,
                       bool newDB = true, bool startApp = true)

--- a/src/test/TestUtils.h
+++ b/src/test/TestUtils.h
@@ -34,10 +34,8 @@ std::vector<Asset> getInvalidAssets(SecretKey const& issuer);
 
 int32_t computeMultiplier(LedgerEntry const& le);
 
-template <class BucketT> class BucketListDepthModifier
+template <IsBucketType BucketT> class BucketListDepthModifier
 {
-    BUCKET_TYPE_ASSERT(BucketT);
-
     uint32_t const mPrevDepth;
 
   public:

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -1318,8 +1318,9 @@ struct MuxChecker
     }
 
     template <typename T>
-    std::enable_if_t<(xdr::xdr_traits<T>::is_container ||
-                      xdr::xdr_traits<T>::is_class)>
+        requires xdr::xdr_traits<T>::is_container ||
+                 xdr::xdr_traits<T>::is_class
+    void
     operator()(T const& t)
     {
         if (!mHasMuxedAccount)
@@ -1329,8 +1330,7 @@ struct MuxChecker
     }
 
     template <typename T>
-    std::enable_if_t<!(xdr::xdr_traits<T>::is_container ||
-                       xdr::xdr_traits<T>::is_class)>
+    void
     operator()(T const& t)
     {
     }

--- a/src/util/BinaryFuseFilter.cpp
+++ b/src/util/BinaryFuseFilter.cpp
@@ -10,14 +10,14 @@
 namespace stellar
 {
 
-template <typename T>
+template <IsSupportedBinaryFuseFilterType T>
 BinaryFuseFilter<T>::BinaryFuseFilter(std::vector<uint64_t>& keyHashes,
                                       binary_fuse_seed_t const& seed)
     : mFilter(keyHashes.size(), keyHashes, seed), mHashSeed(seed)
 {
 }
 
-template <typename T>
+template <IsSupportedBinaryFuseFilterType T>
 BinaryFuseFilter<T>::BinaryFuseFilter(
     SerializedBinaryFuseFilter const& xdrFilter)
     : mFilter(xdrFilter), mHashSeed([&] {
@@ -29,7 +29,7 @@ BinaryFuseFilter<T>::BinaryFuseFilter(
 {
 }
 
-template <typename T>
+template <IsSupportedBinaryFuseFilterType T>
 bool
 BinaryFuseFilter<T>::contains(LedgerKey const& key) const
 {
@@ -39,7 +39,7 @@ BinaryFuseFilter<T>::contains(LedgerKey const& key) const
     return mFilter.contain(hasher.digest());
 }
 
-template <typename T>
+template <IsSupportedBinaryFuseFilterType T>
 bool
 BinaryFuseFilter<T>::operator==(BinaryFuseFilter<T> const& other) const
 {

--- a/src/util/BinaryFuseFilter.h
+++ b/src/util/BinaryFuseFilter.h
@@ -10,19 +10,22 @@
 #include "xdr/Stellar-types.h"
 
 #include <cereal/archives/binary.hpp>
+#include <concepts>
 
 namespace stellar
 {
 
+template <typename T>
+concept IsSupportedBinaryFuseFilterType =
+    std::same_as<T, uint8_t> || std::same_as<T, uint16_t> ||
+    std::same_as<T, uint32_t>;
+
 // This class is a wrapper around the binary_fuse_t library that provides
 // serialization for the XDR BinaryFuseFilter type and provides a deterministic
 // LedgerKey interface.
-template <typename T> class BinaryFuseFilter : public NonMovableOrCopyable
+template <IsSupportedBinaryFuseFilterType T>
+class BinaryFuseFilter : public NonMovableOrCopyable
 {
-    static_assert(std::is_same_v<T, uint8_t> || std::is_same_v<T, uint16_t> ||
-                      std::is_same_v<T, uint32_t>,
-                  "Binary Fuse Filter only supports 8, 16, or 32 bit width");
-
   private:
     binary_fuse_t<T> const mFilter;
 

--- a/src/util/BufferedAsioCerealOutputArchive.h
+++ b/src/util/BufferedAsioCerealOutputArchive.h
@@ -14,9 +14,9 @@ namespace cereal
 
 // Mirrors CEREAL_ARCHIVE_RESTRICT from cereal/details/traits.hpp for single
 // types
-#define CEREAL_ARCHIVE_RESTRICT_SINGLE_TYPE(TYPE) \
-    typename std::enable_if< \
-        cereal::traits::is_same_archive<Archive, TYPE>::value, void>::type
+template <typename Archive, typename T>
+concept IsRestrictedToSingleArchiveType =
+    cereal::traits::is_same_archive<Archive, T>::value;
 
 // This is a basic reimplementation of BinaryOutputArchive
 // (cereal/archives/binary.hpp) that uses our own OutputFileStream instead of
@@ -50,7 +50,8 @@ class BufferedAsioOutputArchive
 
 // Saving for POD types to binary
 template <class T>
-inline typename std::enable_if<std::is_arithmetic<T>::value, void>::type
+    requires std::is_arithmetic_v<T>
+void
 CEREAL_SAVE_FUNCTION_NAME(BufferedAsioOutputArchive& ar, T const& t)
 {
     ar.saveBinary(std::addressof(t), sizeof(t));
@@ -58,17 +59,18 @@ CEREAL_SAVE_FUNCTION_NAME(BufferedAsioOutputArchive& ar, T const& t)
 
 // Serializing NVP types to binary
 template <class Archive, class T>
-
-inline CEREAL_ARCHIVE_RESTRICT_SINGLE_TYPE(BufferedAsioOutputArchive)
-    CEREAL_SERIALIZE_FUNCTION_NAME(Archive& ar, NameValuePair<T>& t)
+    requires IsRestrictedToSingleArchiveType<Archive, BufferedAsioOutputArchive>
+inline void
+CEREAL_SERIALIZE_FUNCTION_NAME(Archive& ar, NameValuePair<T>& t)
 {
     ar(t.value);
 }
 
 // Serializing SizeTags to binary
 template <class Archive, class T>
-inline CEREAL_ARCHIVE_RESTRICT_SINGLE_TYPE(BufferedAsioOutputArchive)
-    CEREAL_SERIALIZE_FUNCTION_NAME(Archive& ar, SizeTag<T>& t)
+    requires IsRestrictedToSingleArchiveType<Archive, BufferedAsioOutputArchive>
+inline void
+CEREAL_SERIALIZE_FUNCTION_NAME(Archive& ar, SizeTag<T>& t)
 {
     ar(t.size);
 }

--- a/src/util/Logging.h
+++ b/src/util/Logging.h
@@ -206,7 +206,8 @@ class Logging
 // custom formatters that can be used by fmt::format
 
 template <typename T>
-inline typename std::enable_if<xdr::xdr_traits<T>::is_enum, std::string>::type
+    requires xdr::xdr_traits<T>::is_enum
+inline std::string
 format_as(T const& u)
 {
     auto res = xdr::xdr_traits<T>::enum_name(u);

--- a/src/util/Logging.h
+++ b/src/util/Logging.h
@@ -34,46 +34,46 @@
 
 #define CLOG_TRACE(partition, f, ...) \
     LOG_CHECK(Logging::get##partition##LogPtr(), spdlog::level::trace, \
-              SPDLOG_LOGGER_TRACE(lg, f, ##__VA_ARGS__))
+              SPDLOG_LOGGER_TRACE(lg, f __VA_OPT__(, ) __VA_ARGS__))
 
 #define CLOG_DEBUG(partition, f, ...) \
     LOG_CHECK(Logging::get##partition##LogPtr(), spdlog::level::debug, \
-              SPDLOG_LOGGER_DEBUG(lg, f, ##__VA_ARGS__))
+              SPDLOG_LOGGER_DEBUG(lg, f __VA_OPT__(, ) __VA_ARGS__))
 
 #define CLOG_INFO(partition, f, ...) \
     LOG_CHECK(Logging::get##partition##LogPtr(), spdlog::level::info, \
-              SPDLOG_LOGGER_INFO(lg, f, ##__VA_ARGS__))
+              SPDLOG_LOGGER_INFO(lg, f __VA_OPT__(, ) __VA_ARGS__))
 
 #define CLOG_WARNING(partition, f, ...) \
     LOG_CHECK(Logging::get##partition##LogPtr(), spdlog::level::warn, \
-              SPDLOG_LOGGER_WARN(lg, f, ##__VA_ARGS__))
+              SPDLOG_LOGGER_WARN(lg, f __VA_OPT__(, ) __VA_ARGS__))
 
 #define CLOG_ERROR(partition, f, ...) \
     LOG_CHECK(Logging::get##partition##LogPtr(), spdlog::level::err, \
-              SPDLOG_LOGGER_ERROR(lg, f, ##__VA_ARGS__))
+              SPDLOG_LOGGER_ERROR(lg, f __VA_OPT__(, ) __VA_ARGS__))
 
 #define CLOG_FATAL(partition, f, ...) \
     LOG_CHECK(Logging::get##partition##LogPtr(), spdlog::level::critical, \
-              SPDLOG_LOGGER_CRITICAL(lg, f, ##__VA_ARGS__))
+              SPDLOG_LOGGER_CRITICAL(lg, f __VA_OPT__(, ) __VA_ARGS__))
 
 #define LOG_TRACE(lg, fmt, ...) \
     LOG_CHECK(lg, spdlog::level::trace, \
-              SPDLOG_LOGGER_TRACE(lg, fmt, ##__VA_ARGS__))
+              SPDLOG_LOGGER_TRACE(lg, fmt __VA_OPT__(, ) __VA_ARGS__))
 #define LOG_DEBUG(lg, fmt, ...) \
     LOG_CHECK(lg, spdlog::level::debug, \
-              SPDLOG_LOGGER_DEBUG(lg, fmt, ##__VA_ARGS__))
+              SPDLOG_LOGGER_DEBUG(lg, fmt __VA_OPT__(, ) __VA_ARGS__))
 #define LOG_INFO(lg, fmt, ...) \
     LOG_CHECK(lg, spdlog::level::info, \
-              SPDLOG_LOGGER_INFO(lg, fmt, ##__VA_ARGS__))
+              SPDLOG_LOGGER_INFO(lg, fmt __VA_OPT__(, ) __VA_ARGS__))
 #define LOG_WARNING(lg, fmt, ...) \
     LOG_CHECK(lg, spdlog::level::warn, \
-              SPDLOG_LOGGER_WARN(lg, fmt, ##__VA_ARGS__))
+              SPDLOG_LOGGER_WARN(lg, fmt __VA_OPT__(, ) __VA_ARGS__))
 #define LOG_ERROR(lg, fmt, ...) \
     LOG_CHECK(lg, spdlog::level::err, \
-              SPDLOG_LOGGER_ERROR(lg, fmt, ##__VA_ARGS__))
+              SPDLOG_LOGGER_ERROR(lg, fmt __VA_OPT__(, ) __VA_ARGS__))
 #define LOG_FATAL(lg, fmt, ...) \
     LOG_CHECK(lg, spdlog::level::critical, \
-              SPDLOG_LOGGER_CRITICAL(lg, fmt, ##__VA_ARGS__))
+              SPDLOG_LOGGER_CRITICAL(lg, fmt __VA_OPT__(, ) __VA_ARGS__))
 
 #define GET_LOG(name) spdlog::get(name)
 #define DEFAULT_LOG stellar::Logging::getDefaultLogPtr()
@@ -90,30 +90,36 @@ typedef std::shared_ptr<spdlog::logger> LogPtr;
 #define LOG(LEVEL) CLOG(LEVEL)
 
 #define CLOG_TRACE(partition, f, ...) \
-    CLOG(LVL_TRACE, #partition) << fmt::format(FMT_STRING(f), ##__VA_ARGS__)
+    CLOG(LVL_TRACE, #partition) \
+        << fmt::format(FMT_STRING(f) __VA_OPT__(, ) __VA_ARGS__)
 #define CLOG_DEBUG(partition, f, ...) \
-    CLOG(LVL_DEBUG, #partition) << fmt::format(FMT_STRING(f), ##__VA_ARGS__)
+    CLOG(LVL_DEBUG, #partition) \
+        << fmt::format(FMT_STRING(f) __VA_OPT__(, ) __VA_ARGS__)
 #define CLOG_INFO(partition, f, ...) \
-    CLOG(LVL_INFO, #partition) << fmt::format(FMT_STRING(f), ##__VA_ARGS__)
+    CLOG(LVL_INFO, #partition) \
+        << fmt::format(FMT_STRING(f) __VA_OPT__(, ) __VA_ARGS__)
 #define CLOG_WARNING(partition, f, ...) \
-    CLOG(LVL_WARNING, #partition) << fmt::format(FMT_STRING(f), ##__VA_ARGS__)
+    CLOG(LVL_WARNING, #partition) \
+        << fmt::format(FMT_STRING(f) __VA_OPT__(, ) __VA_ARGS__)
 #define CLOG_ERROR(partition, f, ...) \
-    CLOG(LVL_ERROR, #partition) << fmt::format(FMT_STRING(f), ##__VA_ARGS__)
+    CLOG(LVL_ERROR, #partition) \
+        << fmt::format(FMT_STRING(f) __VA_OPT__(, ) __VA_ARGS__)
 #define CLOG_FATAL(partition, f, ...) \
-    CLOG(LVL_FATAL, #partition) << fmt::format(FMT_STRING(f), ##__VA_ARGS__)
+    CLOG(LVL_FATAL, #partition) \
+        << fmt::format(FMT_STRING(f) __VA_OPT__(, ) __VA_ARGS__)
 
 #define LOG_TRACE(logger, f, ...) \
-    CLOG(LVL_TRACE, logger) << fmt::format(f, ##__VA_ARGS__)
+    CLOG(LVL_TRACE, logger) << fmt::format(f __VA_OPT__(, ) __VA_ARGS__)
 #define LOG_DEBUG(logger, f, ...) \
-    CLOG(LVL_DEBUG, logger) << fmt::format(f, ##__VA_ARGS__)
+    CLOG(LVL_DEBUG, logger) << fmt::format(f __VA_OPT__(, ) __VA_ARGS__)
 #define LOG_INFO(logger, f, ...) \
-    CLOG(LVL_INFO, logger) << fmt::format(f, ##__VA_ARGS__)
+    CLOG(LVL_INFO, logger) << fmt::format(f __VA_OPT__(, ) __VA_ARGS__)
 #define LOG_WARNING(logger, f, ...) \
-    CLOG(LVL_WARNING, logger) << fmt::format(f, ##__VA_ARGS__)
+    CLOG(LVL_WARNING, logger) << fmt::format(f __VA_OPT__(, ) __VA_ARGS__)
 #define LOG_ERROR(logger, f, ...) \
-    CLOG(LVL_ERROR, logger) << fmt::format(f, ##__VA_ARGS__)
+    CLOG(LVL_ERROR, logger) << fmt::format(f __VA_OPT__(, ) __VA_ARGS__)
 #define LOG_FATAL(logger, f, ...) \
-    CLOG(LVL_FATAL, logger) << fmt::format(f, ##__VA_ARGS__)
+    CLOG(LVL_FATAL, logger) << fmt::format(f __VA_OPT__(, ) __VA_ARGS__)
 #define GET_LOG(name) name
 #define DEFAULT_LOG nullptr
 namespace stellar

--- a/src/util/xdrquery/XDRFieldResolver.h
+++ b/src/util/xdrquery/XDRFieldResolver.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <concepts>
 #include <exception>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
@@ -26,6 +27,13 @@ namespace internal
 {
 using namespace xdr;
 using namespace stellar;
+
+// We need to use concepts to get subsumption
+template <typename T>
+concept IsXdrClass = xdr_traits<T>::is_class;
+
+template <typename T>
+concept IsXdrUnion = IsXdrClass<T> && xdr_traits<T>::is_union;
 
 struct XDRFieldResolver
 {
@@ -51,8 +59,8 @@ struct XDRFieldResolver
     }
 
     template <typename T>
-    typename std::enable_if_t<xdr_traits<T>::is_numeric &&
-                              !xdr_traits<T>::is_enum>
+        requires xdr_traits<T>::is_numeric
+    void
     operator()(T const& t, char const* fieldName)
     {
         if (checkLeafField(fieldName))
@@ -63,7 +71,8 @@ struct XDRFieldResolver
 
     // Retrieve enums as their XDR string representation.
     template <typename T>
-    typename std::enable_if_t<xdr_traits<T>::is_enum>
+        requires xdr_traits<T>::is_enum
+    void
     operator()(T const& t, char const* fieldName)
     {
         if (checkLeafField(fieldName))
@@ -73,9 +82,8 @@ struct XDRFieldResolver
     }
 
     // Retrieve public keys in standard string representation.
-    template <typename T>
-    typename std::enable_if_t<std::is_same_v<PublicKey, T>>
-    operator()(T const& k, char const* fieldName)
+    void
+    operator()(PublicKey const& k, char const* fieldName)
     {
         if (checkLeafField(fieldName))
         {
@@ -84,9 +92,8 @@ struct XDRFieldResolver
     }
 
     // Retrieve SCAddresses in standard string representation.
-    template <typename T>
-    typename std::enable_if_t<std::is_same_v<SCAddress, T>>
-    operator()(T const& k, char const* fieldName)
+    void
+    operator()(SCAddress const& k, char const* fieldName)
     {
         if (checkLeafField(fieldName))
         {
@@ -107,9 +114,9 @@ struct XDRFieldResolver
         }
     }
 
-    template <typename T>
-    typename std::enable_if_t<std::is_same_v<Asset, T> ||
-                              std::is_same_v<TrustLineAsset, T>>
+    template <IsXdrUnion T>
+        requires std::same_as<T, Asset> || std::same_as<T, TrustLineAsset>
+    void
     operator()(T const& asset, char const* fieldName)
     {
         if (!matchFieldToPath(fieldName))
@@ -214,7 +221,8 @@ struct XDRFieldResolver
     }
 
     template <typename T>
-    typename std::enable_if_t<xdr_traits<T>::is_container>
+        requires xdr_traits<T>::is_container
+    void
     operator()(T const& t, char const* fieldName)
     {
         if (matchFieldToPath(fieldName))
@@ -225,11 +233,8 @@ struct XDRFieldResolver
         }
     }
 
-    template <typename T>
-    typename std::enable_if_t<
-        xdr_traits<T>::is_union && !std::is_same_v<PublicKey, T> &&
-        !std::is_same_v<Asset, T> && !std::is_same_v<TrustLineAsset, T> &&
-        !xdr_traits<T>::is_container && !std::is_same_v<SCAddress, T>>
+    template <IsXdrUnion T>
+    void
     operator()(T const& t, char const* fieldName)
     {
         if (!matchFieldToPath(fieldName))
@@ -253,12 +258,8 @@ struct XDRFieldResolver
         }
     }
 
-    template <typename T>
-    typename std::enable_if_t<
-        xdr_traits<T>::is_class && !std::is_same_v<PublicKey, T> &&
-        !std::is_same_v<Asset, T> && !std::is_same_v<TrustLineAsset, T> &&
-        !xdr_traits<T>::is_union && !xdr_traits<T>::is_container &&
-        !std::is_same_v<SCAddress, T>>
+    template <IsXdrClass T>
+    void
     operator()(T const& t, char const* fieldName)
     {
         if (!matchFieldToPath(fieldName))
@@ -334,8 +335,8 @@ struct XDRFieldResolver
         (*this)(asset.liquidityPoolID(), "liquidityPoolID");
     }
 
-    template <typename T>
-    typename std::enable_if_t<xdr_traits<T>::is_union>
+    template <IsXdrUnion T>
+    void
     validateUnion(T const& t, char const* fieldName)
     {
         // The field could have been already matched if it was XDR discriminant.
@@ -358,9 +359,9 @@ struct XDRFieldResolver
         }
     }
 
-    template <typename T>
-    typename std::enable_if_t<std::is_same_v<Asset, T> ||
-                              std::is_same_v<TrustLineAsset, T>>
+    template <IsXdrUnion T>
+        requires std::same_as<T, Asset> || std::same_as<T, TrustLineAsset>
+    void
     validateAsset(T const& asset, char const* fieldName)
     {
         // The field could have been already matched if it was a native asset.


### PR DESCRIPTION
Based on #5091. Clean up codebase using C++20 features, resolves #4673.
* Replace `BUCKET_TYPE_ASSERT` with `IsBucketType` concept
* Use concepts instead of SFINAE[^1][^2]
* Use `__VA_OPT__` instead of `##__VA_ARGS__`
* Remove `IndexT` template parameter from `BucketBase`
* Replace `InternalContractDataMap` implementation with `std::unordered_set` heterogenous lookup

[^1]: There were some places that I left.
 src/test/Catch2.h:47: `struct StringMaker<T, std::enable_if_t<xdr::xdr_traits<T>::valid>>`
 because Catch2 still uses SFINAE
 Leaving `XDRCereal.h`/`XDRCereal.cpp` because I'm working on a separate PR to update it.
 Leaving `FuzzerImpl.cpp` alone since iirc Graydon was working on fuzzing.
 
 [^2]: Note on the update to `src/util/BufferedAsioCerealOutputArchive.h`
 ```cpp
 // Saving for POD types to binary
 template <class T>
 inline typename std::enable_if<std::is_arithmetic<T>::value, void>::type
 ```
 This doesn't actually check for POD types (trivial + standard-layout), so the concept retains a `std::is_arithmetic` check.