### PR TITLE
Add GHA to invoke RPC integration tests on commits to master

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -1,0 +1,55 @@
+name: 'Setup the Go environment'
+description: 'Installs go and restores/saves the build/module cache'
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version: '1.25'
+        # unfortunately we cannot use the provided caching because it uses the
+        # same cache for all workflows/jobs, leading to undesired cache clashes,
+        # causing uncached test runs etc ...
+        # You can see the cache key at https://github.com/actions/setup-go/blob/4e0b6c77c6448caafaff5eed51516cad78e7639a/src/cache-restore.ts#L34
+        # There is a ticket to add prefixes for the cache, which should solve it https://github.com/actions/setup-go/issues/358
+        cache: false
+
+    # Restore original modification time of files based on the date of the most
+    # recent commit that modified them as mtimes affect the Go test cache.
+    # See https://github.com/golang/go/issues/58571 for details
+    - name: Restore modification time of checkout files
+      uses: chetan/git-restore-mtime-action@075f9bc9d159805603419d50f794bd9f33252ebe
+
+
+    # KEY_PREFIX must uniquely identify the specific instance of a job executing.
+    - shell: bash
+      run: |
+        echo 'KEY_PREFIX=${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-${{ inputs.go-version }}-matrix(${{ join(matrix.*,'|') }})' >> $GITHUB_OUTPUT
+        echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+        echo "GOMODCACHE=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+        if [ ${{ runner.os }} != 'Windows' ]; then echo SUDO='sudo' >> $GITHUB_OUTPUT; fi
+      id: variables
+
+    # Cache the Go Modules downloaded during the job.
+    - uses: actions/cache@v4
+      with:
+        path: ${{ steps.variables.outputs.GOMODCACHE }}
+        key: ${{ steps.variables.outputs.KEY_PREFIX }}-go-mod-${{ hashFiles('**/go.sum') }}
+        restore-keys: ${{ steps.variables.outputs.KEY_PREFIX  }}-go-mod-
+
+    # Cache any build and test artifacts during the job, which will speed up
+    # rebuilds and cause test runs to skip tests that have no reason to rerun.
+    - uses: actions/cache@v4
+      with:
+        path: ${{ steps.variables.outputs.GOCACHE }}
+        key: ${{ steps.variables.outputs.KEY_PREFIX  }}-go-build-${{ github.ref }}-${{ hashFiles('**', '!.git') }}
+        restore-keys: |
+          ${{ steps.variables.outputs.KEY_PREFIX }}-go-build-${{ github.ref }}-
+          ${{ steps.variables.outputs.KEY_PREFIX }}-go-build-
+
+    # Reset the cache for master/protected branches, to ensure they build and run the tests from zero
+    # and that the module cache is cleaned (otherwise it accumulates orphan dependencies over time).
+    - if: github.ref_protected
+      shell: bash
+      run: ${{ steps.variables.outputs.SUDO }} rm -rf ${{ steps.variables.outputs.GOMODCACHE }} ${{ steps.variables.outputs.GOCACHE  }}
+

--- a/.github/workflows/rpc.yml
+++ b/.github/workflows/rpc.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   rpc:
-    uses: stellar/stellar-rpc/.github/workflows/integration-tests.yml@protocol-next
+    uses: stellar/stellar-rpc/.github/workflows/integration-tests.yml@efd9eb95f1ed8a7d69d28f12e89762c3ecb64bcc
     with:
       rpc_git_ref: protocol-next
       core_git_ref: ${{ github.sha }}

--- a/.github/workflows/rpc.yml
+++ b/.github/workflows/rpc.yml
@@ -1,0 +1,19 @@
+name: RPC Integration Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rpc:
+    uses: stellar/stellar-rpc/.github/workflows/integration-tests.yml@protocol-next
+    with:
+      rpc_git_ref: protocol-next
+      core_git_ref: ${{ github.sha }}
+      protocol_version: '27'

--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -30,6 +30,7 @@ ENV PATH "/root/.cargo/bin:$PATH"
 RUN ./configure CC="${CC}" CXX="${CXX}" CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" ${CONFIGURE_FLAGS}
 RUN sh -c 'make -j $(nproc)'
 RUN make install
+RUN make clean
 
 # Deploy stage, only includes stuff needed to run.
 FROM ubuntu:noble


### PR DESCRIPTION
# Description
As part of https://github.com/stellar/pod-fsr/issues/2, we want Stellar Core to run RPC integration tests to catch failures prior to downstream integration.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)

Not Applicable:

- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
