### PR TITLE
Bucket snapshot state refactor

### DIFF
--- a/src/bucket/BucketListSnapshot.h
+++ b/src/bucket/BucketListSnapshot.h
@@ -41,8 +41,8 @@ struct StateArchivalSettings;
 class EvictionStatistics;
 template <class BucketT> class BucketListBase;
 template <class BucketT> class BucketLevel;
-class CompleteConstLedgerState;
-class LedgerStateSnapshot;
+class ImmutableLedgerData;
+class ImmutableLedgerView;
 
 // BucketListSnapshotData holds the immutable bucket references that can be
 // safely shared across threads. It contains only bucket pointers and no
@@ -86,7 +86,7 @@ template <class BucketT> class SearchableBucketListSnapshot
 
     // Ledger sequence number for this snapshot, used internally to route
     // queries between current and historical data. Not exposed publicly;
-    // callers should get ledger metadata from CompleteConstLedgerState.
+    // callers should get ledger metadata from ImmutableLedgerData.
     uint32_t mLedgerSeq;
 
     // Per-snapshot mutable stream cache
@@ -234,8 +234,8 @@ class SearchableLiveBucketListSnapshot
         LedgerEntryType type,
         std::function<Loop(BucketEntry const&)> callback) const;
 
-    friend class CompleteConstLedgerState;
-    friend class LedgerStateSnapshot;
+    friend class ImmutableLedgerData;
+    friend class ImmutableLedgerView;
 };
 
 // Hot archive bucket list snapshot
@@ -262,7 +262,7 @@ class SearchableHotArchiveBucketListSnapshot
     void scanAllEntries(
         std::function<Loop(HotArchiveBucketEntry const&)> callback) const;
 
-    friend class LedgerStateSnapshot;
+    friend class ImmutableLedgerView;
 };
 
 extern template struct BucketListSnapshotData<LiveBucket>;

--- a/src/bucket/BucketListSnapshot.h
+++ b/src/bucket/BucketListSnapshot.h
@@ -234,7 +234,6 @@ class SearchableLiveBucketListSnapshot
         LedgerEntryType type,
         std::function<Loop(BucketEntry const&)> callback) const;
 
-    friend class BucketSnapshotState;
     friend class CompleteConstLedgerState;
     friend class LedgerStateSnapshot;
 };

--- a/src/bucket/BucketManager.cpp
+++ b/src/bucket/BucketManager.cpp
@@ -1156,7 +1156,7 @@ BucketManager::startBackgroundEvictionScan(ApplyLedgerStateSnapshot lclSnapshot,
 
     // Start the eviction scan for then _next_ ledger
     auto ledgerSeq = lclSnapshot.getLedgerSeq() + 1;
-    auto ledgerVers = lclSnapshot.getLedgerHeader().ledgerVersion;
+    auto ledgerVers = lclSnapshot.getLedgerHeader().current().ledgerVersion;
 
     auto const& sas = cfg.stateArchivalSettings();
 
@@ -1185,10 +1185,10 @@ BucketManager::resolveBackgroundEvictionScan(
     ZoneScoped;
     releaseAssert(mEvictionStatistics);
     auto timer = mBucketListEvictionMetrics.blockingTime.TimeScope();
-    auto ls = LedgerSnapshot(ltx);
-    auto ledgerSeq = ls.getLedgerHeader().current().ledgerSeq;
-    auto ledgerVers = ls.getLedgerHeader().current().ledgerVersion;
-    auto networkConfig = SorobanNetworkConfig::loadFromLedger(ls);
+    LedgerTxnReadOnly ltxSnap(ltx);
+    auto ledgerSeq = ltxSnap.getLedgerHeader().current().ledgerSeq;
+    auto ledgerVers = ltxSnap.getLedgerHeader().current().ledgerVersion;
+    auto networkConfig = SorobanNetworkConfig::loadFromLedger(ltxSnap);
     releaseAssert(ledgerSeq == lclSnapshot.getLedgerSeq() + 1);
 
     if (!mEvictionFuture.valid())

--- a/src/bucket/BucketManager.cpp
+++ b/src/bucket/BucketManager.cpp
@@ -16,7 +16,7 @@
 #include "history/HistoryManager.h"
 #include "historywork/VerifyBucketWork.h"
 #include "invariant/InvariantManager.h"
-#include "ledger/LedgerStateSnapshot.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "ledger/LedgerTxn.h"
 #include "ledger/LedgerTypeUtils.h"
 #include "ledger/NetworkConfig.h"
@@ -1148,27 +1148,27 @@ BucketManager::maybeSetIndex(
 }
 
 void
-BucketManager::startBackgroundEvictionScan(ApplyLedgerStateSnapshot lclSnapshot,
+BucketManager::startBackgroundEvictionScan(ApplyLedgerView lclApplyView,
                                            SorobanNetworkConfig const& cfg)
 {
     releaseAssert(!mEvictionFuture.valid());
     releaseAssert(mEvictionStatistics);
 
     // Start the eviction scan for then _next_ ledger
-    auto ledgerSeq = lclSnapshot.getLedgerSeq() + 1;
-    auto ledgerVers = lclSnapshot.getLedgerHeader().current().ledgerVersion;
+    auto ledgerSeq = lclApplyView.getLedgerSeq() + 1;
+    auto ledgerVers = lclApplyView.getLedgerHeader().current().ledgerVersion;
 
     auto const& sas = cfg.stateArchivalSettings();
 
     using task_t =
         std::packaged_task<std::unique_ptr<EvictionResultCandidates>()>;
     auto task = std::make_shared<task_t>(
-        [snap = std::move(lclSnapshot), iter = cfg.evictionIterator(),
+        [lclApplyView = std::move(lclApplyView), iter = cfg.evictionIterator(),
          ledgerSeq, ledgerVers, sas, &metrics = mBucketListEvictionMetrics,
          stats = mEvictionStatistics]() mutable {
             auto timer = metrics.backgroundTime.TimeScope();
-            return snap.scanForEviction(ledgerSeq, metrics, iter, stats, sas,
-                                        ledgerVers);
+            return lclApplyView.scanForEviction(ledgerSeq, metrics, iter, stats,
+                                                sas, ledgerVers);
         });
 
     mEvictionFuture = task->get_future();
@@ -1179,7 +1179,7 @@ BucketManager::startBackgroundEvictionScan(ApplyLedgerStateSnapshot lclSnapshot,
 
 EvictedStateVectors
 BucketManager::resolveBackgroundEvictionScan(
-    ApplyLedgerStateSnapshot const& lclSnapshot, AbstractLedgerTxn& ltx,
+    ApplyLedgerView const& lclApplyView, AbstractLedgerTxn& ltx,
     LedgerKeySet const& modifiedKeys)
 {
     ZoneScoped;
@@ -1189,7 +1189,7 @@ BucketManager::resolveBackgroundEvictionScan(
     auto ledgerSeq = ltxSnap.getLedgerHeader().current().ledgerSeq;
     auto ledgerVers = ltxSnap.getLedgerHeader().current().ledgerVersion;
     auto networkConfig = SorobanNetworkConfig::loadFromLedger(ltxSnap);
-    releaseAssert(ledgerSeq == lclSnapshot.getLedgerSeq() + 1);
+    releaseAssert(ledgerSeq == lclApplyView.getLedgerSeq() + 1);
 
     if (!mEvictionFuture.valid())
     {
@@ -1198,7 +1198,7 @@ BucketManager::resolveBackgroundEvictionScan(
         // candidates; this function later validates them by re-checking the
         // Soroban config and reloading the latest TTLs. Any entry restored in
         // the same ledger will be rejected by eviction validation logic.
-        startBackgroundEvictionScan(lclSnapshot, networkConfig);
+        startBackgroundEvictionScan(lclApplyView, networkConfig);
     }
 
     auto evictionCandidates = mEvictionFuture.get();
@@ -1208,7 +1208,7 @@ BucketManager::resolveBackgroundEvictionScan(
     if (!evictionCandidates->isValid(ledgerSeq, ledgerVers,
                                      networkConfig.stateArchivalSettings()))
     {
-        startBackgroundEvictionScan(lclSnapshot, networkConfig);
+        startBackgroundEvictionScan(lclApplyView, networkConfig);
         evictionCandidates = mEvictionFuture.get();
     }
 

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -6,7 +6,7 @@
 
 #include "bucket/BucketMergeMap.h"
 #include "history/HistoryArchive.h"
-#include "ledger/LedgerStateSnapshot.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "ledger/NetworkConfig.h"
 #include "main/Config.h"
 #include "util/ThreadAnnotations.h"
@@ -338,7 +338,7 @@ class BucketManager : NonMovableOrCopyable
     // Scans BucketList for non-live entries to evict starting at the entry
     // pointed to by EvictionIterator. Evicts until `maxEntriesToEvict` entries
     // have been evicted or maxEvictionScanSize bytes have been scanned.
-    void startBackgroundEvictionScan(ApplyLedgerStateSnapshot lclSnapshot,
+    void startBackgroundEvictionScan(ApplyLedgerView lclApplyView,
                                      SorobanNetworkConfig const& networkConfig);
 
     // Returns a pair of vectors representing entries evicted this ledger, where
@@ -347,7 +347,7 @@ class BucketManager : NonMovableOrCopyable
     // ContractCode). Note that when an entry is archived, its TTL key will be
     // included in the deleted keys vector.
     EvictedStateVectors
-    resolveBackgroundEvictionScan(ApplyLedgerStateSnapshot const& lclSnapshot,
+    resolveBackgroundEvictionScan(ApplyLedgerView const& lclApplyView,
                                   AbstractLedgerTxn& ltx,
                                   LedgerKeySet const& modifiedKeys);
 

--- a/src/bucket/test/BucketIndexTests.cpp
+++ b/src/bucket/test/BucketIndexTests.cpp
@@ -11,8 +11,8 @@
 #include "bucket/LiveBucket.h"
 #include "bucket/LiveBucketList.h"
 #include "bucket/test/BucketTestUtils.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "ledger/LedgerManager.h"
-#include "ledger/LedgerStateSnapshot.h"
 #include "ledger/LedgerTypeUtils.h"
 #include "ledger/test/LedgerTestUtils.h"
 #include "main/Application.h"
@@ -215,10 +215,10 @@ class BucketIndexTest
         } while (ledger < mApp->getConfig().QUERY_SNAPSHOT_LEDGERS + 2);
         ++ledger;
 
-        auto snap = getApp().getLedgerManager().copyLedgerStateSnapshot();
+        auto ledgerView = getApp().getLedgerManager().copyImmutableLedgerView();
         auto lk = LedgerEntryKey(canonicalEntry);
 
-        auto currentLoadedEntry = snap.loadLiveEntry(lk);
+        auto currentLoadedEntry = ledgerView.loadLiveEntry(lk);
         REQUIRE(currentLoadedEntry);
 
         // Note: The definition of "historical snapshot" ledger is that the
@@ -229,7 +229,7 @@ class BucketIndexTest
 
         for (uint32_t currLedger = ledger; currLedger > 0; --currLedger)
         {
-            auto loadRes = snap.loadLiveKeysFromLedger({lk}, currLedger);
+            auto loadRes = ledgerView.loadLiveKeysFromLedger({lk}, currLedger);
 
             // If we query an older snapshot, should return <null, notFound>
             if (currLedger < ledger - mApp->getConfig().QUERY_SNAPSHOT_LEDGERS)
@@ -411,7 +411,7 @@ class BucketIndexTest
     virtual void
     run(std::optional<double> expectedHitRate = std::nullopt)
     {
-        auto snap = getApp().getLedgerManager().copyLedgerStateSnapshot();
+        auto ledgerView = getApp().getLedgerManager().copyImmutableLedgerView();
 
         auto& hitMeter = getBM().getCacheHitMeter();
         auto& missMeter = getBM().getCacheMissMeter();
@@ -479,7 +479,7 @@ class BucketIndexTest
         };
 
         // Test bulk load lookup
-        auto loadResult = snap.loadLiveKeys(mKeysToSearch, "test");
+        auto loadResult = ledgerView.loadLiveKeys(mKeysToSearch, "test");
         validateResults(mTestEntries, loadResult);
 
         if (expectedHitRate)
@@ -513,7 +513,7 @@ class BucketIndexTest
         for (auto iter = mKeysToSearch.rbegin(); iter != mKeysToSearch.rend();
              ++iter)
         {
-            auto entryPtr = snap.loadLiveEntry(*iter);
+            auto entryPtr = ledgerView.loadLiveEntry(*iter);
             if (entryPtr)
             {
                 loadResult.emplace_back(*entryPtr);
@@ -528,7 +528,7 @@ class BucketIndexTest
                          mKeysToSearch.size());
 
             // Run bulk lookup again
-            auto loadResult2 = snap.loadLiveKeys(mKeysToSearch, "test");
+            auto loadResult2 = ledgerView.loadLiveKeys(mKeysToSearch, "test");
             validateResults(mTestEntries, loadResult2);
 
             checkHitRate(expectedHitRate, startingHitCount, startingMissCount,
@@ -540,7 +540,7 @@ class BucketIndexTest
     virtual void
     runPerf(size_t n)
     {
-        auto snap = getApp().getLedgerManager().copyLedgerStateSnapshot();
+        auto ledgerView = getApp().getLedgerManager().copyImmutableLedgerView();
         for (size_t i = 0; i < n; ++i)
         {
             LedgerKeySet searchSubset;
@@ -571,7 +571,7 @@ class BucketIndexTest
                 searchSubset.insert(addKeys.begin(), addKeys.end());
             }
 
-            auto blLoad = snap.loadLiveKeys(searchSubset, "test");
+            auto blLoad = ledgerView.loadLiveKeys(searchSubset, "test");
             validateResults(testEntriesSubset, blLoad);
         }
     }
@@ -579,7 +579,7 @@ class BucketIndexTest
     void
     testInvalidKeys()
     {
-        auto snap = getApp().getLedgerManager().copyLedgerStateSnapshot();
+        auto ledgerView = getApp().getLedgerManager().copyImmutableLedgerView();
 
         // Load should return empty vector for keys not in bucket list
         auto keysNotInBL =
@@ -589,12 +589,12 @@ class BucketIndexTest
         LedgerKeySet invalidKeys(keysNotInBL.begin(), keysNotInBL.end());
 
         // Test bulk load
-        REQUIRE(snap.loadLiveKeys(invalidKeys, "test").size() == 0);
+        REQUIRE(ledgerView.loadLiveKeys(invalidKeys, "test").size() == 0);
 
         // Test individual load
         for (auto const& key : invalidKeys)
         {
-            auto entryPtr = snap.loadLiveEntry(key);
+            auto entryPtr = ledgerView.loadLiveEntry(key);
             REQUIRE(!entryPtr);
         }
     }
@@ -748,8 +748,8 @@ class BucketIndexPoolShareTest : public BucketIndexTest
     virtual void
     run(std::optional<double> expectedHitRate = std::nullopt) override
     {
-        auto snap = getApp().getLedgerManager().copyLedgerStateSnapshot();
-        auto loadResult = snap.loadPoolShareTrustLinesByAccountAndAsset(
+        auto ledgerView = getApp().getLedgerManager().copyImmutableLedgerView();
+        auto loadResult = ledgerView.loadPoolShareTrustLinesByAccountAndAsset(
             mAccountToSearch.accountID, mAssetToSearch);
         validateResults(mTestEntries, loadResult);
     }
@@ -1107,7 +1107,7 @@ TEST_CASE("soroban cache population", "[soroban][bucketindex]")
                 lm.getInMemorySorobanStateForTesting();
 
             auto snapshot =
-                test.getApp().getLedgerManager().copyLedgerStateSnapshot();
+                test.getApp().getLedgerManager().copyImmutableLedgerView();
 
             // First, test that the cache is maintained correctly via `addBatch`
             REQUIRE(codeEntries.size() ==
@@ -1315,7 +1315,7 @@ TEST_CASE("hot archive bucket lookups", "[bucket][bucketindex][archive]")
         auto ledger = 1;
 
         // Use snapshot across ledger to test update behavior
-        auto snap = app->getLedgerManager().copyLedgerStateSnapshot();
+        auto ledgerView = app->getLedgerManager().copyImmutableLedgerView();
 
         auto checkLoad =
             [&](LedgerKey const& k,
@@ -1342,12 +1342,12 @@ TEST_CASE("hot archive bucket lookups", "[bucket][bucketindex][archive]")
             LedgerKeySet bulkLoadKeys;
             for (auto const& k : keysToSearch)
             {
-                auto entryPtr = snap.loadArchiveEntry(k);
+                auto entryPtr = ledgerView.loadArchiveEntry(k);
                 checkLoad(k, entryPtr);
                 bulkLoadKeys.emplace(k);
             }
 
-            auto bulkLoadResult = snap.loadArchiveKeys(bulkLoadKeys);
+            auto bulkLoadResult = ledgerView.loadArchiveKeys(bulkLoadKeys);
             for (auto entry : bulkLoadResult)
             {
                 REQUIRE(entry.type() == HOT_ARCHIVE_ARCHIVED);
@@ -1388,7 +1388,7 @@ TEST_CASE("hot archive bucket lookups", "[bucket][bucketindex][archive]")
             HotArchiveBucket::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION);
         addHotArchiveBatchAndUpdateSnapshot(*app, header, archivedEntries,
                                             restoredEntries);
-        snap = app->getLedgerManager().copyLedgerStateSnapshot();
+        ledgerView = app->getLedgerManager().copyImmutableLedgerView();
         checkResult();
 
         // Add a few batches so that entries are no longer in the top bucket
@@ -1396,7 +1396,7 @@ TEST_CASE("hot archive bucket lookups", "[bucket][bucketindex][archive]")
         {
             header.ledgerSeq += 1;
             addHotArchiveBatchAndUpdateSnapshot(*app, header, {}, {});
-            snap = app->getLedgerManager().copyLedgerStateSnapshot();
+            ledgerView = app->getLedgerManager().copyImmutableLedgerView();
         }
 
         // Shadow entries via liveEntry
@@ -1406,17 +1406,18 @@ TEST_CASE("hot archive bucket lookups", "[bucket][bucketindex][archive]")
         header.ledgerSeq += 1;
         addHotArchiveBatchAndUpdateSnapshot(*app, header, {},
                                             {liveShadow1, liveShadow2});
-        snap = app->getLedgerManager().copyLedgerStateSnapshot();
+        ledgerView = app->getLedgerManager().copyImmutableLedgerView();
 
         // Point load
         for (auto const& k : {liveShadow1, liveShadow2})
         {
-            auto entryPtr = snap.loadArchiveEntry(k);
+            auto entryPtr = ledgerView.loadArchiveEntry(k);
             REQUIRE(!entryPtr);
         }
 
         // Bulk load
-        auto bulkLoadResult = snap.loadArchiveKeys({liveShadow1, liveShadow2});
+        auto bulkLoadResult =
+            ledgerView.loadArchiveKeys({liveShadow1, liveShadow2});
         REQUIRE(bulkLoadResult.size() == 0);
 
         // Shadow via archivedEntries
@@ -1425,10 +1426,11 @@ TEST_CASE("hot archive bucket lookups", "[bucket][bucketindex][archive]")
 
         header.ledgerSeq += 1;
         addHotArchiveBatchAndUpdateSnapshot(*app, header, {archivedShadow}, {});
-        snap = app->getLedgerManager().copyLedgerStateSnapshot();
+        ledgerView = app->getLedgerManager().copyImmutableLedgerView();
 
         // Point load
-        auto entryPtr = snap.loadArchiveEntry(LedgerEntryKey(archivedShadow));
+        auto entryPtr =
+            ledgerView.loadArchiveEntry(LedgerEntryKey(archivedShadow));
         REQUIRE(entryPtr);
         REQUIRE(entryPtr->type() ==
                 HotArchiveBucketEntryType::HOT_ARCHIVE_ARCHIVED);
@@ -1436,7 +1438,7 @@ TEST_CASE("hot archive bucket lookups", "[bucket][bucketindex][archive]")
 
         // Bulk load
         auto bulkLoadResult2 =
-            snap.loadArchiveKeys({LedgerEntryKey(archivedShadow)});
+            ledgerView.loadArchiveKeys({LedgerEntryKey(archivedShadow)});
         REQUIRE(bulkLoadResult2.size() == 1);
         REQUIRE(bulkLoadResult2[0].type() == HOT_ARCHIVE_ARCHIVED);
         REQUIRE(bulkLoadResult2[0].archivedEntry() == archivedShadow);
@@ -1603,7 +1605,7 @@ TEST_CASE("getRangeForType bounds verification", "[bucket][bucketindex]")
                               .getCurr();
             verifyIndexBounds(bucket);
 
-            auto snap = app->getLedgerManager().copyLedgerStateSnapshot();
+            auto ledgerView = app->getLedgerManager().copyImmutableLedgerView();
 
             auto verifyScanForType =
                 [&](LedgerEntryType type,
@@ -1616,7 +1618,7 @@ TEST_CASE("getRangeForType bounds verification", "[bucket][bucketindex]")
                         expectedEntries.emplace(LedgerEntryKey(entry), entry);
                     }
 
-                    snap.scanLiveEntriesOfType(
+                    ledgerView.scanLiveEntriesOfType(
                         type, [&](BucketEntry const& be) {
                             auto lk = getBucketLedgerKey(be);
                             REQUIRE(lk.type() == type);
@@ -1637,11 +1639,11 @@ TEST_CASE("getRangeForType bounds verification", "[bucket][bucketindex]")
             verifyScanForType(TRUSTLINE, trustlineEntries);
 
             // Verify that we don't call the callback for non-existent types
-            snap.scanLiveEntriesOfType(CONTRACT_CODE,
-                                       [&](BucketEntry const& be) {
-                                           REQUIRE(false);
-                                           return Loop::INCOMPLETE;
-                                       });
+            ledgerView.scanLiveEntriesOfType(CONTRACT_CODE,
+                                             [&](BucketEntry const& be) {
+                                                 REQUIRE(false);
+                                                 return Loop::INCOMPLETE;
+                                             });
         }
     };
 

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -15,7 +15,7 @@
 #include "bucket/LiveBucketList.h"
 #include "bucket/test/BucketTestUtils.h"
 #include "crypto/Hex.h"
-#include "ledger/LedgerStateSnapshot.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "ledger/LedgerTypeUtils.h"
 #include "ledger/test/LedgerTestUtils.h"
 #include "lib/util/stdrandom.h"
@@ -1112,15 +1112,16 @@ TEST_CASE_VERSIONS("eviction scan", "[bucketlist][archival][soroban]")
             LedgerKey stateArchivalKey(CONFIG_SETTING);
             stateArchivalKey.configSetting().configSettingID =
                 ConfigSettingID::CONFIG_SETTING_STATE_ARCHIVAL;
-            LedgerSnapshot ls(*app);
-            auto stateArchivalEntry = ls.load(stateArchivalKey).current();
+            CheckValidLedgerViewWrapper ledgerView(*app);
+            auto stateArchivalEntry =
+                ledgerView.load(stateArchivalKey).current();
             modifyStateArchivalFn(stateArchivalEntry.data.configSetting()
                                       .stateArchivalSettings());
 
             LedgerKey evictionIterKey(CONFIG_SETTING);
             evictionIterKey.configSetting().configSettingID =
                 ConfigSettingID::CONFIG_SETTING_EVICTION_ITERATOR;
-            auto evictionIterEntry = ls.load(evictionIterKey).current();
+            auto evictionIterEntry = ledgerView.load(evictionIterKey).current();
             modifyEvictionIteratorFn(
                 evictionIterEntry.data.configSetting().evictionIterator());
 
@@ -1209,14 +1210,14 @@ TEST_CASE_VERSIONS("eviction scan", "[bucketlist][archival][soroban]")
         auto checkArchivedBucketList = [&] {
             if (!tempOnly)
             {
-                auto archiveSnap =
-                    app->getLedgerManager().copyLedgerStateSnapshot();
+                auto archiveView =
+                    app->getLedgerManager().copyImmutableLedgerView();
 
                 // Check that persisted entries have been inserted into
                 // HotArchive
                 for (auto const& k : persistentEntries)
                 {
-                    auto archivedEntry = archiveSnap.loadArchiveEntry(k);
+                    auto archivedEntry = archiveView.loadArchiveEntry(k);
                     REQUIRE(archivedEntry);
 
                     auto seen = false;
@@ -1232,14 +1233,14 @@ TEST_CASE_VERSIONS("eviction scan", "[bucketlist][archival][soroban]")
 
                     // Make sure TTL keys are not archived
                     auto ttl = getTTLKey(k);
-                    auto archivedTTL = archiveSnap.loadArchiveEntry(ttl);
+                    auto archivedTTL = archiveView.loadArchiveEntry(ttl);
                     REQUIRE(!archivedTTL);
                 }
 
                 // Temp entries should not be archived
                 for (auto const& k : tempEntries)
                 {
-                    auto archivedEntry = archiveSnap.loadArchiveEntry(k);
+                    auto archivedEntry = archiveView.loadArchiveEntry(k);
                     REQUIRE(!archivedEntry);
                 }
             }
@@ -1722,10 +1723,10 @@ TEST_CASE_VERSIONS("Searchable BucketListDB snapshots", "[bucketlist]")
         }
 
         closeLedger(*app);
-        auto blSnap = app->getLedgerManager().copyLedgerStateSnapshot();
+        auto blLedgerView = app->getLedgerManager().copyImmutableLedgerView();
 
         // Snapshot should automatically update with latest version
-        auto loadedEntry = blSnap.loadLiveEntry(LedgerEntryKey(entry));
+        auto loadedEntry = blLedgerView.loadLiveEntry(LedgerEntryKey(entry));
         REQUIRE((loadedEntry && *loadedEntry == entry));
     }
 }

--- a/src/bucket/test/BucketTestUtils.cpp
+++ b/src/bucket/test/BucketTestUtils.cpp
@@ -174,7 +174,7 @@ template size_t countEntries(std::shared_ptr<HotArchiveBucket> bucket);
 
 std::optional<SorobanNetworkConfig>
 LedgerManagerForBucketTests::finalizeLedgerTxnChanges(
-    ApplyLedgerStateSnapshot const& lclSnapshot, AbstractLedgerTxn& ltx,
+    ApplyLedgerView const& lclApplyView, AbstractLedgerTxn& ltx,
     std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta,
     LedgerHeader lh, uint32_t initialLedgerVers)
 {
@@ -220,7 +220,7 @@ LedgerManagerForBucketTests::finalizeLedgerTxnChanges(
 
                 auto evictedState =
                     mApp.getBucketManager().resolveBackgroundEvictionScan(
-                        lclSnapshot, ltx, keys);
+                        lclApplyView, ltx, keys);
                 if (protocolVersionStartsFrom(
                         initialLedgerVers,
                         LiveBucket::
@@ -318,7 +318,7 @@ LedgerManagerForBucketTests::finalizeLedgerTxnChanges(
             HistoryArchiveState tempHas;
             tempHas.currentLedger = lh.ledgerSeq;
             auto& bm = mApp.getBucketManager();
-            auto tempState = CompleteConstLedgerState::createAndMaybeLoadConfig(
+            auto tempState = ImmutableLedgerData::createAndMaybeLoadConfig(
                 bm.getLiveBucketList(), bm.getHotArchiveBucketList(), tempLcl,
                 tempHas, mApp.getMetrics(), nullptr, 0);
             finalSorobanConfig = tempState->getSorobanConfig();
@@ -341,7 +341,7 @@ LedgerManagerForBucketTests::finalizeLedgerTxnChanges(
     else
     {
         return LedgerManagerImpl::finalizeLedgerTxnChanges(
-            lclSnapshot, ltx, ledgerCloseMeta, lh, initialLedgerVers);
+            lclApplyView, ltx, ledgerCloseMeta, lh, initialLedgerVers);
     }
 }
 

--- a/src/bucket/test/BucketTestUtils.cpp
+++ b/src/bucket/test/BucketTestUtils.cpp
@@ -310,12 +310,18 @@ LedgerManagerForBucketTests::finalizeLedgerTxnChanges(
         if (protocolVersionStartsFrom(lh.ledgerVersion,
                                       SOROBAN_PROTOCOL_VERSION))
         {
-            auto liveData =
-                std::make_shared<BucketListSnapshotData<LiveBucket>>(
-                    mApp.getBucketManager().getLiveBucketList());
-            LedgerSnapshot ls(mApp.getMetrics(), std::move(liveData), lh);
-            finalSorobanConfig =
-                std::make_optional(SorobanNetworkConfig::loadFromLedger(ls));
+            // Tests may inject config upgrades directly into the BucketList, so
+            // we need to construct a temp dummy snapshot to load the injected
+            // config.
+            LedgerHeaderHistoryEntry tempLcl;
+            tempLcl.header = lh;
+            HistoryArchiveState tempHas;
+            tempHas.currentLedger = lh.ledgerSeq;
+            auto& bm = mApp.getBucketManager();
+            auto tempState = CompleteConstLedgerState::createAndMaybeLoadConfig(
+                bm.getLiveBucketList(), bm.getHotArchiveBucketList(), tempLcl,
+                tempHas, mApp.getMetrics(), nullptr, 0);
+            finalSorobanConfig = tempState->getSorobanConfig();
         }
 
         mApplyState.updateInMemorySorobanState(

--- a/src/bucket/test/BucketTestUtils.h
+++ b/src/bucket/test/BucketTestUtils.h
@@ -73,7 +73,7 @@ class LedgerManagerForBucketTests : public LedgerManagerImpl
 
   protected:
     std::optional<SorobanNetworkConfig> finalizeLedgerTxnChanges(
-        ApplyLedgerStateSnapshot const& lclSnapshot, AbstractLedgerTxn& ltx,
+        ApplyLedgerView const& lclApplyView, AbstractLedgerTxn& ltx,
         std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta,
         LedgerHeader lh, uint32_t initialLedgerVers) override;
 

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1587,8 +1587,8 @@ HerderImpl::triggerNextLedger(uint32_t ledgerSeqToTrigger,
     // see if we need to include some upgrades
     std::vector<LedgerUpgrade> upgrades;
     {
-        LedgerSnapshot ls(mApp);
-        upgrades = mUpgrades.createUpgradesFor(lcl.header, ls);
+        CheckValidLedgerViewWrapper ledgerView(mApp);
+        upgrades = mUpgrades.createUpgradesFor(lcl.header, ledgerView);
     }
     for (auto const& upgrade : upgrades)
     {
@@ -1655,8 +1655,8 @@ HerderImpl::setUpgrades(Upgrades::UpgradeParameters const& upgrades)
 std::string
 HerderImpl::getUpgradesJson()
 {
-    auto ls = LedgerSnapshot(mApp);
-    return mUpgrades.getParameters().toDebugJson(ls);
+    auto ledgerView = CheckValidLedgerViewWrapper(mApp);
+    return mUpgrades.getParameters().toDebugJson(ledgerView);
 }
 
 void

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -439,7 +439,7 @@ TransactionQueue::canAdd(
         }
     }
 
-    LedgerSnapshot ls(mApp);
+    CheckValidLedgerViewWrapper ledgerView(mApp);
     // Subtle: transactions are rejected based on the source account limit
     // prior to this point. This is safe because we can't evict transactions
     // from the same source account, so a newer transaction won't replace an
@@ -480,7 +480,7 @@ TransactionQueue::canAdd(
 #endif
     {
         auto validationResult = tx->checkValidForOverlay(
-            mApp.getAppConnector(), ls, 0, 0,
+            mApp.getAppConnector(), ledgerView, 0, 0,
             getUpperBoundCloseTimeOffset(mApp, closeTime), diagnosticEvents,
             validationLedgerSeq);
         if (!validationResult->isSuccess())
@@ -499,12 +499,12 @@ TransactionQueue::canAdd(
     if (!isLoadgenTx && !mApp.getRunInOverlayOnlyMode())
 #endif
     {
-        auto const feeSource = ls.getAccount(tx->getFeeSourceID());
+        auto const feeSource = ledgerView.getAccount(tx->getFeeSourceID());
         auto feeStateIter = mAccountStates.find(tx->getFeeSourceID());
         int64_t totalFees = feeStateIter == mAccountStates.end()
                                 ? 0
                                 : feeStateIter->second.mTotalFees;
-        if (getAvailableBalance(ls.getLedgerHeader().current(),
+        if (getAvailableBalance(ledgerView.getLedgerHeader().current(),
                                 feeSource.current()) -
                 newFullFee <
             totalFees)

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -464,11 +464,12 @@ TransactionQueue::canAdd(
     auto closeTime = mApp.getLedgerManager()
                          .getLastClosedLedgerHeader()
                          .header.scpValue.closeTime;
+    // Validate minSeqLedgerGap and LedgerBounds against the next ledgerSeq,
+    // which is what will be used at apply time.
+    std::optional<uint32_t> validationLedgerSeq;
     if (protocolVersionStartsFrom(ledgerVersion, ProtocolVersion::V_19))
     {
-        // This is done so minSeqLedgerGap is validated against the next
-        // ledgerSeq, which is what will be used at apply time
-        ls.getLedgerHeader().currentToModify().ledgerSeq =
+        validationLedgerSeq =
             mApp.getLedgerManager().getLastClosedLedgerNum() + 1;
     }
 
@@ -480,7 +481,8 @@ TransactionQueue::canAdd(
     {
         auto validationResult = tx->checkValidForOverlay(
             mApp.getAppConnector(), ls, 0, 0,
-            getUpperBoundCloseTimeOffset(mApp, closeTime), diagnosticEvents);
+            getUpperBoundCloseTimeOffset(mApp, closeTime), diagnosticEvents,
+            validationLedgerSeq);
         if (!validationResult->isSuccess())
         {
             return AddResult(TransactionQueue::AddResultCode::ADD_STATUS_ERROR,

--- a/src/herder/TxSetUtils.cpp
+++ b/src/herder/TxSetUtils.cpp
@@ -172,10 +172,15 @@ TxSetUtils::getInvalidTxListWithErrors(
     ZoneScoped;
     releaseAssert(threadIsMain());
     LedgerSnapshot ls(app);
-    // This is done so minSeqLedgerGap is validated against the next
-    // ledgerSeq, which is what will be used at apply time
-    ls.getLedgerHeader().currentToModify().ledgerSeq =
-        app.getLedgerManager().getLastClosedLedgerNum() + 1;
+    // Validate minSeqLedgerGap and LedgerBounds against the next ledgerSeq,
+    // which is what will be used at apply time.
+    std::optional<uint32_t> validationLedgerSeq;
+    if (protocolVersionStartsFrom(ls.getLedgerHeader().current().ledgerVersion,
+                                  ProtocolVersion::V_19))
+    {
+        validationLedgerSeq =
+            app.getLedgerManager().getLastClosedLedgerNum() + 1;
+    }
 
     TxFrameListWithErrors invalidTxsWithError;
     auto& invalidTxs = invalidTxsWithError.first;
@@ -186,9 +191,9 @@ TxSetUtils::getInvalidTxListWithErrors(
     auto diagnostics = DiagnosticEventManager::createDisabled();
     for (auto const& tx : txs)
     {
-        auto txResult = tx->checkValid(app.getAppConnector(), ls, 0,
-                                       lowerBoundCloseTimeOffset,
-                                       upperBoundCloseTimeOffset, diagnostics);
+        auto txResult = tx->checkValid(
+            app.getAppConnector(), ls, 0, lowerBoundCloseTimeOffset,
+            upperBoundCloseTimeOffset, diagnostics, validationLedgerSeq);
         if (!txResult->isSuccess())
         {
             invalidTxs.emplace_back(tx);

--- a/src/herder/TxSetUtils.cpp
+++ b/src/herder/TxSetUtils.cpp
@@ -171,12 +171,13 @@ TxSetUtils::getInvalidTxListWithErrors(
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
-    LedgerSnapshot ls(app);
+    CheckValidLedgerViewWrapper ledgerView(app);
     // Validate minSeqLedgerGap and LedgerBounds against the next ledgerSeq,
     // which is what will be used at apply time.
     std::optional<uint32_t> validationLedgerSeq;
-    if (protocolVersionStartsFrom(ls.getLedgerHeader().current().ledgerVersion,
-                                  ProtocolVersion::V_19))
+    if (protocolVersionStartsFrom(
+            ledgerView.getLedgerHeader().current().ledgerVersion,
+            ProtocolVersion::V_19))
     {
         validationLedgerSeq =
             app.getLedgerManager().getLastClosedLedgerNum() + 1;
@@ -192,7 +193,7 @@ TxSetUtils::getInvalidTxListWithErrors(
     for (auto const& tx : txs)
     {
         auto txResult = tx->checkValid(
-            app.getAppConnector(), ls, 0, lowerBoundCloseTimeOffset,
+            app.getAppConnector(), ledgerView, 0, lowerBoundCloseTimeOffset,
             upperBoundCloseTimeOffset, diagnostics, validationLedgerSeq);
         if (!txResult->isSuccess())
         {
@@ -214,7 +215,7 @@ TxSetUtils::getInvalidTxListWithErrors(
         }
     }
 
-    auto header = ls.getLedgerHeader().current();
+    auto header = ledgerView.getLedgerHeader().current();
     for (auto const& tx : txs)
     {
         // Already added invalid tx
@@ -224,7 +225,7 @@ TxSetUtils::getInvalidTxListWithErrors(
         }
 
         auto feeSourceID = tx->getFeeSourceID();
-        auto feeSource = ls.getAccount(feeSourceID);
+        auto feeSource = ledgerView.getAccount(feeSourceID);
         // feeSource should exist since we've already run checkValid, log
         // internal bug
         if (!feeSource)

--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -174,12 +174,12 @@ namespace stellar
 namespace
 {
 uint32_t
-readMaxSorobanTxSetSize(LedgerSnapshot const& ls)
+readMaxSorobanTxSetSize(CheckValidLedgerViewWrapper const& ledgerView)
 {
     LedgerKey key(LedgerEntryType::CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_CONTRACT_EXECUTION_LANES;
-    return ls.load(key)
+    return ledgerView.load(key)
         .current()
         .data.configSetting()
         .contractExecutionLanes()
@@ -211,7 +211,8 @@ Upgrades::UpgradeParameters::toJson() const
 }
 
 std::string
-Upgrades::UpgradeParameters::toDebugJson(LedgerSnapshot const& ls) const
+Upgrades::UpgradeParameters::toDebugJson(
+    CheckValidLedgerViewWrapper const& ledgerView) const
 {
     Json::Value upgradesJson;
     Json::Reader reader;
@@ -225,8 +226,8 @@ Upgrades::UpgradeParameters::toDebugJson(LedgerSnapshot const& ls) const
             upgradesJson["configupgradesetkey"];
         upgradesJson.removeMember("configupgradesetkey");
 
-        auto upgradeSetPtr =
-            ConfigUpgradeSetFrame::makeFromKey(ls, *mConfigUpgradeSetKey);
+        auto upgradeSetPtr = ConfigUpgradeSetFrame::makeFromKey(
+            ledgerView, *mConfigUpgradeSetKey);
         if (upgradeSetPtr)
         {
             Json::Value configUpgradeSetJson;
@@ -277,7 +278,7 @@ Upgrades::getParameters() const
 
 std::vector<LedgerUpgrade>
 Upgrades::createUpgradesFor(LedgerHeader const& lclHeader,
-                            LedgerSnapshot const& ls) const
+                            CheckValidLedgerViewWrapper const& ledgerView) const
 {
     auto result = std::vector<LedgerUpgrade>{};
     if (!timeForUpgrade(lclHeader.scpValue.closeTime))
@@ -319,10 +320,10 @@ Upgrades::createUpgradesFor(LedgerHeader const& lclHeader,
     auto key = mParams.mConfigUpgradeSetKey;
     if (key)
     {
-        auto cfgUpgrade = ConfigUpgradeSetFrame::makeFromKey(ls, *key);
+        auto cfgUpgrade = ConfigUpgradeSetFrame::makeFromKey(ledgerView, *key);
         if (cfgUpgrade != nullptr &&
             cfgUpgrade->isValidForApply() == UpgradeValidity::VALID &&
-            cfgUpgrade->upgradeNeeded(ls))
+            cfgUpgrade->upgradeNeeded(ledgerView))
         {
             result.emplace_back(LEDGER_UPGRADE_CONFIG);
             result.back().newConfig() = cfgUpgrade->getKey();
@@ -332,7 +333,8 @@ Upgrades::createUpgradesFor(LedgerHeader const& lclHeader,
     {
         if (protocolVersionStartsFrom(lclHeader.ledgerVersion,
                                       SOROBAN_PROTOCOL_VERSION) &&
-            readMaxSorobanTxSetSize(ls) != *mParams.mMaxSorobanTxSetSize)
+            readMaxSorobanTxSetSize(ledgerView) !=
+                *mParams.mMaxSorobanTxSetSize)
         {
             result.emplace_back(LEDGER_UPGRADE_MAX_SOROBAN_TX_SET_SIZE);
             result.back().newMaxSorobanTxSetSize() =
@@ -365,7 +367,7 @@ Upgrades::applyTo(LedgerUpgrade const& upgrade, Application& app,
         break;
     case LEDGER_UPGRADE_CONFIG:
     {
-        LedgerSnapshot ltxState(ltx);
+        CheckValidLedgerViewWrapper ltxState(ltx);
         auto cfgUpgrade =
             ConfigUpgradeSetFrame::makeFromKey(ltxState, upgrade.newConfig());
         if (!cfgUpgrade)
@@ -564,7 +566,7 @@ Upgrades::removeUpgrades(std::vector<UpgradeType>::const_iterator beginUpdates,
 Upgrades::UpgradeValidity
 Upgrades::isValidForApply(UpgradeType const& opaqueUpgrade,
                           LedgerUpgrade& upgrade, Application& app,
-                          LedgerSnapshot const& ls)
+                          CheckValidLedgerViewWrapper const& ledgerView)
 {
     try
     {
@@ -576,7 +578,7 @@ Upgrades::isValidForApply(UpgradeType const& opaqueUpgrade,
     }
 
     bool res = true;
-    auto version = ls.getLedgerHeader().current().ledgerVersion;
+    auto version = ledgerView.getLedgerHeader().current().ledgerVersion;
     switch (upgrade.type())
     {
     case LEDGER_UPGRADE_VERSION:
@@ -609,7 +611,7 @@ Upgrades::isValidForApply(UpgradeType const& opaqueUpgrade,
             return UpgradeValidity::INVALID;
         }
         auto cfgUpgrade =
-            ConfigUpgradeSetFrame::makeFromKey(ls, upgrade.newConfig());
+            ConfigUpgradeSetFrame::makeFromKey(ledgerView, upgrade.newConfig());
         if (!cfgUpgrade)
         {
             return UpgradeValidity::INVALID;
@@ -637,10 +639,12 @@ Upgrades::isValidForApply(UpgradeType const& opaqueUpgrade,
 }
 
 bool
-Upgrades::isValidForNomination(LedgerUpgrade const& upgrade,
-                               LedgerSnapshot const& ls) const
+Upgrades::isValidForNomination(
+    LedgerUpgrade const& upgrade,
+    CheckValidLedgerViewWrapper const& ledgerView) const
 {
-    if (!timeForUpgrade(ls.getLedgerHeader().current().scpValue.closeTime))
+    if (!timeForUpgrade(
+            ledgerView.getLedgerHeader().current().scpValue.closeTime))
     {
         return false;
     }
@@ -668,10 +672,10 @@ Upgrades::isValidForNomination(LedgerUpgrade const& upgrade,
         }
 
         auto cfgUpgrade =
-            ConfigUpgradeSetFrame::makeFromKey(ls, upgrade.newConfig());
+            ConfigUpgradeSetFrame::makeFromKey(ledgerView, upgrade.newConfig());
         return cfgUpgrade &&
                cfgUpgrade->isConsistentWith(ConfigUpgradeSetFrame::makeFromKey(
-                   ls, *mParams.mConfigUpgradeSetKey));
+                   ledgerView, *mParams.mConfigUpgradeSetKey));
     }
     case LEDGER_UPGRADE_MAX_SOROBAN_TX_SET_SIZE:
         return mParams.mMaxSorobanTxSetSize &&
@@ -687,13 +691,13 @@ Upgrades::isValid(UpgradeType const& upgrade, LedgerUpgradeType& upgradeType,
                   bool nomination, Application& app) const
 {
     LedgerUpgrade lupgrade;
-    auto ls = LedgerSnapshot(app);
-    bool res =
-        isValidForApply(upgrade, lupgrade, app, ls) == UpgradeValidity::VALID;
+    auto ledgerView = CheckValidLedgerViewWrapper(app);
+    bool res = isValidForApply(upgrade, lupgrade, app, ledgerView) ==
+               UpgradeValidity::VALID;
 
     if (nomination)
     {
-        res = res && isValidForNomination(lupgrade, ls);
+        res = res && isValidForNomination(lupgrade, ledgerView);
     }
 
     if (res)
@@ -1290,19 +1294,21 @@ Upgrades::applyReserveUpgrade(AbstractLedgerTxn& ltx, uint32_t newReserve)
 }
 
 ConfigUpgradeSetFrameConstPtr
-ConfigUpgradeSetFrame::makeFromKey(LedgerSnapshot const& ls,
-                                   ConfigUpgradeSetKey const& key)
+ConfigUpgradeSetFrame::makeFromKey(
+    CheckValidLedgerViewWrapper const& ledgerView,
+    ConfigUpgradeSetKey const& key)
 {
     auto lk = ConfigUpgradeSetFrame::getLedgerKey(key);
-    auto ltxe = ls.load(lk);
+    auto ltxe = ledgerView.load(lk);
     if (!ltxe)
     {
         return nullptr;
     }
 
-    auto ttlLtxe = ls.load(getTTLKey(lk));
+    auto ttlLtxe = ledgerView.load(getTTLKey(lk));
     releaseAssert(ttlLtxe);
-    if (!isLive(ttlLtxe.current(), ls.getLedgerHeader().current().ledgerSeq))
+    if (!isLive(ttlLtxe.current(),
+                ledgerView.getLedgerHeader().current().ledgerSeq))
     {
         return nullptr;
     }
@@ -1326,7 +1332,7 @@ ConfigUpgradeSetFrame::makeFromKey(LedgerSnapshot const& ls,
     }
 
     return std::shared_ptr<ConfigUpgradeSetFrame>(new ConfigUpgradeSetFrame(
-        upgradeSet, key, ls.getLedgerHeader().current().ledgerVersion));
+        upgradeSet, key, ledgerView.getLedgerHeader().current().ledgerVersion));
 }
 
 ConfigUpgradeSetFrame::ConfigUpgradeSetFrame(
@@ -1414,10 +1420,12 @@ ConfigUpgradeSetFrame::getLedgerKey(ConfigUpgradeSetKey const& upgradeKey)
 }
 
 bool
-ConfigUpgradeSetFrame::upgradeNeeded(LedgerSnapshot const& ls) const
+ConfigUpgradeSetFrame::upgradeNeeded(
+    CheckValidLedgerViewWrapper const& ledgerView) const
 {
-    if (protocolVersionIsBefore(ls.getLedgerHeader().current().ledgerVersion,
-                                SOROBAN_PROTOCOL_VERSION))
+    if (protocolVersionIsBefore(
+            ledgerView.getLedgerHeader().current().ledgerVersion,
+            SOROBAN_PROTOCOL_VERSION))
     {
         return false;
     }
@@ -1436,7 +1444,7 @@ ConfigUpgradeSetFrame::upgradeNeeded(LedgerSnapshot const& ls) const
         LedgerKey key(LedgerEntryType::CONFIG_SETTING);
         key.configSetting().configSettingID = updatedEntry.configSettingID();
         bool isSame =
-            ls.load(key).current().data.configSetting() == updatedEntry;
+            ledgerView.load(key).current().data.configSetting() == updatedEntry;
         if (!isSame)
         {
             return true;

--- a/src/herder/Upgrades.h
+++ b/src/herder/Upgrades.h
@@ -20,7 +20,7 @@ class Config;
 class Database;
 struct LedgerHeader;
 struct LedgerUpgrade;
-class LedgerSnapshot;
+class CheckValidLedgerViewWrapper;
 
 class ConfigUpgradeSetFrame;
 using ConfigUpgradeSetFrameConstPtr =
@@ -70,7 +70,8 @@ class Upgrades
 
         std::string toJson() const;
         void fromJson(std::string const& s);
-        std::string toDebugJson(LedgerSnapshot const& ls) const;
+        std::string
+        toDebugJson(CheckValidLedgerViewWrapper const& ledgerView) const;
     };
 
     Upgrades()
@@ -85,7 +86,7 @@ class Upgrades
     // create upgrades for given ledger
     std::vector<LedgerUpgrade>
     createUpgradesFor(LedgerHeader const& lclHeader,
-                      LedgerSnapshot const& ls) const;
+                      CheckValidLedgerViewWrapper const& ledgerView) const;
 
     // apply upgrade to ledger header
     static void applyTo(LedgerUpgrade const& upgrade, Application& app,
@@ -106,10 +107,10 @@ class Upgrades
     // INVALID if it is unsafe to apply the upgrade for any other reason
     //
     // If the upgrade could be deserialized then lupgrade is set
-    static UpgradeValidity isValidForApply(UpgradeType const& upgrade,
-                                           LedgerUpgrade& lupgrade,
-                                           Application& app,
-                                           LedgerSnapshot const& ls);
+    static UpgradeValidity
+    isValidForApply(UpgradeType const& upgrade, LedgerUpgrade& lupgrade,
+                    Application& app,
+                    CheckValidLedgerViewWrapper const& ledgerView);
 
     // returns true if upgrade is a valid upgrade step
     // in which case it also sets upgradeType
@@ -135,8 +136,9 @@ class Upgrades
 
     // returns true if upgrade is a valid upgrade step
     // in which case it also sets lupgrade
-    bool isValidForNomination(LedgerUpgrade const& upgrade,
-                              LedgerSnapshot const& ls) const;
+    bool
+    isValidForNomination(LedgerUpgrade const& upgrade,
+                         CheckValidLedgerViewWrapper const& ledgerView) const;
 
     static void applyVersionUpgrade(Application& app, AbstractLedgerTxn& ltx,
                                     uint32_t newVersion);
@@ -156,7 +158,8 @@ class ConfigUpgradeSetFrame
 {
   public:
     static ConfigUpgradeSetFrameConstPtr
-    makeFromKey(LedgerSnapshot const& ls, ConfigUpgradeSetKey const& key);
+    makeFromKey(CheckValidLedgerViewWrapper const& ledgerView,
+                ConfigUpgradeSetKey const& key);
 
     static LedgerKey getLedgerKey(ConfigUpgradeSetKey const& upgradeKey);
 
@@ -164,7 +167,7 @@ class ConfigUpgradeSetFrame
 
     ConfigUpgradeSetKey const& getKey() const;
 
-    bool upgradeNeeded(LedgerSnapshot const& ls) const;
+    bool upgradeNeeded(CheckValidLedgerViewWrapper const& ledgerView) const;
 
     void applyTo(AbstractLedgerTxn& ltx, Application& app) const;
 

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -5176,8 +5176,9 @@ TEST_CASE("ledger state update flow with parallel apply", "[herder][parallel]")
                 REQUIRE(lm.getLastClosedLedgerNum() == lcl);
                 REQUIRE(lm.getLastClosedLedgerHAS().currentLedger ==
                         lastHeader.ledgerSeq);
-                REQUIRE(lm.copyLedgerStateSnapshot().getLedgerHeader() ==
-                        lastHeader);
+                REQUIRE(
+                    lm.copyLedgerStateSnapshot().getLedgerHeader().current() ==
+                    lastHeader);
 
                 // Apply state got committed, but has not yet been propagated to
                 // read-only state
@@ -5229,8 +5230,9 @@ TEST_CASE("ledger state update flow with parallel apply", "[herder][parallel]")
                 auto readOnly = lm.getLastClosedLedgerHeader();
                 REQUIRE(readOnly.header.ledgerSeq == lcl + 1);
                 REQUIRE(lm.getLastClosedLedgerNum() == lcl + 1);
-                REQUIRE(lm.copyLedgerStateSnapshot().getLedgerHeader() ==
-                        readOnly.header);
+                REQUIRE(
+                    lm.copyLedgerStateSnapshot().getLedgerHeader().current() ==
+                    readOnly.header);
                 auto has = lm.getLastClosedLedgerHAS();
                 REQUIRE(has.currentLedger == readOnly.header.ledgerSeq);
 

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -311,7 +311,7 @@ testTxSet(uint32 protocolVersion)
     SECTION("invalid tx")
     {
         auto diagnostics = DiagnosticEventManager::createDisabled();
-        LedgerSnapshot ls(*app);
+        CheckValidLedgerViewWrapper ledgerView(*app);
 
         SECTION("no user")
         {
@@ -321,8 +321,8 @@ testTxSet(uint32 protocolVersion)
 
             // Individual tx check: account doesn't exist
             REQUIRE(badTx
-                        ->checkValid(app->getAppConnector(), ls, 0, 0, 0,
-                                     diagnostics)
+                        ->checkValid(app->getAppConnector(), ledgerView, 0, 0,
+                                     0, diagnostics)
                         ->getResultCode() == txNO_ACCOUNT);
 
             SECTION("build block")
@@ -351,8 +351,8 @@ testTxSet(uint32 protocolVersion)
 
             // Individual tx check: bad sequence number
             REQUIRE(badTx
-                        ->checkValid(app->getAppConnector(), ls, 0, 0, 0,
-                                     diagnostics)
+                        ->checkValid(app->getAppConnector(), ledgerView, 0, 0,
+                                     0, diagnostics)
                         ->getResultCode() == txBAD_SEQ);
 
             SECTION("build block")
@@ -382,7 +382,7 @@ testTxSet(uint32 protocolVersion)
 
             // Individual tx check: insufficient balance
             // Need fresh snapshot after account creation
-            LedgerSnapshot lsNew(*app);
+            CheckValidLedgerViewWrapper lsNew(*app);
             REQUIRE(badTx
                         ->checkValid(app->getAppConnector(), lsNew, 0, 0, 0,
                                      diagnostics)
@@ -416,8 +416,8 @@ testTxSet(uint32 protocolVersion)
             // Individual tx check: bad auth (signature invalidated by maxTime
             // change)
             REQUIRE(badTx
-                        ->checkValid(app->getAppConnector(), ls, 0, 0, 0,
-                                     diagnostics)
+                        ->checkValid(app->getAppConnector(), ledgerView, 0, 0,
+                                     0, diagnostics)
                         ->getResultCode() == txBAD_AUTH);
 
             SECTION("build block")
@@ -532,7 +532,7 @@ testTxSetWithFeeBumps(uint32 protocolVersion)
         };
 
     auto diagnostics = DiagnosticEventManager::createDisabled();
-    LedgerSnapshot ls(*app);
+    CheckValidLedgerViewWrapper ledgerView(*app);
 
     SECTION("invalid transaction")
     {
@@ -542,7 +542,7 @@ testTxSetWithFeeBumps(uint32 protocolVersion)
             auto fb1 = feeBump(*app, account2, tx1, minBalance2);
 
             // Individual tx check: fee bump exceeds fee source balance
-            REQUIRE(fb1->checkValid(app->getAppConnector(), ls, 0, 0, 0,
+            REQUIRE(fb1->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0,
                                     diagnostics)
                         ->getResultCode() == txINSUFFICIENT_BALANCE);
 
@@ -568,10 +568,10 @@ testTxSetWithFeeBumps(uint32 protocolVersion)
             auto fb2 = feeBump(*app, account2, tx2, 200);
 
             // Individual tx checks: first exceeds balance, second is valid
-            REQUIRE(fb1->checkValid(app->getAppConnector(), ls, 0, 0, 0,
+            REQUIRE(fb1->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0,
                                     diagnostics)
                         ->getResultCode() == txINSUFFICIENT_BALANCE);
-            REQUIRE(fb2->checkValid(app->getAppConnector(), ls, 0, 0, 0,
+            REQUIRE(fb2->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0,
                                     diagnostics)
                         ->isSuccess());
 
@@ -596,10 +596,10 @@ testTxSetWithFeeBumps(uint32 protocolVersion)
             auto tx2 = transaction(*app, account3, 1, 1, 100);
             auto fb2 = feeBump(*app, account2, tx2, minBalance2);
 
-            REQUIRE(fb1->checkValid(app->getAppConnector(), ls, 0, 0, 0,
+            REQUIRE(fb1->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0,
                                     diagnostics)
                         ->isSuccess());
-            REQUIRE(fb2->checkValid(app->getAppConnector(), ls, 0, 0, 0,
+            REQUIRE(fb2->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0,
                                     diagnostics)
                         ->getResultCode() == txINSUFFICIENT_BALANCE);
 
@@ -625,10 +625,10 @@ testTxSetWithFeeBumps(uint32 protocolVersion)
             auto fb2 = feeBump(*app, account2, tx2, 200);
 
             // Individual tx checks
-            REQUIRE(fb1->checkValid(app->getAppConnector(), ls, 0, 0, 0,
+            REQUIRE(fb1->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0,
                                     diagnostics)
                         ->isSuccess());
-            REQUIRE(fb2->checkValid(app->getAppConnector(), ls, 0, 0, 0,
+            REQUIRE(fb2->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0,
                                     diagnostics)
                         ->getResultCode() == txFEE_BUMP_INNER_FAILED);
 
@@ -657,14 +657,14 @@ testTxSetWithFeeBumps(uint32 protocolVersion)
                 feeBump(*app, account2, tx3, minBalance2 - minBalance0 - 199);
 
             // Individual tx checks
-            REQUIRE(fb1->checkValid(app->getAppConnector(), ls, 0, 0, 0,
+            REQUIRE(fb1->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0,
                                     diagnostics)
                         ->isSuccess());
-            REQUIRE(fb2->checkValid(app->getAppConnector(), ls, 0, 0, 0,
+            REQUIRE(fb2->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0,
                                     diagnostics)
                         ->getResultCode() == txFEE_BUMP_INNER_FAILED);
             // Individually, fb2 is valid, but with fb1 it would exceed balance
-            REQUIRE(fb3->checkValid(app->getAppConnector(), ls, 0, 0, 0,
+            REQUIRE(fb3->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0,
                                     diagnostics)
                         ->isSuccess());
 
@@ -685,10 +685,10 @@ testTxSetWithFeeBumps(uint32 protocolVersion)
         SECTION("two fee bumps, same fee source, valid individually, combined "
                 "exceed balance")
         {
-            LedgerSnapshot ls(*app);
+            CheckValidLedgerViewWrapper ledgerView(*app);
             auto balanceOfFbAccount = getAvailableBalance(
-                ls.getLedgerHeader().current(),
-                ls.getAccount(account2.getPublicKey()).current());
+                ledgerView.getLedgerHeader().current(),
+                ledgerView.getAccount(account2.getPublicKey()).current());
 
             // Enforce balance invariance
             int64_t fee1 = 200;
@@ -704,10 +704,10 @@ testTxSetWithFeeBumps(uint32 protocolVersion)
             auto fb2 = feeBump(*app, account2, tx2, fee2);
             // Individual txs are valid
             auto diagnostics = DiagnosticEventManager::createDisabled();
-            REQUIRE(fb1->checkValid(app->getAppConnector(), ls, 0, 0, 0,
+            REQUIRE(fb1->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0,
                                     diagnostics)
                         ->isSuccess());
-            REQUIRE(fb2->checkValid(app->getAppConnector(), ls, 0, 0, 0,
+            REQUIRE(fb2->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0,
                                     diagnostics)
                         ->isSuccess());
 
@@ -757,10 +757,11 @@ testTxSetWithFeeBumps(uint32 protocolVersion)
                 createUploadWasmTx(*app, sorobanAccount2, 100,
                                    DEFAULT_TEST_RESOURCE_FEE, resources);
 
-            LedgerSnapshot ls(*app);
+            CheckValidLedgerViewWrapper ledgerView(*app);
             auto balanceOfFbAccount = getAvailableBalance(
-                ls.getLedgerHeader().current(),
-                ls.getAccount(feeSourceAccount.getPublicKey()).current());
+                ledgerView.getLedgerHeader().current(),
+                ledgerView.getAccount(feeSourceAccount.getPublicKey())
+                    .current());
 
             // Set fees so that each is valid individually but combined they
             // exceed the fee source's balance
@@ -778,10 +779,10 @@ testTxSetWithFeeBumps(uint32 protocolVersion)
 
             // Individual txs are valid
             auto diagnostics = DiagnosticEventManager::createDisabled();
-            REQUIRE(fb1->checkValid(app->getAppConnector(), ls, 0, 0, 0,
+            REQUIRE(fb1->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0,
                                     diagnostics)
                         ->isSuccess());
-            REQUIRE(fb2->checkValid(app->getAppConnector(), ls, 0, 0, 0,
+            REQUIRE(fb2->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0,
                                     diagnostics)
                         ->isSuccess());
 
@@ -850,12 +851,12 @@ testTxSetWithFeeBumps(uint32 protocolVersion)
 
             auto diagnostics = DiagnosticEventManager::createDisabled();
             REQUIRE(classicFb
-                        ->checkValid(app->getAppConnector(), ls, 0, 0, 0,
-                                     diagnostics)
+                        ->checkValid(app->getAppConnector(), ledgerView, 0, 0,
+                                     0, diagnostics)
                         ->isSuccess());
             REQUIRE(sorobanFb
-                        ->checkValid(app->getAppConnector(), ls, 0, 0, 0,
-                                     diagnostics)
+                        ->checkValid(app->getAppConnector(), ledgerView, 0, 0,
+                                     0, diagnostics)
                         ->isSuccess());
 
             PerPhaseTransactionList invalidPerPhase;
@@ -907,10 +908,10 @@ TEST_CASE("getInvalidTxListWithErrors returns no duplicates")
     auto account3 = root->create("a3", minBalance2);
     auto account4 = root->create("a4", minBalance2);
 
-    LedgerSnapshot ls(*app);
-    auto balanceOfFeeSource =
-        getAvailableBalance(ls.getLedgerHeader().current(),
-                            ls.getAccount(account2.getPublicKey()).current());
+    CheckValidLedgerViewWrapper ledgerView(*app);
+    auto balanceOfFeeSource = getAvailableBalance(
+        ledgerView.getLedgerHeader().current(),
+        ledgerView.getAccount(account2.getPublicKey()).current());
 
     // Create three fee bumps from account2 (fee source):
     // - fb1: fails checkValid (bad sequence number)
@@ -942,12 +943,15 @@ TEST_CASE("getInvalidTxListWithErrors returns no duplicates")
 
     // Verify fb1 fails checkValid - inner tx has bad sequence number
     auto diagnostics = DiagnosticEventManager::createDisabled();
-    REQUIRE(fb1->checkValid(app->getAppConnector(), ls, 0, 0, 0, diagnostics)
+    REQUIRE(fb1->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0,
+                            diagnostics)
                 ->getResultCode() == txFEE_BUMP_INNER_FAILED);
     // Verify fb2 and fb3 pass checkValid individually
-    REQUIRE(fb2->checkValid(app->getAppConnector(), ls, 0, 0, 0, diagnostics)
+    REQUIRE(fb2->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0,
+                            diagnostics)
                 ->isSuccess());
-    REQUIRE(fb3->checkValid(app->getAppConnector(), ls, 0, 0, 0, diagnostics)
+    REQUIRE(fb3->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0,
+                            diagnostics)
                 ->isSuccess());
 
     // Verify combined fees of fb2 + fb3 exceed balance
@@ -5177,7 +5181,7 @@ TEST_CASE("ledger state update flow with parallel apply", "[herder][parallel]")
                 REQUIRE(lm.getLastClosedLedgerHAS().currentLedger ==
                         lastHeader.ledgerSeq);
                 REQUIRE(
-                    lm.copyLedgerStateSnapshot().getLedgerHeader().current() ==
+                    lm.copyImmutableLedgerView().getLedgerHeader().current() ==
                     lastHeader);
 
                 // Apply state got committed, but has not yet been propagated to
@@ -5231,7 +5235,7 @@ TEST_CASE("ledger state update flow with parallel apply", "[herder][parallel]")
                 REQUIRE(readOnly.header.ledgerSeq == lcl + 1);
                 REQUIRE(lm.getLastClosedLedgerNum() == lcl + 1);
                 REQUIRE(
-                    lm.copyLedgerStateSnapshot().getLedgerHeader().current() ==
+                    lm.copyImmutableLedgerView().getLedgerHeader().current() ==
                     readOnly.header);
                 auto has = lm.getLastClosedLedgerHAS();
                 REQUIRE(has.currentLedger == readOnly.header.ledgerSeq);

--- a/src/herder/test/TxSetTests.cpp
+++ b/src/herder/test/TxSetTests.cpp
@@ -1153,8 +1153,8 @@ TEST_CASE("applicable txset validation - transactions belong to correct phase",
                         1)},
                     2000);
             }
-            LedgerSnapshot ls(*app);
-            REQUIRE(tx->checkValid(app->getAppConnector(), ls, 0, 0, 0)
+            CheckValidLedgerViewWrapper ledgerView(*app);
+            REQUIRE(tx->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0)
                         ->isSuccess());
             return tx;
         };
@@ -1314,8 +1314,8 @@ TEST_CASE("applicable txset validation - Soroban resources", "[txset][soroban]")
             auto tx = sorobanTransactionFrameFromOps(
                 app->getNetworkID(), source, {op}, {}, resources, 2000,
                 100'000'000);
-            LedgerSnapshot ls(*app);
-            REQUIRE(tx->checkValid(app->getAppConnector(), ls, 0, 0, 0)
+            CheckValidLedgerViewWrapper ledgerView(*app);
+            REQUIRE(tx->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0)
                         ->isSuccess());
             return tx;
         };
@@ -1681,8 +1681,8 @@ TEST_CASE("generalized tx set with multiple txs per source account",
 
         // tx1 is valid on its own
         {
-            LedgerSnapshot ls(*app);
-            REQUIRE(tx1->checkValid(app->getAppConnector(), ls, 0, 0, 0)
+            CheckValidLedgerViewWrapper ledgerView(*app);
+            REQUIRE(tx1->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0)
                         ->isSuccess());
         }
 
@@ -1714,10 +1714,10 @@ TEST_CASE("generalized tx set with multiple txs per source account",
 
         // Both txs individually are valid
         {
-            LedgerSnapshot ls(*app);
-            REQUIRE(tx1->checkValid(app->getAppConnector(), ls, 0, 0, 0)
+            CheckValidLedgerViewWrapper ledgerView(*app);
+            REQUIRE(tx1->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0)
                         ->isSuccess());
-            REQUIRE(tx2->checkValid(app->getAppConnector(), ls, 0, 0, 0)
+            REQUIRE(tx2->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0)
                         ->isSuccess());
         }
 
@@ -1815,8 +1815,8 @@ TEST_CASE("generalized tx set fees", "[txset][soroban]")
         }
         if (validateTx)
         {
-            REQUIRE(tx->checkValid(app->getAppConnector(), LedgerSnapshot(*app),
-                                   0, 0, 0)
+            REQUIRE(tx->checkValid(app->getAppConnector(),
+                                   CheckValidLedgerViewWrapper(*app), 0, 0, 0)
                         ->isSuccess());
         }
         return tx;
@@ -2023,7 +2023,7 @@ TEST_CASE("generalized tx set fees", "[txset][soroban]")
             auto feeBumpTx = feeBump(*app, *root, tx, 300);
             REQUIRE(feeBumpTx
                         ->checkValid(app->getAppConnector(),
-                                     LedgerSnapshot(*app), 0, 0, 0)
+                                     CheckValidLedgerViewWrapper(*app), 0, 0, 0)
                         ->isSuccess());
             auto ledgerHash =
                 app->getLedgerManager().getLastClosedLedgerHeader().hash;
@@ -2062,7 +2062,7 @@ TEST_CASE("generalized tx set fees", "[txset][soroban]")
             auto feeBumpTx = feeBump(*app, *root, tx, 200);
             REQUIRE(feeBumpTx
                         ->checkValid(app->getAppConnector(),
-                                     LedgerSnapshot(*app), 0, 0, 0)
+                                     CheckValidLedgerViewWrapper(*app), 0, 0, 0)
                         ->isSuccess());
             auto ledgerHash =
                 app->getLedgerManager().getLastClosedLedgerHeader().hash;
@@ -2557,9 +2557,9 @@ runParallelTxSetBuildingTest(bool variableStageCount)
         // its resources.
         auto tx = createUploadWasmTx(*app, source, inclusionFee, resourceFee,
                                      resources);
-        LedgerSnapshot ls(*app);
-        REQUIRE(
-            tx->checkValid(app->getAppConnector(), ls, 0, 0, 0)->isSuccess());
+        CheckValidLedgerViewWrapper ledgerView(*app);
+        REQUIRE(tx->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0)
+                    ->isSuccess());
 
         return tx;
     };

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -14,7 +14,7 @@
 #include "herder/Upgrades.h"
 #include "history/HistoryArchiveManager.h"
 #include "history/test/HistoryTestsUtils.h"
-#include "ledger/LedgerStateSnapshot.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "ledger/LedgerTxn.h"
 #include "ledger/LedgerTxnEntry.h"
 #include "ledger/LedgerTxnHeader.h"
@@ -339,12 +339,12 @@ testListUpgrades(VirtualClock::system_time_point preferredUpgradeDatetime,
         makeTxCountUpgrade(cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE);
     auto baseReserveUpgrade =
         makeBaseReserveUpgrade(cfg.TESTING_UPGRADE_RESERVE);
-    auto ls = LedgerSnapshot(*app);
+    auto ledgerView = CheckValidLedgerViewWrapper(*app);
 
     SECTION("protocol version upgrade needed")
     {
         header.ledgerVersion--;
-        auto upgrades = Upgrades{cfg}.createUpgradesFor(header, ls);
+        auto upgrades = Upgrades{cfg}.createUpgradesFor(header, ledgerView);
         auto expected = shouldListAny
                             ? std::vector<LedgerUpgrade>{protocolVersionUpgrade}
                             : std::vector<LedgerUpgrade>{};
@@ -354,7 +354,7 @@ testListUpgrades(VirtualClock::system_time_point preferredUpgradeDatetime,
     SECTION("base fee upgrade needed")
     {
         header.baseFee /= 2;
-        auto upgrades = Upgrades{cfg}.createUpgradesFor(header, ls);
+        auto upgrades = Upgrades{cfg}.createUpgradesFor(header, ledgerView);
         auto expected = shouldListAny
                             ? std::vector<LedgerUpgrade>{baseFeeUpgrade}
                             : std::vector<LedgerUpgrade>{};
@@ -364,7 +364,7 @@ testListUpgrades(VirtualClock::system_time_point preferredUpgradeDatetime,
     SECTION("tx count upgrade needed")
     {
         header.maxTxSetSize /= 2;
-        auto upgrades = Upgrades{cfg}.createUpgradesFor(header, ls);
+        auto upgrades = Upgrades{cfg}.createUpgradesFor(header, ledgerView);
         auto expected = shouldListAny
                             ? std::vector<LedgerUpgrade>{txCountUpgrade}
                             : std::vector<LedgerUpgrade>{};
@@ -374,7 +374,7 @@ testListUpgrades(VirtualClock::system_time_point preferredUpgradeDatetime,
     SECTION("base reserve upgrade needed")
     {
         header.baseReserve /= 2;
-        auto upgrades = Upgrades{cfg}.createUpgradesFor(header, ls);
+        auto upgrades = Upgrades{cfg}.createUpgradesFor(header, ledgerView);
         auto expected = shouldListAny
                             ? std::vector<LedgerUpgrade>{baseReserveUpgrade}
                             : std::vector<LedgerUpgrade>{};
@@ -387,7 +387,7 @@ testListUpgrades(VirtualClock::system_time_point preferredUpgradeDatetime,
         header.baseFee /= 2;
         header.maxTxSetSize /= 2;
         header.baseReserve /= 2;
-        auto upgrades = Upgrades{cfg}.createUpgradesFor(header, ls);
+        auto upgrades = Upgrades{cfg}.createUpgradesFor(header, ledgerView);
         auto expected =
             shouldListAny
                 ? std::vector<LedgerUpgrade>{protocolVersionUpgrade,
@@ -706,14 +706,14 @@ TEST_CASE("config upgrade validation", "[upgrades]")
         LedgerTxn ltx(app->getLedgerTxnRoot());
         ltx.loadHeader().current() = header;
 
-        auto ls = LedgerSnapshot(ltx);
+        auto ledgerView = CheckValidLedgerViewWrapper(ltx);
         LedgerUpgrade outUpgrade;
         SECTION("valid")
         {
             REQUIRE(Upgrades::isValidForApply(
                         toUpgradeType(makeConfigUpgrade(*configUpgradeSet)),
                         outUpgrade, *app,
-                        ls) == Upgrades::UpgradeValidity::VALID);
+                        ledgerView) == Upgrades::UpgradeValidity::VALID);
             REQUIRE(outUpgrade.newConfig() == configUpgradeSet->getKey());
         }
         SECTION("unknown upgrade")
@@ -725,7 +725,7 @@ TEST_CASE("config upgrade validation", "[upgrades]")
                 ConfigUpgradeSetKey{contractID, upgradeHash};
 
             REQUIRE(Upgrades::isValidForApply(toUpgradeType(ledgerUpgrade),
-                                              outUpgrade, *app, ls) ==
+                                              outUpgrade, *app, ledgerView) ==
                     Upgrades::UpgradeValidity::INVALID);
         }
         SECTION("not valid")
@@ -741,8 +741,8 @@ TEST_CASE("config upgrade validation", "[upgrades]")
                     REQUIRE(Upgrades::isValidForApply(
                                 toUpgradeType(
                                     makeConfigUpgrade(*configUpgradeSetFrame)),
-                                outUpgrade, *app,
-                                ls) == Upgrades::UpgradeValidity::XDR_INVALID);
+                                outUpgrade, *app, ledgerView) ==
+                            Upgrades::UpgradeValidity::XDR_INVALID);
                 };
                 SECTION("no updated entries")
                 {
@@ -796,7 +796,8 @@ TEST_CASE("config upgrade validation", "[upgrades]")
                     upgrade.newConfig() = upgradeKey;
 
                     REQUIRE(Upgrades::isValidForApply(toUpgradeType(upgrade),
-                                                      outUpgrade, *app, ls) ==
+                                                      outUpgrade, *app,
+                                                      ledgerView) ==
                             Upgrades::UpgradeValidity::INVALID);
                 }
             }
@@ -807,7 +808,7 @@ TEST_CASE("config upgrade validation", "[upgrades]")
                         toUpgradeType(makeConfigUpgrade(
                             *makeMaxContractSizeBytesTestUpgrade(ltx, 0))),
                         outUpgrade, *app,
-                        ls) == Upgrades::UpgradeValidity::INVALID);
+                        ledgerView) == Upgrades::UpgradeValidity::INVALID);
         }
     }
 
@@ -879,11 +880,11 @@ TEST_CASE("config upgrade validation for protocol 23", "[upgrades]")
         }
         LedgerTxn ltx(app->getLedgerTxnRoot());
         ltx.loadHeader().current() = header;
-        auto ls = LedgerSnapshot(ltx);
+        auto ledgerView = CheckValidLedgerViewWrapper(ltx);
         LedgerUpgrade outUpgrade;
         return Upgrades::isValidForApply(
             toUpgradeType(makeConfigUpgrade(*configUpgradeSet)), outUpgrade,
-            *app, ls);
+            *app, ledgerView);
     };
 
     SECTION("valid for apply")
@@ -1098,11 +1099,11 @@ TEST_CASE("upgrades affect in-memory Soroban state state size",
             .getLedgerManager()
             .getSorobanInMemoryStateSizeForTesting();
     auto getExpectedInMemorySize = [&]() {
-        LedgerSnapshot ls(test.getApp());
+        CheckValidLedgerViewWrapper ledgerView(test.getApp());
         auto res = expectedInMemorySizeDelta;
         for (auto const& key : addedKeys)
         {
-            auto le = ls.load(key);
+            auto le = ledgerView.load(key);
             res += ledgerEntrySizeForRent(le.current(),
                                           xdr::xdr_size(le.current()), 23,
                                           test.getNetworkCfg());
@@ -1111,11 +1112,11 @@ TEST_CASE("upgrades affect in-memory Soroban state state size",
     };
 
     auto getStateSizeWindow = [&]() {
-        LedgerSnapshot ls(test.getApp());
+        CheckValidLedgerViewWrapper ledgerView(test.getApp());
         LedgerKey key(CONFIG_SETTING);
         key.configSetting().configSettingID =
             ConfigSettingID::CONFIG_SETTING_LIVE_SOROBAN_STATE_SIZE_WINDOW;
-        auto le = ls.load(key);
+        auto le = ledgerView.load(key);
         REQUIRE(le);
         std::vector<uint64_t> windowFromLtx =
             le.current().data.configSetting().liveSorobanStateSizeWindow();
@@ -1408,11 +1409,11 @@ TEST_CASE("config upgrades applied to ledger", "[soroban][upgrades]")
                         .liveSorobanStateSizeWindowSampleSize == size);
         };
         auto loadWindow = [&]() {
-            LedgerSnapshot ls(*app);
+            CheckValidLedgerViewWrapper ledgerView(*app);
             LedgerKey key(CONFIG_SETTING);
             key.configSetting().configSettingID =
                 ConfigSettingID::CONFIG_SETTING_LIVE_SOROBAN_STATE_SIZE_WINDOW;
-            return ls.load(key)
+            return ledgerView.load(key)
                 .current()
                 .data.configSetting()
                 .liveSorobanStateSizeWindow();
@@ -2975,8 +2976,8 @@ TEST_CASE("parallel Soroban settings upgrade", "[upgrades]")
     }
 
     {
-        LedgerSnapshot ls(*app);
-        REQUIRE(!ls.load(getParallelComputeSettingsLedgerKey()));
+        CheckValidLedgerViewWrapper ledgerView(*app);
+        REQUIRE(!ledgerView.load(getParallelComputeSettingsLedgerKey()));
     }
 
     executeUpgrade(*app, makeProtocolVersionUpgrade(static_cast<uint32_t>(
@@ -2984,9 +2985,9 @@ TEST_CASE("parallel Soroban settings upgrade", "[upgrades]")
 
     // Make sure initial value is correct.
     {
-        LedgerSnapshot ls(*app);
+        CheckValidLedgerViewWrapper ledgerView(*app);
         auto parellelComputeEntry =
-            ls.load(getParallelComputeSettingsLedgerKey())
+            ledgerView.load(getParallelComputeSettingsLedgerKey())
                 .current()
                 .data.configSetting();
         REQUIRE(parellelComputeEntry.configSettingID() ==
@@ -3011,9 +3012,9 @@ TEST_CASE("parallel Soroban settings upgrade", "[upgrades]")
         executeUpgrade(*app, makeConfigUpgrade(*configUpgradeSet));
     }
 
-    LedgerSnapshot ls(*app);
+    CheckValidLedgerViewWrapper ledgerView(*app);
 
-    REQUIRE(ls.load(getParallelComputeSettingsLedgerKey())
+    REQUIRE(ledgerView.load(getParallelComputeSettingsLedgerKey())
                 .current()
                 .data.configSetting()
                 .contractParallelCompute()
@@ -4055,7 +4056,7 @@ TEST_CASE("p24 upgrade fixes corrupted hot archive entries",
     };
     auto runUpgradeAndGetSnapshot = [&]() {
         executeUpgrade(*app, makeProtocolVersionUpgrade(fixedProtocolVersion));
-        return app->getAppConnector().copyLedgerStateSnapshot();
+        return app->getAppConnector().copyImmutableLedgerView();
     };
     auto const& corruptedEntries =
         p23_hot_archive_bug::internal::P23_CORRUPTED_HOT_ARCHIVE_ENTRIES;

--- a/src/invariant/ArchivedStateConsistency.cpp
+++ b/src/invariant/ArchivedStateConsistency.cpp
@@ -6,7 +6,7 @@
 #include "bucket/BucketListSnapshot.h"
 #include "bucket/LedgerCmp.h"
 #include "invariant/InvariantManager.h"
-#include "ledger/LedgerStateSnapshot.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "ledger/LedgerTypeUtils.h"
 #include "main/Application.h"
 #include "transactions/TransactionUtils.h"
@@ -38,7 +38,7 @@ ArchivedStateConsistency::getName() const
 
 std::string
 ArchivedStateConsistency::checkOnLedgerCommit(
-    ApplyLedgerStateSnapshot const& lclSnapshot,
+    ApplyLedgerView const& lclApplyView,
     std::vector<LedgerEntry> const& persitentEvictedFromLive,
     std::vector<LedgerKey> const& tempAndTTLEvictedFromLive,
     UnorderedMap<LedgerKey, LedgerEntry> const& restoredFromArchive,
@@ -48,8 +48,8 @@ ArchivedStateConsistency::checkOnLedgerCommit(
                              LogSlowExecution::Mode::AUTOMATIC_RAII, "took",
                              std::chrono::milliseconds(1));
 
-    auto ledgerSeq = lclSnapshot.getLedgerSeq() + 1;
-    auto ledgerVers = lclSnapshot.getLedgerHeader().current().ledgerVersion;
+    auto ledgerSeq = lclApplyView.getLedgerSeq() + 1;
+    auto ledgerVers = lclApplyView.getLedgerHeader().current().ledgerVersion;
 
     if (protocolVersionIsBefore(
             ledgerVers,
@@ -93,13 +93,13 @@ ArchivedStateConsistency::checkOnLedgerCommit(
     // Preload from both live and archived state
     UnorderedMap<LedgerKey, LedgerEntry> preloadedLiveEntries;
     auto preloadedLiveVector =
-        lclSnapshot.loadLiveKeys(allKeys, "ArchivedStateConsistency");
+        lclApplyView.loadLiveKeys(allKeys, "ArchivedStateConsistency");
     for (auto const& entry : preloadedLiveVector)
     {
         preloadedLiveEntries[LedgerEntryKey(entry)] = entry;
     }
 
-    auto preloadedArchivedVector = lclSnapshot.loadArchiveKeys(allKeys);
+    auto preloadedArchivedVector = lclApplyView.loadArchiveKeys(allKeys);
     UnorderedMap<LedgerKey, HotArchiveBucketEntry> preloadedArchivedEntries;
     for (auto const& entry : preloadedArchivedVector)
     {

--- a/src/invariant/ArchivedStateConsistency.cpp
+++ b/src/invariant/ArchivedStateConsistency.cpp
@@ -49,7 +49,7 @@ ArchivedStateConsistency::checkOnLedgerCommit(
                              std::chrono::milliseconds(1));
 
     auto ledgerSeq = lclSnapshot.getLedgerSeq() + 1;
-    auto ledgerVers = lclSnapshot.getLedgerHeader().ledgerVersion;
+    auto ledgerVers = lclSnapshot.getLedgerHeader().current().ledgerVersion;
 
     if (protocolVersionIsBefore(
             ledgerVers,

--- a/src/invariant/ArchivedStateConsistency.h
+++ b/src/invariant/ArchivedStateConsistency.h
@@ -34,7 +34,7 @@ class ArchivedStateConsistency : public Invariant
     virtual std::string getName() const override;
 
     virtual std::string checkOnLedgerCommit(
-        ApplyLedgerStateSnapshot const& lclSnapshot,
+        ApplyLedgerView const& lclApplyView,
         std::vector<LedgerEntry> const& persitentEvictedFromLive,
         std::vector<LedgerKey> const& tempAndTTLEvictedFromLive,
         UnorderedMap<LedgerKey, LedgerEntry> const& restoredFromArchive,

--- a/src/invariant/BucketListStateConsistency.cpp
+++ b/src/invariant/BucketListStateConsistency.cpp
@@ -7,8 +7,8 @@
 #include "bucket/LiveBucket.h"
 #include "invariant/Invariant.h"
 #include "invariant/InvariantManager.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "ledger/InMemorySorobanState.h"
-#include "ledger/LedgerStateSnapshot.h"
 #include "ledger/LedgerTypeUtils.h"
 #include "ledger/NetworkConfig.h"
 #include "main/Application.h"
@@ -23,7 +23,7 @@ BucketListStateConsistency::BucketListStateConsistency() : Invariant(true)
 {
 }
 
-// This checks for consistency between the in-memory snapshot and live
+// This checks for consistency between the in-memory applyView and live
 // BucketList, along with other important properties. We check these properties:
 // 1. Every live entry in the BL is reflected in the in-memory cache
 // 2. No entry exists in the cache, but not the BL
@@ -36,14 +36,14 @@ BucketListStateConsistency::BucketListStateConsistency() : Invariant(true)
 // 7. The cached total entry sizes match the sum of actual entry sizes
 std::string
 BucketListStateConsistency::checkSnapshot(
-    ApplyLedgerStateSnapshot const& snapshot,
+    ApplyLedgerView const& applyView,
     InMemorySorobanState const& inMemorySnapshot,
     std::function<bool()> isStopping)
 {
     LogSlowExecution logSlow("BucketListStateConsistency::checkSnapshot",
                              LogSlowExecution::Mode::AUTOMATIC_RAII, "took",
                              std::chrono::minutes(2));
-    auto const& header = snapshot.getLedgerHeader().current();
+    auto const& header = applyView.getLedgerHeader().current();
 
     if (protocolVersionIsBefore(header.ledgerVersion, SOROBAN_PROTOCOL_VERSION))
     {
@@ -66,11 +66,11 @@ BucketListStateConsistency::checkSnapshot(
     std::string errorMsg;
 
     // Property 7: Track total entry sizes for validation
-    auto sorobanConfig = SorobanNetworkConfig::loadFromLedger(snapshot);
+    auto sorobanConfig = SorobanNetworkConfig::loadFromLedger(applyView);
     uint64_t expectedSorobanSize = 0;
 
     auto checkLiveEntry = [&seenLiveNonTTLKeys, &seenDeadKeys, &errorMsg,
-                           &inMemorySnapshot, &snapshot, checkHotArchive,
+                           &inMemorySnapshot, &applyView, checkHotArchive,
                            &isStopping, &expectedSorobanSize, &header,
                            &sorobanConfig](BucketEntry const& be) {
         if (isStopping())
@@ -90,7 +90,7 @@ BucketListStateConsistency::checkSnapshot(
             }
 
             // This is the newest version of this entry, check that it exists in
-            // the in-memory snapshot
+            // the in-memory applyView
             auto inMemoryEntry = inMemorySnapshot.get(lk);
             if (!inMemoryEntry)
             {
@@ -116,7 +116,7 @@ BucketListStateConsistency::checkSnapshot(
             }
 
             // Check property 5: live entry should not exist in hot archive
-            if (checkHotArchive && snapshot.loadArchiveEntry(lk))
+            if (checkHotArchive && applyView.loadArchiveEntry(lk))
             {
                 errorMsg = fmt::format(
                     FMT_STRING("BucketListStateConsistency invariant failed: "
@@ -158,7 +158,7 @@ BucketListStateConsistency::checkSnapshot(
     };
 
     // First check contract data entries.
-    snapshot.scanLiveEntriesOfType(CONTRACT_DATA, checkLiveEntry);
+    applyView.scanLiveEntriesOfType(CONTRACT_DATA, checkLiveEntry);
 
     // Note: All BucketList scans will exit early if isStopping() is true or if
     // there is an error, so we need to call shouldAbortInvariantScan after each
@@ -175,7 +175,7 @@ BucketListStateConsistency::checkSnapshot(
     // keys since we will need them when checking TTL entries.
     seenDeadKeys.clear();
 
-    snapshot.scanLiveEntriesOfType(CONTRACT_CODE, checkLiveEntry);
+    applyView.scanLiveEntriesOfType(CONTRACT_CODE, checkLiveEntry);
     if (shouldAbortInvariantScan(errorMsg, isStopping))
     {
         return errorMsg;
@@ -258,7 +258,7 @@ BucketListStateConsistency::checkSnapshot(
                 return Loop::COMPLETE;
             }
 
-            // Check that the TTL exists in the in-memory snapshot
+            // Check that the TTL exists in the in-memory applyView
             auto inMemoryTTL = inMemorySnapshot.get(ttlKey);
             if (!inMemoryTTL)
             {
@@ -304,7 +304,7 @@ BucketListStateConsistency::checkSnapshot(
     };
 
     seenDeadKeys.clear();
-    snapshot.scanLiveEntriesOfType(TTL, checkTTLEntry);
+    applyView.scanLiveEntriesOfType(TTL, checkTTLEntry);
     if (shouldAbortInvariantScan(errorMsg, isStopping))
     {
         return errorMsg;
@@ -376,7 +376,7 @@ BucketListStateConsistency::checkSnapshot(
             return Loop::INCOMPLETE;
         };
 
-        snapshot.scanAllArchiveEntries(checkHotArchiveEntry);
+        applyView.scanAllArchiveEntries(checkHotArchiveEntry);
         if (shouldAbortInvariantScan(errorMsg, isStopping))
         {
             return errorMsg;

--- a/src/invariant/BucketListStateConsistency.cpp
+++ b/src/invariant/BucketListStateConsistency.cpp
@@ -43,7 +43,7 @@ BucketListStateConsistency::checkSnapshot(
     LogSlowExecution logSlow("BucketListStateConsistency::checkSnapshot",
                              LogSlowExecution::Mode::AUTOMATIC_RAII, "took",
                              std::chrono::minutes(2));
-    auto const& header = snapshot.getLedgerHeader();
+    auto const& header = snapshot.getLedgerHeader().current();
 
     if (protocolVersionIsBefore(header.ledgerVersion, SOROBAN_PROTOCOL_VERSION))
     {
@@ -66,8 +66,7 @@ BucketListStateConsistency::checkSnapshot(
     std::string errorMsg;
 
     // Property 7: Track total entry sizes for validation
-    LedgerSnapshot lsForConfig(snapshot);
-    auto sorobanConfig = SorobanNetworkConfig::loadFromLedger(lsForConfig);
+    auto sorobanConfig = SorobanNetworkConfig::loadFromLedger(snapshot);
     uint64_t expectedSorobanSize = 0;
 
     auto checkLiveEntry = [&seenLiveNonTTLKeys, &seenDeadKeys, &errorMsg,

--- a/src/invariant/BucketListStateConsistency.h
+++ b/src/invariant/BucketListStateConsistency.h
@@ -19,7 +19,7 @@ class BucketListStateConsistency : public Invariant
     virtual std::string getName() const override;
 
     virtual std::string
-    checkSnapshot(ApplyLedgerStateSnapshot const& snapshot,
+    checkSnapshot(ApplyLedgerView const& applyView,
                   InMemorySorobanState const& inMemorySnapshot,
                   std::function<bool()> isStopping) override;
 };

--- a/src/invariant/ConservationOfLumens.cpp
+++ b/src/invariant/ConservationOfLumens.cpp
@@ -5,8 +5,8 @@
 #include "invariant/ConservationOfLumens.h"
 #include "invariant/Invariant.h"
 #include "invariant/InvariantManager.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "ledger/LedgerManager.h"
-#include "ledger/LedgerStateSnapshot.h"
 #include "ledger/LedgerTxn.h"
 #include "main/Application.h"
 #include "transactions/TransactionUtils.h"
@@ -223,7 +223,7 @@ processEntryIfNew(LedgerEntry const& entry, LedgerKey const& key,
 
 // Scan live bucket list for entries that can hold the native asset
 static void
-scanLiveBuckets(ApplyLedgerStateSnapshot const& snapshot, Asset const& asset,
+scanLiveBuckets(ApplyLedgerView const& applyView, Asset const& asset,
                 AssetContractInfo const& assetContractInfo, int64_t& sumBalance,
                 std::string& errorMsg, std::function<bool()> const& isStopping)
 {
@@ -238,7 +238,7 @@ scanLiveBuckets(ApplyLedgerStateSnapshot const& snapshot, Asset const& asset,
 
         std::unordered_set<LedgerKey> countedKeys;
 
-        snapshot.scanLiveEntriesOfType(
+        applyView.scanLiveEntriesOfType(
             type, [&](BucketEntry const& be) -> Loop {
                 if (isStopping())
                 {
@@ -270,14 +270,13 @@ scanLiveBuckets(ApplyLedgerStateSnapshot const& snapshot, Asset const& asset,
 }
 
 static void
-scanHotArchiveBuckets(ApplyLedgerStateSnapshot const& snapshot,
-                      Asset const& asset,
+scanHotArchiveBuckets(ApplyLedgerView const& applyView, Asset const& asset,
                       AssetContractInfo const& assetContractInfo,
                       int64_t& sumBalance, std::string& errorMsg,
                       std::function<bool()> const& isStopping)
 {
     std::unordered_set<LedgerKey> countedKeys;
-    snapshot.scanAllArchiveEntries([&](HotArchiveBucketEntry const& be) {
+    applyView.scanAllArchiveEntries([&](HotArchiveBucketEntry const& be) {
         if (isStopping())
         {
             return Loop::COMPLETE;
@@ -310,7 +309,7 @@ scanHotArchiveBuckets(ApplyLedgerStateSnapshot const& snapshot,
 
 std::string
 ConservationOfLumens::checkSnapshot(
-    ApplyLedgerStateSnapshot const& snapshot,
+    ApplyLedgerView const& applyView,
     InMemorySorobanState const& inMemorySnapshot,
     std::function<bool()> isStopping)
 {
@@ -318,7 +317,7 @@ ConservationOfLumens::checkSnapshot(
                              LogSlowExecution::Mode::AUTOMATIC_RAII, "took",
                              std::chrono::seconds(90));
 
-    auto const& header = snapshot.getLedgerHeader().current();
+    auto const& header = applyView.getLedgerHeader().current();
 
     // This invariant can fail prior to v24 due to bugs
     if (protocolVersionIsBefore(header.ledgerVersion, ProtocolVersion::V_24))
@@ -343,7 +342,7 @@ ConservationOfLumens::checkSnapshot(
 
     // Scan the Live BucketList for native balances using loopAllBuckets
 
-    scanLiveBuckets(snapshot, nativeAsset, mLumenContractInfo, sumBalance,
+    scanLiveBuckets(applyView, nativeAsset, mLumenContractInfo, sumBalance,
                     errorMsg, isStopping);
 
     if (shouldAbortInvariantScan(errorMsg, isStopping))
@@ -352,8 +351,8 @@ ConservationOfLumens::checkSnapshot(
     }
 
     // Scan the Hot Archive for native balances
-    scanHotArchiveBuckets(snapshot, nativeAsset, mLumenContractInfo, sumBalance,
-                          errorMsg, isStopping);
+    scanHotArchiveBuckets(applyView, nativeAsset, mLumenContractInfo,
+                          sumBalance, errorMsg, isStopping);
 
     if (shouldAbortInvariantScan(errorMsg, isStopping))
     {

--- a/src/invariant/ConservationOfLumens.cpp
+++ b/src/invariant/ConservationOfLumens.cpp
@@ -318,7 +318,7 @@ ConservationOfLumens::checkSnapshot(
                              LogSlowExecution::Mode::AUTOMATIC_RAII, "took",
                              std::chrono::seconds(90));
 
-    auto const& header = snapshot.getLedgerHeader();
+    auto const& header = snapshot.getLedgerHeader().current();
 
     // This invariant can fail prior to v24 due to bugs
     if (protocolVersionIsBefore(header.ledgerVersion, ProtocolVersion::V_24))

--- a/src/invariant/ConservationOfLumens.h
+++ b/src/invariant/ConservationOfLumens.h
@@ -34,7 +34,7 @@ class ConservationOfLumens : public Invariant
         std::vector<ContractEvent> const& events, AppConnector& app) override;
 
     virtual std::string
-    checkSnapshot(ApplyLedgerStateSnapshot const& snapshot,
+    checkSnapshot(ApplyLedgerView const& applyView,
                   InMemorySorobanState const& inMemorySnapshot,
                   std::function<bool()> isStopping) override;
 

--- a/src/invariant/Invariant.h
+++ b/src/invariant/Invariant.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "bucket/BucketUtils.h"
-#include "ledger/LedgerStateSnapshot.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "xdr/Stellar-ledger.h"
 #include <cstdint>
 #include <memory>
@@ -73,7 +73,7 @@ class Invariant
 
     virtual std::string
     checkOnLedgerCommit(
-        ApplyLedgerStateSnapshot const& lclSnapshot,
+        ApplyLedgerView const& lclApplyView,
         std::vector<LedgerEntry> const& persitentEvictedFromLive,
         std::vector<LedgerKey> const& tempAndTTLEvictedFromLive,
         UnorderedMap<LedgerKey, LedgerEntry> const& restoredFromArchive,
@@ -83,7 +83,7 @@ class Invariant
     }
 
     virtual std::string
-    checkSnapshot(ApplyLedgerStateSnapshot const& snapshot,
+    checkSnapshot(ApplyLedgerView const& applyView,
                   InMemorySorobanState const& inMemorySnapshot,
                   std::function<bool()> isStopping)
     {

--- a/src/invariant/InvariantManager.h
+++ b/src/invariant/InvariantManager.h
@@ -16,8 +16,8 @@ class Application;
 class Bucket;
 class Invariant;
 class LedgerManager;
-class LedgerStateSnapshot;
-class ApplyLedgerStateSnapshot;
+class ImmutableLedgerView;
+class ApplyLedgerView;
 struct EvictedStateVectors;
 struct LedgerTxnDelta;
 struct Operation;
@@ -56,7 +56,7 @@ class InvariantManager
                                        AppConnector& app) = 0;
 
     virtual void checkOnLedgerCommit(
-        ApplyLedgerStateSnapshot const& lclSnapshot,
+        ApplyLedgerView const& lclApplyView,
         std::vector<LedgerEntry> const& persitentEvictedFromLive,
         std::vector<LedgerKey> const& tempAndTTLEvictedFromLive,
         UnorderedMap<LedgerKey, LedgerEntry> const& restoredFromArchive,
@@ -65,10 +65,10 @@ class InvariantManager
     // This is used for expensive invariants that can't run in a blocking
     // fashion, such as invariants that require scanning the entire BucketList.
     // The invariant will periodically run on a background thread against the
-    // given ledger state snapshot. These invariants will only run if
+    // given ledger state applyView. These invariants will only run if
     // INVARIANT_EXTRA_CHECKS is enabled.
     virtual void
-    runStateSnapshotInvariant(ApplyLedgerStateSnapshot const& snapshot,
+    runStateSnapshotInvariant(ApplyLedgerView const& applyView,
                               InMemorySorobanState const& inMemorySnapshot,
                               std::function<bool()> isStopping) = 0;
 
@@ -80,8 +80,8 @@ class InvariantManager
 
     virtual bool shouldRunInvariantSnapshot() const = 0;
 
-    // Mark the start of a snapshot invariant run. Should be called when a
-    // snapshot for a scan is first created to prevent expensive redundant
+    // Mark the start of a applyView invariant run. Should be called when a
+    // applyView for a scan is first created to prevent expensive redundant
     // copies.
     virtual void markStartOfInvariantSnapshot() = 0;
 

--- a/src/invariant/InvariantManagerImpl.cpp
+++ b/src/invariant/InvariantManagerImpl.cpp
@@ -12,9 +12,9 @@
 #include "invariant/Invariant.h"
 #include "invariant/InvariantDoesNotHold.h"
 #include "invariant/InvariantManagerImpl.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "ledger/InMemorySorobanState.h"
 #include "ledger/LedgerManager.h"
-#include "ledger/LedgerStateSnapshot.h"
 #include "ledger/LedgerTxn.h"
 #include "lib/util/finally.h"
 #include "main/Application.h"
@@ -172,7 +172,7 @@ InvariantManagerImpl::checkOnOperationApply(
 
 void
 InvariantManagerImpl::checkOnLedgerCommit(
-    ApplyLedgerStateSnapshot const& lclSnapshot,
+    ApplyLedgerView const& lclApplyView,
     std::vector<LedgerEntry> const& persitentEvictedFromLive,
     std::vector<LedgerKey> const& tempAndTTLEvictedFromLive,
     UnorderedMap<LedgerKey, LedgerEntry> const& restoredFromArchive,
@@ -181,7 +181,7 @@ InvariantManagerImpl::checkOnLedgerCommit(
     for (auto invariant : mEnabled)
     {
         auto result = invariant->checkOnLedgerCommit(
-            lclSnapshot, persitentEvictedFromLive, tempAndTTLEvictedFromLive,
+            lclApplyView, persitentEvictedFromLive, tempAndTTLEvictedFromLive,
             restoredFromArchive, restoredFromLiveState);
         if (result.empty())
         {
@@ -191,7 +191,7 @@ InvariantManagerImpl::checkOnLedgerCommit(
         auto message = fmt::format(
             FMT_STRING(R"(Invariant "{}" does not hold on ledger commit: {})"),
             invariant->getName(), result);
-        onInvariantFailure(invariant, message, lclSnapshot.getLedgerSeq() + 1);
+        onInvariantFailure(invariant, message, lclApplyView.getLedgerSeq() + 1);
     }
 }
 
@@ -280,7 +280,7 @@ InvariantManagerImpl::start(LedgerManager const& ledgerManager)
 {
     releaseAssert(threadIsMain());
 
-    // If state snapshot invariants are enabled, run a snapshot on the
+    // If state applyView invariants are enabled, run a applyView on the
     // initial startup state, then schedule the next run.
     if (mConfig.INVARIANT_EXTRA_CHECKS)
     {
@@ -320,7 +320,7 @@ InvariantManagerImpl::handleInvariantFailure(bool isStrict,
     }
 }
 
-// The snapshot invariant is triggered periodically based on wall clock time,
+// The applyView invariant is triggered periodically based on wall clock time,
 // managed by the InvariantManagerImpl timing loop. After the given period has
 // elapsed from out last scan, snapshotTimerFired will set
 // mShouldRunStateSnapshotInvariant() to true. On the next ledger close,
@@ -328,7 +328,7 @@ InvariantManagerImpl::handleInvariantFailure(bool isStrict,
 // required state, then call this function in a background thread.
 void
 InvariantManagerImpl::runStateSnapshotInvariant(
-    ApplyLedgerStateSnapshot const& snapshot,
+    ApplyLedgerView const& applyView,
     InMemorySorobanState const& inMemorySnapshot,
     std::function<bool()> isStopping)
 {
@@ -340,11 +340,11 @@ InvariantManagerImpl::runStateSnapshotInvariant(
     {
         for (auto const& invariant : mEnabled)
         {
-            auto result = invariant->checkSnapshot(snapshot, inMemorySnapshot,
+            auto result = invariant->checkSnapshot(applyView, inMemorySnapshot,
                                                    isStopping);
             if (!result.empty())
             {
-                onInvariantFailure(invariant, result, snapshot.getLedgerSeq());
+                onInvariantFailure(invariant, result, applyView.getLedgerSeq());
             }
         }
     }
@@ -353,7 +353,8 @@ InvariantManagerImpl::runStateSnapshotInvariant(
         // Snapshot-based invariants run in a background thread. Abort on
         // failure to match the behavior of strict invariants on the main
         // thread.
-        printErrorAndAbort("Exception in state snapshot invariant: ", e.what());
+        printErrorAndAbort("Exception in state applyView invariant: ",
+                           e.what());
     }
 }
 
@@ -387,7 +388,7 @@ InvariantManagerImpl::snapshotTimerFired()
     {
         CLOG_WARNING(
             Invariant,
-            "Skipping state snapshot invariant trigger "
+            "Skipping state applyView invariant trigger "
             "because a previous scan is still running. "
             "STATE_SNAPSHOT_INVARIANT_LEDGER_FREQUENCY may be too short");
         mStateSnapshotInvariantSkipped.inc();
@@ -417,7 +418,7 @@ InvariantManagerImpl::markStartOfInvariantSnapshot()
     // Safe to call from any thread since both flags are atomic. Since we check
     // mStateSnapshotInvariantRunning before setting
     // mShouldRunStateSnapshotInvariant, make sure we reset
-    // mStateSnapshotInvariantRunning first to prevent multiple snapshot
+    // mStateSnapshotInvariantRunning first to prevent multiple applyView
     // triggers.
     mStateSnapshotInvariantRunning = true;
     mShouldRunStateSnapshotInvariant = false;

--- a/src/invariant/InvariantManagerImpl.h
+++ b/src/invariant/InvariantManagerImpl.h
@@ -61,7 +61,7 @@ class InvariantManagerImpl : public InvariantManager
         std::unordered_set<LedgerKey> const& shadowedKeys) override;
 
     virtual void checkOnLedgerCommit(
-        ApplyLedgerStateSnapshot const& lclSnapshot,
+        ApplyLedgerView const& lclApplyView,
         std::vector<LedgerEntry> const& persitentEvictedFromLive,
         std::vector<LedgerKey> const& tempAndTTLEvictedFromLive,
         UnorderedMap<LedgerKey, LedgerEntry> const& restoredFromArchive,
@@ -80,7 +80,7 @@ class InvariantManagerImpl : public InvariantManager
     bool shouldRunInvariantSnapshot() const override;
     void markStartOfInvariantSnapshot() override;
 
-    void runStateSnapshotInvariant(ApplyLedgerStateSnapshot const& snapshot,
+    void runStateSnapshotInvariant(ApplyLedgerView const& applyView,
                                    InMemorySorobanState const& inMemorySnapshot,
                                    std::function<bool()> isStopping) override;
 

--- a/src/invariant/test/ConservationOfLumensTests.cpp
+++ b/src/invariant/test/ConservationOfLumensTests.cpp
@@ -7,7 +7,7 @@
 #include "invariant/InvariantDoesNotHold.h"
 #include "invariant/InvariantManager.h"
 #include "invariant/test/InvariantTestUtils.h"
-#include "ledger/LedgerStateSnapshot.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "ledger/LedgerTxn.h"
 #include "ledger/LedgerTxnHeader.h"
 #include "ledger/test/LedgerTestUtils.h"
@@ -337,12 +337,12 @@ TEST_CASE(
 
     // Verify the snapshot invariant passes
     {
-        auto snap = app.getLedgerManager().copyApplyLedgerStateSnapshot();
+        auto applyView = app.getLedgerManager().copyApplyLedgerView();
         auto& inMemoryState =
             app.getLedgerManager().getInMemorySorobanStateForTesting();
 
         REQUIRE_NOTHROW(app.getInvariantManager().runStateSnapshotInvariant(
-            snap, inMemoryState, []() { return false; }));
+            applyView, inMemoryState, []() { return false; }));
     }
 
     // Now, manually modify totalCoins to be inconsistent. The invariant should
@@ -356,14 +356,14 @@ TEST_CASE(
 
         closeLedger(test.getApp());
 
-        auto snap = app.getLedgerManager().copyApplyLedgerStateSnapshot();
+        auto applyView = app.getLedgerManager().copyApplyLedgerView();
         auto& inMemoryState =
             app.getLedgerManager().getInMemorySorobanStateForTesting();
 
         Asset native(ASSET_TYPE_NATIVE);
         auto lumenInfo = getAssetContractInfo(native, app.getNetworkID());
         ConservationOfLumens invariant(lumenInfo);
-        auto result = invariant.checkSnapshot(snap, inMemoryState,
+        auto result = invariant.checkSnapshot(applyView, inMemoryState,
                                               []() { return false; });
         REQUIRE_FALSE(result.empty());
         REQUIRE(result.find("Total native asset supply mismatch") !=
@@ -424,12 +424,12 @@ TEST_CASE("ConservationOfLumens snapshot invariant detects bucket corruption",
 
         app->getInvariantManager().enableInvariant("ConservationOfLumens");
 
-        auto snap = app->getLedgerManager().copyApplyLedgerStateSnapshot();
+        auto applyView = app->getLedgerManager().copyApplyLedgerView();
         auto& inMemoryState =
             app->getLedgerManager().getInMemorySorobanStateForTesting();
 
         REQUIRE_NOTHROW(app->getInvariantManager().runStateSnapshotInvariant(
-            snap, inMemoryState, []() { return false; }));
+            applyView, inMemoryState, []() { return false; }));
     }
 
     SECTION("Invariant fails when bucket balance doesn't match totalCoins")
@@ -457,14 +457,14 @@ TEST_CASE("ConservationOfLumens snapshot invariant detects bucket corruption",
 
         BucketTestUtils::closeLedger(*app);
 
-        auto snap = app->getLedgerManager().copyApplyLedgerStateSnapshot();
+        auto applyView = app->getLedgerManager().copyApplyLedgerView();
         auto& inMemoryState =
             app->getLedgerManager().getInMemorySorobanStateForTesting();
 
         Asset native(ASSET_TYPE_NATIVE);
         auto lumenInfo = getAssetContractInfo(native, app->getNetworkID());
         ConservationOfLumens invariant(lumenInfo);
-        auto result = invariant.checkSnapshot(snap, inMemoryState,
+        auto result = invariant.checkSnapshot(applyView, inMemoryState,
                                               []() { return false; });
         REQUIRE_FALSE(result.empty());
         REQUIRE(result.find("Total native asset supply mismatch") !=
@@ -517,12 +517,12 @@ TEST_CASE("ConservationOfLumens snapshot invariant detects bucket corruption",
 
         app->getInvariantManager().enableInvariant("ConservationOfLumens");
 
-        auto snap = app->getLedgerManager().copyApplyLedgerStateSnapshot();
+        auto applyView = app->getLedgerManager().copyApplyLedgerView();
         auto& inMemoryState =
             app->getLedgerManager().getInMemorySorobanStateForTesting();
 
         REQUIRE_NOTHROW(app->getInvariantManager().runStateSnapshotInvariant(
-            snap, inMemoryState, []() { return false; }));
+            applyView, inMemoryState, []() { return false; }));
     }
 
     SECTION("Invariant detects corrupted native balance in hot archive")
@@ -573,13 +573,13 @@ TEST_CASE("ConservationOfLumens snapshot invariant detects bucket corruption",
         BucketTestUtils::closeLedger(*app);
 
         {
-            auto snap = app->getLedgerManager().copyApplyLedgerStateSnapshot();
+            auto applyView = app->getLedgerManager().copyApplyLedgerView();
             auto& inMemoryState =
                 app->getLedgerManager().getInMemorySorobanStateForTesting();
 
             REQUIRE_NOTHROW(
                 app->getInvariantManager().runStateSnapshotInvariant(
-                    snap, inMemoryState, []() { return false; }));
+                    applyView, inMemoryState, []() { return false; }));
         }
 
         // Corrupt the other live balance by adding 123 stroops to the balance
@@ -593,14 +593,14 @@ TEST_CASE("ConservationOfLumens snapshot invariant detects bucket corruption",
         BucketTestUtils::closeLedger(*app);
 
         {
-            auto snap = app->getLedgerManager().copyApplyLedgerStateSnapshot();
+            auto applyView = app->getLedgerManager().copyApplyLedgerView();
             auto& inMemoryState =
                 app->getLedgerManager().getInMemorySorobanStateForTesting();
 
             Asset native(ASSET_TYPE_NATIVE);
             auto lumenInfo = getAssetContractInfo(native, app->getNetworkID());
             ConservationOfLumens invariant(lumenInfo);
-            auto result = invariant.checkSnapshot(snap, inMemoryState,
+            auto result = invariant.checkSnapshot(applyView, inMemoryState,
                                                   []() { return false; });
             REQUIRE_FALSE(result.empty());
             REQUIRE(result.find("Total native asset supply mismatch") !=

--- a/src/invariant/test/InvariantTests.cpp
+++ b/src/invariant/test/InvariantTests.cpp
@@ -12,8 +12,8 @@
 #include "invariant/Invariant.h"
 #include "invariant/InvariantDoesNotHold.h"
 #include "invariant/InvariantManager.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "ledger/InMemorySorobanState.h"
-#include "ledger/LedgerStateSnapshot.h"
 #include "ledger/LedgerTxn.h"
 #include "ledger/LedgerTypeUtils.h"
 #include "ledger/NetworkConfig.h"
@@ -368,25 +368,26 @@ TEST_CASE_VERSIONS("State archival eviction invariant", "[invariant][archival]")
         }
 
         // Make sure the entries have not been evicted
-        auto snap = app->getLedgerManager().copyLedgerStateSnapshot();
-        REQUIRE(snap.loadLiveEntry(LedgerEntryKey(tempEntry)));
-        REQUIRE(snap.loadLiveEntry(LedgerEntryKey(persistentEntry)));
-        REQUIRE(snap.loadLiveEntry(getTTLKey(tempEntry)));
-        REQUIRE(snap.loadLiveEntry(getTTLKey(persistentEntry)));
-        REQUIRE(!snap.loadArchiveEntry(LedgerEntryKey(tempEntry)));
-        REQUIRE(!snap.loadArchiveEntry(LedgerEntryKey(persistentEntry)));
+        auto ledgerView = app->getLedgerManager().copyImmutableLedgerView();
+        REQUIRE(ledgerView.loadLiveEntry(LedgerEntryKey(tempEntry)));
+        REQUIRE(ledgerView.loadLiveEntry(LedgerEntryKey(persistentEntry)));
+        REQUIRE(ledgerView.loadLiveEntry(getTTLKey(tempEntry)));
+        REQUIRE(ledgerView.loadLiveEntry(getTTLKey(persistentEntry)));
+        REQUIRE(!ledgerView.loadArchiveEntry(LedgerEntryKey(tempEntry)));
+        REQUIRE(!ledgerView.loadArchiveEntry(LedgerEntryKey(persistentEntry)));
 
         SECTION("Entries properly evicted")
         {
             closeLedger(*app);
 
-            snap = app->getLedgerManager().copyLedgerStateSnapshot();
-            REQUIRE(!snap.loadLiveEntry(LedgerEntryKey(tempEntry)));
-            REQUIRE(!snap.loadLiveEntry(LedgerEntryKey(persistentEntry)));
-            REQUIRE(!snap.loadLiveEntry(getTTLKey(tempEntry)));
-            REQUIRE(!snap.loadLiveEntry(getTTLKey(persistentEntry)));
-            REQUIRE(!snap.loadArchiveEntry(LedgerEntryKey(tempEntry)));
-            REQUIRE(snap.loadArchiveEntry(LedgerEntryKey(persistentEntry)));
+            ledgerView = app->getLedgerManager().copyImmutableLedgerView();
+            REQUIRE(!ledgerView.loadLiveEntry(LedgerEntryKey(tempEntry)));
+            REQUIRE(!ledgerView.loadLiveEntry(LedgerEntryKey(persistentEntry)));
+            REQUIRE(!ledgerView.loadLiveEntry(getTTLKey(tempEntry)));
+            REQUIRE(!ledgerView.loadLiveEntry(getTTLKey(persistentEntry)));
+            REQUIRE(!ledgerView.loadArchiveEntry(LedgerEntryKey(tempEntry)));
+            REQUIRE(
+                ledgerView.loadArchiveEntry(LedgerEntryKey(persistentEntry)));
         }
 
         SECTION("invariant check")
@@ -397,17 +398,16 @@ TEST_CASE_VERSIONS("State archival eviction invariant", "[invariant][archival]")
             auto ledgerVersion =
                 lm.getLastClosedLedgerHeader().header.ledgerVersion;
 
-            auto applySnap =
-                app->getLedgerManager().copyApplyLedgerStateSnapshot();
+            auto applyView = app->getLedgerManager().copyApplyLedgerView();
 
             // Manually trigger eviction so we can test the invariant directly
             LedgerTxn ltx(app->getLedgerTxnRoot());
             ltx.loadHeader().current().ledgerSeq++;
             auto evictedState =
-                app->getBucketManager().resolveBackgroundEvictionScan(applySnap,
+                app->getBucketManager().resolveBackgroundEvictionScan(applyView,
                                                                       ltx, {});
 
-            applySnap = app->getLedgerManager().copyApplyLedgerStateSnapshot();
+            applyView = app->getLedgerManager().copyApplyLedgerView();
 
             // Persistent entry
             REQUIRE(evictedState.archivedEntries.size() == 1);
@@ -431,7 +431,7 @@ TEST_CASE_VERSIONS("State archival eviction invariant", "[invariant][archival]")
 
                 REQUIRE_THROWS_AS(
                     app->getInvariantManager().checkOnLedgerCommit(
-                        applySnap, evictedState.archivedEntries,
+                        applyView, evictedState.archivedEntries,
                         evictedState.deletedKeys, emptyMap, emptyMap),
                     InvariantDoesNotHold);
             }
@@ -449,7 +449,7 @@ TEST_CASE_VERSIONS("State archival eviction invariant", "[invariant][archival]")
 
                 REQUIRE_THROWS_AS(
                     app->getInvariantManager().checkOnLedgerCommit(
-                        applySnap, evictedState.archivedEntries,
+                        applyView, evictedState.archivedEntries,
                         evictedState.deletedKeys, emptyMap, emptyMap),
                     InvariantDoesNotHold);
             }
@@ -464,7 +464,7 @@ TEST_CASE_VERSIONS("State archival eviction invariant", "[invariant][archival]")
 
                 REQUIRE_THROWS_AS(
                     app->getInvariantManager().checkOnLedgerCommit(
-                        applySnap, evictedState.archivedEntries,
+                        applyView, evictedState.archivedEntries,
                         evictedState.deletedKeys, emptyMap, emptyMap),
                     InvariantDoesNotHold);
             }
@@ -484,7 +484,7 @@ TEST_CASE_VERSIONS("State archival eviction invariant", "[invariant][archival]")
 
                 REQUIRE_THROWS_AS(
                     app->getInvariantManager().checkOnLedgerCommit(
-                        applySnap, evictedState.archivedEntries,
+                        applyView, evictedState.archivedEntries,
                         evictedState.deletedKeys, emptyMap, emptyMap),
                     InvariantDoesNotHold);
             }
@@ -499,7 +499,7 @@ TEST_CASE_VERSIONS("State archival eviction invariant", "[invariant][archival]")
 
                 REQUIRE_THROWS_AS(
                     app->getInvariantManager().checkOnLedgerCommit(
-                        applySnap, evictedState.archivedEntries,
+                        applyView, evictedState.archivedEntries,
                         evictedState.deletedKeys, emptyMap, emptyMap),
                     InvariantDoesNotHold);
             }
@@ -519,7 +519,7 @@ TEST_CASE_VERSIONS("State archival eviction invariant", "[invariant][archival]")
 
                 REQUIRE_THROWS_AS(
                     app->getInvariantManager().checkOnLedgerCommit(
-                        applySnap, evictedState.archivedEntries,
+                        applyView, evictedState.archivedEntries,
                         evictedState.deletedKeys, emptyMap, emptyMap),
                     InvariantDoesNotHold);
             }
@@ -538,7 +538,7 @@ TEST_CASE_VERSIONS("State archival eviction invariant", "[invariant][archival]")
                 {
                     REQUIRE_THROWS_AS(
                         app->getInvariantManager().checkOnLedgerCommit(
-                            applySnap, evictedState.archivedEntries,
+                            applyView, evictedState.archivedEntries,
                             evictedState.deletedKeys, emptyMap, emptyMap),
                         InvariantDoesNotHold);
                 }
@@ -546,7 +546,7 @@ TEST_CASE_VERSIONS("State archival eviction invariant", "[invariant][archival]")
                 {
                     REQUIRE_NOTHROW(
                         app->getInvariantManager().checkOnLedgerCommit(
-                            applySnap, evictedState.archivedEntries,
+                            applyView, evictedState.archivedEntries,
                             evictedState.deletedKeys, emptyMap, emptyMap));
                 }
             }
@@ -557,7 +557,7 @@ TEST_CASE_VERSIONS("State archival eviction invariant", "[invariant][archival]")
                 evictedState.deletedKeys.push_back(getTTLKey(liveTempEntry));
                 REQUIRE_THROWS_AS(
                     app->getInvariantManager().checkOnLedgerCommit(
-                        applySnap, evictedState.archivedEntries,
+                        applyView, evictedState.archivedEntries,
                         evictedState.deletedKeys, emptyMap, emptyMap),
                     InvariantDoesNotHold);
             }
@@ -567,7 +567,7 @@ TEST_CASE_VERSIONS("State archival eviction invariant", "[invariant][archival]")
                 // Valid eviction should always pass
                 UnorderedMap<LedgerKey, LedgerEntry> emptyMap;
                 REQUIRE_NOTHROW(app->getInvariantManager().checkOnLedgerCommit(
-                    applySnap, evictedState.archivedEntries,
+                    applyView, evictedState.archivedEntries,
                     evictedState.deletedKeys, emptyMap, emptyMap));
             }
         }
@@ -597,7 +597,7 @@ TEST_CASE("BucketList state consistency invariant", "[invariant]")
     closeLedger(*app);
 
     auto makeSnap = [&]() {
-        return app->getLedgerManager().copyApplyLedgerStateSnapshot();
+        return app->getLedgerManager().copyApplyLedgerView();
     };
 
     auto noopIsStopping = []() { return false; };

--- a/src/ledger/ImmutableLedgerView.cpp
+++ b/src/ledger/ImmutableLedgerView.cpp
@@ -2,7 +2,7 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
-#include "ledger/LedgerStateSnapshot.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "bucket/BucketManager.h"
 #include "bucket/HotArchiveBucketList.h"
 #include "bucket/LiveBucketList.h"
@@ -150,19 +150,19 @@ LedgerTxnReadOnly::load(LedgerKey const& key) const
 
 void
 LedgerTxnReadOnly::executeWithMaybeInnerSnapshot(
-    std::function<void(LedgerSnapshot const& ls)> f) const
+    std::function<void(CheckValidLedgerViewWrapper const& ledgerView)> f) const
 {
     LedgerTxn inner(mLedgerTxn);
-    LedgerSnapshot lsg(inner);
-    return f(lsg);
+    CheckValidLedgerViewWrapper ledgerView(inner);
+    return f(ledgerView);
 }
 
-LedgerSnapshot::LedgerSnapshot(AbstractLedgerTxn& ltx)
+CheckValidLedgerViewWrapper::CheckValidLedgerViewWrapper(AbstractLedgerTxn& ltx)
     : mGetter(std::make_unique<LedgerTxnReadOnly>(ltx))
 {
 }
 
-LedgerSnapshot::LedgerSnapshot(Application& app)
+CheckValidLedgerViewWrapper::CheckValidLedgerViewWrapper(Application& app)
 {
     releaseAssert(threadIsMain());
 #ifdef BUILD_TESTS
@@ -177,43 +177,44 @@ LedgerSnapshot::LedgerSnapshot(Application& app)
     else
 #endif
     {
-        mGetter = std::make_unique<LedgerStateSnapshot>(
-            app.getLedgerManager().copyLedgerStateSnapshot());
+        mGetter = std::make_unique<ImmutableLedgerView>(
+            app.getLedgerManager().copyImmutableLedgerView());
     }
 }
 
-LedgerSnapshot::LedgerSnapshot(LedgerStateSnapshot const& snap)
-    : mGetter(std::make_unique<LedgerStateSnapshot>(snap))
+CheckValidLedgerViewWrapper::CheckValidLedgerViewWrapper(
+    ImmutableLedgerView const& ledgerView)
+    : mGetter(std::make_unique<ImmutableLedgerView>(ledgerView))
 {
 }
 
 LedgerHeaderWrapper
-LedgerSnapshot::getLedgerHeader() const
+CheckValidLedgerViewWrapper::getLedgerHeader() const
 {
     return mGetter->getLedgerHeader();
 }
 
 LedgerEntryWrapper
-LedgerSnapshot::getAccount(AccountID const& account) const
+CheckValidLedgerViewWrapper::getAccount(AccountID const& account) const
 {
     return mGetter->getAccount(account);
 }
 
 LedgerEntryWrapper
-LedgerSnapshot::load(LedgerKey const& key) const
+CheckValidLedgerViewWrapper::load(LedgerKey const& key) const
 {
     return mGetter->load(key);
 }
 
 void
-LedgerSnapshot::executeWithMaybeInnerSnapshot(
-    std::function<void(LedgerSnapshot const& ls)> f) const
+CheckValidLedgerViewWrapper::executeWithMaybeInnerSnapshot(
+    std::function<void(CheckValidLedgerViewWrapper const& ledgerView)> f) const
 {
     return mGetter->executeWithMaybeInnerSnapshot(f);
 }
 
 void
-CompleteConstLedgerState::checkInvariant() const
+ImmutableLedgerData::checkInvariant() const
 {
     releaseAssert(mLastClosedHistoryArchiveState.currentLedger ==
                   mLastClosedLedgerHeader.header.ledgerSeq);
@@ -251,11 +252,11 @@ rotateHistorical(
 }
 } // anonymous namespace
 
-CompleteConstLedgerState::CompleteConstLedgerState(
+ImmutableLedgerData::ImmutableLedgerData(
     LiveBucketList const& liveBL, HotArchiveBucketList const& hotArchiveBL,
     LedgerHeaderHistoryEntry const& lcl, HistoryArchiveState const& has,
     std::optional<SorobanNetworkConfig> sorobanConfig,
-    CompleteConstLedgerStatePtr prevState, uint32_t numHistorical)
+    ImmutableLedgerDataPtr prevState, uint32_t numHistorical)
     : mLiveBucketData(
           std::make_shared<BucketListSnapshotData<LiveBucket>>(liveBL))
     , mLiveHistoricalSnapshots(
@@ -285,34 +286,34 @@ CompleteConstLedgerState::CompleteConstLedgerState(
 }
 
 SorobanNetworkConfig const&
-CompleteConstLedgerState::getSorobanConfig() const
+ImmutableLedgerData::getSorobanConfig() const
 {
     return mSorobanConfig.value();
 }
 
 bool
-CompleteConstLedgerState::hasSorobanConfig() const
+ImmutableLedgerData::hasSorobanConfig() const
 {
     return mSorobanConfig.has_value();
 }
 
 LedgerHeaderHistoryEntry const&
-CompleteConstLedgerState::getLastClosedLedgerHeader() const
+ImmutableLedgerData::getLastClosedLedgerHeader() const
 {
     return mLastClosedLedgerHeader;
 }
 
 HistoryArchiveState const&
-CompleteConstLedgerState::getLastClosedHistoryArchiveState() const
+ImmutableLedgerData::getLastClosedHistoryArchiveState() const
 {
     return mLastClosedHistoryArchiveState;
 }
 
-CompleteConstLedgerStatePtr
-CompleteConstLedgerState::createAndMaybeLoadConfig(
+ImmutableLedgerDataPtr
+ImmutableLedgerData::createAndMaybeLoadConfig(
     LiveBucketList const& liveBL, HotArchiveBucketList const& hotArchiveBL,
     LedgerHeaderHistoryEntry const& lcl, HistoryArchiveState const& has,
-    MetricsRegistry& metrics, CompleteConstLedgerStatePtr prevState,
+    MetricsRegistry& metrics, ImmutableLedgerDataPtr prevState,
     uint32_t numHistoricalSnapshots)
 {
     std::optional<SorobanNetworkConfig> sorobanConfig;
@@ -321,18 +322,18 @@ CompleteConstLedgerState::createAndMaybeLoadConfig(
     {
         // Bootstrap: build a lightweight temporary state (no historical
         // snapshots) just to load config from the current live bucket list.
-        auto tempState = std::make_shared<CompleteConstLedgerState>(
+        auto tempState = std::make_shared<ImmutableLedgerData>(
             liveBL, hotArchiveBL, lcl, has, /*sorobanConfig*/ std::nullopt,
             /*prevState*/ nullptr, /*numHistoricalSnapshots*/ 0);
-        LedgerStateSnapshot tempSnap(tempState, metrics);
-        sorobanConfig = SorobanNetworkConfig::loadFromLedger(tempSnap);
+        ImmutableLedgerView tempView(tempState, metrics);
+        sorobanConfig = SorobanNetworkConfig::loadFromLedger(tempView);
     }
-    return std::make_shared<CompleteConstLedgerState>(
+    return std::make_shared<ImmutableLedgerData>(
         liveBL, hotArchiveBL, lcl, has, std::move(sorobanConfig),
         std::move(prevState), numHistoricalSnapshots);
 }
 
-LedgerStateSnapshot::LedgerStateSnapshot(CompleteConstLedgerStatePtr state,
+ImmutableLedgerView::ImmutableLedgerView(ImmutableLedgerDataPtr state,
                                          MetricsRegistry& metrics)
     : mState(state)
     , mLiveSnapshot(metrics, state->mLiveBucketData,
@@ -345,15 +346,15 @@ LedgerStateSnapshot::LedgerStateSnapshot(CompleteConstLedgerStatePtr state,
 {
 }
 
-CompleteConstLedgerState const&
-LedgerStateSnapshot::getState() const
+ImmutableLedgerData const&
+ImmutableLedgerView::getState() const
 {
     releaseAssert(mState);
     return *mState;
 }
 
 LedgerHeaderWrapper
-LedgerStateSnapshot::getLedgerHeader() const
+ImmutableLedgerView::getLedgerHeader() const
 {
     // Avoid copying the header by aliasing the lifetime to mState shared_ptr
     return LedgerHeaderWrapper(std::shared_ptr<LedgerHeader const>(
@@ -361,26 +362,26 @@ LedgerStateSnapshot::getLedgerHeader() const
 }
 
 uint32_t
-LedgerStateSnapshot::getLedgerSeq() const
+ImmutableLedgerView::getLedgerSeq() const
 {
     return mState->getLastClosedLedgerHeader().header.ledgerSeq;
 }
 
 LedgerEntryWrapper
-LedgerStateSnapshot::getAccount(AccountID const& account) const
+ImmutableLedgerView::getAccount(AccountID const& account) const
 {
     return LedgerEntryWrapper(loadLiveEntry(accountKey(account)));
 }
 
 LedgerEntryWrapper
-LedgerStateSnapshot::getAccount(LedgerHeaderWrapper const& header,
+ImmutableLedgerView::getAccount(LedgerHeaderWrapper const& header,
                                 TransactionFrame const& tx) const
 {
     return getAccount(tx.getSourceID());
 }
 
 LedgerEntryWrapper
-LedgerStateSnapshot::getAccount(LedgerHeaderWrapper const& header,
+ImmutableLedgerView::getAccount(LedgerHeaderWrapper const& header,
                                 TransactionFrame const& tx,
                                 AccountID const& AccountID) const
 {
@@ -388,30 +389,30 @@ LedgerStateSnapshot::getAccount(LedgerHeaderWrapper const& header,
 }
 
 LedgerEntryWrapper
-LedgerStateSnapshot::load(LedgerKey const& key) const
+ImmutableLedgerView::load(LedgerKey const& key) const
 {
     return LedgerEntryWrapper(loadLiveEntry(key));
 }
 
 void
-LedgerStateSnapshot::executeWithMaybeInnerSnapshot(
-    std::function<void(LedgerSnapshot const& ls)> f) const
+ImmutableLedgerView::executeWithMaybeInnerSnapshot(
+    std::function<void(CheckValidLedgerViewWrapper const& ledgerView)> f) const
 {
     throw std::runtime_error(
-        "LedgerStateSnapshot::executeWithMaybeInnerSnapshot is illegal: "
-        "LedgerStateSnapshot has no nested snapshots");
+        "ImmutableLedgerView::executeWithMaybeInnerSnapshot is illegal: "
+        "ImmutableLedgerView has no nested snapshots");
 }
 
 // === Live BucketList wrapper methods ===
 
 std::shared_ptr<LedgerEntry const>
-LedgerStateSnapshot::loadLiveEntry(LedgerKey const& k) const
+ImmutableLedgerView::loadLiveEntry(LedgerKey const& k) const
 {
     return mLiveSnapshot.load(k);
 }
 
 std::vector<LedgerEntry>
-LedgerStateSnapshot::loadLiveKeys(
+ImmutableLedgerView::loadLiveKeys(
     std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys,
     std::string const& label) const
 {
@@ -419,7 +420,7 @@ LedgerStateSnapshot::loadLiveKeys(
 }
 
 std::optional<std::vector<LedgerEntry>>
-LedgerStateSnapshot::loadLiveKeysFromLedger(
+ImmutableLedgerView::loadLiveKeysFromLedger(
     std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys,
     uint32_t ledgerSeq) const
 {
@@ -427,7 +428,7 @@ LedgerStateSnapshot::loadLiveKeysFromLedger(
 }
 
 std::vector<LedgerEntry>
-LedgerStateSnapshot::loadPoolShareTrustLinesByAccountAndAsset(
+ImmutableLedgerView::loadPoolShareTrustLinesByAccountAndAsset(
     AccountID const& accountID, Asset const& asset) const
 {
     return mLiveSnapshot.loadPoolShareTrustLinesByAccountAndAsset(accountID,
@@ -435,14 +436,14 @@ LedgerStateSnapshot::loadPoolShareTrustLinesByAccountAndAsset(
 }
 
 std::vector<InflationWinner>
-LedgerStateSnapshot::loadInflationWinners(size_t maxWinners,
+ImmutableLedgerView::loadInflationWinners(size_t maxWinners,
                                           int64_t minBalance) const
 {
     return mLiveSnapshot.loadInflationWinners(maxWinners, minBalance);
 }
 
 std::unique_ptr<EvictionResultCandidates>
-LedgerStateSnapshot::scanForEviction(uint32_t ledgerSeq,
+ImmutableLedgerView::scanForEviction(uint32_t ledgerSeq,
                                      EvictionMetrics& metrics,
                                      EvictionIterator iter,
                                      std::shared_ptr<EvictionStatistics> stats,
@@ -454,7 +455,7 @@ LedgerStateSnapshot::scanForEviction(uint32_t ledgerSeq,
 }
 
 void
-LedgerStateSnapshot::scanLiveEntriesOfType(
+ImmutableLedgerView::scanLiveEntriesOfType(
     LedgerEntryType type,
     std::function<Loop(BucketEntry const&)> callback) const
 {
@@ -464,20 +465,20 @@ LedgerStateSnapshot::scanLiveEntriesOfType(
 // === Hot Archive BucketList wrapper methods ===
 
 std::shared_ptr<HotArchiveBucketEntry const>
-LedgerStateSnapshot::loadArchiveEntry(LedgerKey const& k) const
+ImmutableLedgerView::loadArchiveEntry(LedgerKey const& k) const
 {
     return mHotArchiveSnapshot.load(k);
 }
 
 std::vector<HotArchiveBucketEntry>
-LedgerStateSnapshot::loadArchiveKeys(
+ImmutableLedgerView::loadArchiveKeys(
     std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys) const
 {
     return mHotArchiveSnapshot.loadKeys(inKeys);
 }
 
 std::optional<std::vector<HotArchiveBucketEntry>>
-LedgerStateSnapshot::loadArchiveKeysFromLedger(
+ImmutableLedgerView::loadArchiveKeysFromLedger(
     std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys,
     uint32_t ledgerSeq) const
 {
@@ -485,15 +486,15 @@ LedgerStateSnapshot::loadArchiveKeysFromLedger(
 }
 
 void
-LedgerStateSnapshot::scanAllArchiveEntries(
+ImmutableLedgerView::scanAllArchiveEntries(
     std::function<Loop(HotArchiveBucketEntry const&)> callback) const
 {
     mHotArchiveSnapshot.scanAllEntries(std::move(callback));
 }
 
-ApplyLedgerStateSnapshot::ApplyLedgerStateSnapshot(
-    CompleteConstLedgerStatePtr state, MetricsRegistry& metrics)
-    : LedgerStateSnapshot(std::move(state), metrics)
+ApplyLedgerView::ApplyLedgerView(ImmutableLedgerDataPtr state,
+                                 MetricsRegistry& metrics)
+    : ImmutableLedgerView(std::move(state), metrics)
 {
 }
 }

--- a/src/ledger/ImmutableLedgerView.h
+++ b/src/ledger/ImmutableLedgerView.h
@@ -17,9 +17,9 @@ namespace stellar
 
 class Application;
 class TransactionFrame;
-class LedgerSnapshot;
-class ApplyLedgerStateSnapshot;
-class CompleteConstLedgerState;
+class CheckValidLedgerViewWrapper;
+class ApplyLedgerView;
+class ImmutableLedgerData;
 class EvictionStatistics;
 struct EvictionMetrics;
 struct EvictionResultCandidates;
@@ -31,8 +31,7 @@ class HotArchiveBucketList;
 // NB: we can't use unique_ptr here, because this object gets passed to a
 // lambda, and std::function requires its callable to be copyable (C++23 fixes
 // this with std::move_only_function, but we're not there yet).
-using CompleteConstLedgerStatePtr =
-    std::shared_ptr<CompleteConstLedgerState const>;
+using ImmutableLedgerDataPtr = std::shared_ptr<ImmutableLedgerData const>;
 
 // A unified ledger entry interface that supports LedgerEntry representations
 // for both legacy SQL and BucketList snapshots. When working with LedgerTxn,
@@ -76,10 +75,10 @@ class LedgerHeaderWrapper
 
 // A unified interface for read-only ledger state snapshot.
 // Supports SQL (via read-only LedgerTxn), as well as BucketList snapshots.
-class AbstractLedgerStateSnapshot
+class AbstractLedgerView
 {
   public:
-    virtual ~AbstractLedgerStateSnapshot() = default;
+    virtual ~AbstractLedgerView() = default;
     virtual LedgerHeaderWrapper getLedgerHeader() const = 0;
     virtual LedgerEntryWrapper getAccount(AccountID const& account) const = 0;
     virtual LedgerEntryWrapper getAccount(LedgerHeaderWrapper const& header,
@@ -92,11 +91,11 @@ class AbstractLedgerStateSnapshot
     // to support the replay of old buggy protocols (<8), see
     // `TransactionFrame::loadSourceAccount`
     virtual void executeWithMaybeInnerSnapshot(
-        std::function<void(LedgerSnapshot const&)> f) const = 0;
+        std::function<void(CheckValidLedgerViewWrapper const&)> f) const = 0;
 };
 
 // A concrete implementation of read-only SQL snapshot wrapper
-class LedgerTxnReadOnly : public AbstractLedgerStateSnapshot
+class LedgerTxnReadOnly : public AbstractLedgerView
 {
     // Callers are expected to manage `AbstractLedgerTxn` themselves.
     // LedgerTxnReadOnly guarantees that LedgerTxn, LedgerTxnHeader and
@@ -115,32 +114,33 @@ class LedgerTxnReadOnly : public AbstractLedgerStateSnapshot
                                   AccountID const& AccountID) const override;
     LedgerEntryWrapper load(LedgerKey const& key) const override;
     void executeWithMaybeInnerSnapshot(
-        std::function<void(LedgerSnapshot const&)> f) const override;
+        std::function<void(CheckValidLedgerViewWrapper const&)> f)
+        const override;
 };
 
 // A copyable value type that provides searchable access to a
-// CompleteConstLedgerState. Each instance maintains its own file stream cache
-// for bucket I/O. Multiple LedgerStateSnapshot instances can safely wrap the
-// same CompleteConstLedgerState.
-class LedgerStateSnapshot : public virtual AbstractLedgerStateSnapshot
+// ImmutableLedgerData. Each instance maintains its own file stream cache
+// for bucket I/O. Multiple ImmutableLedgerView instances can safely wrap the
+// same ImmutableLedgerData.
+class ImmutableLedgerView : public virtual AbstractLedgerView
 {
-    std::shared_ptr<CompleteConstLedgerState const> mState;
+    std::shared_ptr<ImmutableLedgerData const> mState;
     SearchableLiveBucketListSnapshot mLiveSnapshot;
     SearchableHotArchiveBucketListSnapshot mHotArchiveSnapshot;
     std::reference_wrapper<MetricsRegistry> mMetrics;
 
-    friend class CompleteConstLedgerState;
+    friend class ImmutableLedgerData;
 
   public:
-    // Construct from CompleteConstLedgerState
-    explicit LedgerStateSnapshot(CompleteConstLedgerStatePtr state,
+    // Construct from ImmutableLedgerData
+    explicit ImmutableLedgerView(ImmutableLedgerDataPtr state,
                                  MetricsRegistry& metrics);
 
-    CompleteConstLedgerState const& getState() const;
+    ImmutableLedgerData const& getState() const;
     LedgerHeaderWrapper getLedgerHeader() const override;
     uint32_t getLedgerSeq() const;
 
-    // === AbstractLedgerStateSnapshot overrides ===
+    // === AbstractLedgerView overrides ===
     LedgerEntryWrapper getAccount(AccountID const& account) const override;
     LedgerEntryWrapper getAccount(LedgerHeaderWrapper const& header,
                                   TransactionFrame const& tx) const override;
@@ -149,7 +149,8 @@ class LedgerStateSnapshot : public virtual AbstractLedgerStateSnapshot
                                   AccountID const& AccountID) const override;
     LedgerEntryWrapper load(LedgerKey const& key) const override;
     void executeWithMaybeInnerSnapshot(
-        std::function<void(LedgerSnapshot const&)> f) const override;
+        std::function<void(CheckValidLedgerViewWrapper const&)> f)
+        const override;
 
     // === Live BucketList methods ===
     std::shared_ptr<LedgerEntry const> loadLiveEntry(LedgerKey const& k) const;
@@ -184,52 +185,52 @@ class LedgerStateSnapshot : public virtual AbstractLedgerStateSnapshot
         std::function<Loop(HotArchiveBucketEntry const&)> callback) const;
 };
 
-// A strong typedef for LedgerStateSnapshot that represents a snapshot used
-// during apply time. This is identical to LedgerStateSnapshot in practice, but
+// A strong typedef for ImmutableLedgerView that represents a snapshot used
+// during apply time. This is identical to ImmutableLedgerView in practice, but
 // is a distinct type to prevent accidental interchange between apply-time
 // snapshots and other snapshots (e.g., from mLastClosedLedgerState).
-class ApplyLedgerStateSnapshot : private LedgerStateSnapshot,
-                                 public virtual AbstractLedgerStateSnapshot
+class ApplyLedgerView : private ImmutableLedgerView,
+                        public virtual AbstractLedgerView
 {
   public:
-    explicit ApplyLedgerStateSnapshot(CompleteConstLedgerStatePtr state,
-                                      MetricsRegistry& metrics);
+    explicit ApplyLedgerView(ImmutableLedgerDataPtr state,
+                             MetricsRegistry& metrics);
 
-    using LedgerStateSnapshot::executeWithMaybeInnerSnapshot;
-    using LedgerStateSnapshot::getAccount;
-    using LedgerStateSnapshot::getLedgerHeader;
-    using LedgerStateSnapshot::getLedgerSeq;
-    using LedgerStateSnapshot::getState;
-    using LedgerStateSnapshot::load;
-    using LedgerStateSnapshot::loadArchiveEntry;
-    using LedgerStateSnapshot::loadArchiveKeys;
-    using LedgerStateSnapshot::loadArchiveKeysFromLedger;
-    using LedgerStateSnapshot::loadInflationWinners;
-    using LedgerStateSnapshot::loadLiveEntry;
-    using LedgerStateSnapshot::loadLiveKeys;
-    using LedgerStateSnapshot::loadLiveKeysFromLedger;
-    using LedgerStateSnapshot::loadPoolShareTrustLinesByAccountAndAsset;
-    using LedgerStateSnapshot::scanAllArchiveEntries;
-    using LedgerStateSnapshot::scanForEviction;
-    using LedgerStateSnapshot::scanLiveEntriesOfType;
+    using ImmutableLedgerView::executeWithMaybeInnerSnapshot;
+    using ImmutableLedgerView::getAccount;
+    using ImmutableLedgerView::getLedgerHeader;
+    using ImmutableLedgerView::getLedgerSeq;
+    using ImmutableLedgerView::getState;
+    using ImmutableLedgerView::load;
+    using ImmutableLedgerView::loadArchiveEntry;
+    using ImmutableLedgerView::loadArchiveKeys;
+    using ImmutableLedgerView::loadArchiveKeysFromLedger;
+    using ImmutableLedgerView::loadInflationWinners;
+    using ImmutableLedgerView::loadLiveEntry;
+    using ImmutableLedgerView::loadLiveKeys;
+    using ImmutableLedgerView::loadLiveKeysFromLedger;
+    using ImmutableLedgerView::loadPoolShareTrustLinesByAccountAndAsset;
+    using ImmutableLedgerView::scanAllArchiveEntries;
+    using ImmutableLedgerView::scanForEviction;
+    using ImmutableLedgerView::scanLiveEntriesOfType;
 };
 
 // A helper class to create and query read-only snapshots
 // Automatically decides whether to create a BucketList (recommended), or SQL
 // snapshot (deprecated, but currently supported)
-// NOTE: LedgerSnapshot is meant to be short-lived, and should not be persisted
-// across _different_ ledgers, as the state under the hood might change. Users
-// are expected to construct a new LedgerSnapshot each time they want to query
-// ledger state.
-class LedgerSnapshot : public NonMovableOrCopyable
+// NOTE: CheckValidLedgerViewWrapper is meant to be short-lived, and should not
+// be persisted across _different_ ledgers, as the state under the hood might
+// change. Users are expected to construct a new CheckValidLedgerViewWrapper
+// each time they want to query ledger state.
+class CheckValidLedgerViewWrapper : public NonMovableOrCopyable
 {
-    std::unique_ptr<AbstractLedgerStateSnapshot const> mGetter;
+    std::unique_ptr<AbstractLedgerView const> mGetter;
     std::unique_ptr<LedgerTxn> mLegacyLedgerTxn;
 
   public:
-    LedgerSnapshot(AbstractLedgerTxn& ltx);
-    LedgerSnapshot(Application& app);
-    explicit LedgerSnapshot(LedgerStateSnapshot const& snap);
+    CheckValidLedgerViewWrapper(AbstractLedgerTxn& ltx);
+    CheckValidLedgerViewWrapper(Application& app);
+    explicit CheckValidLedgerViewWrapper(ImmutableLedgerView const& ledgerView);
     LedgerHeaderWrapper getLedgerHeader() const;
     LedgerEntryWrapper getAccount(AccountID const& account) const;
     LedgerEntryWrapper
@@ -250,7 +251,7 @@ class LedgerSnapshot : public NonMovableOrCopyable
     // to support the replay of old buggy protocols (<8), see
     // `TransactionFrame::loadSourceAccount`
     void executeWithMaybeInnerSnapshot(
-        std::function<void(LedgerSnapshot const&)> f) const;
+        std::function<void(CheckValidLedgerViewWrapper const&)> f) const;
 };
 
 // Immutable wrapper for a complete ledger state snapshot.
@@ -268,8 +269,8 @@ class LedgerSnapshot : public NonMovableOrCopyable
 // All member objects are immutable. Getters return const references;
 // however, these references should not be assumed to have long lifetimes.
 // A new ledger closure may cause LedgerManager to replace the current
-// CompleteConstLedgerState instance.
-class CompleteConstLedgerState : public NonMovableOrCopyable
+// ImmutableLedgerData instance.
+class ImmutableLedgerData : public NonMovableOrCopyable
 {
   private:
     // Raw immutable bucket data for the live and hot archive bucket lists
@@ -291,27 +292,27 @@ class CompleteConstLedgerState : public NonMovableOrCopyable
 
     void checkInvariant() const;
 
-    friend class LedgerStateSnapshot;
+    friend class ImmutableLedgerView;
 
   public:
     // Construct a new ledger state, rotating historical snapshots from
     // prevState. If prevState is null, history maps will be empty.
     // sorobanConfig is nullopt for pre-Soroban protocol versions, or when
     // building the empty initial state at startup.
-    CompleteConstLedgerState(LiveBucketList const& liveBL,
-                             HotArchiveBucketList const& hotArchiveBL,
-                             LedgerHeaderHistoryEntry const& lcl,
-                             HistoryArchiveState const& has,
-                             std::optional<SorobanNetworkConfig> sorobanConfig,
-                             CompleteConstLedgerStatePtr prevState,
-                             uint32_t numHistoricalSnapshots);
+    ImmutableLedgerData(LiveBucketList const& liveBL,
+                        HotArchiveBucketList const& hotArchiveBL,
+                        LedgerHeaderHistoryEntry const& lcl,
+                        HistoryArchiveState const& has,
+                        std::optional<SorobanNetworkConfig> sorobanConfig,
+                        ImmutableLedgerDataPtr prevState,
+                        uint32_t numHistoricalSnapshots);
 
-    // Factory: constructs a CompleteConstLedgerState, auto-loading the
+    // Factory: constructs a ImmutableLedgerData, auto-loading the
     // SorobanNetworkConfig from the bucket list when the protocol requires it.
-    static CompleteConstLedgerStatePtr createAndMaybeLoadConfig(
+    static ImmutableLedgerDataPtr createAndMaybeLoadConfig(
         LiveBucketList const& liveBL, HotArchiveBucketList const& hotArchiveBL,
         LedgerHeaderHistoryEntry const& lcl, HistoryArchiveState const& has,
-        MetricsRegistry& metrics, CompleteConstLedgerStatePtr prevState,
+        MetricsRegistry& metrics, ImmutableLedgerDataPtr prevState,
         uint32_t numHistoricalSnapshots);
 
     SorobanNetworkConfig const& getSorobanConfig() const;

--- a/src/ledger/InMemorySorobanState.cpp
+++ b/src/ledger/InMemorySorobanState.cpp
@@ -4,7 +4,7 @@
 
 #include "ledger/InMemorySorobanState.h"
 #include "bucket/BucketListSnapshot.h"
-#include "ledger/LedgerStateSnapshot.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "ledger/LedgerTypeUtils.h"
 #include "ledger/SorobanMetrics.h"
 #include "util/GlobalChecks.h"
@@ -445,17 +445,17 @@ InMemorySorobanState::getTTL(LedgerKey const& ledgerKey) const
 
 void
 InMemorySorobanState::initializeStateFromSnapshot(
-    ApplyLedgerStateSnapshot const& snap)
+    ApplyLedgerView const& applyView)
 {
     releaseAssertOrThrow(mContractDataEntries.empty());
     releaseAssertOrThrow(mContractCodeEntries.empty());
     releaseAssertOrThrow(mPendingTTLs.empty());
 
-    auto const& lclHeader = snap.getLedgerHeader().current();
+    auto const& lclHeader = applyView.getLedgerHeader().current();
     auto ledgerVersion = lclHeader.ledgerVersion;
     if (protocolVersionStartsFrom(ledgerVersion, SOROBAN_PROTOCOL_VERSION))
     {
-        auto sorobanConfig = SorobanNetworkConfig::loadFromLedger(snap);
+        auto sorobanConfig = SorobanNetworkConfig::loadFromLedger(applyView);
         // Check if entry is a DEADENTRY and add it to deletedKeys. Otherwise,
         // check if the entry is shadowed by a DEADENTRY.
         std::unordered_set<LedgerKey> deletedKeys;
@@ -522,9 +522,9 @@ InMemorySorobanState::initializeStateFromSnapshot(
             return Loop::INCOMPLETE;
         };
 
-        snap.scanLiveEntriesOfType(CONTRACT_DATA, contractDataHandler);
-        snap.scanLiveEntriesOfType(TTL, ttlHandler);
-        snap.scanLiveEntriesOfType(CONTRACT_CODE, contractCodeHandler);
+        applyView.scanLiveEntriesOfType(CONTRACT_DATA, contractDataHandler);
+        applyView.scanLiveEntriesOfType(TTL, ttlHandler);
+        applyView.scanLiveEntriesOfType(CONTRACT_CODE, contractCodeHandler);
     }
 
     mLastClosedLedgerSeq = lclHeader.ledgerSeq;

--- a/src/ledger/InMemorySorobanState.cpp
+++ b/src/ledger/InMemorySorobanState.cpp
@@ -451,12 +451,11 @@ InMemorySorobanState::initializeStateFromSnapshot(
     releaseAssertOrThrow(mContractCodeEntries.empty());
     releaseAssertOrThrow(mPendingTTLs.empty());
 
-    auto const& lclHeader = snap.getLedgerHeader();
+    auto const& lclHeader = snap.getLedgerHeader().current();
     auto ledgerVersion = lclHeader.ledgerVersion;
     if (protocolVersionStartsFrom(ledgerVersion, SOROBAN_PROTOCOL_VERSION))
     {
-        LedgerSnapshot ls(snap);
-        auto sorobanConfig = SorobanNetworkConfig::loadFromLedger(ls);
+        auto sorobanConfig = SorobanNetworkConfig::loadFromLedger(snap);
         // Check if entry is a DEADENTRY and add it to deletedKeys. Otherwise,
         // check if the entry is shadowed by a DEADENTRY.
         std::unordered_set<LedgerKey> deletedKeys;

--- a/src/ledger/InMemorySorobanState.h
+++ b/src/ledger/InMemorySorobanState.h
@@ -17,7 +17,7 @@
 
 namespace stellar
 {
-class ApplyLedgerStateSnapshot;
+class ApplyLedgerView;
 
 class InvariantManagerImpl;
 class SorobanMetrics;
@@ -439,7 +439,7 @@ class InMemorySorobanState
     // is reading state when these functions are called.
 
     // Initialize the map from a bucket list snapshot
-    void initializeStateFromSnapshot(ApplyLedgerStateSnapshot const& snap);
+    void initializeStateFromSnapshot(ApplyLedgerView const& applyView);
 
     // Update the map with entries from a ledger close. ledgerSeq must be
     // exactly mLastClosedLedgerSeq + 1.

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -6,8 +6,8 @@
 
 #include "catchup/LedgerApplyManager.h"
 #include "history/HistoryManager.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "ledger/LedgerCloseMetaFrame.h"
-#include "ledger/LedgerStateSnapshot.h"
 #include "ledger/NetworkConfig.h"
 #include "main/ApplicationImpl.h"
 #include "rust/RustBridge.h"
@@ -232,20 +232,20 @@ class LedgerManager
 
     // Create a thread-safe copy of the current canonical ledger state
     // snapshot. Can be called from any thread (except for apply, which must use
-    // copyApplyLedgerStateSnapshot instead).
-    virtual LedgerStateSnapshot copyLedgerStateSnapshot() const = 0;
+    // copyApplyLedgerView instead).
+    virtual ImmutableLedgerView copyImmutableLedgerView() const = 0;
 
     // Create a thread-safe copy of the current canonical ledger state
     // snapshot, typed as an apply-time snapshot. Used by legacy (pre-V23)
-    // code paths that need an ApplyLedgerStateSnapshot but don't have
+    // code paths that need an ApplyLedgerView but don't have
     // access to ApplyState.
     // TODO: Refactor such that this doesn't have to be a public function
-    virtual ApplyLedgerStateSnapshot copyApplyLedgerStateSnapshot() const = 0;
+    virtual ApplyLedgerView copyApplyLedgerView() const = 0;
 
-    // Refresh `snapshot` if its ledger seq differs from the current canonical
+    // Refresh `ledgerView` if its ledger seq differs from the current canonical
     // state. No-op otherwise. Can be called from any thread.
     virtual void
-    maybeUpdateLedgerStateSnapshot(LedgerStateSnapshot& snapshot) const = 0;
+    maybeUpdateImmutableLedgerView(ImmutableLedgerView& ledgerView) const = 0;
 
     // return the HAS that corresponds to the last closed ledger as persisted in
     // the database
@@ -346,7 +346,7 @@ class LedgerManager
     virtual void
     advanceLedgerStateAndPublish(uint32_t ledgerSeq, bool calledViaExternalize,
                                  LedgerCloseData const& ledgerData,
-                                 CompleteConstLedgerStatePtr newLedgerState,
+                                 ImmutableLedgerDataPtr newLedgerState,
                                  bool upgradeApplied) = 0;
 
     virtual void assertSetupPhase() const = 0;

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1134,8 +1134,7 @@ LedgerManagerImpl::ApplyState::maybeRebuildModuleCache(
 
     // linearTerm is in 1/128ths in the cost model, to reduce rounding error.
     uint64_t scale = 128;
-    LedgerSnapshot lsForConfig(snap);
-    auto sorobanConfig = SorobanNetworkConfig::loadFromLedger(lsForConfig);
+    auto sorobanConfig = SorobanNetworkConfig::loadFromLedger(snap);
     auto const& memParams = sorobanConfig.memCostParams();
     if (memParams.size() > (size_t)stellar::VmInstantiation)
     {
@@ -2110,25 +2109,23 @@ LedgerManagerImpl::buildLedgerState(
     mApplyState.threadInvariant();
     auto& bm = mApp.getBucketManager();
 
-    // If the caller didn't provide a SorobanNetworkConfig, load it from the
-    // BucketList (at this point the BucketList must have already been updated).
-    if (!sorobanConfig && protocolVersionStartsFrom(header.ledgerVersion,
-                                                    SOROBAN_PROTOCOL_VERSION))
-    {
-        auto liveData = std::make_shared<BucketListSnapshotData<LiveBucket>>(
-            bm.getLiveBucketList());
-        LedgerSnapshot ls(mApp.getMetrics(), std::move(liveData), header);
-        sorobanConfig = SorobanNetworkConfig::loadFromLedger(ls);
-    }
-
     LedgerHeaderHistoryEntry lcl;
     lcl.header = header;
     lcl.hash = xdrSha256(header);
 
-    return std::make_shared<CompleteConstLedgerState>(
+    if (sorobanConfig)
+    {
+        // Caller already loaded config (e.g. from LTX during ledger close)
+        return std::make_shared<CompleteConstLedgerState>(
+            bm.getLiveBucketList(), bm.getHotArchiveBucketList(), lcl, has,
+            std::move(sorobanConfig), std::move(prevState),
+            mNumHistoricalSnapshots);
+    }
+
+    // Auto-load SorobanNetworkConfig from the BucketList
+    return CompleteConstLedgerState::createAndMaybeLoadConfig(
         bm.getLiveBucketList(), bm.getHotArchiveBucketList(), lcl, has,
-        std::move(sorobanConfig), std::move(prevState),
-        mNumHistoricalSnapshots);
+        mApp.getMetrics(), std::move(prevState), mNumHistoricalSnapshots);
 }
 
 CompleteConstLedgerStatePtr

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -265,7 +265,7 @@ LedgerManagerImpl::ApplyState::getSorobanInMemoryStateSizeForTesting() const
 
 void
 LedgerManagerImpl::ApplyState::setLedgerStateForTesting(
-    CompleteConstLedgerStatePtr state)
+    ImmutableLedgerDataPtr state)
 {
     mLedgerState = std::move(state);
 }
@@ -352,14 +352,14 @@ LedgerManagerImpl::LedgerManagerImpl(Application& app)
     LedgerHeaderHistoryEntry emptyLcl;
     HistoryArchiveState emptyHas;
 
-    auto initialState = std::make_shared<CompleteConstLedgerState>(
+    auto initialState = std::make_shared<ImmutableLedgerData>(
         bm.getLiveBucketList(), bm.getHotArchiveBucketList(), emptyLcl,
         emptyHas, /*sorobanConfig*/ std::nullopt, /*prevState*/ nullptr,
         mNumHistoricalSnapshots);
 
     mApplyState.setLedgerState(initialState);
     {
-        SharedLockExclusive lock(mLedgerStateSnapshotMutex);
+        SharedLockExclusive lock(mLastClosedLedgerStateMutex);
         mLastClosedLedgerState = initialState;
     }
 
@@ -493,13 +493,12 @@ LedgerManagerImpl::startNewLedger(LedgerHeader const& genesisLedger)
     CLOG_INFO(Ledger, "Root account: {}", skey.getStrKeyPublic());
     CLOG_INFO(Ledger, "Root account seed: {}", skey.getStrKeySeed().value);
 
-    ApplyLedgerStateSnapshot snap = [this] {
-        SharedLockShared guard(mLedgerStateSnapshotMutex);
-        return ApplyLedgerStateSnapshot(mLastClosedLedgerState,
-                                        mApp.getMetrics());
+    ApplyLedgerView applyView = [this] {
+        SharedLockShared guard(mLastClosedLedgerStateMutex);
+        return ApplyLedgerView(mLastClosedLedgerState, mApp.getMetrics());
     }();
     auto output =
-        sealLedgerTxnAndStoreInBucketsAndDB(snap, ltx,
+        sealLedgerTxnAndStoreInBucketsAndDB(applyView, ltx,
                                             /*ledgerCloseMeta*/ nullptr,
                                             /*initialLedgerVers*/ 0);
     advanceLastClosedLedgerState(output);
@@ -623,7 +622,7 @@ LedgerManagerImpl::loadLastKnownLedgerInternal(bool skipBuildingFullState)
         CLOG_INFO(Perf, "Populated in-memory Soroban state in {:.3f} sec",
                   populateSecs.count());
 
-        maybeRunSnapshotInvariantFromLedgerState(copyApplyLedgerStateSnapshot(),
+        maybeRunSnapshotInvariantFromLedgerState(copyApplyLedgerView(),
                                                  /* runInParallel */ false);
     }
     mApplyState.markEndOfSetupPhase();
@@ -656,7 +655,7 @@ uint32_t
 LedgerManagerImpl::getLastMaxTxSetSize() const
 {
     releaseAssert(!mApp.threadIsType(Application::ThreadType::APPLY));
-    SharedLockShared guard(mLedgerStateSnapshotMutex);
+    SharedLockShared guard(mLastClosedLedgerStateMutex);
     releaseAssert(mLastClosedLedgerState);
     return mLastClosedLedgerState->getLastClosedLedgerHeader()
         .header.maxTxSetSize;
@@ -666,7 +665,7 @@ uint32_t
 LedgerManagerImpl::getLastMaxTxSetSizeOps() const
 {
     releaseAssert(!mApp.threadIsType(Application::ThreadType::APPLY));
-    SharedLockShared guard(mLedgerStateSnapshotMutex);
+    SharedLockShared guard(mLastClosedLedgerStateMutex);
     releaseAssert(mLastClosedLedgerState);
     auto n =
         mLastClosedLedgerState->getLastClosedLedgerHeader().header.maxTxSetSize;
@@ -716,7 +715,7 @@ int64_t
 LedgerManagerImpl::getLastMinBalance(uint32_t ownerCount) const
 {
     releaseAssert(!mApp.threadIsType(Application::ThreadType::APPLY));
-    SharedLockShared guard(mLedgerStateSnapshotMutex);
+    SharedLockShared guard(mLastClosedLedgerStateMutex);
     releaseAssert(mLastClosedLedgerState);
     auto const& lh = mLastClosedLedgerState->getLastClosedLedgerHeader().header;
     if (protocolVersionIsBefore(lh.ledgerVersion, ProtocolVersion::V_9))
@@ -729,7 +728,7 @@ uint32_t
 LedgerManagerImpl::getLastReserve() const
 {
     releaseAssert(!mApp.threadIsType(Application::ThreadType::APPLY));
-    SharedLockShared guard(mLedgerStateSnapshotMutex);
+    SharedLockShared guard(mLastClosedLedgerStateMutex);
     releaseAssert(mLastClosedLedgerState);
     return mLastClosedLedgerState->getLastClosedLedgerHeader()
         .header.baseReserve;
@@ -739,7 +738,7 @@ uint32_t
 LedgerManagerImpl::getLastTxFee() const
 {
     releaseAssert(!mApp.threadIsType(Application::ThreadType::APPLY));
-    SharedLockShared guard(mLedgerStateSnapshotMutex);
+    SharedLockShared guard(mLastClosedLedgerStateMutex);
     releaseAssert(mLastClosedLedgerState);
     return mLastClosedLedgerState->getLastClosedLedgerHeader().header.baseFee;
 }
@@ -751,7 +750,7 @@ LedgerManagerImpl::getLastClosedLedgerHeader() const
     // which is only replaced on the main thread (advanceLastClosedLedgerState).
     // A cross-thread caller could hold a dangling reference after replacement.
     releaseAssert(threadIsMain());
-    SharedLockShared guard(mLedgerStateSnapshotMutex);
+    SharedLockShared guard(mLastClosedLedgerStateMutex);
     releaseAssert(mLastClosedLedgerState);
     return mLastClosedLedgerState->getLastClosedLedgerHeader();
 }
@@ -760,7 +759,7 @@ HistoryArchiveState
 LedgerManagerImpl::getLastClosedLedgerHAS() const
 {
     releaseAssert(!mApp.threadIsType(Application::ThreadType::APPLY));
-    SharedLockShared guard(mLedgerStateSnapshotMutex);
+    SharedLockShared guard(mLastClosedLedgerStateMutex);
     releaseAssert(mLastClosedLedgerState);
     return mLastClosedLedgerState->getLastClosedHistoryArchiveState();
 }
@@ -769,14 +768,14 @@ uint32_t
 LedgerManagerImpl::getLastClosedLedgerNum() const
 {
     releaseAssert(!mApp.threadIsType(Application::ThreadType::APPLY));
-    SharedLockShared guard(mLedgerStateSnapshotMutex);
+    SharedLockShared guard(mLastClosedLedgerStateMutex);
     releaseAssert(mLastClosedLedgerState);
     return mLastClosedLedgerState->getLastClosedLedgerHeader().header.ledgerSeq;
 }
 
 void
 LedgerManagerImpl::maybeRunSnapshotInvariantFromLedgerState(
-    ApplyLedgerStateSnapshot const& ledgerState, bool runInParallel)
+    ApplyLedgerView const& applyView, bool runInParallel)
 {
     if (!mApp.getConfig().INVARIANT_EXTRA_CHECKS || mApp.isStopping() ||
         !mApp.getInvariantManager().shouldRunInvariantSnapshot())
@@ -793,17 +792,16 @@ LedgerManagerImpl::maybeRunSnapshotInvariantFromLedgerState(
             mApplyState.getInMemorySorobanState());
 
     // Verify consistency of all snapshot state.
-    auto ledgerSeq = ledgerState.getLedgerSeq();
+    auto ledgerSeq = applyView.getLedgerSeq();
     inMemorySnapshotForInvariant->assertLastClosedLedger(ledgerSeq);
 
     // Note: No race condition acquiring app by reference, as all worker
     // threads are joined before application destruction.
     // Make sure we make a new snapshot copy since invariant will run on another
     // thread.
-    auto cb = [snap = ledgerState, &app = mApp,
-               inMemorySnapshotForInvariant]() {
+    auto cb = [applyView, &app = mApp, inMemorySnapshotForInvariant]() {
         app.getInvariantManager().runStateSnapshotInvariant(
-            std::move(snap), *inMemorySnapshotForInvariant,
+            std::move(applyView), *inMemorySnapshotForInvariant,
             [&app]() { return app.isStopping(); });
     };
 
@@ -824,7 +822,7 @@ LedgerManagerImpl::getLastClosedSorobanNetworkConfig() const
     // which is only replaced on the main thread (advanceLastClosedLedgerState).
     // A cross-thread caller could hold a dangling reference after replacement.
     releaseAssert(threadIsMain());
-    SharedLockShared guard(mLedgerStateSnapshotMutex);
+    SharedLockShared guard(mLastClosedLedgerStateMutex);
     releaseAssert(mLastClosedLedgerState);
     releaseAssert(mLastClosedLedgerState->hasSorobanConfig());
     return mLastClosedLedgerState->getSorobanConfig();
@@ -834,7 +832,7 @@ bool
 LedgerManagerImpl::hasLastClosedSorobanNetworkConfig() const
 {
     releaseAssert(!mApp.threadIsType(Application::ThreadType::APPLY));
-    SharedLockShared guard(mLedgerStateSnapshotMutex);
+    SharedLockShared guard(mLastClosedLedgerStateMutex);
     releaseAssert(mLastClosedLedgerState);
     return mLastClosedLedgerState->hasSorobanConfig();
 }
@@ -1006,8 +1004,7 @@ void
 LedgerManagerImpl::ApplyState::populateInMemorySorobanState()
 {
     assertSetupPhase();
-    mInMemorySorobanState.initializeStateFromSnapshot(
-        copyLedgerStateSnapshot());
+    mInMemorySorobanState.initializeStateFromSnapshot(copyApplyLedgerView());
 }
 
 void
@@ -1080,7 +1077,7 @@ LedgerManagerImpl::ApplyState::startCompilingAllContracts(
         }
     }
     mCompiler = std::make_unique<SharedModuleCacheCompiler>(
-        copyLedgerStateSnapshot(), mNumCompilationThreads, versions);
+        copyApplyLedgerView(), mNumCompilationThreads, versions);
     mCompiler->start();
 }
 
@@ -1097,7 +1094,7 @@ LedgerManagerImpl::ApplyState::maybeRebuildModuleCache(
     uint32_t minLedgerVersion)
 {
     assertCommittingPhase();
-    auto snap = copyLedgerStateSnapshot();
+    auto applyView = copyApplyLedgerView();
 
     // There is (currently) a grow-only arena underlying the module cache, so as
     // entries are uploaded and evicted that arena will still grow. To cap this
@@ -1134,7 +1131,7 @@ LedgerManagerImpl::ApplyState::maybeRebuildModuleCache(
 
     // linearTerm is in 1/128ths in the cost model, to reduce rounding error.
     uint64_t scale = 128;
-    auto sorobanConfig = SorobanNetworkConfig::loadFromLedger(snap);
+    auto sorobanConfig = SorobanNetworkConfig::loadFromLedger(applyView);
     auto const& memParams = sorobanConfig.memCostParams();
     if (memParams.size() > (size_t)stellar::VmInstantiation)
     {
@@ -1395,8 +1392,8 @@ LedgerManagerImpl::ledgerCloseComplete(uint32_t lcl, bool calledViaExternalize,
 void
 LedgerManagerImpl::advanceLedgerStateAndPublish(
     uint32_t ledgerSeq, bool calledViaExternalize,
-    LedgerCloseData const& ledgerData,
-    CompleteConstLedgerStatePtr newLedgerState, bool upgradeApplied)
+    LedgerCloseData const& ledgerData, ImmutableLedgerDataPtr newLedgerState,
+    bool upgradeApplied)
 {
 #ifdef BUILD_TESTS
     if (mAdvanceLedgerStateAndPublishOverride)
@@ -1663,9 +1660,9 @@ LedgerManagerImpl::applyLedger(LedgerCloseData const& ledgerData,
     for (size_t i = 0; i < sv.upgrades.size(); i++)
     {
         LedgerUpgrade lupgrade;
-        LedgerSnapshot ls(ltx);
-        auto valid =
-            Upgrades::isValidForApply(sv.upgrades[i], lupgrade, mApp, ls);
+        CheckValidLedgerViewWrapper ledgerView(ltx);
+        auto valid = Upgrades::isValidForApply(sv.upgrades[i], lupgrade, mApp,
+                                               ledgerView);
         switch (valid)
         {
         case Upgrades::UpgradeValidity::VALID:
@@ -1713,9 +1710,9 @@ LedgerManagerImpl::applyLedger(LedgerCloseData const& ledgerData,
     auto maybeNewVersion = ltx.loadHeader().current().ledgerVersion;
     auto ledgerSeq = ltx.loadHeader().current().ledgerSeq;
 
-    auto lclSnap = mApplyState.copyLedgerStateSnapshot();
+    auto lclApplyView = mApplyState.copyApplyLedgerView();
     auto appliedLedgerState = sealLedgerTxnAndStoreInBucketsAndDB(
-        lclSnap, ltx, ledgerCloseMeta, initialLedgerVers);
+        lclApplyView, ltx, ledgerCloseMeta, initialLedgerVers);
 
     // NB: from now on, the ledger state may not change, but LCL still hasn't
     // advanced properly. Hence when requesting the ledger state data (such as
@@ -1838,12 +1835,12 @@ LedgerManagerImpl::applyLedger(LedgerCloseData const& ledgerData,
                 .header.ledgerVersion,
             SOROBAN_PROTOCOL_VERSION))
     {
-        // Construct an ApplyLedgerStateSnapshot from `appliedLedgerState`,
+        // Construct an ApplyLedgerView from `appliedLedgerState`,
         // which holds the latest committed state, since the main thread has
         // not yet updated the non-apply lcl snapshot
-        ApplyLedgerStateSnapshot snap(appliedLedgerState, mApp.getMetrics());
+        ApplyLedgerView applyView(appliedLedgerState, mApp.getMetrics());
         mApp.getBucketManager().startBackgroundEvictionScan(
-            std::move(snap), appliedLedgerState->getSorobanConfig());
+            std::move(applyView), appliedLedgerState->getSorobanConfig());
     }
 
     // At this point, we've committed all changes to the Apply State for this
@@ -1857,8 +1854,7 @@ LedgerManagerImpl::applyLedger(LedgerCloseData const& ledgerData,
     // Both the apply-state snapshot and the in-memory Soroban state are
     // captured here at the same point (after commit), so they are guaranteed
     // to be from the same ledger.
-    maybeRunSnapshotInvariantFromLedgerState(
-        mApplyState.copyLedgerStateSnapshot());
+    maybeRunSnapshotInvariantFromLedgerState(mApplyState.copyApplyLedgerView());
 
     // Steps 6, 7, 8 are done in `advanceLedgerStateAndPublish`
     // NB: appliedLedgerState is invalidated after this call.
@@ -2081,13 +2077,13 @@ LedgerManagerImpl::maybeResetLedgerCloseMetaDebugStream(uint32_t ledgerSeq)
 
 void
 LedgerManagerImpl::advanceLastClosedLedgerState(
-    CompleteConstLedgerStatePtr newLedgerState)
+    ImmutableLedgerDataPtr newLedgerState)
 {
     releaseAssert(threadIsMain());
     releaseAssert(newLedgerState);
 
     JITTER_INJECT_DELAY();
-    SharedLockExclusive lock(mLedgerStateSnapshotMutex);
+    SharedLockExclusive lock(mLastClosedLedgerStateMutex);
     JITTER_INJECT_DELAY();
     if (mLastClosedLedgerState)
     {
@@ -2100,10 +2096,10 @@ LedgerManagerImpl::advanceLastClosedLedgerState(
     mLastClosedLedgerState = newLedgerState;
 }
 
-CompleteConstLedgerStatePtr
+ImmutableLedgerDataPtr
 LedgerManagerImpl::buildLedgerState(
     LedgerHeader const& header, HistoryArchiveState const& has,
-    CompleteConstLedgerStatePtr prevState,
+    ImmutableLedgerDataPtr prevState,
     std::optional<SorobanNetworkConfig> sorobanConfig)
 {
     mApplyState.threadInvariant();
@@ -2116,19 +2112,19 @@ LedgerManagerImpl::buildLedgerState(
     if (sorobanConfig)
     {
         // Caller already loaded config (e.g. from LTX during ledger close)
-        return std::make_shared<CompleteConstLedgerState>(
+        return std::make_shared<ImmutableLedgerData>(
             bm.getLiveBucketList(), bm.getHotArchiveBucketList(), lcl, has,
             std::move(sorobanConfig), std::move(prevState),
             mNumHistoricalSnapshots);
     }
 
     // Auto-load SorobanNetworkConfig from the BucketList
-    return CompleteConstLedgerState::createAndMaybeLoadConfig(
+    return ImmutableLedgerData::createAndMaybeLoadConfig(
         bm.getLiveBucketList(), bm.getHotArchiveBucketList(), lcl, has,
         mApp.getMetrics(), std::move(prevState), mNumHistoricalSnapshots);
 }
 
-CompleteConstLedgerStatePtr
+ImmutableLedgerDataPtr
 LedgerManagerImpl::advanceApplySnapshotAndMakeLedgerState(
     LedgerHeader const& header, HistoryArchiveState const& has,
     std::optional<SorobanNetworkConfig> sorobanConfig)
@@ -2139,64 +2135,64 @@ LedgerManagerImpl::advanceApplySnapshotAndMakeLedgerState(
     return state;
 }
 
-LedgerStateSnapshot
-LedgerManagerImpl::copyLedgerStateSnapshot() const
+ImmutableLedgerView
+LedgerManagerImpl::copyImmutableLedgerView() const
 {
-    // Apply thread must use the ApplyState's copyLedgerStateSnapshot.
+    // Apply thread must use the ApplyState's copyImmutableLedgerView.
     releaseAssert(!mApp.threadIsType(Application::ThreadType::APPLY));
 
     JITTER_INJECT_DELAY();
-    SharedLockShared guard(mLedgerStateSnapshotMutex);
+    SharedLockShared guard(mLastClosedLedgerStateMutex);
     JITTER_INJECT_DELAY();
     releaseAssert(mLastClosedLedgerState);
-    return LedgerStateSnapshot(mLastClosedLedgerState, mApp.getMetrics());
+    return ImmutableLedgerView(mLastClosedLedgerState, mApp.getMetrics());
 }
 
-ApplyLedgerStateSnapshot
-LedgerManagerImpl::copyApplyLedgerStateSnapshot() const
+ApplyLedgerView
+LedgerManagerImpl::copyApplyLedgerView() const
 {
     // Apply-thread state may be ahead of mLastClosedLedgerState during
     // parallel ledger close, so always read from ApplyState.
     mApplyState.threadInvariant();
-    return mApplyState.copyLedgerStateSnapshot();
+    return mApplyState.copyApplyLedgerView();
 }
 
 void
-LedgerManagerImpl::maybeUpdateLedgerStateSnapshot(
-    LedgerStateSnapshot& snapshot) const
+LedgerManagerImpl::maybeUpdateImmutableLedgerView(
+    ImmutableLedgerView& ledgerView) const
 {
     JITTER_INJECT_DELAY();
-    SharedLockShared guard(mLedgerStateSnapshotMutex);
+    SharedLockShared guard(mLastClosedLedgerStateMutex);
     JITTER_INJECT_DELAY();
 
     releaseAssert(mLastClosedLedgerState);
-    if (snapshot.getLedgerSeq() !=
+    if (ledgerView.getLedgerSeq() !=
         mLastClosedLedgerState->getLastClosedLedgerHeader().header.ledgerSeq)
     {
-        snapshot =
-            LedgerStateSnapshot(mLastClosedLedgerState, mApp.getMetrics());
+        ledgerView =
+            ImmutableLedgerView(mLastClosedLedgerState, mApp.getMetrics());
     }
 }
 
 void
-LedgerManagerImpl::ApplyState::setLedgerState(CompleteConstLedgerStatePtr state)
+LedgerManagerImpl::ApplyState::setLedgerState(ImmutableLedgerDataPtr state)
 {
     assertWritablePhase();
     mLedgerState = std::move(state);
 }
 
-CompleteConstLedgerStatePtr
+ImmutableLedgerDataPtr
 LedgerManagerImpl::ApplyState::getLedgerState() const
 {
     releaseAssert(mLedgerState);
     return mLedgerState;
 }
 
-ApplyLedgerStateSnapshot
-LedgerManagerImpl::ApplyState::copyLedgerStateSnapshot() const
+ApplyLedgerView
+LedgerManagerImpl::ApplyState::copyApplyLedgerView() const
 {
     releaseAssert(mLedgerState);
-    return ApplyLedgerStateSnapshot(mLedgerState, mAppConnector.getMetrics());
+    return ApplyLedgerView(mLedgerState, mAppConnector.getMetrics());
 }
 
 #ifdef BUILD_TESTS
@@ -2209,7 +2205,7 @@ LedgerManagerImpl::updateCanonicalStateForTesting(LedgerHeader const& header)
     has.currentLedger = header.ledgerSeq;
 
     JITTER_INJECT_DELAY();
-    SharedLockExclusive lock(mLedgerStateSnapshotMutex);
+    SharedLockExclusive lock(mLastClosedLedgerStateMutex);
     JITTER_INJECT_DELAY();
 
     auto state =
@@ -2546,7 +2542,7 @@ LedgerManagerImpl::applySorobanStages(AppConnector& app, AbstractLedgerTxn& ltx,
 {
     ZoneScoped;
     GlobalParallelApplyLedgerState globalParState(
-        app, mApplyState.copyLedgerStateSnapshot(), ltx, stages,
+        app, mApplyState.copyApplyLedgerView(), ltx, stages,
         mApplyState.getInMemorySorobanState(), sorobanConfig);
     // LedgerTxn is not passed into applySorobanStage, so there's no risk
     // of the header being updated while we apply the stages.
@@ -2947,7 +2943,7 @@ LedgerManagerImpl::storePersistentStateAndLedgerHeaderInDB(
 // NB: This is a separate method so a testing subclass can override it.
 std::optional<SorobanNetworkConfig>
 LedgerManagerImpl::finalizeLedgerTxnChanges(
-    ApplyLedgerStateSnapshot const& lclSnapshot, AbstractLedgerTxn& ltx,
+    ApplyLedgerView const& lclApplyView, AbstractLedgerTxn& ltx,
     std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta,
     LedgerHeader lh, uint32_t initialLedgerVers)
 {
@@ -2966,7 +2962,7 @@ LedgerManagerImpl::finalizeLedgerTxnChanges(
         auto sorobanConfig = SorobanNetworkConfig::loadFromLedger(ltx);
         auto evictedState =
             mApp.getBucketManager().resolveBackgroundEvictionScan(
-                lclSnapshot, ltx, ltx.getAllKeysWithoutSealing());
+                lclApplyView, ltx, ltx.getAllKeysWithoutSealing());
 
         if (protocolVersionStartsFrom(
                 initialLedgerVers,
@@ -2986,7 +2982,7 @@ LedgerManagerImpl::finalizeLedgerTxnChanges(
             }
 
             mApp.getInvariantManager().checkOnLedgerCommit(
-                lclSnapshot, evictedState.archivedEntries,
+                lclApplyView, evictedState.archivedEntries,
                 evictedState.deletedKeys, restoredHotArchiveKeyMap,
                 ltx.getRestoredLiveBucketListKeys());
 
@@ -2998,7 +2994,7 @@ LedgerManagerImpl::finalizeLedgerTxnChanges(
             if (isP24UpgradeLedger && gIsProductionNetwork)
             {
                 p23_hot_archive_bug::addHotArchiveBatchWithP23HotArchiveFix(
-                    ltx, mApp, lclSnapshot, lh, evictedState.archivedEntries,
+                    ltx, mApp, lclApplyView, lh, evictedState.archivedEntries,
                     restoredHotArchiveKeys);
             }
             else
@@ -3012,7 +3008,7 @@ LedgerManagerImpl::finalizeLedgerTxnChanges(
                 {
                     mApp.getProtocol23CorruptionDataVerifier()
                         ->verifyArchivalOfCorruptedEntry(
-                            evictedState, lclSnapshot, lh.ledgerSeq,
+                            evictedState, lclApplyView, lh.ledgerSeq,
                             lh.ledgerVersion);
                 }
             }
@@ -3054,9 +3050,9 @@ LedgerManagerImpl::finalizeLedgerTxnChanges(
     return finalSorobanConfig;
 }
 
-CompleteConstLedgerStatePtr
+ImmutableLedgerDataPtr
 LedgerManagerImpl::sealLedgerTxnAndStoreInBucketsAndDB(
-    ApplyLedgerStateSnapshot const& lclSnapshot, AbstractLedgerTxn& ltx,
+    ApplyLedgerView const& lclApplyView, AbstractLedgerTxn& ltx,
     std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta,
     uint32_t initialLedgerVers)
 {
@@ -3093,9 +3089,9 @@ LedgerManagerImpl::sealLedgerTxnAndStoreInBucketsAndDB(
     // initial protocol version of ledger instead of the ledger version of
     // the current ltx header, which may have been modified via an upgrade.
     auto sorobanConfig = finalizeLedgerTxnChanges(
-        lclSnapshot, ltx, ledgerCloseMeta, ledgerHeader, initialLedgerVers);
+        lclApplyView, ltx, ledgerCloseMeta, ledgerHeader, initialLedgerVers);
 
-    CompleteConstLedgerStatePtr res;
+    ImmutableLedgerDataPtr res;
     ltx.unsealHeader([this, &res, sorobanConfig = std::move(sorobanConfig)](
                          LedgerHeader& lh) mutable {
         mApp.getBucketManager().snapshotLedger(lh);

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -159,7 +159,7 @@ class LedgerManagerImpl : public LedgerManager
         AppConnector& mAppConnector;
 
         // Ledger state snapshot that is the base for current ledger apply
-        CompleteConstLedgerStatePtr mLedgerState;
+        ImmutableLedgerDataPtr mLedgerState;
 
         // The current reusable / inter-ledger soroban module cache.
         ::rust::Box<rust_bridge::SorobanModuleCache> mModuleCache;
@@ -212,7 +212,7 @@ class LedgerManagerImpl : public LedgerManager
         ::rust::Box<rust_bridge::SorobanModuleCache> const&
         getModuleCacheForTesting();
         uint64_t getSorobanInMemoryStateSizeForTesting() const;
-        void setLedgerStateForTesting(CompleteConstLedgerStatePtr state);
+        void setLedgerStateForTesting(ImmutableLedgerDataPtr state);
 #endif
 
         ::rust::Box<rust_bridge::SorobanModuleCache> const&
@@ -264,10 +264,10 @@ class LedgerManagerImpl : public LedgerManager
             AbstractLedgerTxn& upgradeLtx);
 
         // Advance the ledger state to the provided snapshot.
-        void setLedgerState(CompleteConstLedgerStatePtr state);
+        void setLedgerState(ImmutableLedgerDataPtr state);
 
-        CompleteConstLedgerStatePtr getLedgerState() const;
-        ApplyLedgerStateSnapshot copyLedgerStateSnapshot() const;
+        ImmutableLedgerDataPtr getLedgerState() const;
+        ApplyLedgerView copyApplyLedgerView() const;
 
         // Throws if current state is not READY_TO_APPLY, advances to APPLYING
         void markStartOfApplying();
@@ -299,14 +299,14 @@ class LedgerManagerImpl : public LedgerManager
     // the apply thread, and one for everyone else, managed by the main thread.
     // mLastClosedLedgerState is managed by the main thread and is copyable
     // by all threads (except for apply). This is protected by
-    // mLedgerStateSnapshotMutex.
+    // mLastClosedLedgerStateMutex.
     // When background apply is enabled, the apply thread will advance it's own
     // snapshot immediately after applying a ledger, then post the result back
     // to main thread. This means the apply snapshot may be ahead of
     // mLastClosedLedgerState at any given point.
-    mutable ANNOTATED_SHARED_MUTEX(mLedgerStateSnapshotMutex);
-    CompleteConstLedgerStatePtr
-        mLastClosedLedgerState GUARDED_BY(mLedgerStateSnapshotMutex);
+    mutable ANNOTATED_SHARED_MUTEX(mLastClosedLedgerStateMutex);
+    ImmutableLedgerDataPtr
+        mLastClosedLedgerState GUARDED_BY(mLastClosedLedgerStateMutex);
 
     // Max number of historical snapshots to maintain.
     uint32_t const mNumHistoricalSnapshots;
@@ -396,8 +396,8 @@ class LedgerManagerImpl : public LedgerManager
     // initialLedgerVers must be the ledger version at the start of the ledger.
     // On the ledger in which a protocol upgrade from vN to vN + 1 occurs,
     // initialLedgerVers must be vN.
-    CompleteConstLedgerStatePtr sealLedgerTxnAndStoreInBucketsAndDB(
-        ApplyLedgerStateSnapshot const& lclSnapshot, AbstractLedgerTxn& ltx,
+    ImmutableLedgerDataPtr sealLedgerTxnAndStoreInBucketsAndDB(
+        ApplyLedgerView const& lclApplyView, AbstractLedgerTxn& ltx,
         std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta,
         uint32_t initialLedgerVers);
 
@@ -409,8 +409,9 @@ class LedgerManagerImpl : public LedgerManager
     // the apply-state snapshot, then kicks off the snapshot invariant check.
     // If runInParallel is false, runs on the calling thread (useful at
     // startup).
-    void maybeRunSnapshotInvariantFromLedgerState(
-        ApplyLedgerStateSnapshot const& ledgerState, bool runInParallel = true);
+    void
+    maybeRunSnapshotInvariantFromLedgerState(ApplyLedgerView const& applyView,
+                                             bool runInParallel = true);
 
     static void prefetchTransactionData(AbstractLedgerTxnParent& rootLtx,
                                         ApplicableTxSetFrame const& txSet,
@@ -435,8 +436,7 @@ class LedgerManagerImpl : public LedgerManager
     void publishSorobanMetrics();
 
     // Update cached last closed ledger state values managed by this class.
-    void
-    advanceLastClosedLedgerState(CompleteConstLedgerStatePtr newLedgerState);
+    void advanceLastClosedLedgerState(ImmutableLedgerDataPtr newLedgerState);
 
     // Internal helper for loading last known ledger and an option to skip
     // building the 'full' state (including in-memory Soroban state, module
@@ -455,22 +455,22 @@ class LedgerManagerImpl : public LedgerManager
     // NB: LedgerHeader is a copy here to prevent footguns in case ltx
     // invalidates any header references
     virtual std::optional<SorobanNetworkConfig> finalizeLedgerTxnChanges(
-        ApplyLedgerStateSnapshot const& lclSnapshot, AbstractLedgerTxn& ltx,
+        ApplyLedgerView const& lclApplyView, AbstractLedgerTxn& ltx,
         std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta,
         LedgerHeader lh, uint32_t initialLedgerVers);
 
-    // Build a new CompleteConstLedgerState from the current BucketLists,
+    // Build a new ImmutableLedgerData from the current BucketLists,
     // copying then updating historical snapshots from prevState. If
     // sorobanConfig is not provided, it is loaded from a temporary bucket
     // snapshot when the protocol requires it.
-    CompleteConstLedgerStatePtr
+    ImmutableLedgerDataPtr
     buildLedgerState(LedgerHeader const& header, HistoryArchiveState const& has,
-                     CompleteConstLedgerStatePtr prevState,
+                     ImmutableLedgerDataPtr prevState,
                      std::optional<SorobanNetworkConfig> sorobanConfig);
 
     // Build a new ledger state and advance ApplyState snapshot to it. This does
     // not yet publish or post the new snapshot to the main thread.
-    CompleteConstLedgerStatePtr advanceApplySnapshotAndMakeLedgerState(
+    ImmutableLedgerDataPtr advanceApplySnapshotAndMakeLedgerState(
         LedgerHeader const& header, HistoryArchiveState const& has,
         std::optional<SorobanNetworkConfig> sorobanConfig);
     void logTxApplyMetrics(AbstractLedgerTxn& ltx, size_t numTxs,
@@ -548,11 +548,11 @@ class LedgerManagerImpl : public LedgerManager
 
     void applyLedger(LedgerCloseData const& ledgerData,
                      bool calledViaExternalize) override;
-    void
-    advanceLedgerStateAndPublish(uint32_t ledgerSeq, bool calledViaExternalize,
-                                 LedgerCloseData const& ledgerData,
-                                 CompleteConstLedgerStatePtr newLedgerState,
-                                 bool queueRebuildNeeded) override;
+    void advanceLedgerStateAndPublish(uint32_t ledgerSeq,
+                                      bool calledViaExternalize,
+                                      LedgerCloseData const& ledgerData,
+                                      ImmutableLedgerDataPtr newLedgerState,
+                                      bool queueRebuildNeeded) override;
     void ledgerCloseComplete(uint32_t lcl, bool calledViaExternalize,
                              LedgerCloseData const& ledgerData,
                              bool queueRebuildNeeded);
@@ -565,10 +565,10 @@ class LedgerManagerImpl : public LedgerManager
     void maybeResetLedgerCloseMetaDebugStream(uint32_t ledgerSeq);
 
     SorobanMetrics& getSorobanMetrics() override;
-    LedgerStateSnapshot copyLedgerStateSnapshot() const override;
-    ApplyLedgerStateSnapshot copyApplyLedgerStateSnapshot() const override;
-    void maybeUpdateLedgerStateSnapshot(
-        LedgerStateSnapshot& snapshot) const override;
+    ImmutableLedgerView copyImmutableLedgerView() const override;
+    ApplyLedgerView copyApplyLedgerView() const override;
+    void maybeUpdateImmutableLedgerView(
+        ImmutableLedgerView& ledgerView) const override;
 #ifdef BUILD_TESTS
     void updateCanonicalStateForTesting(LedgerHeader const& header) override;
 #endif

--- a/src/ledger/LedgerStateSnapshot.cpp
+++ b/src/ledger/LedgerStateSnapshot.cpp
@@ -72,23 +72,10 @@ LedgerHeaderWrapper::LedgerHeaderWrapper(LedgerTxnHeader&& header)
 {
 }
 
-LedgerHeaderWrapper::LedgerHeaderWrapper(std::shared_ptr<LedgerHeader> header)
-    : mHeader(header)
+LedgerHeaderWrapper::LedgerHeaderWrapper(
+    std::shared_ptr<LedgerHeader const> header)
+    : mHeader(std::move(header))
 {
-}
-
-LedgerHeader&
-LedgerHeaderWrapper::currentToModify()
-{
-    switch (mHeader.index())
-    {
-    case 0:
-        return std::get<0>(mHeader).current();
-    case 1:
-        return *std::get<1>(mHeader);
-    default:
-        throw std::runtime_error("Invalid LedgerHeaderWrapper index");
-    }
 }
 
 LedgerHeader const&
@@ -171,13 +158,15 @@ LedgerTxnReadOnly::executeWithMaybeInnerSnapshot(
 
 BucketSnapshotState::BucketSnapshotState(LedgerStateSnapshot const& snap)
     : mLiveSnap(snap.mLiveSnapshot)
-    , mLedgerHeader(std::make_shared<LedgerHeader>(snap.getLedgerHeader()))
+    , mLedgerHeader(
+          std::make_shared<LedgerHeader const>(snap.getLedgerHeader()))
 {
 }
 
 BucketSnapshotState::BucketSnapshotState(ApplyLedgerStateSnapshot const& snap)
     : mLiveSnap(static_cast<LedgerStateSnapshot const&>(snap).mLiveSnapshot)
-    , mLedgerHeader(std::make_shared<LedgerHeader>(snap.getLedgerHeader()))
+    , mLedgerHeader(
+          std::make_shared<LedgerHeader const>(snap.getLedgerHeader()))
 {
 }
 
@@ -186,7 +175,7 @@ BucketSnapshotState::BucketSnapshotState(
     std::shared_ptr<BucketListSnapshotData<LiveBucket> const> liveData,
     LedgerHeader const& header)
     : mLiveSnap(metrics, std::move(liveData), {}, header.ledgerSeq)
-    , mLedgerHeader(std::make_shared<LedgerHeader>(header))
+    , mLedgerHeader(std::make_shared<LedgerHeader const>(header))
 {
 }
 

--- a/src/ledger/LedgerStateSnapshot.cpp
+++ b/src/ledger/LedgerStateSnapshot.cpp
@@ -11,6 +11,7 @@
 #include "main/Application.h"
 #include "transactions/TransactionFrame.h"
 #include "transactions/TransactionUtils.h"
+#include "util/ProtocolVersion.h"
 #include "xdr/Stellar-ledger.h"
 
 namespace stellar
@@ -156,75 +157,6 @@ LedgerTxnReadOnly::executeWithMaybeInnerSnapshot(
     return f(lsg);
 }
 
-BucketSnapshotState::BucketSnapshotState(LedgerStateSnapshot const& snap)
-    : mLiveSnap(snap.mLiveSnapshot)
-    , mLedgerHeader(
-          std::make_shared<LedgerHeader const>(snap.getLedgerHeader()))
-{
-}
-
-BucketSnapshotState::BucketSnapshotState(ApplyLedgerStateSnapshot const& snap)
-    : mLiveSnap(static_cast<LedgerStateSnapshot const&>(snap).mLiveSnapshot)
-    , mLedgerHeader(
-          std::make_shared<LedgerHeader const>(snap.getLedgerHeader()))
-{
-}
-
-BucketSnapshotState::BucketSnapshotState(
-    MetricsRegistry& metrics,
-    std::shared_ptr<BucketListSnapshotData<LiveBucket> const> liveData,
-    LedgerHeader const& header)
-    : mLiveSnap(metrics, std::move(liveData), {}, header.ledgerSeq)
-    , mLedgerHeader(std::make_shared<LedgerHeader const>(header))
-{
-}
-
-BucketSnapshotState::~BucketSnapshotState()
-{
-}
-
-LedgerHeaderWrapper
-BucketSnapshotState::getLedgerHeader() const
-{
-    return LedgerHeaderWrapper(mLedgerHeader);
-}
-
-LedgerEntryWrapper
-BucketSnapshotState::getAccount(AccountID const& account) const
-{
-    return LedgerEntryWrapper(mLiveSnap.load(accountKey(account)));
-}
-
-LedgerEntryWrapper
-BucketSnapshotState::getAccount(LedgerHeaderWrapper const& header,
-                                TransactionFrame const& tx) const
-{
-    return getAccount(tx.getSourceID());
-}
-
-LedgerEntryWrapper
-BucketSnapshotState::getAccount(LedgerHeaderWrapper const& header,
-                                TransactionFrame const& tx,
-                                AccountID const& AccountID) const
-{
-    return getAccount(AccountID);
-}
-
-LedgerEntryWrapper
-BucketSnapshotState::load(LedgerKey const& key) const
-{
-    return LedgerEntryWrapper(mLiveSnap.load(key));
-}
-
-void
-BucketSnapshotState::executeWithMaybeInnerSnapshot(
-    std::function<void(LedgerSnapshot const& ls)> f) const
-{
-    throw std::runtime_error(
-        "BucketSnapshotState::executeWithMaybeInnerSnapshot is illegal: "
-        "BucketSnapshotState has no nested snapshots");
-}
-
 LedgerSnapshot::LedgerSnapshot(AbstractLedgerTxn& ltx)
     : mGetter(std::make_unique<LedgerTxnReadOnly>(ltx))
 {
@@ -245,27 +177,13 @@ LedgerSnapshot::LedgerSnapshot(Application& app)
     else
 #endif
     {
-        auto snap = app.getLedgerManager().copyLedgerStateSnapshot();
-        mGetter = std::make_unique<BucketSnapshotState>(snap);
+        mGetter = std::make_unique<LedgerStateSnapshot>(
+            app.getLedgerManager().copyLedgerStateSnapshot());
     }
 }
 
 LedgerSnapshot::LedgerSnapshot(LedgerStateSnapshot const& snap)
-    : mGetter(std::make_unique<BucketSnapshotState>(snap))
-{
-}
-
-LedgerSnapshot::LedgerSnapshot(ApplyLedgerStateSnapshot const& snap)
-    : mGetter(std::make_unique<BucketSnapshotState>(snap))
-{
-}
-
-LedgerSnapshot::LedgerSnapshot(
-    MetricsRegistry& metrics,
-    std::shared_ptr<BucketListSnapshotData<LiveBucket> const> liveData,
-    LedgerHeader const& header)
-    : mGetter(std::make_unique<BucketSnapshotState>(
-          metrics, std::move(liveData), header))
+    : mGetter(std::make_unique<LedgerStateSnapshot>(snap))
 {
 }
 
@@ -390,6 +308,30 @@ CompleteConstLedgerState::getLastClosedHistoryArchiveState() const
     return mLastClosedHistoryArchiveState;
 }
 
+CompleteConstLedgerStatePtr
+CompleteConstLedgerState::createAndMaybeLoadConfig(
+    LiveBucketList const& liveBL, HotArchiveBucketList const& hotArchiveBL,
+    LedgerHeaderHistoryEntry const& lcl, HistoryArchiveState const& has,
+    MetricsRegistry& metrics, CompleteConstLedgerStatePtr prevState,
+    uint32_t numHistoricalSnapshots)
+{
+    std::optional<SorobanNetworkConfig> sorobanConfig;
+    if (protocolVersionStartsFrom(lcl.header.ledgerVersion,
+                                  SOROBAN_PROTOCOL_VERSION))
+    {
+        // Bootstrap: build a lightweight temporary state (no historical
+        // snapshots) just to load config from the current live bucket list.
+        auto tempState = std::make_shared<CompleteConstLedgerState>(
+            liveBL, hotArchiveBL, lcl, has, /*sorobanConfig*/ std::nullopt,
+            /*prevState*/ nullptr, /*numHistoricalSnapshots*/ 0);
+        LedgerStateSnapshot tempSnap(tempState, metrics);
+        sorobanConfig = SorobanNetworkConfig::loadFromLedger(tempSnap);
+    }
+    return std::make_shared<CompleteConstLedgerState>(
+        liveBL, hotArchiveBL, lcl, has, std::move(sorobanConfig),
+        std::move(prevState), numHistoricalSnapshots);
+}
+
 LedgerStateSnapshot::LedgerStateSnapshot(CompleteConstLedgerStatePtr state,
                                          MetricsRegistry& metrics)
     : mState(state)
@@ -410,16 +352,54 @@ LedgerStateSnapshot::getState() const
     return *mState;
 }
 
-LedgerHeader const&
+LedgerHeaderWrapper
 LedgerStateSnapshot::getLedgerHeader() const
 {
-    return mState->getLastClosedLedgerHeader().header;
+    // Avoid copying the header by aliasing the lifetime to mState shared_ptr
+    return LedgerHeaderWrapper(std::shared_ptr<LedgerHeader const>(
+        mState, &mState->getLastClosedLedgerHeader().header));
 }
 
 uint32_t
 LedgerStateSnapshot::getLedgerSeq() const
 {
     return mState->getLastClosedLedgerHeader().header.ledgerSeq;
+}
+
+LedgerEntryWrapper
+LedgerStateSnapshot::getAccount(AccountID const& account) const
+{
+    return LedgerEntryWrapper(loadLiveEntry(accountKey(account)));
+}
+
+LedgerEntryWrapper
+LedgerStateSnapshot::getAccount(LedgerHeaderWrapper const& header,
+                                TransactionFrame const& tx) const
+{
+    return getAccount(tx.getSourceID());
+}
+
+LedgerEntryWrapper
+LedgerStateSnapshot::getAccount(LedgerHeaderWrapper const& header,
+                                TransactionFrame const& tx,
+                                AccountID const& AccountID) const
+{
+    return getAccount(AccountID);
+}
+
+LedgerEntryWrapper
+LedgerStateSnapshot::load(LedgerKey const& key) const
+{
+    return LedgerEntryWrapper(loadLiveEntry(key));
+}
+
+void
+LedgerStateSnapshot::executeWithMaybeInnerSnapshot(
+    std::function<void(LedgerSnapshot const& ls)> f) const
+{
+    throw std::runtime_error(
+        "LedgerStateSnapshot::executeWithMaybeInnerSnapshot is illegal: "
+        "LedgerStateSnapshot has no nested snapshots");
 }
 
 // === Live BucketList wrapper methods ===

--- a/src/ledger/LedgerStateSnapshot.h
+++ b/src/ledger/LedgerStateSnapshot.h
@@ -122,7 +122,7 @@ class LedgerTxnReadOnly : public AbstractLedgerStateSnapshot
 // CompleteConstLedgerState. Each instance maintains its own file stream cache
 // for bucket I/O. Multiple LedgerStateSnapshot instances can safely wrap the
 // same CompleteConstLedgerState.
-class LedgerStateSnapshot
+class LedgerStateSnapshot : public virtual AbstractLedgerStateSnapshot
 {
     std::shared_ptr<CompleteConstLedgerState const> mState;
     SearchableLiveBucketListSnapshot mLiveSnapshot;
@@ -130,7 +130,6 @@ class LedgerStateSnapshot
     std::reference_wrapper<MetricsRegistry> mMetrics;
 
     friend class CompleteConstLedgerState;
-    friend class BucketSnapshotState;
 
   public:
     // Construct from CompleteConstLedgerState
@@ -138,8 +137,19 @@ class LedgerStateSnapshot
                                  MetricsRegistry& metrics);
 
     CompleteConstLedgerState const& getState() const;
-    LedgerHeader const& getLedgerHeader() const;
+    LedgerHeaderWrapper getLedgerHeader() const override;
     uint32_t getLedgerSeq() const;
+
+    // === AbstractLedgerStateSnapshot overrides ===
+    LedgerEntryWrapper getAccount(AccountID const& account) const override;
+    LedgerEntryWrapper getAccount(LedgerHeaderWrapper const& header,
+                                  TransactionFrame const& tx) const override;
+    LedgerEntryWrapper getAccount(LedgerHeaderWrapper const& header,
+                                  TransactionFrame const& tx,
+                                  AccountID const& AccountID) const override;
+    LedgerEntryWrapper load(LedgerKey const& key) const override;
+    void executeWithMaybeInnerSnapshot(
+        std::function<void(LedgerSnapshot const&)> f) const override;
 
     // === Live BucketList methods ===
     std::shared_ptr<LedgerEntry const> loadLiveEntry(LedgerKey const& k) const;
@@ -178,17 +188,19 @@ class LedgerStateSnapshot
 // during apply time. This is identical to LedgerStateSnapshot in practice, but
 // is a distinct type to prevent accidental interchange between apply-time
 // snapshots and other snapshots (e.g., from mLastClosedLedgerState).
-class ApplyLedgerStateSnapshot : private LedgerStateSnapshot
+class ApplyLedgerStateSnapshot : private LedgerStateSnapshot,
+                                 public virtual AbstractLedgerStateSnapshot
 {
-    friend class BucketSnapshotState;
-
   public:
     explicit ApplyLedgerStateSnapshot(CompleteConstLedgerStatePtr state,
                                       MetricsRegistry& metrics);
 
+    using LedgerStateSnapshot::executeWithMaybeInnerSnapshot;
+    using LedgerStateSnapshot::getAccount;
     using LedgerStateSnapshot::getLedgerHeader;
     using LedgerStateSnapshot::getLedgerSeq;
     using LedgerStateSnapshot::getState;
+    using LedgerStateSnapshot::load;
     using LedgerStateSnapshot::loadArchiveEntry;
     using LedgerStateSnapshot::loadArchiveKeys;
     using LedgerStateSnapshot::loadArchiveKeysFromLedger;
@@ -200,33 +212,6 @@ class ApplyLedgerStateSnapshot : private LedgerStateSnapshot
     using LedgerStateSnapshot::scanAllArchiveEntries;
     using LedgerStateSnapshot::scanForEviction;
     using LedgerStateSnapshot::scanLiveEntriesOfType;
-};
-
-// A concrete implementation of read-only BucketList snapshot wrapper
-class BucketSnapshotState : public AbstractLedgerStateSnapshot
-{
-    SearchableLiveBucketListSnapshot mLiveSnap;
-    std::shared_ptr<LedgerHeader const> mLedgerHeader;
-
-  public:
-    explicit BucketSnapshotState(LedgerStateSnapshot const& snap);
-    explicit BucketSnapshotState(ApplyLedgerStateSnapshot const& snap);
-    BucketSnapshotState(
-        MetricsRegistry& metrics,
-        std::shared_ptr<BucketListSnapshotData<LiveBucket> const> liveData,
-        LedgerHeader const& header);
-    ~BucketSnapshotState() override;
-
-    LedgerHeaderWrapper getLedgerHeader() const override;
-    LedgerEntryWrapper getAccount(AccountID const& account) const override;
-    LedgerEntryWrapper getAccount(LedgerHeaderWrapper const& header,
-                                  TransactionFrame const& tx) const override;
-    LedgerEntryWrapper getAccount(LedgerHeaderWrapper const& header,
-                                  TransactionFrame const& tx,
-                                  AccountID const& AccountID) const override;
-    LedgerEntryWrapper load(LedgerKey const& key) const override;
-    void executeWithMaybeInnerSnapshot(
-        std::function<void(LedgerSnapshot const&)> f) const override;
 };
 
 // A helper class to create and query read-only snapshots
@@ -245,13 +230,6 @@ class LedgerSnapshot : public NonMovableOrCopyable
     LedgerSnapshot(AbstractLedgerTxn& ltx);
     LedgerSnapshot(Application& app);
     explicit LedgerSnapshot(LedgerStateSnapshot const& snap);
-    explicit LedgerSnapshot(ApplyLedgerStateSnapshot const& snap);
-    // Construct from a lightweight live bucket snapshot + header,
-    // without requiring a full CompleteConstLedgerState.
-    LedgerSnapshot(
-        MetricsRegistry& metrics,
-        std::shared_ptr<BucketListSnapshotData<LiveBucket> const> liveData,
-        LedgerHeader const& header);
     LedgerHeaderWrapper getLedgerHeader() const;
     LedgerEntryWrapper getAccount(AccountID const& account) const;
     LedgerEntryWrapper
@@ -327,6 +305,14 @@ class CompleteConstLedgerState : public NonMovableOrCopyable
                              std::optional<SorobanNetworkConfig> sorobanConfig,
                              CompleteConstLedgerStatePtr prevState,
                              uint32_t numHistoricalSnapshots);
+
+    // Factory: constructs a CompleteConstLedgerState, auto-loading the
+    // SorobanNetworkConfig from the bucket list when the protocol requires it.
+    static CompleteConstLedgerStatePtr createAndMaybeLoadConfig(
+        LiveBucketList const& liveBL, HotArchiveBucketList const& hotArchiveBL,
+        LedgerHeaderHistoryEntry const& lcl, HistoryArchiveState const& has,
+        MetricsRegistry& metrics, CompleteConstLedgerStatePtr prevState,
+        uint32_t numHistoricalSnapshots);
 
     SorobanNetworkConfig const& getSorobanConfig() const;
     bool hasSorobanConfig() const;

--- a/src/ledger/LedgerStateSnapshot.h
+++ b/src/ledger/LedgerStateSnapshot.h
@@ -60,12 +60,11 @@ class LedgerEntryWrapper
 // cosmetic for BucketList snapshots, since those are immutable.
 class LedgerHeaderWrapper
 {
-    std::variant<LedgerTxnHeader, std::shared_ptr<LedgerHeader>> mHeader;
+    std::variant<LedgerTxnHeader, std::shared_ptr<LedgerHeader const>> mHeader;
 
   public:
     explicit LedgerHeaderWrapper(LedgerTxnHeader&& header);
-    explicit LedgerHeaderWrapper(std::shared_ptr<LedgerHeader> header);
-    LedgerHeader& currentToModify();
+    explicit LedgerHeaderWrapper(std::shared_ptr<LedgerHeader const> header);
     LedgerHeader const& current() const;
     LedgerTxnHeader const&
     getLedgerTxnHeader() const
@@ -207,9 +206,7 @@ class ApplyLedgerStateSnapshot : private LedgerStateSnapshot
 class BucketSnapshotState : public AbstractLedgerStateSnapshot
 {
     SearchableLiveBucketListSnapshot mLiveSnap;
-    // Store a copy of the header. This is needed for validation flow where
-    // for certain validation scenarios the header needs to be modified.
-    std::shared_ptr<LedgerHeader> mLedgerHeader;
+    std::shared_ptr<LedgerHeader const> mLedgerHeader;
 
   public:
     explicit BucketSnapshotState(LedgerStateSnapshot const& snap);

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -2985,7 +2985,7 @@ LedgerTxnRoot::Impl::commitChild(EntryIterator iter,
     mPrefetchMisses = 0;
 
     // std::optional<...>::reset does not throw
-    mLedgerStateSnapshot.reset();
+    mApplyLedgerView.reset();
 
     mThreadInvariant.clearActiveThread();
 }
@@ -3092,8 +3092,7 @@ LedgerTxnRoot::Impl::prefetch(UnorderedSet<LedgerKey> const& keys)
     {
         insertIfNotLoaded(keysToSearch, key);
     }
-    auto blLoad =
-        getLedgerStateSnapshot().loadLiveKeys(keysToSearch, "prefetch");
+    auto blLoad = getApplyLedgerView().loadLiveKeys(keysToSearch, "prefetch");
     cacheResult(populateLoadedEntries(keysToSearch, blLoad));
 
     return total;
@@ -3364,16 +3363,15 @@ LedgerTxnRoot::Impl::areEntriesMissingInCacheForOffer(OfferEntry const& oe)
     return false;
 }
 
-ApplyLedgerStateSnapshot const&
-LedgerTxnRoot::Impl::getLedgerStateSnapshot() const
+ApplyLedgerView const&
+LedgerTxnRoot::Impl::getApplyLedgerView() const
 {
-    if (!mLedgerStateSnapshot)
+    if (!mApplyLedgerView)
     {
-        mLedgerStateSnapshot =
-            mApp.getLedgerManager().copyApplyLedgerStateSnapshot();
+        mApplyLedgerView = mApp.getLedgerManager().copyApplyLedgerView();
     }
 
-    return *mLedgerStateSnapshot;
+    return *mApplyLedgerView;
 }
 
 std::shared_ptr<LedgerEntry const>
@@ -3509,7 +3507,7 @@ LedgerTxnRoot::Impl::getPoolShareTrustLinesByAccountAndAsset(
     try
     {
         trustLines =
-            getLedgerStateSnapshot().loadPoolShareTrustLinesByAccountAndAsset(
+            getApplyLedgerView().loadPoolShareTrustLinesByAccountAndAsset(
                 account, asset);
     }
     catch (std::exception& e)
@@ -3560,8 +3558,7 @@ LedgerTxnRoot::Impl::getInflationWinners(size_t maxWinners, int64_t minVotes)
 {
     try
     {
-        return getLedgerStateSnapshot().loadInflationWinners(maxWinners,
-                                                             minVotes);
+        return getApplyLedgerView().loadInflationWinners(maxWinners, minVotes);
     }
     catch (std::exception& e)
     {
@@ -3646,7 +3643,7 @@ LedgerTxnRoot::Impl::getNewestVersion(InternalLedgerKey const& gkey) const
         }
         else
         {
-            entry = getLedgerStateSnapshot().loadLiveEntry(key);
+            entry = getApplyLedgerView().loadLiveEntry(key);
         }
     }
     catch (std::exception& e)
@@ -3715,7 +3712,7 @@ LedgerTxnRoot::Impl::rollbackChild() noexcept
     mChild = nullptr;
     mPrefetchHits = 0;
     mPrefetchMisses = 0;
-    mLedgerStateSnapshot.reset();
+    mApplyLedgerView.reset();
     mThreadInvariant.clearActiveThread();
 }
 

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "database/Database.h"
-#include "ledger/LedgerStateSnapshot.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "ledger/LedgerTxn.h"
 #include "util/RandomEvictionCache.h"
 #include "util/UnorderedSet.h"
@@ -628,7 +628,7 @@ class LedgerTxnRoot::Impl
     mutable BestOffers mBestOffers;
     mutable uint64_t mPrefetchHits{0};
     mutable uint64_t mPrefetchMisses{0};
-    mutable std::optional<ApplyLedgerStateSnapshot> mLedgerStateSnapshot;
+    mutable std::optional<ApplyLedgerView> mApplyLedgerView;
 
     size_t mBulkLoadBatchSize;
     std::unique_ptr<soci::transaction> mTransaction;
@@ -697,7 +697,7 @@ class LedgerTxnRoot::Impl
 
     bool areEntriesMissingInCacheForOffer(OfferEntry const& oe);
 
-    ApplyLedgerStateSnapshot const& getLedgerStateSnapshot() const;
+    ApplyLedgerView const& getApplyLedgerView() const;
 
   public:
     // Constructor has the strong exception safety guarantee

--- a/src/ledger/NetworkConfig.cpp
+++ b/src/ledger/NetworkConfig.cpp
@@ -1751,7 +1751,7 @@ SorobanNetworkConfig::initializeGenesisLedgerForTesting(
 }
 
 SorobanNetworkConfig
-SorobanNetworkConfig::loadFromLedger(LedgerSnapshot const& ls)
+SorobanNetworkConfig::loadFromLedger(AbstractLedgerStateSnapshot const& ls)
 {
     ZoneScoped;
     SorobanNetworkConfig config;
@@ -1791,8 +1791,8 @@ SorobanNetworkConfig::loadFromLedger(LedgerSnapshot const& ls)
 SorobanNetworkConfig
 SorobanNetworkConfig::loadFromLedger(AbstractLedgerTxn& ltx)
 {
-    LedgerSnapshot ls(ltx);
-    return SorobanNetworkConfig::loadFromLedger(ls);
+    LedgerTxnReadOnly snap(ltx);
+    return SorobanNetworkConfig::loadFromLedger(snap);
 }
 
 #ifdef BUILD_TESTS
@@ -1804,7 +1804,7 @@ SorobanNetworkConfig::emptyConfig()
 #endif
 
 void
-SorobanNetworkConfig::loadMaxContractSize(LedgerSnapshot const& ls)
+SorobanNetworkConfig::loadMaxContractSize(AbstractLedgerStateSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -1818,7 +1818,8 @@ SorobanNetworkConfig::loadMaxContractSize(LedgerSnapshot const& ls)
 }
 
 void
-SorobanNetworkConfig::loadMaxContractDataKeySize(LedgerSnapshot const& ls)
+SorobanNetworkConfig::loadMaxContractDataKeySize(
+    AbstractLedgerStateSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -1833,7 +1834,8 @@ SorobanNetworkConfig::loadMaxContractDataKeySize(LedgerSnapshot const& ls)
 }
 
 void
-SorobanNetworkConfig::loadMaxContractDataEntrySize(LedgerSnapshot const& ls)
+SorobanNetworkConfig::loadMaxContractDataEntrySize(
+    AbstractLedgerStateSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -1848,7 +1850,7 @@ SorobanNetworkConfig::loadMaxContractDataEntrySize(LedgerSnapshot const& ls)
 }
 
 void
-SorobanNetworkConfig::loadComputeSettings(LedgerSnapshot const& ls)
+SorobanNetworkConfig::loadComputeSettings(AbstractLedgerStateSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -1867,7 +1869,8 @@ SorobanNetworkConfig::loadComputeSettings(LedgerSnapshot const& ls)
 }
 
 void
-SorobanNetworkConfig::loadLedgerAccessSettings(LedgerSnapshot const& ls)
+SorobanNetworkConfig::loadLedgerAccessSettings(
+    AbstractLedgerStateSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -1914,7 +1917,8 @@ SorobanNetworkConfig::loadLedgerAccessSettings(LedgerSnapshot const& ls)
 }
 
 void
-SorobanNetworkConfig::loadHistoricalSettings(LedgerSnapshot const& ls)
+SorobanNetworkConfig::loadHistoricalSettings(
+    AbstractLedgerStateSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -1930,7 +1934,8 @@ SorobanNetworkConfig::loadHistoricalSettings(LedgerSnapshot const& ls)
 }
 
 void
-SorobanNetworkConfig::loadContractEventsSettings(LedgerSnapshot const& ls)
+SorobanNetworkConfig::loadContractEventsSettings(
+    AbstractLedgerStateSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -1946,7 +1951,8 @@ SorobanNetworkConfig::loadContractEventsSettings(LedgerSnapshot const& ls)
 }
 
 void
-SorobanNetworkConfig::loadBandwidthSettings(LedgerSnapshot const& ls)
+SorobanNetworkConfig::loadBandwidthSettings(
+    AbstractLedgerStateSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -1963,7 +1969,7 @@ SorobanNetworkConfig::loadBandwidthSettings(LedgerSnapshot const& ls)
 }
 
 void
-SorobanNetworkConfig::loadCpuCostParams(LedgerSnapshot const& ls)
+SorobanNetworkConfig::loadCpuCostParams(AbstractLedgerStateSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -1977,7 +1983,7 @@ SorobanNetworkConfig::loadCpuCostParams(LedgerSnapshot const& ls)
 }
 
 void
-SorobanNetworkConfig::loadMemCostParams(LedgerSnapshot const& ls)
+SorobanNetworkConfig::loadMemCostParams(AbstractLedgerStateSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -1991,7 +1997,8 @@ SorobanNetworkConfig::loadMemCostParams(LedgerSnapshot const& ls)
 }
 
 void
-SorobanNetworkConfig::loadExecutionLanesSettings(LedgerSnapshot const& ls)
+SorobanNetworkConfig::loadExecutionLanesSettings(
+    AbstractLedgerStateSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -2007,7 +2014,8 @@ SorobanNetworkConfig::loadExecutionLanesSettings(LedgerSnapshot const& ls)
 }
 
 void
-SorobanNetworkConfig::loadLiveSorobanStateSizeWindow(LedgerSnapshot const& ls)
+SorobanNetworkConfig::loadLiveSorobanStateSizeWindow(
+    AbstractLedgerStateSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -2037,7 +2045,8 @@ SorobanNetworkConfig::loadLiveSorobanStateSizeWindow(LedgerSnapshot const& ls)
 }
 
 void
-SorobanNetworkConfig::loadEvictionIterator(LedgerSnapshot const& ls)
+SorobanNetworkConfig::loadEvictionIterator(
+    AbstractLedgerStateSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -2050,7 +2059,8 @@ SorobanNetworkConfig::loadEvictionIterator(LedgerSnapshot const& ls)
 }
 
 void
-SorobanNetworkConfig::loadParallelComputeConfig(LedgerSnapshot const& ls)
+SorobanNetworkConfig::loadParallelComputeConfig(
+    AbstractLedgerStateSnapshot const& ls)
 {
     ZoneScoped;
     LedgerKey key(CONFIG_SETTING);
@@ -2065,7 +2075,8 @@ SorobanNetworkConfig::loadParallelComputeConfig(LedgerSnapshot const& ls)
 }
 
 void
-SorobanNetworkConfig::loadLedgerCostExtConfig(LedgerSnapshot const& ls)
+SorobanNetworkConfig::loadLedgerCostExtConfig(
+    AbstractLedgerStateSnapshot const& ls)
 {
     ZoneScoped;
     LedgerKey key(CONFIG_SETTING);
@@ -2080,7 +2091,7 @@ SorobanNetworkConfig::loadLedgerCostExtConfig(LedgerSnapshot const& ls)
 }
 
 void
-SorobanNetworkConfig::loadSCPTimingConfig(LedgerSnapshot const& ls)
+SorobanNetworkConfig::loadSCPTimingConfig(AbstractLedgerStateSnapshot const& ls)
 {
     ZoneScoped;
     LedgerKey key(CONFIG_SETTING);
@@ -2121,7 +2132,8 @@ SorobanNetworkConfig::maxContractDataEntrySizeBytes() const
 }
 
 void
-SorobanNetworkConfig::loadStateArchivalSettings(LedgerSnapshot const& ls)
+SorobanNetworkConfig::loadStateArchivalSettings(
+    AbstractLedgerStateSnapshot const& ls)
 {
     ZoneScoped;
 
@@ -2529,7 +2541,8 @@ SorobanNetworkConfig::isFreezeBypassTx(Hash const& txHash) const
 }
 
 void
-SorobanNetworkConfig::loadFrozenLedgerKeys(LedgerSnapshot const& ls)
+SorobanNetworkConfig::loadFrozenLedgerKeys(
+    AbstractLedgerStateSnapshot const& ls)
 {
     ZoneScoped;
     mFrozenLedgerKeys.clear();
@@ -2550,7 +2563,7 @@ SorobanNetworkConfig::loadFrozenLedgerKeys(LedgerSnapshot const& ls)
 }
 
 void
-SorobanNetworkConfig::loadFreezeBypassTxs(LedgerSnapshot const& ls)
+SorobanNetworkConfig::loadFreezeBypassTxs(AbstractLedgerStateSnapshot const& ls)
 {
     ZoneScoped;
     mFreezeBypassTxs.clear();

--- a/src/ledger/NetworkConfig.cpp
+++ b/src/ledger/NetworkConfig.cpp
@@ -6,7 +6,7 @@
 #include "bucket/BucketManager.h"
 #include "bucket/LiveBucketList.h"
 #include "bucket/test/BucketTestUtils.h"
-#include "ledger/LedgerStateSnapshot.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "main/Application.h"
 #include "util/Logging.h"
 #include "util/ProtocolVersion.h"
@@ -1751,7 +1751,7 @@ SorobanNetworkConfig::initializeGenesisLedgerForTesting(
 }
 
 SorobanNetworkConfig
-SorobanNetworkConfig::loadFromLedger(AbstractLedgerStateSnapshot const& ls)
+SorobanNetworkConfig::loadFromLedger(AbstractLedgerView const& ls)
 {
     ZoneScoped;
     SorobanNetworkConfig config;
@@ -1804,7 +1804,7 @@ SorobanNetworkConfig::emptyConfig()
 #endif
 
 void
-SorobanNetworkConfig::loadMaxContractSize(AbstractLedgerStateSnapshot const& ls)
+SorobanNetworkConfig::loadMaxContractSize(AbstractLedgerView const& ls)
 {
     ZoneScoped;
 
@@ -1818,8 +1818,7 @@ SorobanNetworkConfig::loadMaxContractSize(AbstractLedgerStateSnapshot const& ls)
 }
 
 void
-SorobanNetworkConfig::loadMaxContractDataKeySize(
-    AbstractLedgerStateSnapshot const& ls)
+SorobanNetworkConfig::loadMaxContractDataKeySize(AbstractLedgerView const& ls)
 {
     ZoneScoped;
 
@@ -1834,8 +1833,7 @@ SorobanNetworkConfig::loadMaxContractDataKeySize(
 }
 
 void
-SorobanNetworkConfig::loadMaxContractDataEntrySize(
-    AbstractLedgerStateSnapshot const& ls)
+SorobanNetworkConfig::loadMaxContractDataEntrySize(AbstractLedgerView const& ls)
 {
     ZoneScoped;
 
@@ -1850,7 +1848,7 @@ SorobanNetworkConfig::loadMaxContractDataEntrySize(
 }
 
 void
-SorobanNetworkConfig::loadComputeSettings(AbstractLedgerStateSnapshot const& ls)
+SorobanNetworkConfig::loadComputeSettings(AbstractLedgerView const& ls)
 {
     ZoneScoped;
 
@@ -1869,8 +1867,7 @@ SorobanNetworkConfig::loadComputeSettings(AbstractLedgerStateSnapshot const& ls)
 }
 
 void
-SorobanNetworkConfig::loadLedgerAccessSettings(
-    AbstractLedgerStateSnapshot const& ls)
+SorobanNetworkConfig::loadLedgerAccessSettings(AbstractLedgerView const& ls)
 {
     ZoneScoped;
 
@@ -1917,8 +1914,7 @@ SorobanNetworkConfig::loadLedgerAccessSettings(
 }
 
 void
-SorobanNetworkConfig::loadHistoricalSettings(
-    AbstractLedgerStateSnapshot const& ls)
+SorobanNetworkConfig::loadHistoricalSettings(AbstractLedgerView const& ls)
 {
     ZoneScoped;
 
@@ -1934,8 +1930,7 @@ SorobanNetworkConfig::loadHistoricalSettings(
 }
 
 void
-SorobanNetworkConfig::loadContractEventsSettings(
-    AbstractLedgerStateSnapshot const& ls)
+SorobanNetworkConfig::loadContractEventsSettings(AbstractLedgerView const& ls)
 {
     ZoneScoped;
 
@@ -1951,8 +1946,7 @@ SorobanNetworkConfig::loadContractEventsSettings(
 }
 
 void
-SorobanNetworkConfig::loadBandwidthSettings(
-    AbstractLedgerStateSnapshot const& ls)
+SorobanNetworkConfig::loadBandwidthSettings(AbstractLedgerView const& ls)
 {
     ZoneScoped;
 
@@ -1969,7 +1963,7 @@ SorobanNetworkConfig::loadBandwidthSettings(
 }
 
 void
-SorobanNetworkConfig::loadCpuCostParams(AbstractLedgerStateSnapshot const& ls)
+SorobanNetworkConfig::loadCpuCostParams(AbstractLedgerView const& ls)
 {
     ZoneScoped;
 
@@ -1983,7 +1977,7 @@ SorobanNetworkConfig::loadCpuCostParams(AbstractLedgerStateSnapshot const& ls)
 }
 
 void
-SorobanNetworkConfig::loadMemCostParams(AbstractLedgerStateSnapshot const& ls)
+SorobanNetworkConfig::loadMemCostParams(AbstractLedgerView const& ls)
 {
     ZoneScoped;
 
@@ -1997,8 +1991,7 @@ SorobanNetworkConfig::loadMemCostParams(AbstractLedgerStateSnapshot const& ls)
 }
 
 void
-SorobanNetworkConfig::loadExecutionLanesSettings(
-    AbstractLedgerStateSnapshot const& ls)
+SorobanNetworkConfig::loadExecutionLanesSettings(AbstractLedgerView const& ls)
 {
     ZoneScoped;
 
@@ -2015,7 +2008,7 @@ SorobanNetworkConfig::loadExecutionLanesSettings(
 
 void
 SorobanNetworkConfig::loadLiveSorobanStateSizeWindow(
-    AbstractLedgerStateSnapshot const& ls)
+    AbstractLedgerView const& ls)
 {
     ZoneScoped;
 
@@ -2045,8 +2038,7 @@ SorobanNetworkConfig::loadLiveSorobanStateSizeWindow(
 }
 
 void
-SorobanNetworkConfig::loadEvictionIterator(
-    AbstractLedgerStateSnapshot const& ls)
+SorobanNetworkConfig::loadEvictionIterator(AbstractLedgerView const& ls)
 {
     ZoneScoped;
 
@@ -2059,8 +2051,7 @@ SorobanNetworkConfig::loadEvictionIterator(
 }
 
 void
-SorobanNetworkConfig::loadParallelComputeConfig(
-    AbstractLedgerStateSnapshot const& ls)
+SorobanNetworkConfig::loadParallelComputeConfig(AbstractLedgerView const& ls)
 {
     ZoneScoped;
     LedgerKey key(CONFIG_SETTING);
@@ -2075,8 +2066,7 @@ SorobanNetworkConfig::loadParallelComputeConfig(
 }
 
 void
-SorobanNetworkConfig::loadLedgerCostExtConfig(
-    AbstractLedgerStateSnapshot const& ls)
+SorobanNetworkConfig::loadLedgerCostExtConfig(AbstractLedgerView const& ls)
 {
     ZoneScoped;
     LedgerKey key(CONFIG_SETTING);
@@ -2091,7 +2081,7 @@ SorobanNetworkConfig::loadLedgerCostExtConfig(
 }
 
 void
-SorobanNetworkConfig::loadSCPTimingConfig(AbstractLedgerStateSnapshot const& ls)
+SorobanNetworkConfig::loadSCPTimingConfig(AbstractLedgerView const& ls)
 {
     ZoneScoped;
     LedgerKey key(CONFIG_SETTING);
@@ -2132,8 +2122,7 @@ SorobanNetworkConfig::maxContractDataEntrySizeBytes() const
 }
 
 void
-SorobanNetworkConfig::loadStateArchivalSettings(
-    AbstractLedgerStateSnapshot const& ls)
+SorobanNetworkConfig::loadStateArchivalSettings(AbstractLedgerView const& ls)
 {
     ZoneScoped;
 
@@ -2541,8 +2530,7 @@ SorobanNetworkConfig::isFreezeBypassTx(Hash const& txHash) const
 }
 
 void
-SorobanNetworkConfig::loadFrozenLedgerKeys(
-    AbstractLedgerStateSnapshot const& ls)
+SorobanNetworkConfig::loadFrozenLedgerKeys(AbstractLedgerView const& ls)
 {
     ZoneScoped;
     mFrozenLedgerKeys.clear();
@@ -2563,7 +2551,7 @@ SorobanNetworkConfig::loadFrozenLedgerKeys(
 }
 
 void
-SorobanNetworkConfig::loadFreezeBypassTxs(AbstractLedgerStateSnapshot const& ls)
+SorobanNetworkConfig::loadFreezeBypassTxs(AbstractLedgerView const& ls)
 {
     ZoneScoped;
     mFreezeBypassTxs.clear();

--- a/src/ledger/NetworkConfig.h
+++ b/src/ledger/NetworkConfig.h
@@ -14,7 +14,7 @@
 namespace stellar
 {
 
-class AbstractLedgerStateSnapshot;
+class AbstractLedgerView;
 class Application;
 
 // Defines the minimum values allowed for the network configuration
@@ -261,8 +261,7 @@ class SorobanNetworkConfig
 {
   public:
     // Static factory function to create a SorobanNetworkConfig from ledger
-    static SorobanNetworkConfig
-    loadFromLedger(AbstractLedgerStateSnapshot const& snap);
+    static SorobanNetworkConfig loadFromLedger(AbstractLedgerView const& snap);
     static SorobanNetworkConfig loadFromLedger(AbstractLedgerTxn& ltx);
 
 #ifdef BUILD_TESTS
@@ -479,25 +478,25 @@ class SorobanNetworkConfig
   private:
     SorobanNetworkConfig() = default;
 
-    void loadMaxContractSize(AbstractLedgerStateSnapshot const& ls);
-    void loadMaxContractDataKeySize(AbstractLedgerStateSnapshot const& ls);
-    void loadMaxContractDataEntrySize(AbstractLedgerStateSnapshot const& ls);
-    void loadComputeSettings(AbstractLedgerStateSnapshot const& ls);
-    void loadLedgerAccessSettings(AbstractLedgerStateSnapshot const& ls);
-    void loadHistoricalSettings(AbstractLedgerStateSnapshot const& ls);
-    void loadContractEventsSettings(AbstractLedgerStateSnapshot const& ls);
-    void loadBandwidthSettings(AbstractLedgerStateSnapshot const& ls);
-    void loadCpuCostParams(AbstractLedgerStateSnapshot const& ls);
-    void loadMemCostParams(AbstractLedgerStateSnapshot const& ls);
-    void loadStateArchivalSettings(AbstractLedgerStateSnapshot const& ls);
-    void loadExecutionLanesSettings(AbstractLedgerStateSnapshot const& ls);
-    void loadLiveSorobanStateSizeWindow(AbstractLedgerStateSnapshot const& ls);
-    void loadEvictionIterator(AbstractLedgerStateSnapshot const& ls);
-    void loadParallelComputeConfig(AbstractLedgerStateSnapshot const& ls);
-    void loadLedgerCostExtConfig(AbstractLedgerStateSnapshot const& ls);
-    void loadSCPTimingConfig(AbstractLedgerStateSnapshot const& ls);
-    void loadFrozenLedgerKeys(AbstractLedgerStateSnapshot const& ls);
-    void loadFreezeBypassTxs(AbstractLedgerStateSnapshot const& ls);
+    void loadMaxContractSize(AbstractLedgerView const& ls);
+    void loadMaxContractDataKeySize(AbstractLedgerView const& ls);
+    void loadMaxContractDataEntrySize(AbstractLedgerView const& ls);
+    void loadComputeSettings(AbstractLedgerView const& ls);
+    void loadLedgerAccessSettings(AbstractLedgerView const& ls);
+    void loadHistoricalSettings(AbstractLedgerView const& ls);
+    void loadContractEventsSettings(AbstractLedgerView const& ls);
+    void loadBandwidthSettings(AbstractLedgerView const& ls);
+    void loadCpuCostParams(AbstractLedgerView const& ls);
+    void loadMemCostParams(AbstractLedgerView const& ls);
+    void loadStateArchivalSettings(AbstractLedgerView const& ls);
+    void loadExecutionLanesSettings(AbstractLedgerView const& ls);
+    void loadLiveSorobanStateSizeWindow(AbstractLedgerView const& ls);
+    void loadEvictionIterator(AbstractLedgerView const& ls);
+    void loadParallelComputeConfig(AbstractLedgerView const& ls);
+    void loadLedgerCostExtConfig(AbstractLedgerView const& ls);
+    void loadSCPTimingConfig(AbstractLedgerView const& ls);
+    void loadFrozenLedgerKeys(AbstractLedgerView const& ls);
+    void loadFreezeBypassTxs(AbstractLedgerView const& ls);
     void computeRentWriteFee(uint32_t protocolVersion);
 
 #ifdef BUILD_TESTS

--- a/src/ledger/NetworkConfig.h
+++ b/src/ledger/NetworkConfig.h
@@ -14,8 +14,8 @@
 namespace stellar
 {
 
+class AbstractLedgerStateSnapshot;
 class Application;
-class LedgerSnapshot;
 
 // Defines the minimum values allowed for the network configuration
 // settings during upgrades. An upgrade that does not follow the minimums
@@ -261,7 +261,8 @@ class SorobanNetworkConfig
 {
   public:
     // Static factory function to create a SorobanNetworkConfig from ledger
-    static SorobanNetworkConfig loadFromLedger(LedgerSnapshot const& ls);
+    static SorobanNetworkConfig
+    loadFromLedger(AbstractLedgerStateSnapshot const& snap);
     static SorobanNetworkConfig loadFromLedger(AbstractLedgerTxn& ltx);
 
 #ifdef BUILD_TESTS
@@ -478,25 +479,25 @@ class SorobanNetworkConfig
   private:
     SorobanNetworkConfig() = default;
 
-    void loadMaxContractSize(LedgerSnapshot const& ls);
-    void loadMaxContractDataKeySize(LedgerSnapshot const& ls);
-    void loadMaxContractDataEntrySize(LedgerSnapshot const& ls);
-    void loadComputeSettings(LedgerSnapshot const& ls);
-    void loadLedgerAccessSettings(LedgerSnapshot const& ls);
-    void loadHistoricalSettings(LedgerSnapshot const& ls);
-    void loadContractEventsSettings(LedgerSnapshot const& ls);
-    void loadBandwidthSettings(LedgerSnapshot const& ls);
-    void loadCpuCostParams(LedgerSnapshot const& ls);
-    void loadMemCostParams(LedgerSnapshot const& ls);
-    void loadStateArchivalSettings(LedgerSnapshot const& ls);
-    void loadExecutionLanesSettings(LedgerSnapshot const& ls);
-    void loadLiveSorobanStateSizeWindow(LedgerSnapshot const& ls);
-    void loadEvictionIterator(LedgerSnapshot const& ls);
-    void loadParallelComputeConfig(LedgerSnapshot const& ls);
-    void loadLedgerCostExtConfig(LedgerSnapshot const& ls);
-    void loadSCPTimingConfig(LedgerSnapshot const& ls);
-    void loadFrozenLedgerKeys(LedgerSnapshot const& ls);
-    void loadFreezeBypassTxs(LedgerSnapshot const& ls);
+    void loadMaxContractSize(AbstractLedgerStateSnapshot const& ls);
+    void loadMaxContractDataKeySize(AbstractLedgerStateSnapshot const& ls);
+    void loadMaxContractDataEntrySize(AbstractLedgerStateSnapshot const& ls);
+    void loadComputeSettings(AbstractLedgerStateSnapshot const& ls);
+    void loadLedgerAccessSettings(AbstractLedgerStateSnapshot const& ls);
+    void loadHistoricalSettings(AbstractLedgerStateSnapshot const& ls);
+    void loadContractEventsSettings(AbstractLedgerStateSnapshot const& ls);
+    void loadBandwidthSettings(AbstractLedgerStateSnapshot const& ls);
+    void loadCpuCostParams(AbstractLedgerStateSnapshot const& ls);
+    void loadMemCostParams(AbstractLedgerStateSnapshot const& ls);
+    void loadStateArchivalSettings(AbstractLedgerStateSnapshot const& ls);
+    void loadExecutionLanesSettings(AbstractLedgerStateSnapshot const& ls);
+    void loadLiveSorobanStateSizeWindow(AbstractLedgerStateSnapshot const& ls);
+    void loadEvictionIterator(AbstractLedgerStateSnapshot const& ls);
+    void loadParallelComputeConfig(AbstractLedgerStateSnapshot const& ls);
+    void loadLedgerCostExtConfig(AbstractLedgerStateSnapshot const& ls);
+    void loadSCPTimingConfig(AbstractLedgerStateSnapshot const& ls);
+    void loadFrozenLedgerKeys(AbstractLedgerStateSnapshot const& ls);
+    void loadFreezeBypassTxs(AbstractLedgerStateSnapshot const& ls);
     void computeRentWriteFee(uint32_t protocolVersion);
 
 #ifdef BUILD_TESTS

--- a/src/ledger/P23HotArchiveBug.cpp
+++ b/src/ledger/P23HotArchiveBug.cpp
@@ -9,7 +9,7 @@
 
 #include "bucket/BucketManager.h"
 #include "bucket/BucketUtils.h"
-#include "ledger/LedgerStateSnapshot.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "ledger/LedgerTxn.h"
 #include "ledger/LedgerTxnImpl.h"
 #include "main/Application.h"
@@ -34,9 +34,8 @@ using namespace internal;
 
 void
 addHotArchiveBatchWithP23HotArchiveFix(
-    AbstractLedgerTxn& ltx, Application& app,
-    ApplyLedgerStateSnapshot const& snapshot, LedgerHeader header,
-    std::vector<LedgerEntry> const& archivedEntries,
+    AbstractLedgerTxn& ltx, Application& app, ApplyLedgerView const& applyView,
+    LedgerHeader header, std::vector<LedgerEntry> const& archivedEntries,
     std::vector<LedgerKey> const& restoredEntries)
 {
     LedgerKeySet currentBatchKeys;
@@ -65,7 +64,7 @@ addHotArchiveBatchWithP23HotArchiveFix(
         // Hot Archive that match our expectations for the corrupted entries.
 
         // Ensure that the entry exists in Hot Archive.
-        auto hotArchiveEntry = snapshot.loadArchiveEntry(corruptedEntryKey);
+        auto hotArchiveEntry = applyView.loadArchiveEntry(corruptedEntryKey);
         if (!hotArchiveEntry)
         {
             CLOG_WARNING(
@@ -334,9 +333,8 @@ Protocol23CorruptionDataVerifier::verifyRestorationOfCorruptedEntry(
 
 void
 Protocol23CorruptionDataVerifier::verifyArchivalOfCorruptedEntry(
-    EvictedStateVectors const& evictedState,
-    ApplyLedgerStateSnapshot const& snapshot, uint32_t ledgerSeq,
-    uint32_t protocolVersion)
+    EvictedStateVectors const& evictedState, ApplyLedgerView const& applyView,
+    uint32_t ledgerSeq, uint32_t protocolVersion)
 {
     if (!protocolVersionEquals(protocolVersion, ProtocolVersion::V_23))
     {
@@ -359,7 +357,7 @@ Protocol23CorruptionDataVerifier::verifyArchivalOfCorruptedEntry(
     {
         // Load the correct value from the live database.
         auto evictedLedgerKey = LedgerEntryKey(evictedEntry);
-        auto databaseEntry = snapshot.loadLiveEntry(evictedLedgerKey);
+        auto databaseEntry = applyView.loadLiveEntry(evictedLedgerKey);
         releaseAssert(databaseEntry != nullptr);
 
         // If there was a corruption

--- a/src/ledger/P23HotArchiveBug.h
+++ b/src/ledger/P23HotArchiveBug.h
@@ -18,7 +18,7 @@ namespace stellar
 {
 class Application;
 class AbstractLedgerTxn;
-class ApplyLedgerStateSnapshot;
+class ApplyLedgerView;
 class Config;
 struct EvictedStateVectors;
 
@@ -87,11 +87,10 @@ class Protocol23CorruptionDataVerifier
     // This should be called for every eviction that occurs during catchup,
     // non-corrupted evictions are ignored.
     // This is thread-safe.
-    void
-    verifyArchivalOfCorruptedEntry(EvictedStateVectors const& evictedState,
-                                   ApplyLedgerStateSnapshot const& snapshot,
-                                   uint32_t ledgerSeq,
-                                   uint32_t protocolVersion);
+    void verifyArchivalOfCorruptedEntry(EvictedStateVectors const& evictedState,
+                                        ApplyLedgerView const& applyView,
+                                        uint32_t ledgerSeq,
+                                        uint32_t protocolVersion);
     // Verifies that the batch of Hot Archive fixes on protocol 24 upgrade
     // corresponds to the expected data (i.e. only entries that were never
     // restored have been fixed, and that the fix comes back to the correct
@@ -174,9 +173,8 @@ class Protocol23CorruptionEventReconciler
 };
 
 void addHotArchiveBatchWithP23HotArchiveFix(
-    AbstractLedgerTxn& ltx, Application& app,
-    ApplyLedgerStateSnapshot const& snapshot, LedgerHeader header,
-    std::vector<LedgerEntry> const& archivedEntries,
+    AbstractLedgerTxn& ltx, Application& app, ApplyLedgerView const& applyView,
+    LedgerHeader header, std::vector<LedgerEntry> const& archivedEntries,
     std::vector<LedgerKey> const& restoredEntries);
 
 } // namespace p23_hot_archive_bug

--- a/src/ledger/SharedModuleCacheCompiler.cpp
+++ b/src/ledger/SharedModuleCacheCompiler.cpp
@@ -21,10 +21,10 @@ size_t const SharedModuleCacheCompiler::BUFFERED_WASM_CAPACITY =
 // The snapshot is passed by copy here to ensure the background loading thread
 // has its own instance since snapshots themselves aren't thread safe.
 SharedModuleCacheCompiler::SharedModuleCacheCompiler(
-    ApplyLedgerStateSnapshot snap, size_t numThreads,
+    ApplyLedgerView applyView, size_t numThreads,
     std::vector<uint32_t> const& ledgerVersions)
     : mModuleCache(rust_bridge::new_module_cache())
-    , mSnap(std::move(snap))
+    , mApplyLedgerView(std::move(applyView))
     , mNumThreads(numThreads)
     , mLedgerVersions(ledgerVersions)
     , mStarted(std::chrono::steady_clock::now())
@@ -148,7 +148,7 @@ SharedModuleCacheCompiler::start()
         std::unordered_set<Hash> seenContracts;
         size_t liveContracts{0};
         // Note: this access is safe since we only have a single loading thread.
-        this->mSnap.scanLiveEntriesOfType(
+        this->mApplyLedgerView.scanLiveEntriesOfType(
             CONTRACT_CODE, [&](BucketEntry const& entry) {
                 Hash h;
                 switch (entry.type())

--- a/src/ledger/SharedModuleCacheCompiler.h
+++ b/src/ledger/SharedModuleCacheCompiler.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "ledger/LedgerStateSnapshot.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "rust/RustBridge.h"
 #include "util/NonCopyable.h"
 #include "xdrpp/types.h"
@@ -25,7 +25,7 @@ namespace stellar
 class SharedModuleCacheCompiler : NonMovableOrCopyable
 {
     ::rust::Box<stellar::rust_bridge::SorobanModuleCache> mModuleCache;
-    ApplyLedgerStateSnapshot mSnap;
+    ApplyLedgerView mApplyLedgerView;
     std::deque<xdr::xvector<uint8_t>> mWasms;
 
     size_t const mNumThreads;
@@ -55,7 +55,7 @@ class SharedModuleCacheCompiler : NonMovableOrCopyable
     bool popAndCompileWasm(size_t thread, std::unique_lock<std::mutex>& lock);
 
   public:
-    SharedModuleCacheCompiler(ApplyLedgerStateSnapshot snap, size_t numThreads,
+    SharedModuleCacheCompiler(ApplyLedgerView applyView, size_t numThreads,
                               std::vector<uint32_t> const& ledgerVersions);
     ~SharedModuleCacheCompiler();
     void start();

--- a/src/ledger/test/ImmutableLedgerViewTests.cpp
+++ b/src/ledger/test/ImmutableLedgerViewTests.cpp
@@ -2,7 +2,7 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
-// Randomized testing for LedgerStateSnapshot, designed to
+// Randomized testing for ImmutableLedgerView, designed to
 // stress-test the snapshot interface under concurrent access with timing
 // variations to expose race conditions, stale reads, and data inconsistencies.
 
@@ -11,7 +11,7 @@
 #include "bucket/BucketBase.h"
 #include "bucket/LedgerCmp.h"
 #include "bucket/test/BucketTestUtils.h"
-#include "ledger/LedgerStateSnapshot.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "ledger/test/LedgerTestUtils.h"
 #include "main/Application.h"
 #include "test/TestUtils.h"
@@ -177,7 +177,7 @@ struct ThreadGroup
 };
 
 // ---------------------------------------------------------------------------
-// SnapshotThread: holds a LedgerStateSnapshot together with the ledger
+// SnapshotThread: holds a ImmutableLedgerView together with the ledger
 // sequence the owning thread expects that snapshot to be at.  The expected
 // seq is private and only updated by explicit mutation operations, so any
 // unsynchronized drift is immediately detectable.
@@ -185,14 +185,15 @@ struct ThreadGroup
 class SnapshotThread
 {
     mutable ANNOTATED_SHARED_MUTEX(mMutex);
-    LedgerStateSnapshot mSnapshot GUARDED_BY(mMutex);
+    ImmutableLedgerView mLedgerView GUARDED_BY(mMutex);
     // Updated only by mutation methods; a mismatch with
-    // mSnapshot.getLedgerSeq() indicates a race or corruption.
+    // mLedgerView.getLedgerSeq() indicates a race or corruption.
     uint32_t mExpectedSeq;
 
   public:
-    explicit SnapshotThread(LedgerStateSnapshot snap)
-        : mSnapshot(std::move(snap)), mExpectedSeq(mSnapshot.getLedgerSeq())
+    explicit SnapshotThread(ImmutableLedgerView ledgerView)
+        : mLedgerView(std::move(ledgerView))
+        , mExpectedSeq(mLedgerView.getLedgerSeq())
     {
     }
 
@@ -204,22 +205,23 @@ class SnapshotThread
 
     // Read-only access.  Only the owning thread reads without a lock;
     // other threads use copySnapshot() which takes a shared lock.
-    LedgerStateSnapshot const&
-    snapshot() const NO_THREAD_SAFETY_ANALYSIS
+    ImmutableLedgerView const&
+    ledgerView() const NO_THREAD_SAFETY_ANALYSIS
     {
-        return mSnapshot;
+        return mLedgerView;
     }
 
     bool
     seqMatchesExpected() const NO_THREAD_SAFETY_ANALYSIS
     {
-        return mSnapshot.getLedgerSeq() == mExpectedSeq;
+        return mLedgerView.getLedgerSeq() == mExpectedSeq;
     }
 
     bool
     headerMatchesExpected() const NO_THREAD_SAFETY_ANALYSIS
     {
-        return mSnapshot.getLedgerHeader().ledgerSeq == mExpectedSeq;
+        return mLedgerView.getLedgerHeader().current().ledgerSeq ==
+               mExpectedSeq;
     }
 
     // --- Mutation operations (take exclusive lock, update mExpectedSeq) ---
@@ -229,8 +231,8 @@ class SnapshotThread
     maybeUpdate(LedgerManager const& lm)
     {
         SharedLockExclusive lock(mMutex);
-        lm.maybeUpdateLedgerStateSnapshot(mSnapshot);
-        auto newSeq = mSnapshot.getLedgerSeq();
+        lm.maybeUpdateImmutableLedgerView(mLedgerView);
+        auto newSeq = mLedgerView.getLedgerSeq();
         bool ok = newSeq >= mExpectedSeq;
         mExpectedSeq = newSeq;
         return ok;
@@ -241,29 +243,29 @@ class SnapshotThread
     freshCopy(LedgerManager const& lm)
     {
         SharedLockExclusive lock(mMutex);
-        mSnapshot = lm.copyLedgerStateSnapshot();
-        auto newSeq = mSnapshot.getLedgerSeq();
+        mLedgerView = lm.copyImmutableLedgerView();
+        auto newSeq = mLedgerView.getLedgerSeq();
         bool ok = newSeq >= mExpectedSeq;
         mExpectedSeq = newSeq;
         return ok;
     }
 
     // Copy the snapshot under a shared lock (peer-copy source).
-    LedgerStateSnapshot
+    ImmutableLedgerView
     copySnapshot() const
     {
         SharedLockShared lock(mMutex);
-        return mSnapshot;
+        return mLedgerView;
     }
 
     // Replace with a snapshot copied from a peer.  The peer may be
     // behind, so no monotonicity check.
     void
-    replaceWith(LedgerStateSnapshot snap)
+    replaceWith(ImmutableLedgerView ledgerView)
     {
         SharedLockExclusive lock(mMutex);
-        mSnapshot = std::move(snap);
-        mExpectedSeq = mSnapshot.getLedgerSeq();
+        mLedgerView = std::move(ledgerView);
+        mExpectedSeq = mLedgerView.getLedgerSeq();
     }
 };
 
@@ -379,7 +381,7 @@ SnapshotStressTest::SnapshotStressTest(int numThreads, unsigned seed,
     for (int i = 0; i < mNumThreads; i++)
     {
         mThreads.push_back(std::make_unique<SnapshotThread>(
-            mApp.getLedgerManager().copyLedgerStateSnapshot()));
+            mApp.getLedgerManager().copyImmutableLedgerView()));
     }
 }
 
@@ -406,8 +408,8 @@ SnapshotStressTest::run()
 
     // Liveness check: after all ledgers are closed, a fresh snapshot must
     // reflect the final ledger sequence.
-    auto finalSnapshot = mApp.getLedgerManager().copyLedgerStateSnapshot();
-    REQUIRE(finalSnapshot.getLedgerSeq() == mPregen.lastSeq);
+    auto finalLedgerView = mApp.getLedgerManager().copyImmutableLedgerView();
+    REQUIRE(finalLedgerView.getLedgerSeq() == mPregen.lastSeq);
 }
 
 // Each worker randomly picks an operation, executes it, then checks the
@@ -430,7 +432,7 @@ SnapshotStressTest::workerLoop(int threadIdx)
             {
                 fail(fmt::format("seq drifted {}->{} seed={}",
                                  sthread.expectedSeq(),
-                                 sthread.snapshot().getLedgerSeq(), mSeed));
+                                 sthread.ledgerView().getLedgerSeq(), mSeed));
                 break;
             }
 
@@ -541,7 +543,7 @@ SnapshotStressTest::readCurrent(SnapshotThread& sthread, bool archive,
         auto const& [key, expected] = randMapEntry(state, rng);
         if (archive)
         {
-            auto loaded = sthread.snapshot().loadArchiveEntry(key);
+            auto loaded = sthread.ledgerView().loadArchiveEntry(key);
             if (!loaded || loaded->type() != HOT_ARCHIVE_ARCHIVED ||
                 loaded->archivedEntry() != expected)
             {
@@ -552,7 +554,7 @@ SnapshotStressTest::readCurrent(SnapshotThread& sthread, bool archive,
         }
         else
         {
-            auto loaded = sthread.snapshot().loadLiveEntry(key);
+            auto loaded = sthread.ledgerView().loadLiveEntry(key);
             if (!loaded || *loaded != expected)
             {
                 fail(fmt::format("{} mismatch seq={} seed={}", opName, seq,
@@ -578,7 +580,7 @@ SnapshotStressTest::readCurrent(SnapshotThread& sthread, bool archive,
                 if (archive)
                 {
                     auto loaded =
-                        sthread.snapshot().loadArchiveEntry(futureKey);
+                        sthread.ledgerView().loadArchiveEntry(futureKey);
                     if (loaded && loaded->type() == HOT_ARCHIVE_ARCHIVED)
                     {
                         fail(fmt::format("{} false positive: found future key "
@@ -589,7 +591,7 @@ SnapshotStressTest::readCurrent(SnapshotThread& sthread, bool archive,
                 }
                 else
                 {
-                    if (sthread.snapshot().loadLiveEntry(futureKey))
+                    if (sthread.ledgerView().loadLiveEntry(futureKey))
                     {
                         fail(fmt::format("{} false positive: found future key "
                                          "from seq={} in snapshot at seq={} "
@@ -666,7 +668,7 @@ SnapshotStressTest::readHistoricalQuery(SnapshotThread& sthread, bool archive,
     if (archive)
     {
         auto result =
-            sthread.snapshot().loadArchiveKeysFromLedger(queryKeys, histSeq);
+            sthread.ledgerView().loadArchiveKeysFromLedger(queryKeys, histSeq);
         if (!retained)
         {
             if (result.has_value())
@@ -699,7 +701,7 @@ SnapshotStressTest::readHistoricalQuery(SnapshotThread& sthread, bool archive,
     else
     {
         auto result =
-            sthread.snapshot().loadLiveKeysFromLedger(queryKeys, histSeq);
+            sthread.ledgerView().loadLiveKeysFromLedger(queryKeys, histSeq);
         if (!retained)
         {
             if (result.has_value())
@@ -789,14 +791,15 @@ SnapshotStressTest::checkSelfConsistency(SnapshotThread const& sthread)
         fail(fmt::format("consistency: expected seq {} != snapshot seq {} "
                          "seed={}",
                          sthread.expectedSeq(),
-                         sthread.snapshot().getLedgerSeq(), mSeed));
+                         sthread.ledgerView().getLedgerSeq(), mSeed));
         return;
     }
     if (!sthread.headerMatchesExpected())
     {
-        fail(fmt::format("header/seq mismatch {}/{} seed={}",
-                         sthread.snapshot().getLedgerHeader().ledgerSeq,
-                         sthread.expectedSeq(), mSeed));
+        fail(fmt::format(
+            "header/seq mismatch {}/{} seed={}",
+            sthread.ledgerView().getLedgerHeader().current().ledgerSeq,
+            sthread.expectedSeq(), mSeed));
     }
 }
 
@@ -831,16 +834,16 @@ SnapshotStressTest::closeLedgers()
 }
 
 // ---------------------------------------------------------------------------
-// Unit-test helper: verify that every entry in `entries` is found in `snap`
-// with matching data.
+// Unit-test helper: verify that every entry in `entries` is found in
+// `ledgerView` with matching data.
 // ---------------------------------------------------------------------------
 void
-requireEntries(LedgerStateSnapshot& snap,
+requireEntries(ImmutableLedgerView& ledgerView,
                std::vector<LedgerEntry> const& entries)
 {
     for (auto const& entry : entries)
     {
-        auto loaded = snap.loadLiveEntry(LedgerEntryKey(entry));
+        auto loaded = ledgerView.loadLiveEntry(LedgerEntryKey(entry));
         REQUIRE(loaded);
         CHECK(*loaded == entry);
     }
@@ -884,7 +887,7 @@ TEST_CASE("basic snapshot copy semantics and isolation", "[snapshot]")
     // Add first batch, take snapshot S1.
     addLiveBatchAndUpdateSnapshot(*app, makeHeader(seq1, protocolVersion),
                                   entries1, {}, {});
-    auto s1 = lm.copyLedgerStateSnapshot();
+    auto s1 = lm.copyImmutableLedgerView();
     REQUIRE(s1.getLedgerSeq() == seq1);
 
     // Advance to seq2 with new entries.
@@ -907,13 +910,13 @@ TEST_CASE("basic snapshot copy semantics and isolation", "[snapshot]")
     }
 
     // maybeUpdate S1: should refresh it to seq2 (jump +1).
-    lm.maybeUpdateLedgerStateSnapshot(s1);
+    lm.maybeUpdateImmutableLedgerView(s1);
     REQUIRE(s1.getLedgerSeq() == seq2);
     requireEntries(s1, entries1);
     requireEntries(s1, entries2);
 
     // maybeUpdate again with no new ledger close: no-op.
-    lm.maybeUpdateLedgerStateSnapshot(s1);
+    lm.maybeUpdateImmutableLedgerView(s1);
     REQUIRE(s1.getLedgerSeq() == seq2);
 
     // Advance to seq3.
@@ -930,7 +933,7 @@ TEST_CASE("basic snapshot copy semantics and isolation", "[snapshot]")
 
     // maybeUpdate S2: still at seq1, jumps +2 (seq1 -> seq3).
     REQUIRE(s2.getLedgerSeq() == seq1);
-    lm.maybeUpdateLedgerStateSnapshot(s2);
+    lm.maybeUpdateImmutableLedgerView(s2);
     REQUIRE(s2.getLedgerSeq() == seq3);
     requireEntries(s2, entries1);
     requireEntries(s2, entries2);
@@ -938,7 +941,7 @@ TEST_CASE("basic snapshot copy semantics and isolation", "[snapshot]")
 
     // maybeUpdate S1: at seq2, jumps +1 (seq2 -> seq3).
     REQUIRE(s1.getLedgerSeq() == seq2);
-    lm.maybeUpdateLedgerStateSnapshot(s1);
+    lm.maybeUpdateImmutableLedgerView(s1);
     REQUIRE(s1.getLedgerSeq() == seq3);
     requireEntries(s1, entries3);
 }
@@ -999,8 +1002,8 @@ TEST_CASE("invariant check concurrent with state advance", "[snapshot]")
     addLiveBatchAndUpdateSnapshot(*app, makeHeader(seq1, protocolVersion),
                                   initialEntries, {}, {});
 
-    auto snapshot = app->getLedgerManager().copyLedgerStateSnapshot();
-    REQUIRE(snapshot.getLedgerSeq() == seq1);
+    auto ledgerView = app->getLedgerManager().copyImmutableLedgerView();
+    REQUIRE(ledgerView.getLedgerSeq() == seq1);
 
     // Build expected state map for the snapshot at seq1.
     UnorderedMap<LedgerKey, LedgerEntry> expectedAtSeq1;
@@ -1028,7 +1031,7 @@ TEST_CASE("invariant check concurrent with state advance", "[snapshot]")
             for (auto type : {ACCOUNT, TRUSTLINE, OFFER, DATA,
                               CLAIMABLE_BALANCE, LIQUIDITY_POOL})
             {
-                snapshot.scanLiveEntriesOfType(
+                ledgerView.scanLiveEntriesOfType(
                     type, [&](BucketEntry const& be) -> Loop {
                         if (be.type() == LIVEENTRY || be.type() == INITENTRY)
                         {

--- a/src/main/AppConnector.cpp
+++ b/src/main/AppConnector.cpp
@@ -169,25 +169,25 @@ AppConnector::threadIsType(Application::ThreadType type) const
     return mApp.threadIsType(type);
 }
 
-LedgerStateSnapshot
-AppConnector::copyLedgerStateSnapshot()
+ImmutableLedgerView
+AppConnector::copyImmutableLedgerView()
 {
-    return mApp.getLedgerManager().copyLedgerStateSnapshot();
+    return mApp.getLedgerManager().copyImmutableLedgerView();
 }
 
-ApplyLedgerStateSnapshot
-AppConnector::copyApplyLedgerStateSnapshot()
+ApplyLedgerView
+AppConnector::copyApplyLedgerView()
 {
-    return mApp.getLedgerManager().copyApplyLedgerStateSnapshot();
+    return mApp.getLedgerManager().copyApplyLedgerView();
 }
 
 void
-AppConnector::maybeUpdateLedgerStateSnapshot(LedgerStateSnapshot& snapshot)
+AppConnector::maybeUpdateImmutableLedgerView(ImmutableLedgerView& ledgerView)
 {
-    mApp.getLedgerManager().maybeUpdateLedgerStateSnapshot(snapshot);
+    mApp.getLedgerManager().maybeUpdateImmutableLedgerView(ledgerView);
 }
 
-LedgerStateSnapshot&
+ImmutableLedgerView&
 AppConnector::getOverlayThreadSnapshot()
 {
     return mApp.getOverlayManager().getOverlayThreadSnapshot();

--- a/src/main/AppConnector.h
+++ b/src/main/AppConnector.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "bucket/BucketUtils.h"
-#include "ledger/LedgerStateSnapshot.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "main/Application.h"
 #include "main/Config.h"
 #include "rust/RustBridge.h"
@@ -73,13 +73,13 @@ class AppConnector
 
     bool isStopping() const;
 
-    LedgerStateSnapshot copyLedgerStateSnapshot();
-    ApplyLedgerStateSnapshot copyApplyLedgerStateSnapshot();
-    void maybeUpdateLedgerStateSnapshot(LedgerStateSnapshot& snapshot);
+    ImmutableLedgerView copyImmutableLedgerView();
+    ApplyLedgerView copyApplyLedgerView();
+    void maybeUpdateImmutableLedgerView(ImmutableLedgerView& ledgerView);
 
     // Get a snapshot of ledger state for use by the overlay thread only. Must
     // only be called from the overlay thread.
-    LedgerStateSnapshot& getOverlayThreadSnapshot();
+    ImmutableLedgerView& getOverlayThreadSnapshot();
 
     // Protocol 23 data corruption bug data verifier. This typically is null,
     // unless a path to a CSV file containing the corruption data was provided

--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -730,8 +730,8 @@ dumpLedger(Config cfg, std::string const& outputFile,
     auto& lm = app->getLedgerManager();
 
     lm.partiallyLoadLastKnownLedgerForUtils();
-    auto liveSnapshot = app->getAppConnector().copyLedgerStateSnapshot();
-    auto ttlGetter = [&liveSnapshot, includeAllStates,
+    auto liveLedgerView = app->getAppConnector().copyImmutableLedgerView();
+    auto ttlGetter = [&liveLedgerView, includeAllStates,
                       dumpHotArchive](LedgerKey const& key) -> uint32_t {
         if (includeAllStates || dumpHotArchive)
         {
@@ -739,7 +739,7 @@ dumpLedger(Config cfg, std::string const& outputFile,
                 "TTL is undefined when `--include-all-states` or "
                 "`--hot-archive` flag is set.");
         }
-        auto entry = liveSnapshot.loadLiveEntry(key);
+        auto entry = liveLedgerView.loadLiveEntry(key);
         if (!entry)
         {
             throw std::runtime_error("No TTL entry found for key: " +
@@ -869,10 +869,10 @@ dumpWasmBlob(Config cfg, std::string const& hash, std::string const& dir)
         LOG_INFO(DEFAULT_LOG, "Wrote {} bytes to {}", entry.code.size(),
                  filename);
     };
-    auto snap = app->getLedgerManager().copyLedgerStateSnapshot();
+    auto ledgerView = app->getLedgerManager().copyImmutableLedgerView();
     if (hash == "ALL")
     {
-        snap.scanLiveEntriesOfType(
+        ledgerView.scanLiveEntriesOfType(
             CONTRACT_CODE, [&](BucketEntry const& entry) {
                 if (entry.type() == INITENTRY || entry.type() == LIVEENTRY)
                 {
@@ -888,7 +888,7 @@ dumpWasmBlob(Config cfg, std::string const& hash, std::string const& dir)
         LedgerKey key;
         key.type(LedgerEntryType::CONTRACT_CODE);
         key.contractCode().hash = hexToBin256(hash);
-        auto entry = snap.loadLiveEntry(key);
+        auto entry = ledgerView.loadLiveEntry(key);
         if (entry && entry->data.type() == LedgerEntryType::CONTRACT_CODE)
         {
             auto const& codeEntry = entry->data.contractCode();

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -641,9 +641,9 @@ CommandHandler::upgrades(std::string const& params, std::string& retStr)
             decoder::decode_b64(configXdrIter->second, buffer);
             ConfigUpgradeSetKey key;
             xdr::xdr_from_opaque(buffer, key);
-            auto ls = LedgerSnapshot(mApp);
+            auto ledgerView = CheckValidLedgerViewWrapper(mApp);
 
-            auto ptr = ConfigUpgradeSetFrame::makeFromKey(ls, key);
+            auto ptr = ConfigUpgradeSetFrame::makeFromKey(ledgerView, key);
 
             if (!ptr ||
                 ptr->isValidForApply() != Upgrades::UpgradeValidity::VALID)
@@ -810,9 +810,9 @@ CommandHandler::dumpProposedSettings(std::string const& params,
         decoder::decode_b64(blob, buffer);
         ConfigUpgradeSetKey key;
         xdr::xdr_from_opaque(buffer, key);
-        auto ls = LedgerSnapshot(mApp);
+        auto ledgerView = CheckValidLedgerViewWrapper(mApp);
 
-        auto ptr = ConfigUpgradeSetFrame::makeFromKey(ls, key);
+        auto ptr = ConfigUpgradeSetFrame::makeFromKey(ledgerView, key);
 
         if (!ptr || ptr->isValidForApply() != Upgrades::UpgradeValidity::VALID)
         {
@@ -1041,12 +1041,12 @@ CommandHandler::sorobanInfo(std::string const& params, std::string& retStr)
         }
         else if (format == "detailed")
         {
-            LedgerSnapshot lsg(mApp);
+            CheckValidLedgerViewWrapper ledgerView(mApp);
             xdr::xvector<ConfigSettingEntry> entries;
             for (auto c : xdr::xdr_traits<ConfigSettingID>::enum_values())
             {
-                auto entry =
-                    lsg.load(configSettingKey(static_cast<ConfigSettingID>(c)));
+                auto entry = ledgerView.load(
+                    configSettingKey(static_cast<ConfigSettingID>(c)));
                 if (!entry)
                 {
                     continue;
@@ -1058,7 +1058,7 @@ CommandHandler::sorobanInfo(std::string const& params, std::string& retStr)
         }
         else if (format == "upgrade_xdr")
         {
-            LedgerSnapshot lsg(mApp);
+            CheckValidLedgerViewWrapper ledgerView(mApp);
 
             ConfigUpgradeSet upgradeSet;
             for (auto c : xdr::xdr_traits<ConfigSettingID>::enum_values())
@@ -1069,7 +1069,7 @@ CommandHandler::sorobanInfo(std::string const& params, std::string& retStr)
                 {
                     continue;
                 }
-                auto entry = lsg.load(configSettingKey(configSettingID));
+                auto entry = ledgerView.load(configSettingKey(configSettingID));
                 if (!entry)
                 {
                     continue;
@@ -1513,8 +1513,8 @@ CommandHandler::testAcc(std::string const& params, std::string& retStr)
             key = getAccount(accName->second.c_str());
         }
 
-        LedgerSnapshot lsg(mApp);
-        auto acc = lsg.load(accountKey(key.getPublicKey()));
+        CheckValidLedgerViewWrapper ledgerView(mApp);
+        auto acc = ledgerView.load(accountKey(key.getPublicKey()));
         if (acc)
         {
             auto const& ae = acc.current().data.account();

--- a/src/main/QueryServer.cpp
+++ b/src/main/QueryServer.cpp
@@ -78,8 +78,8 @@ QueryServer::QueryServer(std::string const& address, unsigned short port,
 #ifdef BUILD_TESTS
     if (useMainThreadForTesting)
     {
-        mSnapshots.emplace(std::this_thread::get_id(),
-                           mAppConnector.copyLedgerStateSnapshot());
+        mLedgerViews.emplace(std::this_thread::get_id(),
+                             mAppConnector.copyImmutableLedgerView());
     }
     else
 #endif
@@ -87,7 +87,7 @@ QueryServer::QueryServer(std::string const& address, unsigned short port,
         auto workerPids = mServer.start();
         for (auto pid : workerPids)
         {
-            mSnapshots.emplace(pid, mAppConnector.copyLedgerStateSnapshot());
+            mLedgerViews.emplace(pid, mAppConnector.copyImmutableLedgerView());
         }
     }
 }
@@ -171,8 +171,8 @@ QueryServer::getLedgerEntryRaw(std::string const& params,
 
     if (!keys.empty())
     {
-        auto& snapshot = mSnapshots.at(std::this_thread::get_id());
-        mAppConnector.maybeUpdateLedgerStateSnapshot(snapshot);
+        auto& ledgerView = mLedgerViews.at(std::this_thread::get_id());
+        mAppConnector.maybeUpdateImmutableLedgerView(ledgerView);
 
         LedgerKeySet orderedKeys;
         for (auto const& key : keys)
@@ -184,13 +184,13 @@ QueryServer::getLedgerEntryRaw(std::string const& params,
 
         std::vector<LedgerEntry> loadedKeys;
 
-        // If a snapshot ledger is specified, use it to get the ledger entry
+        // If a ledgerView ledger is specified, use it to get the ledger entry
         if (snapshotLedger)
         {
             root["ledgerSeq"] = *snapshotLedger;
 
             auto loadedKeysOp =
-                snapshot.loadLiveKeysFromLedger(orderedKeys, *snapshotLedger);
+                ledgerView.loadLiveKeysFromLedger(orderedKeys, *snapshotLedger);
 
             // Return 404 if ledgerSeq not found
             if (!loadedKeysOp)
@@ -204,8 +204,8 @@ QueryServer::getLedgerEntryRaw(std::string const& params,
         // Otherwise default to current ledger
         else
         {
-            loadedKeys = snapshot.loadLiveKeys(orderedKeys, "query");
-            root["ledgerSeq"] = snapshot.getLedgerSeq();
+            loadedKeys = ledgerView.loadLiveKeys(orderedKeys, "query");
+            root["ledgerSeq"] = ledgerView.getLedgerSeq();
         }
 
         for (auto const& le : loadedKeys)
@@ -253,8 +253,8 @@ QueryServer::getLedgerEntry(std::string const& params, std::string const& body,
         return false;
     }
 
-    auto& snapshot = mSnapshots.at(std::this_thread::get_id());
-    mAppConnector.maybeUpdateLedgerStateSnapshot(snapshot);
+    auto& ledgerView = mLedgerViews.at(std::this_thread::get_id());
+    mAppConnector.maybeUpdateImmutableLedgerView(ledgerView);
     LedgerKeySet keysToSearch;
 
     // Keep track of keys in their original order for response ordering
@@ -283,11 +283,11 @@ QueryServer::getLedgerEntry(std::string const& params, std::string const& body,
     std::vector<LedgerEntry> liveEntries;
     std::vector<HotArchiveBucketEntry> archivedEntries;
     uint32_t ledgerSeq =
-        snapshotLedger ? *snapshotLedger : snapshot.getLedgerSeq();
+        snapshotLedger ? *snapshotLedger : ledgerView.getLedgerSeq();
     root["ledgerSeq"] = ledgerSeq;
 
     auto liveEntriesOp =
-        snapshot.loadLiveKeysFromLedger(keysToSearch, ledgerSeq);
+        ledgerView.loadLiveKeysFromLedger(keysToSearch, ledgerSeq);
 
     // Return 404 if ledgerSeq not found
     if (!liveEntriesOp)
@@ -316,7 +316,7 @@ QueryServer::getLedgerEntry(std::string const& params, std::string const& body,
     // Only query archive for soroban keys we didn't find in the live bucketList
     if (!hotArchiveKeysToSearch.empty())
     {
-        auto archivedEntriesOp = snapshot.loadArchiveKeysFromLedger(
+        auto archivedEntriesOp = ledgerView.loadArchiveKeysFromLedger(
             hotArchiveKeysToSearch, ledgerSeq);
         if (!archivedEntriesOp)
         {
@@ -339,10 +339,10 @@ QueryServer::getLedgerEntry(std::string const& params, std::string const& body,
     std::vector<LedgerEntry> ttlEntries;
     if (!ttlKeys.empty())
     {
-        // We haven't updated the live snapshot so we know the have a snapshot
-        // available for ledgerSeq
+        // We haven't updated the live ledgerView so we know the have a
+        // ledgerView available for ledgerSeq
         ttlEntries = std::move(
-            snapshot.loadLiveKeysFromLedger(ttlKeys, ledgerSeq).value());
+            ledgerView.loadLiveKeysFromLedger(ttlKeys, ledgerSeq).value());
     }
 
     std::unordered_map<LedgerKey, LedgerEntry> ttlMap;

--- a/src/main/QueryServer.h
+++ b/src/main/QueryServer.h
@@ -6,7 +6,7 @@
 
 #include "lib/httpthreaded/server.hpp"
 
-#include "ledger/LedgerStateSnapshot.h"
+#include "ledger/ImmutableLedgerView.h"
 #include <atomic>
 #include <functional>
 #include <string>
@@ -26,7 +26,7 @@ class QueryServer
 
     httpThreaded::server::server mServer;
 
-    std::unordered_map<std::thread::id, LedgerStateSnapshot> mSnapshots;
+    std::unordered_map<std::thread::id, ImmutableLedgerView> mLedgerViews;
 
     AppConnector& mAppConnector;
 

--- a/src/overlay/OverlayManager.h
+++ b/src/overlay/OverlayManager.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "crypto/BLAKE2.h"
-#include "ledger/LedgerStateSnapshot.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "overlay/Peer.h"
 
 /**
@@ -215,6 +215,6 @@ class OverlayManager
 
     // Get a snapshot of ledger state for use by the overlay thread only. Caller
     // is responsible for updating the snapshot as needed.
-    virtual LedgerStateSnapshot& getOverlayThreadSnapshot() = 0;
+    virtual ImmutableLedgerView& getOverlayThreadSnapshot() = 0;
 };
 }

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -1432,7 +1432,7 @@ OverlayManagerImpl::recordMessageMetric(StellarMessage const& stellarMsg,
     }
 }
 
-LedgerStateSnapshot&
+ImmutableLedgerView&
 OverlayManagerImpl::getOverlayThreadSnapshot()
 {
     releaseAssert(mApp.threadIsType(Application::ThreadType::OVERLAY));
@@ -1441,7 +1441,7 @@ OverlayManagerImpl::getOverlayThreadSnapshot()
     {
         // Create a new snapshot
         mOverlayThreadSnapshot =
-            mApp.getLedgerManager().copyLedgerStateSnapshot();
+            mApp.getLedgerManager().copyImmutableLedgerView();
     }
     return *mOverlayThreadSnapshot;
 }

--- a/src/overlay/OverlayManagerImpl.h
+++ b/src/overlay/OverlayManagerImpl.h
@@ -9,7 +9,7 @@
 #include "PeerDoor.h"
 #include "PeerManager.h"
 #include "herder/TxSetFrame.h"
-#include "ledger/LedgerStateSnapshot.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "ledger/LedgerTxn.h"
 #include "overlay/Floodgate.h"
 #include "overlay/OverlayManager.h"
@@ -168,7 +168,7 @@ class OverlayManagerImpl : public OverlayManager
     void recordMessageMetric(StellarMessage const& stellarMsg,
                              Peer::pointer peer) override;
 
-    LedgerStateSnapshot& getOverlayThreadSnapshot() override;
+    ImmutableLedgerView& getOverlayThreadSnapshot() override;
 
   private:
     struct ResolvedPeers
@@ -186,7 +186,7 @@ class OverlayManagerImpl : public OverlayManager
         mScheduledMessages;
 
     // Snapshot of ledger state for use ONLY by the overlay thread
-    std::optional<LedgerStateSnapshot> mOverlayThreadSnapshot;
+    std::optional<ImmutableLedgerView> mOverlayThreadSnapshot;
 
     void triggerPeerResolution();
     std::pair<std::vector<PeerBareAddress>, bool>

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -70,20 +70,20 @@ populateSignatureCache(AppConnector& app, TransactionFrameBaseConstPtr tx)
     releaseAssert(app.getConfig().BACKGROUND_TX_SIG_VERIFICATION &&
                   app.threadIsType(Application::ThreadType::OVERLAY));
 
-    auto& snapshot = app.getOverlayThreadSnapshot();
-    app.maybeUpdateLedgerStateSnapshot(snapshot);
-    LedgerSnapshot ledgerSnapshot(snapshot);
+    auto& overlayView = app.getOverlayThreadSnapshot();
+    app.maybeUpdateImmutableLedgerView(overlayView);
+    CheckValidLedgerViewWrapper ledgerView(overlayView);
 
-    // Use ledgerSnapshot to check all transactions in `tx`. We use a lambda to
+    // Use ledgerView to check all transactions in `tx`. We use a lambda to
     // simplify checking of both outer and inner transactions in the case of fee
     // bumps.
-    auto const checkTxSignatures = [&ledgerSnapshot](
+    auto const checkTxSignatures = [&ledgerView](
                                        TransactionFrameBaseConstPtr tx) {
         auto const& hash = tx->getContentsHash();
         auto const& signatures = txbridge::getSignatures(tx->getEnvelope());
 
         SignatureChecker signatureChecker(
-            ledgerSnapshot.getLedgerHeader().current().ledgerVersion, hash,
+            ledgerView.getLedgerHeader().current().ledgerVersion, hash,
             signatures, true);
 
         // Do not report signature cache metrics during background validation.
@@ -94,8 +94,7 @@ populateSignatureCache(AppConnector& app, TransactionFrameBaseConstPtr tx)
 
         // NOTE: Use getFeeSourceID so that this works for both TransactionFrame
         // and FeeBumpTransactionFrame
-        auto const sourceAccount =
-            ledgerSnapshot.getAccount(tx->getFeeSourceID());
+        auto const sourceAccount = ledgerView.getAccount(tx->getFeeSourceID());
 
         if (!sourceAccount)
         {
@@ -116,10 +115,10 @@ populateSignatureCache(AppConnector& app, TransactionFrameBaseConstPtr tx)
         // Check all transaction signatures
         tx->checkAllTransactionSignatures(
             signatureChecker, sourceAccount,
-            ledgerSnapshot.getLedgerHeader().current().ledgerVersion);
+            ledgerView.getLedgerHeader().current().ledgerVersion);
 
         // Check all operation signatures.
-        tx->checkOperationSignatures(signatureChecker, ledgerSnapshot, nullptr);
+        tx->checkOperationSignatures(signatureChecker, ledgerView, nullptr);
     };
 
     checkTxSignatures(tx);

--- a/src/overlay/test/OverlayTests.cpp
+++ b/src/overlay/test/OverlayTests.cpp
@@ -3417,7 +3417,7 @@ TEST_CASE("populateSignatureCache tests", "[overlay]")
         // Now call checkValid (normal path), which DOES check payload
         // signers. Since the cache was not populated, we should see a miss.
         LedgerTxn ltx(app->getLedgerTxnRoot());
-        auto ls = LedgerSnapshot(ltx);
+        auto ls = CheckValidLedgerViewWrapper(ltx);
         auto diagnostics = DiagnosticEventManager::createDisabled();
         auto result =
             payTx->checkValid(app->getAppConnector(), ls, 0, 0, 0, diagnostics);
@@ -3486,10 +3486,10 @@ TEST_CASE("populateSignatureCache tests", "[overlay]")
         REQUIRE(!isValid);
 
         // Verify it fails with bad auth, not other reasons
-        auto ls = LedgerSnapshot(ltx);
+        auto ledgerView = CheckValidLedgerViewWrapper(ltx);
         auto diagnostics = DiagnosticEventManager::createDisabled();
-        auto result = paymentTx->checkValid(app->getAppConnector(), ls, 0, 0, 0,
-                                            diagnostics);
+        auto result = paymentTx->checkValid(app->getAppConnector(), ledgerView,
+                                            0, 0, 0, diagnostics);
         REQUIRE(result->getResultCode() == txBAD_AUTH);
 
         // We expect a single cache miss at this point from the application of

--- a/src/simulation/ApplyLoad.cpp
+++ b/src/simulation/ApplyLoad.cpp
@@ -13,6 +13,7 @@
 #include "bucket/test/BucketTestUtils.h"
 #include "herder/Herder.h"
 #include "herder/HerderImpl.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "ledger/InMemorySorobanState.h"
 #include "ledger/LedgerManager.h"
 #include "ledger/LedgerManagerImpl.h"
@@ -923,11 +924,11 @@ ApplyLoad::applyConfigUpgrade(SorobanUpgradeConfig const& upgradeConfig)
         upgradeBytes, mUpgradeCodeKey, mUpgradeInstanceKey, std::nullopt,
         resources);
     {
-        LedgerSnapshot ls(mApp);
+        CheckValidLedgerViewWrapper ledgerView(mApp);
         auto diagnostics =
             DiagnosticEventManager::createForValidation(mApp.getConfig());
-        auto validationRes = invokeTx->checkValid(mApp.getAppConnector(), ls, 0,
-                                                  0, 0, diagnostics);
+        auto validationRes = invokeTx->checkValid(
+            mApp.getAppConnector(), ledgerView, 0, 0, 0, diagnostics);
         if (!validationRes->isSuccess())
         {
             if (validationRes->getResultCode() == txSOROBAN_INVALID)
@@ -1559,12 +1560,14 @@ ApplyLoad::benchmarkLimitsIteration()
     stellar::shuffle(std::begin(shuffledAccounts), std::end(shuffledAccounts),
                      getGlobalRandomEngine());
 
-    LedgerSnapshot ls(mApp);
+    CheckValidLedgerViewWrapper ledgerView(mApp);
     auto appConnector = mApp.getAppConnector();
 
-    auto addTx = [&ls, &appConnector, &txs](TransactionFrameBasePtr tx) {
+    auto addTx = [&ledgerView, &appConnector,
+                  &txs](TransactionFrameBasePtr tx) {
         auto diagnostics = DiagnosticEventManager::createDisabled();
-        auto res = tx->checkValid(appConnector, ls, 0, 0, 0, diagnostics);
+        auto res =
+            tx->checkValid(appConnector, ledgerView, 0, 0, 0, diagnostics);
         releaseAssert(res && res->isSuccess());
         txs.emplace_back(tx);
     };
@@ -2038,7 +2041,7 @@ ApplyLoad::generateClassicPayments(std::vector<TransactionFrameBasePtr>& txs,
     releaseAssert(accounts.size() >=
                   startAccountIdx + config.APPLY_LOAD_CLASSIC_TXS_PER_LEDGER);
 
-    LedgerSnapshot ls(mApp);
+    CheckValidLedgerViewWrapper ledgerView(mApp);
     auto appConnector = mApp.getAppConnector();
     auto diagnostics = DiagnosticEventManager::createDisabled();
 
@@ -2051,7 +2054,8 @@ ApplyLoad::generateClassicPayments(std::vector<TransactionFrameBasePtr>& txs,
         auto [_, tx] = mTxGenerator.paymentTransaction(
             mNumAccounts, 0, lm.getLastClosedLedgerNum() + 1, it->first, 1,
             std::nullopt);
-        auto res = tx->checkValid(appConnector, ls, 0, 0, 0, diagnostics);
+        auto res =
+            tx->checkValid(appConnector, ledgerView, 0, 0, 0, diagnostics);
         releaseAssert(res && res->isSuccess());
         txs.emplace_back(tx);
     }
@@ -2133,7 +2137,7 @@ ApplyLoad::generateSacPayments(std::vector<TransactionFrameBasePtr>& txs,
             txs.push_back(tx.second);
         }
     }
-    LedgerSnapshot ls(mApp);
+    CheckValidLedgerViewWrapper ledgerView(mApp);
     auto diag = DiagnosticEventManager::createDisabled();
     // Validate all the generated transactions. This serves 2 purposes:
     // - ensure that the tx generator works as expected
@@ -2144,8 +2148,9 @@ ApplyLoad::generateSacPayments(std::vector<TransactionFrameBasePtr>& txs,
     // more realistic than including it.
     for (auto const& tx : txs)
     {
-        releaseAssert(tx->checkValid(mApp.getAppConnector(), ls, 0, 0, 0, diag)
-                          ->isSuccess());
+        releaseAssert(
+            tx->checkValid(mApp.getAppConnector(), ledgerView, 0, 0, 0, diag)
+                ->isSuccess());
     }
 }
 void
@@ -2333,12 +2338,13 @@ ApplyLoad::generateTokenTransfers(std::vector<TransactionFrameBasePtr>& txs,
         txs.push_back(tx.second);
     }
 
-    LedgerSnapshot ls(mApp);
+    CheckValidLedgerViewWrapper ledgerView(mApp);
     auto diag = DiagnosticEventManager::createDisabled();
     for (auto const& tx : txs)
     {
-        releaseAssert(tx->checkValid(mApp.getAppConnector(), ls, 0, 0, 0, diag)
-                          ->isSuccess());
+        releaseAssert(
+            tx->checkValid(mApp.getAppConnector(), ledgerView, 0, 0, 0, diag)
+                ->isSuccess());
     }
 }
 
@@ -3198,7 +3204,7 @@ ApplyLoad::generateSoroswapSwaps(std::vector<TransactionFrameBasePtr>& txs,
         txs.push_back(tx);
     }
 
-    LedgerSnapshot ls(mApp);
+    CheckValidLedgerViewWrapper ls(mApp);
     auto diag = DiagnosticEventManager::createDisabled();
     for (auto const& tx : txs)
     {

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -1119,16 +1119,16 @@ LoadGenerator::checkSorobanStateSynced(Application& app,
     }
 
     std::vector<LedgerKey> result;
-    LedgerSnapshot lsg(mApp);
+    CheckValidLedgerViewWrapper ledgerView(mApp);
     for (auto const& lk : mContractInstanceKeys)
     {
-        if (!lsg.load(lk))
+        if (!ledgerView.load(lk))
         {
             result.emplace_back(lk);
         }
     }
 
-    if (mCodeKey && !lsg.load(*mCodeKey))
+    if (mCodeKey && !ledgerView.load(*mCodeKey))
     {
         result.emplace_back(*mCodeKey);
     }

--- a/src/simulation/TxGenerator.cpp
+++ b/src/simulation/TxGenerator.cpp
@@ -48,11 +48,11 @@ sampleDiscrete(std::vector<T> const& values,
 uint64_t
 footprintSize(Application& app, xdr::xvector<stellar::LedgerKey> const& keys)
 {
-    LedgerSnapshot lsg(app);
+    CheckValidLedgerViewWrapper ledgerView(app);
     uint64_t total = 0;
     for (auto const& key : keys)
     {
-        auto entry = lsg.load(key);
+        auto entry = ledgerView.load(key);
         if (entry)
         {
             total += xdr::xdr_size(entry.current());
@@ -86,8 +86,8 @@ TxGenerator::updateMinBalance()
 bool
 TxGenerator::isLive(LedgerKey const& lk, uint32_t ledgerNum) const
 {
-    LedgerSnapshot lsg(mApp);
-    auto ttlEntryPtr = lsg.load(getTTLKey(lk));
+    CheckValidLedgerViewWrapper ledgerView(mApp);
+    auto ttlEntryPtr = ledgerView.load(getTTLKey(lk));
 
     return ttlEntryPtr && stellar::isLive(ttlEntryPtr.current(), ledgerNum);
 }
@@ -127,8 +127,8 @@ TxGenerator::generateFee(std::optional<uint32_t> maxGeneratedFeeRate,
 bool
 TxGenerator::loadAccount(TestAccount& account)
 {
-    LedgerSnapshot lsg(mApp);
-    auto const entry = lsg.getAccount(account.getPublicKey());
+    CheckValidLedgerViewWrapper ledgerView(mApp);
+    auto const entry = ledgerView.getAccount(account.getPublicKey());
     if (!entry)
     {
         return false;
@@ -944,7 +944,7 @@ TxGenerator::getConfigUpgradeSetFromLoadConfig(
 {
     xdr::xvector<ConfigSettingEntry> updatedEntries;
 
-    LedgerSnapshot lsg(mApp);
+    CheckValidLedgerViewWrapper ledgerView(mApp);
     for (auto t : xdr::xdr_traits<ConfigSettingID>::enum_values())
     {
         auto type = static_cast<ConfigSettingID>(t);
@@ -983,7 +983,7 @@ TxGenerator::getConfigUpgradeSetFromLoadConfig(
             continue;
         }
 
-        auto entryPtr = lsg.load(configSettingKey(type));
+        auto entryPtr = ledgerView.load(configSettingKey(type));
         // This could happen if we have not yet upgraded
         if ((t == CONFIG_SETTING_CONTRACT_PARALLEL_COMPUTE_V0 ||
              t == CONFIG_SETTING_CONTRACT_LEDGER_COST_EXT_V0 ||

--- a/src/simulation/test/LoadGeneratorTests.cpp
+++ b/src/simulation/test/LoadGeneratorTests.cpp
@@ -5,8 +5,8 @@
 #include "bucket/BucketManager.h"
 #include "crypto/SHA.h"
 #include "crypto/SecretKey.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "ledger/LedgerManager.h"
-#include "ledger/LedgerStateSnapshot.h"
 #include "main/Config.h"
 #include "simulation/ApplyLoad.h"
 #include "simulation/LoadGenerator.h"
@@ -958,14 +958,14 @@ TEST_CASE("apply load", "[loadgen][applyload][acceptance]")
                                            expectedArchivedEntries - 1};
     std::set<LedgerKey, LedgerEntryIdCmp> sampleKeys;
 
-    auto snap = app->getLedgerManager().copyLedgerStateSnapshot();
+    auto ledgerView = app->getLedgerManager().copyImmutableLedgerView();
 
     for (auto idx : sampleIndices)
     {
         sampleKeys.insert(ApplyLoad::getKeyForArchivedEntry(idx));
     }
 
-    auto sampleEntries = snap.loadArchiveKeys(sampleKeys);
+    auto sampleEntries = ledgerView.loadArchiveKeys(sampleKeys);
     REQUIRE(sampleEntries.size() == sampleKeys.size());
 
     al.execute();

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -936,7 +936,7 @@ class FuzzTransactionFrame : public TransactionFrame
         // Do not track metrics related to background signature verification in
         // the fuzzer.
         signatureChecker.disableCacheMetricsTracking();
-        LedgerSnapshot ltxStmt(ltx);
+        CheckValidLedgerViewWrapper ltxStmt(ltx);
         // if any ill-formed Operations, do not attempt transaction application
         auto isInvalidOperation = [&](auto const& op, auto& opResult) {
             auto diagnostics =

--- a/src/test/TestAccount.cpp
+++ b/src/test/TestAccount.cpp
@@ -33,8 +33,8 @@ TestAccount::updateSequenceNumber()
 {
     if (mSn == 0)
     {
-        LedgerSnapshot lsg(mApp);
-        auto const entry = lsg.load(accountKey(getPublicKey()));
+        CheckValidLedgerViewWrapper ledgerView(mApp);
+        auto const entry = ledgerView.load(accountKey(getPublicKey()));
         if (entry)
         {
             mSn = entry.current().data.account().seqNum;
@@ -45,8 +45,8 @@ TestAccount::updateSequenceNumber()
 uint32_t
 TestAccount::getTrustlineFlags(Asset const& asset) const
 {
-    LedgerSnapshot lsg(mApp);
-    auto const trust = lsg.load(trustlineKey(getPublicKey(), asset));
+    CheckValidLedgerViewWrapper ledgerView(mApp);
+    auto const trust = ledgerView.load(trustlineKey(getPublicKey(), asset));
     REQUIRE(trust);
     return trust.current().data.trustLine().flags;
 }
@@ -63,10 +63,10 @@ TestAccount::getTrustlineBalance(Asset const& asset) const
 int64_t
 TestAccount::getTrustlineBalance(PoolID const& poolID) const
 {
-    LedgerSnapshot lsg(mApp);
+    CheckValidLedgerViewWrapper ledgerView(mApp);
     TrustLineAsset asset(ASSET_TYPE_POOL_SHARE);
     asset.liquidityPoolID() = poolID;
-    auto const trustLine = lsg.load(trustlineKey(getPublicKey(), asset));
+    auto const trustLine = ledgerView.load(trustlineKey(getPublicKey(), asset));
     REQUIRE(trustLine);
     return trustLine.current().data.trustLine().balance;
 }
@@ -74,25 +74,25 @@ TestAccount::getTrustlineBalance(PoolID const& poolID) const
 int64_t
 TestAccount::getBalance() const
 {
-    LedgerSnapshot lsg(mApp);
-    auto const entry = lsg.getAccount(getPublicKey());
+    CheckValidLedgerViewWrapper ledgerView(mApp);
+    auto const entry = ledgerView.getAccount(getPublicKey());
     return entry.current().data.account().balance;
 }
 
 int64_t
 TestAccount::getAvailableBalance() const
 {
-    LedgerSnapshot lsg(mApp);
-    auto const entry = lsg.getAccount(getPublicKey());
-    return stellar::getAvailableBalance(lsg.getLedgerHeader().current(),
+    CheckValidLedgerViewWrapper ledgerView(mApp);
+    auto const entry = ledgerView.getAccount(getPublicKey());
+    return stellar::getAvailableBalance(ledgerView.getLedgerHeader().current(),
                                         entry.current());
 }
 
 uint32_t
 TestAccount::getNumSubEntries() const
 {
-    LedgerSnapshot lsg(mApp);
-    auto const entry = lsg.getAccount(getPublicKey());
+    CheckValidLedgerViewWrapper ledgerView(mApp);
+    auto const entry = ledgerView.getAccount(getPublicKey());
     return entry.current().data.account().numSubEntries;
 }
 
@@ -146,8 +146,8 @@ TestAccount::create(SecretKey const& secretKey, uint64_t initialBalance)
 
     std::unique_ptr<LedgerEntry> destBefore;
     {
-        LedgerSnapshot lsg(mApp);
-        auto const entry = lsg.getAccount(publicKey);
+        CheckValidLedgerViewWrapper ledgerView(mApp);
+        auto const entry = ledgerView.getAccount(publicKey);
         if (entry)
         {
             destBefore = std::make_unique<LedgerEntry>(entry.current());
@@ -160,8 +160,8 @@ TestAccount::create(SecretKey const& secretKey, uint64_t initialBalance)
     }
     catch (...)
     {
-        LedgerSnapshot lsg(mApp);
-        auto const destAfter = lsg.getAccount(publicKey);
+        CheckValidLedgerViewWrapper ledgerView(mApp);
+        auto const destAfter = ledgerView.getAccount(publicKey);
         // check that the target account didn't change
         REQUIRE(!!destBefore == !!destAfter);
         if (destBefore && destAfter)
@@ -172,8 +172,8 @@ TestAccount::create(SecretKey const& secretKey, uint64_t initialBalance)
     }
 
     {
-        LedgerSnapshot lsg(mApp);
-        REQUIRE(lsg.getAccount(publicKey));
+        CheckValidLedgerViewWrapper ledgerView(mApp);
+        REQUIRE(ledgerView.getAccount(publicKey));
     }
     return TestAccount{mApp, secretKey};
 }
@@ -190,10 +190,10 @@ TestAccount::createBatch(std::vector<SecretKey> const& secretKeys,
     }
     applyOpsBatch(ops);
     std::vector<TestAccount> accounts;
-    LedgerSnapshot ls(mApp);
+    CheckValidLedgerViewWrapper ledgerView(mApp);
     for (auto const& secretKey : secretKeys)
     {
-        REQUIRE(ls.getAccount(secretKey.getPublicKey()));
+        REQUIRE(ledgerView.getAccount(secretKey.getPublicKey()));
         accounts.emplace_back(mApp, secretKey);
     }
     return accounts;
@@ -222,9 +222,9 @@ TestAccount::merge(PublicKey const& into)
 {
     applyTx(tx({accountMerge(into)}), mApp);
 
-    LedgerSnapshot lsg(mApp);
-    REQUIRE(lsg.getAccount(into));
-    REQUIRE(!lsg.getAccount(getPublicKey()));
+    CheckValidLedgerViewWrapper ledgerView(mApp);
+    REQUIRE(ledgerView.getAccount(into));
+    REQUIRE(!ledgerView.getAccount(getPublicKey()));
 }
 
 void
@@ -339,11 +339,11 @@ TestAccount::loadTrustLine(Asset const& asset) const
 TrustLineEntry
 TestAccount::loadTrustLine(TrustLineAsset const& asset) const
 {
-    LedgerSnapshot lsg(mApp);
+    CheckValidLedgerViewWrapper ledgerView(mApp);
     LedgerKey key(TRUSTLINE);
     key.trustLine().accountID = getPublicKey();
     key.trustLine().asset = asset;
-    return lsg.load(key).current().data.trustLine();
+    return ledgerView.load(key).current().data.trustLine();
 }
 
 bool
@@ -355,11 +355,11 @@ TestAccount::hasTrustLine(Asset const& asset) const
 bool
 TestAccount::hasTrustLine(TrustLineAsset const& asset) const
 {
-    LedgerSnapshot lsg(mApp);
+    CheckValidLedgerViewWrapper ledgerView(mApp);
     LedgerKey key(TRUSTLINE);
     key.trustLine().accountID = getPublicKey();
     key.trustLine().asset = asset;
-    return static_cast<bool>(lsg.load(key));
+    return static_cast<bool>(ledgerView.load(key));
 }
 
 void
@@ -373,8 +373,8 @@ TestAccount::manageData(std::string const& name, DataValue* value)
 {
     applyTx(tx({txtest::manageData(name, value)}), mApp);
 
-    LedgerTxn ls(mApp.getLedgerTxnRoot());
-    auto data = stellar::loadData(ls, getPublicKey(), name);
+    LedgerTxn ltx(mApp.getLedgerTxnRoot());
+    auto data = stellar::loadData(ltx, getPublicKey(), name);
     if (value)
     {
         REQUIRE(data);
@@ -391,18 +391,20 @@ TestAccount::bumpSequence(SequenceNumber to)
 {
     applyTx(tx({txtest::bumpSequence(to)}), mApp, false);
 
-    LedgerSnapshot lsg(mApp);
-    if (protocolVersionStartsFrom(lsg.getLedgerHeader().current().ledgerVersion,
-                                  ProtocolVersion::V_19))
+    CheckValidLedgerViewWrapper ledgerView(mApp);
+    if (protocolVersionStartsFrom(
+            ledgerView.getLedgerHeader().current().ledgerVersion,
+            ProtocolVersion::V_19))
     {
-        auto const account = lsg.getAccount(getPublicKey());
+        auto const account = ledgerView.getAccount(getPublicKey());
         REQUIRE(account);
 
         auto const& v3 =
             getAccountEntryExtensionV3(account.current().data.account());
-        REQUIRE(v3.seqLedger == lsg.getLedgerHeader().current().ledgerSeq);
+        REQUIRE(v3.seqLedger ==
+                ledgerView.getLedgerHeader().current().ledgerSeq);
         REQUIRE(v3.seqTime ==
-                lsg.getLedgerHeader().current().scpValue.closeTime);
+                ledgerView.getLedgerHeader().current().scpValue.closeTime);
     }
 }
 
@@ -502,8 +504,8 @@ TestAccount::pay(PublicKey const& destination, int64_t amount)
 {
     std::unique_ptr<LedgerEntry> toAccount;
     {
-        LedgerSnapshot lsg(mApp);
-        auto const toAccountEntry = lsg.getAccount(destination);
+        CheckValidLedgerViewWrapper ledgerView(mApp);
+        auto const toAccountEntry = ledgerView.getAccount(destination);
         toAccount =
             toAccountEntry
                 ? std::make_unique<LedgerEntry>(toAccountEntry.current())
@@ -514,7 +516,7 @@ TestAccount::pay(PublicKey const& destination, int64_t amount)
         }
         else
         {
-            REQUIRE(lsg.getAccount(getPublicKey()));
+            REQUIRE(ledgerView.getAccount(getPublicKey()));
         }
     }
 
@@ -526,8 +528,8 @@ TestAccount::pay(PublicKey const& destination, int64_t amount)
     }
     catch (...)
     {
-        LedgerSnapshot lsg(mApp);
-        auto const toAccountAfter = lsg.getAccount(destination);
+        CheckValidLedgerViewWrapper ledgerView(mApp);
+        auto const toAccountAfter = ledgerView.getAccount(destination);
         // check that the target account didn't change
         REQUIRE(!!toAccount == !!toAccountAfter);
         if (toAccount && toAccountAfter &&
@@ -539,8 +541,8 @@ TestAccount::pay(PublicKey const& destination, int64_t amount)
         throw;
     }
 
-    LedgerSnapshot lsg(mApp);
-    auto const toAccountAfter = lsg.getAccount(destination);
+    CheckValidLedgerViewWrapper ledgerView(mApp);
+    auto const toAccountAfter = ledgerView.getAccount(destination);
     REQUIRE(toAccount);
     REQUIRE(toAccountAfter);
 }

--- a/src/test/TestUtils.cpp
+++ b/src/test/TestUtils.cpp
@@ -4,7 +4,7 @@
 
 #include "TestUtils.h"
 #include "herder/TxSetFrame.h"
-#include "ledger/LedgerStateSnapshot.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "ledger/test/LedgerTestUtils.h"
 #include "simulation/LoadGenerator.h"
 #include "simulation/Simulation.h"

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -711,14 +711,14 @@ loadAccount(AbstractLedgerTxn& ltx, PublicKey const& k, bool mustExist)
 bool
 doesAccountExist(Application& app, PublicKey const& k)
 {
-    LedgerSnapshot lss(app);
+    CheckValidLedgerViewWrapper lss(app);
     return (bool)lss.getAccount(k);
 }
 
 xdr::xvector<Signer, 20>
 getAccountSigners(PublicKey const& k, Application& app)
 {
-    LedgerSnapshot lss(app);
+    CheckValidLedgerViewWrapper lss(app);
     auto account = lss.getAccount(k);
     return account.current().data.account().signers;
 }
@@ -2048,8 +2048,8 @@ makeConfigUpgradeSet(AbstractLedgerTxn& ltx, ConfigUpgradeSet configUpgradeSet,
     ltx.create(InternalLedgerEntry(ttl));
 
     auto upgradeKey = ConfigUpgradeSetKey{contractID, hashOfUpgradeSet};
-    LedgerSnapshot lsg(ltx);
-    return ConfigUpgradeSetFrame::makeFromKey(lsg, upgradeKey);
+    CheckValidLedgerViewWrapper ledgerView(ltx);
+    return ConfigUpgradeSetFrame::makeFromKey(ledgerView, upgradeKey);
 }
 
 LedgerUpgrade

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -246,7 +246,8 @@ FeeBumpTransactionFrame::checkSignature(SignatureChecker& signatureChecker,
 
 bool
 FeeBumpTransactionFrame::checkOperationSignatures(
-    SignatureChecker& signatureChecker, LedgerSnapshot const& ls,
+    SignatureChecker& signatureChecker,
+    CheckValidLedgerViewWrapper const& ledgerView,
     MutableTransactionResultBase* txResult) const
 {
     // Fee bumps do not contain explicit operations, so this check trivially
@@ -271,8 +272,9 @@ FeeBumpTransactionFrame::checkAllTransactionSignatures(
 
 MutableTxResultPtr
 FeeBumpTransactionFrame::checkValidImpl(
-    AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
-    uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+    AppConnector& app, CheckValidLedgerViewWrapper const& ledgerView,
+    SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
+    uint64_t upperBoundCloseTimeOffset,
     DiagnosticEventManager& diagnosticEvents, bool isOverlayValidation,
     std::optional<uint32_t> validationLedgerSeq) const
 {
@@ -285,16 +287,17 @@ FeeBumpTransactionFrame::checkValidImpl(
     // the fees that would end up being applied. However, this is what Core
     // used to return for a while, and some users may rely on this, so we
     // maintain this logic for the time being.
-    int64_t minBaseFee = ls.getLedgerHeader().current().baseFee;
-    auto feeCharged = getFee(ls.getLedgerHeader().current(), minBaseFee, false);
+    int64_t minBaseFee = ledgerView.getLedgerHeader().current().baseFee;
+    auto feeCharged =
+        getFee(ledgerView.getLedgerHeader().current(), minBaseFee, false);
     auto txResult = FeeBumpMutableTransactionResult::createSuccess(
         *mInnerTx, feeCharged, 0);
 
-    auto ledgerVersion = ls.getLedgerHeader().current().ledgerVersion;
+    auto ledgerVersion = ledgerView.getLedgerHeader().current().ledgerVersion;
     SignatureChecker signatureChecker{ledgerVersion, getContentsHash(),
                                       mEnvelope.feeBump().signatures,
                                       isOverlayValidation};
-    if (commonValid(signatureChecker, ls, false, *txResult) !=
+    if (commonValid(signatureChecker, ledgerView, false, *txResult) !=
         ValidationType::kFullyValid)
     {
         return txResult;
@@ -324,7 +327,7 @@ FeeBumpTransactionFrame::checkValidImpl(
     }
 
     mInnerTx->checkValidWithOptionallyChargedFee(
-        app, ls, current, false, lowerBoundCloseTimeOffset,
+        app, ledgerView, current, false, lowerBoundCloseTimeOffset,
         upperBoundCloseTimeOffset, getContentsHash(), *txResult,
         diagnosticEvents, isOverlayValidation, validationLedgerSeq);
 
@@ -333,24 +336,26 @@ FeeBumpTransactionFrame::checkValidImpl(
 
 MutableTxResultPtr
 FeeBumpTransactionFrame::checkValid(
-    AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
-    uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+    AppConnector& app, CheckValidLedgerViewWrapper const& ledgerView,
+    SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
+    uint64_t upperBoundCloseTimeOffset,
     DiagnosticEventManager& diagnosticEvents,
     std::optional<uint32_t> validationLedgerSeq) const
 {
-    return checkValidImpl(app, ls, current, lowerBoundCloseTimeOffset,
+    return checkValidImpl(app, ledgerView, current, lowerBoundCloseTimeOffset,
                           upperBoundCloseTimeOffset, diagnosticEvents, false,
                           validationLedgerSeq);
 }
 
 MutableTxResultPtr
 FeeBumpTransactionFrame::checkValidForOverlay(
-    AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
-    uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+    AppConnector& app, CheckValidLedgerViewWrapper const& ledgerView,
+    SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
+    uint64_t upperBoundCloseTimeOffset,
     DiagnosticEventManager& diagnosticEvents,
     std::optional<uint32_t> validationLedgerSeq) const
 {
-    return checkValidImpl(app, ls, current, lowerBoundCloseTimeOffset,
+    return checkValidImpl(app, ledgerView, current, lowerBoundCloseTimeOffset,
                           upperBoundCloseTimeOffset, diagnosticEvents, true,
                           validationLedgerSeq);
 }
@@ -366,12 +371,13 @@ FeeBumpTransactionFrame::checkSorobanResources(
 
 std::optional<LedgerEntryWrapper>
 FeeBumpTransactionFrame::commonValidPreSeqNum(
-    LedgerSnapshot const& ls, MutableTransactionResultBase& txResult) const
+    CheckValidLedgerViewWrapper const& ledgerView,
+    MutableTransactionResultBase& txResult) const
 {
     // this function does validations that are independent of the account state
     //    (stay true regardless of other side effects)
 
-    auto header = ls.getLedgerHeader();
+    auto header = ledgerView.getLedgerHeader();
     if (protocolVersionIsBefore(header.current().ledgerVersion,
                                 ProtocolVersion::V_13))
     {
@@ -432,7 +438,7 @@ FeeBumpTransactionFrame::commonValidPreSeqNum(
         }
     }
 
-    auto feeSource = ls.getAccount(getFeeSourceID());
+    auto feeSource = ledgerView.getAccount(getFeeSourceID());
     if (!feeSource)
     {
         txResult.setError(txNO_ACCOUNT);
@@ -444,14 +450,15 @@ FeeBumpTransactionFrame::commonValidPreSeqNum(
 
 FeeBumpTransactionFrame::ValidationType
 FeeBumpTransactionFrame::commonValid(
-    SignatureChecker& signatureChecker, LedgerSnapshot const& ls, bool applying,
+    SignatureChecker& signatureChecker,
+    CheckValidLedgerViewWrapper const& ledgerView, bool applying,
     MutableTransactionResultBase& txResult) const
 {
     ValidationType res = ValidationType::kInvalid;
 
     // Get the fee source account during commonValidPreSeqNum to avoid redundant
     // account loading
-    auto feeSource = commonValidPreSeqNum(ls, txResult);
+    auto feeSource = commonValidPreSeqNum(ledgerView, txResult);
     if (!feeSource)
     {
         return res;
@@ -459,7 +466,7 @@ FeeBumpTransactionFrame::commonValid(
 
     if (!checkAllTransactionSignatures(
             signatureChecker, *feeSource,
-            ls.getLedgerHeader().current().ledgerVersion))
+            ledgerView.getLedgerHeader().current().ledgerVersion))
     {
         txResult.setError(txBAD_AUTH);
         return res;
@@ -467,7 +474,7 @@ FeeBumpTransactionFrame::commonValid(
 
     res = ValidationType::kInvalidPostAuth;
 
-    auto header = ls.getLedgerHeader();
+    auto header = ledgerView.getLedgerHeader();
     // if we are in applying mode fee was already deduced from signing account
     // balance, if not, we need to check if after that deduction this account
     // will still have minimum balance

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -273,7 +273,8 @@ MutableTxResultPtr
 FeeBumpTransactionFrame::checkValidImpl(
     AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
     uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
-    DiagnosticEventManager& diagnosticEvents, bool isOverlayValidation) const
+    DiagnosticEventManager& diagnosticEvents, bool isOverlayValidation,
+    std::optional<uint32_t> validationLedgerSeq) const
 {
     if (!xdr::check_xdr_depth(mEnvelope, 500) || !XDRProvidesValidFee())
     {
@@ -325,7 +326,7 @@ FeeBumpTransactionFrame::checkValidImpl(
     mInnerTx->checkValidWithOptionallyChargedFee(
         app, ls, current, false, lowerBoundCloseTimeOffset,
         upperBoundCloseTimeOffset, getContentsHash(), *txResult,
-        diagnosticEvents, isOverlayValidation);
+        diagnosticEvents, isOverlayValidation, validationLedgerSeq);
 
     return txResult;
 }
@@ -334,20 +335,24 @@ MutableTxResultPtr
 FeeBumpTransactionFrame::checkValid(
     AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
     uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
-    DiagnosticEventManager& diagnosticEvents) const
+    DiagnosticEventManager& diagnosticEvents,
+    std::optional<uint32_t> validationLedgerSeq) const
 {
     return checkValidImpl(app, ls, current, lowerBoundCloseTimeOffset,
-                          upperBoundCloseTimeOffset, diagnosticEvents, false);
+                          upperBoundCloseTimeOffset, diagnosticEvents, false,
+                          validationLedgerSeq);
 }
 
 MutableTxResultPtr
 FeeBumpTransactionFrame::checkValidForOverlay(
     AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
     uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
-    DiagnosticEventManager& diagnosticEvents) const
+    DiagnosticEventManager& diagnosticEvents,
+    std::optional<uint32_t> validationLedgerSeq) const
 {
     return checkValidImpl(app, ls, current, lowerBoundCloseTimeOffset,
-                          upperBoundCloseTimeOffset, diagnosticEvents, true);
+                          upperBoundCloseTimeOffset, diagnosticEvents, true,
+                          validationLedgerSeq);
 }
 
 bool

--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -61,13 +61,11 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
 
     void removeOneTimeSignerKeyFromFeeSource(AbstractLedgerTxn& ltx) const;
 
-    MutableTxResultPtr checkValidImpl(AppConnector& app,
-                                      LedgerSnapshot const& ls,
-                                      SequenceNumber current,
-                                      uint64_t lowerBoundCloseTimeOffset,
-                                      uint64_t upperBoundCloseTimeOffset,
-                                      DiagnosticEventManager& diagnosticEvents,
-                                      bool isOverlayValidation) const;
+    MutableTxResultPtr checkValidImpl(
+        AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
+        uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+        DiagnosticEventManager& diagnosticEvents, bool isOverlayValidation,
+        std::optional<uint32_t> validationLedgerSeq = std::nullopt) const;
 
   public:
     FeeBumpTransactionFrame(Hash const& networkID,
@@ -121,11 +119,15 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
     checkValid(AppConnector& app, LedgerSnapshot const& ls,
                SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
                uint64_t upperBoundCloseTimeOffset,
-               DiagnosticEventManager& diagnosticEvents) const override;
+               DiagnosticEventManager& diagnosticEvents,
+               std::optional<uint32_t> validationLedgerSeq =
+                   std::nullopt) const override;
     MutableTxResultPtr checkValidForOverlay(
         AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
         uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
-        DiagnosticEventManager& diagnosticEvents) const override;
+        DiagnosticEventManager& diagnosticEvents,
+        std::optional<uint32_t> validationLedgerSeq =
+            std::nullopt) const override;
     bool checkSorobanResources(
         SorobanNetworkConfig const& cfg, uint32_t ledgerVersion,
         DiagnosticEventManager& diagnosticEvents) const override;

--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -34,7 +34,8 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
                         int32_t neededWeight) const override;
 
     bool checkOperationSignatures(
-        SignatureChecker& signatureChecker, LedgerSnapshot const& ls,
+        SignatureChecker& signatureChecker,
+        CheckValidLedgerViewWrapper const& ledgerView,
         MutableTransactionResultBase* txResult) const override;
 
     bool checkAllTransactionSignatures(SignatureChecker& signatureChecker,
@@ -44,7 +45,7 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
     // If check passes, returns the fee source account. Otherwise returns
     // nullopt.
     std::optional<LedgerEntryWrapper>
-    commonValidPreSeqNum(LedgerSnapshot const& ls,
+    commonValidPreSeqNum(CheckValidLedgerViewWrapper const& ledgerView,
                          MutableTransactionResultBase& txResult) const;
 
     enum ValidationType
@@ -56,14 +57,16 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
     };
 
     ValidationType commonValid(SignatureChecker& signatureChecker,
-                               LedgerSnapshot const& ls, bool applying,
+                               CheckValidLedgerViewWrapper const& ledgerView,
+                               bool applying,
                                MutableTransactionResultBase& txResult) const;
 
     void removeOneTimeSignerKeyFromFeeSource(AbstractLedgerTxn& ltx) const;
 
     MutableTxResultPtr checkValidImpl(
-        AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
-        uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+        AppConnector& app, CheckValidLedgerViewWrapper const& ledgerView,
+        SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
+        uint64_t upperBoundCloseTimeOffset,
         DiagnosticEventManager& diagnosticEvents, bool isOverlayValidation,
         std::optional<uint32_t> validationLedgerSeq = std::nullopt) const;
 
@@ -115,16 +118,18 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
                                MutableTransactionResultBase& txResult,
                                TxEventManager& txEventManager) const override;
 
-    MutableTxResultPtr
-    checkValid(AppConnector& app, LedgerSnapshot const& ls,
-               SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
-               uint64_t upperBoundCloseTimeOffset,
-               DiagnosticEventManager& diagnosticEvents,
-               std::optional<uint32_t> validationLedgerSeq =
-                   std::nullopt) const override;
+    MutableTxResultPtr checkValid(AppConnector& app,
+                                  CheckValidLedgerViewWrapper const& ledgerView,
+                                  SequenceNumber current,
+                                  uint64_t lowerBoundCloseTimeOffset,
+                                  uint64_t upperBoundCloseTimeOffset,
+                                  DiagnosticEventManager& diagnosticEvents,
+                                  std::optional<uint32_t> validationLedgerSeq =
+                                      std::nullopt) const override;
     MutableTxResultPtr checkValidForOverlay(
-        AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
-        uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+        AppConnector& app, CheckValidLedgerViewWrapper const& ledgerView,
+        SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
+        uint64_t upperBoundCloseTimeOffset,
         DiagnosticEventManager& diagnosticEvents,
         std::optional<uint32_t> validationLedgerSeq =
             std::nullopt) const override;

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -272,7 +272,7 @@ class InvokeHostFunctionApplyHelper : virtual LedgerAccessHelper
     rust::Vec<uint32_t> mAutoRestoredRwEntryIndices;
     HostFunctionMetrics mMetrics;
     // Used for hot archive access only
-    ApplyLedgerStateSnapshot mStateSnapshot;
+    ApplyLedgerView mApplyLedgerView;
     rust::Box<rust_bridge::SorobanModuleCache> const& mModuleCache;
     DiagnosticEventManager& mDiagnosticEvents;
 
@@ -285,8 +285,7 @@ class InvokeHostFunctionApplyHelper : virtual LedgerAccessHelper
         OperationResult& res,
         std::optional<RefundableFeeTracker>& refundableFeeTracker,
         OperationMetaBuilder& opMeta, InvokeHostFunctionOpFrame const& opFrame,
-        SorobanNetworkConfig const& sorobanConfig,
-        ApplyLedgerStateSnapshot stateSnapshot,
+        SorobanNetworkConfig const& sorobanConfig, ApplyLedgerView applyView,
         rust::Box<rust_bridge::SorobanModuleCache> const& moduleCache)
         : mApp(app)
         , mRes(res)
@@ -299,7 +298,7 @@ class InvokeHostFunctionApplyHelper : virtual LedgerAccessHelper
         , mAppConfig(app.getConfig())
         , mMetrics(app.getSorobanMetrics(),
                    app.getConfig().DISABLE_SOROBAN_METRICS_FOR_TESTING)
-        , mStateSnapshot(std::move(stateSnapshot))
+        , mApplyLedgerView(std::move(applyView))
         , mModuleCache(moduleCache)
         , mDiagnosticEvents(mOpMeta.getDiagnosticEventManager())
     {
@@ -426,7 +425,7 @@ class InvokeHostFunctionApplyHelper : virtual LedgerAccessHelper
                         continue;
                     }
 
-                    auto archiveEntry = mStateSnapshot.loadArchiveEntry(lk);
+                    auto archiveEntry = mApplyLedgerView.loadArchiveEntry(lk);
                     if (archiveEntry)
                     {
                         releaseAssertOrThrow(
@@ -991,8 +990,7 @@ class InvokeHostFunctionPreV23ApplyHelper
         rust::Box<rust_bridge::SorobanModuleCache> const& moduleCache)
         : InvokeHostFunctionApplyHelper(
               app, sorobanBasePrngSeed, res, refundableFeeTracker, opMeta,
-              opFrame, sorobanConfig, app.copyApplyLedgerStateSnapshot(),
-              moduleCache)
+              opFrame, sorobanConfig, app.copyApplyLedgerView(), moduleCache)
         , PreV23LedgerAccessHelper(ltx)
     {
     }

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -148,7 +148,7 @@ OperationFrame::apply(
     ZoneScoped;
     CLOG_TRACE(Tx, "{}", xdrToCerealString(mOperation, "Operation"));
 
-    LedgerSnapshot ltxState(ltx);
+    CheckValidLedgerViewWrapper ltxState(ltx);
     bool applyRes = checkValid(
         app, signatureChecker, sorobanConfig ? &sorobanConfig.value() : nullptr,
         ltxState, true, res, opMeta.getDiagnosticEventManager());
@@ -215,12 +215,13 @@ OperationFrame::isOpSupported(LedgerHeader const&) const
 
 bool
 OperationFrame::checkSignature(SignatureChecker& signatureChecker,
-                               LedgerSnapshot const& ls, OperationResult* res,
-                               bool forApply) const
+                               CheckValidLedgerViewWrapper const& ledgerView,
+                               OperationResult* res, bool forApply) const
 {
     ZoneScoped;
-    auto header = ls.getLedgerHeader();
-    auto sourceAccount = ls.getAccount(header, mParentTx, getSourceID());
+    auto header = ledgerView.getLedgerHeader();
+    auto sourceAccount =
+        ledgerView.getAccount(header, mParentTx, getSourceID());
     if (sourceAccount)
     {
         auto neededThreshold =
@@ -282,27 +283,28 @@ bool
 OperationFrame::checkValid(AppConnector& app,
                            SignatureChecker& signatureChecker,
                            SorobanNetworkConfig const* cfg,
-                           LedgerSnapshot const& ls, bool forApply,
-                           OperationResult& res,
+                           CheckValidLedgerViewWrapper const& ledgerView,
+                           bool forApply, OperationResult& res,
                            DiagnosticEventManager& diagnosticEvents) const
 {
     ZoneScoped;
     bool validationResult = false;
     auto validate = [this, &res, forApply, &signatureChecker, &app,
                      &diagnosticEvents, &validationResult,
-                     &cfg](LedgerSnapshot const& ls) {
-        if (!isOpSupported(ls.getLedgerHeader().current()))
+                     &cfg](CheckValidLedgerViewWrapper const& ledgerView) {
+        if (!isOpSupported(ledgerView.getLedgerHeader().current()))
         {
             res.code(opNOT_SUPPORTED);
             validationResult = false;
             return;
         }
 
-        auto ledgerVersion = ls.getLedgerHeader().current().ledgerVersion;
+        auto ledgerVersion =
+            ledgerView.getLedgerHeader().current().ledgerVersion;
         if (!forApply ||
             protocolVersionIsBefore(ledgerVersion, ProtocolVersion::V_10))
         {
-            if (!checkSignature(signatureChecker, ls, &res, forApply))
+            if (!checkSignature(signatureChecker, ledgerView, &res, forApply))
             {
                 validationResult = false;
                 return;
@@ -319,7 +321,8 @@ OperationFrame::checkValid(AppConnector& app,
             // If we're applying, it's possible an earlier op modified the TX
             // source, so we need to check again.
             if ((mOperation.sourceAccount || forApply) &&
-                !ls.getAccount(ls.getLedgerHeader(), mParentTx, getSourceID()))
+                !ledgerView.getAccount(ledgerView.getLedgerHeader(), mParentTx,
+                                       getSourceID()))
             {
                 res.code(opNO_ACCOUNT);
                 validationResult = false;
@@ -343,16 +346,17 @@ OperationFrame::checkValid(AppConnector& app,
 
     // Older protocol versions contain buggy account loading code,
     // so preserve nested LedgerTxn to avoid writing to the ledger
-    if (protocolVersionIsBefore(ls.getLedgerHeader().current().ledgerVersion,
-                                ProtocolVersion::V_8) &&
+    if (protocolVersionIsBefore(
+            ledgerView.getLedgerHeader().current().ledgerVersion,
+            ProtocolVersion::V_8) &&
         forApply)
     {
-        ls.executeWithMaybeInnerSnapshot(validate);
+        ledgerView.executeWithMaybeInnerSnapshot(validate);
     }
     else
     {
         // Validate using read-only snapshot
-        validate(ls);
+        validate(ledgerView);
     }
 
     return validationResult;

--- a/src/transactions/OperationFrame.h
+++ b/src/transactions/OperationFrame.h
@@ -97,14 +97,15 @@ class OperationFrame
     // to `nullptr` if they do not directly need the result of signature
     // validation (such as in the case of background signature validation).
     bool checkSignature(SignatureChecker& signatureChecker,
-                        LedgerSnapshot const& ls, OperationResult* res,
-                        bool forApply) const;
+                        CheckValidLedgerViewWrapper const& ledgerView,
+                        OperationResult* res, bool forApply) const;
 
     AccountID getSourceID() const;
     MuxedAccount getSourceAccount() const;
 
     bool checkValid(AppConnector& app, SignatureChecker& signatureChecker,
-                    SorobanNetworkConfig const* cfg, LedgerSnapshot const& ls,
+                    SorobanNetworkConfig const* cfg,
+                    CheckValidLedgerViewWrapper const& ledgerView,
                     bool forApply, OperationResult& res,
                     DiagnosticEventManager& diagnosticEvents) const;
 

--- a/src/transactions/ParallelApplyUtils.cpp
+++ b/src/transactions/ParallelApplyUtils.cpp
@@ -295,19 +295,19 @@ ParallelLedgerAccessHelper::eraseLedgerEntryIfExists(LedgerKey const& key)
 // them are complete.
 class ThreadParalllelApplyLedgerState;
 GlobalParallelApplyLedgerState::GlobalParallelApplyLedgerState(
-    AppConnector& app, ApplyLedgerStateSnapshot snapshot,
-    AbstractLedgerTxn& ltx, std::vector<ApplyStage> const& stages,
+    AppConnector& app, ApplyLedgerView applyView, AbstractLedgerTxn& ltx,
+    std::vector<ApplyStage> const& stages,
     InMemorySorobanState const& inMemoryState,
     SorobanNetworkConfig const& sorobanConfig)
     : LedgerEntryScope(ScopeIdT(0, ltx.getHeader().ledgerSeq))
-    , mLCLSnapshot(std::move(snapshot))
+    , mLCLApplyView(std::move(applyView))
     , mInMemorySorobanState(inMemoryState)
     , mSorobanConfig(sorobanConfig)
 {
-    releaseAssertOrThrow(mLCLSnapshot.getLedgerSeq() ==
+    releaseAssertOrThrow(mLCLApplyView.getLedgerSeq() ==
                          mInMemorySorobanState.getLedgerSeq());
     releaseAssertOrThrow(ltx.getHeader().ledgerSeq ==
-                         mLCLSnapshot.getLedgerSeq() + 1);
+                         mLCLApplyView.getLedgerSeq() + 1);
 
     // From now on, we will be using globalState, liveSnapshots, and the
     // hotArchive to collect all entries. Before we continue though, we need to
@@ -570,7 +570,7 @@ ThreadParallelApplyLedgerState::collectClusterFootprintEntriesFromGlobal(
     // As part of the initialization of this thread state, we need to
     // collect all the keys that are in the global state map. For any keys
     // we need not in the global state, we will fetch them from the live
-    // snapshot, in memory soroban state, or the hot archive later.
+    // applyView, in memory soroban state, or the hot archive later.
     GlobalParallelApplyEntryMap const& globalEntryMap =
         global.getGlobalEntryMap();
 
@@ -611,7 +611,7 @@ ThreadParallelApplyLedgerState::ThreadParallelApplyLedgerState(
     AppConnector& app, GlobalParallelApplyLedgerState const& global,
     Cluster const& cluster, size_t clusterIdx)
     : LedgerEntryScope(ScopeIdT(clusterIdx, global.mScopeID.mLedger))
-    , mLCLSnapshot(global.mLCLSnapshot)
+    , mLCLApplyView(global.mLCLApplyView)
     , mInMemorySorobanState(global.mInMemorySorobanState)
     , mSorobanConfig(global.mSorobanConfig)
     , mModuleCache(app.getModuleCache())
@@ -718,7 +718,7 @@ ThreadParallelApplyLedgerState::getLiveEntryOpt(LedgerKey const& key) const
     // collectClusterFootprintEntriesFromGlobal (even if it's marked for
     // deletion), so if the keys does not exist in mThreadEntryMap, it can't
     // exist in the global entry map either. We still need to check the in
-    // memory soroban state or the live snapshot.
+    // memory soroban state or the live applyView.
 
     // Check InMemorySorobanState cache for soroban types
     std::shared_ptr<LedgerEntry const> res;
@@ -728,7 +728,7 @@ ThreadParallelApplyLedgerState::getLiveEntryOpt(LedgerKey const& key) const
     }
     else
     {
-        res = mLCLSnapshot.loadLiveEntry(key);
+        res = mLCLApplyView.loadLiveEntry(key);
     }
 
     return scopeAdoptEntryOpt(res ? std::make_optional(*res) : std::nullopt);
@@ -805,7 +805,7 @@ ThreadParallelApplyLedgerState::setEffectsDeltaFromSuccessfulTx(
         }
         else
         {
-            // If the entry was not found in the live snapshot, we check if it
+            // If the entry was not found in the live applyView, we check if it
             // was restored from the hot archive instead.
             auto const& hotArchiveRestores =
                 res.getRestoredEntries().hotArchive;
@@ -861,10 +861,10 @@ ThreadParallelApplyLedgerState::getSorobanConfig() const
     return mSorobanConfig;
 }
 
-ApplyLedgerStateSnapshot const&
+ApplyLedgerView const&
 ThreadParallelApplyLedgerState::getSnapshot() const
 {
-    return mLCLSnapshot;
+    return mLCLApplyView;
 }
 
 rust::Box<rust_bridge::SorobanModuleCache> const&
@@ -911,7 +911,7 @@ TxParallelApplyLedgerState::upsertEntry(LedgerKey const& key,
     ZoneScoped;
     // There are 4 cases:
     //
-    //  1. The entry exists in the parent maps (thread state or live snapshot)
+    //  1. The entry exists in the parent maps (thread state or live applyView)
     //     but not in mTxEntryMap: we insert it into mTxEntryMap. This is a
     //     "logical update" even though it's a local insert. We return false.
     //
@@ -958,7 +958,7 @@ TxParallelApplyLedgerState::eraseEntryIfExists(LedgerKey const& key)
     if (liveEntryExistedAlready)
     {
         // NB: we only erase an entry if it doesn't already exist in
-        // parents (thread state or live snapshot), otherwise
+        // parents (thread state or live applyView), otherwise
         // we will produce mismatched erases that don't relate to
         // any pre-state key when calculating the ledger delta.
         CLOG_TRACE(Tx, "parallel apply thread {} erasing {}",

--- a/src/transactions/ParallelApplyUtils.h
+++ b/src/transactions/ParallelApplyUtils.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
+#include "ledger/ImmutableLedgerView.h"
 #include "ledger/InMemorySorobanState.h"
 #include "ledger/LedgerEntryScope.h"
-#include "ledger/LedgerStateSnapshot.h"
 #include "ledger/LedgerTxn.h"
 #include "ledger/LedgerTypeUtils.h"
 #include "transactions/ParallelApplyStage.h"
@@ -71,9 +71,9 @@ class ParallelLedgerInfo
 class ThreadParallelApplyLedgerState
     : public LedgerEntryScope<StaticLedgerEntryScope::ThreadParApply>
 {
-    // Copy of the LCL state snapshot from the global state, with fresh
+    // Copy of the LCL state applyView from the global state, with fresh
     // file caches for thread safety.
-    ApplyLedgerStateSnapshot mLCLSnapshot;
+    ApplyLedgerView mLCLApplyView;
 
     // Reference to the live in-memory Soroban state. For Soroban entries
     // (CONTRACT_DATA, CONTRACT_CODE, TTL), query this in-memory state instead
@@ -168,13 +168,13 @@ class ThreadParallelApplyLedgerState
     void commitChangesFromSuccessfulTx(ParallelTxSuccessVal const& res,
                                        TxBundle const& txBundle);
 
-    // The snapshot ledger sequence number is one less than the
+    // The applyView ledger sequence number is one less than the
     // applying ledger sequence number.
     uint32_t getSnapshotLedgerSeq() const;
 
     SorobanNetworkConfig const& getSorobanConfig() const;
 
-    ApplyLedgerStateSnapshot const& getSnapshot() const;
+    ApplyLedgerView const& getSnapshot() const;
 
     rust::Box<rust_bridge::SorobanModuleCache> const& getModuleCache() const;
 };
@@ -182,13 +182,13 @@ class ThreadParallelApplyLedgerState
 class GlobalParallelApplyLedgerState
     : public LedgerEntryScope<StaticLedgerEntryScope::GlobalParApply>
 {
-    // Contains the full LCL state snapshot from the start of the ledger
+    // Contains the full LCL state applyView from the start of the ledger
     // close, providing access to both the live bucket list and the hot archive
     // bucket list. Note that this does not reflect changes from the classic
-    // apply phase, but is a snapshot of the start of the ledger.
-    ApplyLedgerStateSnapshot mLCLSnapshot;
+    // apply phase, but is a applyView of the start of the ledger.
+    ApplyLedgerView mLCLApplyView;
 
-    // Contains an exact one-to-one in-memory mapping of the live snapshot for
+    // Contains an exact one-to-one in-memory mapping of the live applyView for
     // CONTRACT_DATA, CONTRACT_CODE, and TTL entries. For these entry types,
     // only mInMemorySorobanState should be queried. If the in-memory state
     // returns null for a key, it does NOT indicate a "cache miss," rather the
@@ -242,8 +242,7 @@ class GlobalParallelApplyLedgerState
                             std::unordered_set<LedgerKey> const& readWriteSet);
 
   public:
-    GlobalParallelApplyLedgerState(AppConnector& app,
-                                   ApplyLedgerStateSnapshot snapshot,
+    GlobalParallelApplyLedgerState(AppConnector& app, ApplyLedgerView applyView,
                                    AbstractLedgerTxn& ltx,
                                    std::vector<ApplyStage> const& stages,
                                    InMemorySorobanState const& inMemoryState,
@@ -260,7 +259,7 @@ class GlobalParallelApplyLedgerState
 
     void commitChangesToLedgerTxn(AbstractLedgerTxn& ltx) const;
 
-    // The snapshot ledger sequence number is one less than the
+    // The applyView ledger sequence number is one less than the
     // applying ledger sequence number.
     uint32_t getSnapshotLedgerSeq() const;
 
@@ -295,11 +294,11 @@ class TxParallelApplyLedgerState
     // _deleted_ in this tx.
     //
     // Deletions will only be added if there was a previously-existing entry to
-    // delete in the parent (thread or live snapshot) maps. A stray delete here
+    // delete in the parent (thread or live applyView) maps. A stray delete here
     // (eg. a std::nullptr entry) not-related to a previous live LE is a bug.
     //
     // Any entry in this map is implicitly dirty. Merely loading data from the
-    // thread map or the live snapshot does not add an entry to this map.
+    // thread map or the live applyView does not add an entry to this map.
     TxModifiedEntryMap mTxEntryMap;
 
   public:

--- a/src/transactions/RestoreFootprintOpFrame.cpp
+++ b/src/transactions/RestoreFootprintOpFrame.cpp
@@ -288,7 +288,7 @@ class RestoreFootprintParallelApplyHelper
     : virtual public RestoreFootprintApplyHelper,
       virtual public ParallelLedgerAccessHelper
 {
-    ApplyLedgerStateSnapshot mSnapshot;
+    ApplyLedgerView mApplyLedgerView;
 
   public:
     RestoreFootprintParallelApplyHelper(
@@ -299,14 +299,14 @@ class RestoreFootprintParallelApplyHelper
         : RestoreFootprintApplyHelper(app, res, refundableFeeTracker, opMeta,
                                       opFrame, threadState.getSorobanConfig())
         , ParallelLedgerAccessHelper(threadState, ledgerInfo)
-        , mSnapshot(threadState.getSnapshot())
+        , mApplyLedgerView(threadState.getSnapshot())
     {
     }
 
     std::optional<LedgerEntry>
     getHotArchiveEntry(LedgerKey const& key) override
     {
-        auto ptr = mSnapshot.loadArchiveEntry(key);
+        auto ptr = mApplyLedgerView.loadArchiveEntry(key);
         if (ptr)
         {
             return ptr->archivedEntry();

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -554,7 +554,8 @@ TransactionFrame::checkExtraSigners(SignatureChecker& signatureChecker) const
 
 bool
 TransactionFrame::checkOperationSignatures(
-    SignatureChecker& signatureChecker, LedgerSnapshot const& ls,
+    SignatureChecker& signatureChecker,
+    CheckValidLedgerViewWrapper const& ledgerView,
     MutableTransactionResultBase* txResult) const
 {
     ZoneScoped;
@@ -563,7 +564,7 @@ TransactionFrame::checkOperationSignatures(
     {
         auto const& op = mOperations[i];
         auto opResult = txResult ? &txResult->getOpResultAt(i) : nullptr;
-        if (!op->checkSignature(signatureChecker, ls, opResult, false))
+        if (!op->checkSignature(signatureChecker, ledgerView, opResult, false))
         {
             allOpsValid = false;
         }
@@ -1314,7 +1315,7 @@ TransactionFrame::isTooEarlyForAccount(uint32_t ledgerVersion,
 std::optional<LedgerEntryWrapper>
 TransactionFrame::commonValidPreSeqNum(
     AppConnector& app, SorobanNetworkConfig const* cfg,
-    LedgerSnapshot const& ls, bool chargeFee,
+    CheckValidLedgerViewWrapper const& ledgerView, bool chargeFee,
     uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
     Hash const& envelopeContentsHash, std::optional<FeePair> sorobanResourceFee,
     MutableTransactionResultBase& txResult,
@@ -1325,7 +1326,8 @@ TransactionFrame::commonValidPreSeqNum(
     // this function does validations that are independent of the account state
     //    (stay true regardless of other side effects)
 
-    uint32_t ledgerVersion = ls.getLedgerHeader().current().ledgerVersion;
+    uint32_t ledgerVersion =
+        ledgerView.getLedgerHeader().current().ledgerVersion;
     if ((protocolVersionIsBefore(ledgerVersion, ProtocolVersion::V_13) &&
          (mEnvelope.type() == ENVELOPE_TYPE_TX ||
           hasMuxedAccount(mEnvelope))) ||
@@ -1386,7 +1388,7 @@ TransactionFrame::commonValidPreSeqNum(
         }
 
         if (protocolVersionStartsFrom(
-                ls.getLedgerHeader().current().ledgerVersion,
+                ledgerView.getLedgerHeader().current().ledgerVersion,
                 ProtocolVersion::V_25))
         {
             if (!validateSorobanMemo())
@@ -1509,7 +1511,7 @@ TransactionFrame::commonValidPreSeqNum(
         }
     }
 
-    auto header = ls.getLedgerHeader();
+    auto header = ledgerView.getLedgerHeader();
 
     // If we have an overriding ledger sequence for validation (like when tx
     // queue is accepting TXs for the next ledger), use that for time-based
@@ -1543,7 +1545,7 @@ TransactionFrame::commonValidPreSeqNum(
         return std::nullopt;
     }
 
-    auto sourceAccount = ls.getAccount(header, *this);
+    auto sourceAccount = ledgerView.getAccount(header, *this);
     if (!sourceAccount)
     {
         txResult.setInnermostError(txNO_ACCOUNT);
@@ -1620,8 +1622,9 @@ TransactionFrame::processSignatures(
     if (auto code = txResult.getInnermostResultCode();
         code == txSUCCESS || code == txFAILED)
     {
-        LedgerSnapshot ls(ltxOuter);
-        allOpsValid = checkOperationSignatures(signatureChecker, ls, &txResult);
+        CheckValidLedgerViewWrapper ledgerView(ltxOuter);
+        allOpsValid =
+            checkOperationSignatures(signatureChecker, ledgerView, &txResult);
     }
 
     removeOneTimeSignerFromAllSourceAccounts(ltxOuter);
@@ -1671,10 +1674,11 @@ TransactionFrame::isBadSeq(LedgerHeaderWrapper const& header,
 TransactionFrame::ValidationType
 TransactionFrame::commonValid(
     AppConnector& app, SorobanNetworkConfig const* cfg,
-    SignatureChecker& signatureChecker, LedgerSnapshot const& ls,
-    SequenceNumber current, bool applying, bool chargeFee,
-    uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
-    Hash const& envelopeContentsHash, std::optional<FeePair> sorobanResourceFee,
+    SignatureChecker& signatureChecker,
+    CheckValidLedgerViewWrapper const& ledgerView, SequenceNumber current,
+    bool applying, bool chargeFee, uint64_t lowerBoundCloseTimeOffset,
+    uint64_t upperBoundCloseTimeOffset, Hash const& envelopeContentsHash,
+    std::optional<FeePair> sorobanResourceFee,
     MutableTransactionResultBase& txResult,
     DiagnosticEventManager& diagnosticEvents,
     std::optional<uint32_t> validationLedgerSeq) const
@@ -1686,8 +1690,8 @@ TransactionFrame::commonValid(
                      lowerBoundCloseTimeOffset, upperBoundCloseTimeOffset, &app,
                      chargeFee, sorobanResourceFee, &txResult,
                      &diagnosticEvents, &current, &res, &cfg,
-                     &envelopeContentsHash,
-                     validationLedgerSeq](LedgerSnapshot const& ls) {
+                     &envelopeContentsHash, validationLedgerSeq](
+                        CheckValidLedgerViewWrapper const& ledgerView) {
         if (applying &&
             (lowerBoundCloseTimeOffset != 0 || upperBoundCloseTimeOffset != 0))
         {
@@ -1698,7 +1702,7 @@ TransactionFrame::commonValid(
         // Get the source account during commonValidPreSeqNum to avoid
         // redundant account loading
         auto sourceAccount = commonValidPreSeqNum(
-            app, cfg, ls, chargeFee, lowerBoundCloseTimeOffset,
+            app, cfg, ledgerView, chargeFee, lowerBoundCloseTimeOffset,
             upperBoundCloseTimeOffset, envelopeContentsHash, sorobanResourceFee,
             txResult, diagnosticEvents, validationLedgerSeq);
 
@@ -1707,7 +1711,7 @@ TransactionFrame::commonValid(
             return;
         }
 
-        auto header = ls.getLedgerHeader();
+        auto header = ledgerView.getLedgerHeader();
 
         // in older versions, the account's sequence number is updated when
         // taking fees
@@ -1771,16 +1775,17 @@ TransactionFrame::commonValid(
 
     // Older protocol versions contain buggy account loading code,
     // so preserve nested LedgerTxn to avoid writing to the ledger
-    if (protocolVersionIsBefore(ls.getLedgerHeader().current().ledgerVersion,
-                                ProtocolVersion::V_8) &&
+    if (protocolVersionIsBefore(
+            ledgerView.getLedgerHeader().current().ledgerVersion,
+            ProtocolVersion::V_8) &&
         applying)
     {
-        ls.executeWithMaybeInnerSnapshot(validate);
+        ledgerView.executeWithMaybeInnerSnapshot(validate);
     }
     else
     {
         // Validate using read-only snapshot
-        validate(ls);
+        validate(ledgerView);
     }
     return res;
 }
@@ -1904,8 +1909,8 @@ TransactionFrame::removeAccountSigner(AbstractLedgerTxn& ltxOuter,
 
 void
 TransactionFrame::checkValidWithOptionallyChargedFee(
-    AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
-    bool chargeFee, uint64_t lowerBoundCloseTimeOffset,
+    AppConnector& app, CheckValidLedgerViewWrapper const& ledgerView,
+    SequenceNumber current, bool chargeFee, uint64_t lowerBoundCloseTimeOffset,
     uint64_t upperBoundCloseTimeOffset, Hash const& envelopeContentsHash,
     MutableTransactionResultBase& txResult,
     DiagnosticEventManager& diagnosticEvents, bool isOverlayValidation,
@@ -1915,12 +1920,12 @@ TransactionFrame::checkValidWithOptionallyChargedFee(
     mCachedAccountPreProtocol8.reset();
 
     SignatureChecker signatureChecker{
-        ls.getLedgerHeader().current().ledgerVersion, getContentsHash(),
+        ledgerView.getLedgerHeader().current().ledgerVersion, getContentsHash(),
         getSignatures(mEnvelope), isOverlayValidation};
 
     std::optional<FeePair> sorobanResourceFee;
     SorobanNetworkConfig const* sorobanConfig = nullptr;
-    auto ledgerVersion = ls.getLedgerHeader().current().ledgerVersion;
+    auto ledgerVersion = ledgerView.getLedgerHeader().current().ledgerVersion;
     // Load sorobanConfig for all transactions at protocol >= V20.
     if (protocolVersionStartsFrom(ledgerVersion, SOROBAN_PROTOCOL_VERSION))
     {
@@ -1932,8 +1937,8 @@ TransactionFrame::checkValidWithOptionallyChargedFee(
                 ledgerVersion, *sorobanConfig, app.getConfig());
         }
     }
-    if (commonValid(app, sorobanConfig, signatureChecker, ls, current, false,
-                    chargeFee, lowerBoundCloseTimeOffset,
+    if (commonValid(app, sorobanConfig, signatureChecker, ledgerView, current,
+                    false, chargeFee, lowerBoundCloseTimeOffset,
                     upperBoundCloseTimeOffset, envelopeContentsHash,
                     sorobanResourceFee, txResult, diagnosticEvents,
                     validationLedgerSeq) != ValidationType::kMaybeValid)
@@ -1946,8 +1951,8 @@ TransactionFrame::checkValidWithOptionallyChargedFee(
         auto const& op = mOperations[i];
         auto& opResult = txResult.getOpResultAt(i);
 
-        if (!op->checkValid(app, signatureChecker, sorobanConfig, ls, false,
-                            opResult, diagnosticEvents))
+        if (!op->checkValid(app, signatureChecker, sorobanConfig, ledgerView,
+                            false, opResult, diagnosticEvents))
         {
             // it's OK to just fast fail here and not try to call
             // checkValid on all operations as the resulting object
@@ -1965,8 +1970,9 @@ TransactionFrame::checkValidWithOptionallyChargedFee(
 
 MutableTxResultPtr
 TransactionFrame::checkValidImpl(
-    AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
-    uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+    AppConnector& app, CheckValidLedgerViewWrapper const& ledgerView,
+    SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
+    uint64_t upperBoundCloseTimeOffset,
     DiagnosticEventManager& diagnosticEvents, bool isOverlayValidation,
     std::optional<uint32_t> validationLedgerSeq) const
 {
@@ -1995,36 +2001,40 @@ TransactionFrame::checkValidImpl(
     // aren't the fees that would end up being applied. However, this is
     // what Core used to return for a while, and some users may rely on
     // this, so we maintain this logic for the time being.
-    int64_t minBaseFee = ls.getLedgerHeader().current().baseFee;
-    auto feeCharged = getFee(ls.getLedgerHeader().current(), minBaseFee, false);
+    int64_t minBaseFee = ledgerView.getLedgerHeader().current().baseFee;
+    auto feeCharged =
+        getFee(ledgerView.getLedgerHeader().current(), minBaseFee, false);
     auto txResult = MutableTransactionResult::createSuccess(*this, feeCharged);
     checkValidWithOptionallyChargedFee(
-        app, ls, current, true, lowerBoundCloseTimeOffset,
+        app, ledgerView, current, true, lowerBoundCloseTimeOffset,
         upperBoundCloseTimeOffset, getContentsHash(), *txResult,
         diagnosticEvents, isOverlayValidation, validationLedgerSeq);
     return txResult;
 }
 
 MutableTxResultPtr
-TransactionFrame::checkValid(
-    AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
-    uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
-    DiagnosticEventManager& diagnosticEvents,
-    std::optional<uint32_t> validationLedgerSeq) const
+TransactionFrame::checkValid(AppConnector& app,
+                             CheckValidLedgerViewWrapper const& ledgerView,
+                             SequenceNumber current,
+                             uint64_t lowerBoundCloseTimeOffset,
+                             uint64_t upperBoundCloseTimeOffset,
+                             DiagnosticEventManager& diagnosticEvents,
+                             std::optional<uint32_t> validationLedgerSeq) const
 {
-    return checkValidImpl(app, ls, current, lowerBoundCloseTimeOffset,
+    return checkValidImpl(app, ledgerView, current, lowerBoundCloseTimeOffset,
                           upperBoundCloseTimeOffset, diagnosticEvents, false,
                           validationLedgerSeq);
 }
 
 MutableTxResultPtr
 TransactionFrame::checkValidForOverlay(
-    AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
-    uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+    AppConnector& app, CheckValidLedgerViewWrapper const& ledgerView,
+    SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
+    uint64_t upperBoundCloseTimeOffset,
     DiagnosticEventManager& diagnosticEvents,
     std::optional<uint32_t> validationLedgerSeq) const
 {
-    return checkValidImpl(app, ls, current, lowerBoundCloseTimeOffset,
+    return checkValidImpl(app, ledgerView, current, lowerBoundCloseTimeOffset,
                           upperBoundCloseTimeOffset, diagnosticEvents, true,
                           validationLedgerSeq);
 }
@@ -2126,7 +2136,7 @@ TransactionFrame::commonPreApply(bool chargeFee, AppConnector& app,
     // Pass in nullopt, we always use the header ledgerSeq in the apply path for
     // validation.
     LedgerTxn ltxTx(ltx);
-    LedgerSnapshot lsTx(ltxTx);
+    CheckValidLedgerViewWrapper lsTx(ltxTx);
     auto cv =
         commonValid(app, sorobanConfig, *signatureChecker, lsTx, 0, true,
                     chargeFee, 0, 0, envelopeContentsHash, sorobanResourceFee,

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -1220,13 +1220,13 @@ TransactionFrame::computePreApplySorobanResourceFee(
 }
 
 bool
-TransactionFrame::isTooEarly(LedgerHeaderWrapper const& header,
+TransactionFrame::isTooEarly(uint32_t ledgerVersion, uint64_t closeTime,
+                             uint32_t ledgerSeq,
                              uint64_t lowerBoundCloseTimeOffset) const
 {
     auto const tb = getTimeBounds();
     if (tb)
     {
-        uint64 closeTime = header.current().scpValue.closeTime;
         if (tb->minTime &&
             (tb->minTime > (closeTime + lowerBoundCloseTimeOffset)))
         {
@@ -1234,18 +1234,18 @@ TransactionFrame::isTooEarly(LedgerHeaderWrapper const& header,
         }
     }
 
-    if (protocolVersionStartsFrom(header.current().ledgerVersion,
-                                  ProtocolVersion::V_19))
+    if (protocolVersionStartsFrom(ledgerVersion, ProtocolVersion::V_19))
     {
         auto const lb = getLedgerBounds();
-        return lb && lb->minLedger > header.current().ledgerSeq;
+        return lb && lb->minLedger > ledgerSeq;
     }
 
     return false;
 }
 
 bool
-TransactionFrame::isTooLate(LedgerHeaderWrapper const& header,
+TransactionFrame::isTooLate(uint32_t ledgerVersion, uint64_t closeTime,
+                            uint32_t ledgerSeq,
                             uint64_t upperBoundCloseTimeOffset) const
 {
     auto const tb = getTimeBounds();
@@ -1254,7 +1254,6 @@ TransactionFrame::isTooLate(LedgerHeaderWrapper const& header,
         // Prior to consensus, we can pass in an upper bound estimate on when we
         // expect the ledger to close so we don't accept transactions that will
         // expire by the time they are applied
-        uint64 closeTime = header.current().scpValue.closeTime;
         if (tb->maxTime &&
             (tb->maxTime < (closeTime + upperBoundCloseTimeOffset)))
         {
@@ -1262,23 +1261,21 @@ TransactionFrame::isTooLate(LedgerHeaderWrapper const& header,
         }
     }
 
-    if (protocolVersionStartsFrom(header.current().ledgerVersion,
-                                  ProtocolVersion::V_19))
+    if (protocolVersionStartsFrom(ledgerVersion, ProtocolVersion::V_19))
     {
         auto const lb = getLedgerBounds();
-        return lb && lb->maxLedger != 0 &&
-               lb->maxLedger <= header.current().ledgerSeq;
+        return lb && lb->maxLedger != 0 && lb->maxLedger <= ledgerSeq;
     }
     return false;
 }
 
 bool
-TransactionFrame::isTooEarlyForAccount(LedgerHeaderWrapper const& header,
+TransactionFrame::isTooEarlyForAccount(uint32_t ledgerVersion,
+                                       uint64_t closeTime, uint32_t ledgerSeq,
                                        LedgerEntryWrapper const& sourceAccount,
                                        uint64_t lowerBoundCloseTimeOffset) const
 {
-    if (protocolVersionIsBefore(header.current().ledgerVersion,
-                                ProtocolVersion::V_19))
+    if (protocolVersionIsBefore(ledgerVersion, ProtocolVersion::V_19))
     {
         return false;
     }
@@ -1292,8 +1289,7 @@ TransactionFrame::isTooEarlyForAccount(LedgerHeaderWrapper const& header,
                           : 0;
     auto minSeqAge = getMinSeqAge();
 
-    auto lowerBoundCloseTime =
-        header.current().scpValue.closeTime + lowerBoundCloseTimeOffset;
+    auto lowerBoundCloseTime = closeTime + lowerBoundCloseTimeOffset;
     if (minSeqAge > lowerBoundCloseTime ||
         lowerBoundCloseTime - minSeqAge < accSeqTime)
     {
@@ -1306,7 +1302,6 @@ TransactionFrame::isTooEarlyForAccount(LedgerHeaderWrapper const& header,
             : 0;
     auto minSeqLedgerGap = getMinSeqLedgerGap();
 
-    auto ledgerSeq = header.current().ledgerSeq;
     if (minSeqLedgerGap > ledgerSeq ||
         ledgerSeq - minSeqLedgerGap < accSeqLedger)
     {
@@ -1323,7 +1318,8 @@ TransactionFrame::commonValidPreSeqNum(
     uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
     Hash const& envelopeContentsHash, std::optional<FeePair> sorobanResourceFee,
     MutableTransactionResultBase& txResult,
-    DiagnosticEventManager& diagnosticEvents) const
+    DiagnosticEventManager& diagnosticEvents,
+    std::optional<uint32_t> validationLedgerSeq) const
 {
     ZoneScoped;
     // this function does validations that are independent of the account state
@@ -1514,12 +1510,21 @@ TransactionFrame::commonValidPreSeqNum(
     }
 
     auto header = ls.getLedgerHeader();
-    if (isTooEarly(header, lowerBoundCloseTimeOffset))
+
+    // If we have an overriding ledger sequence for validation (like when tx
+    // queue is accepting TXs for the next ledger), use that for time-based
+    // checks instead of the ledgerSeq from the header.
+    auto ledgerSeq = validationLedgerSeq.value_or(header.current().ledgerSeq);
+    auto closeTime = header.current().scpValue.closeTime;
+
+    if (isTooEarly(ledgerVersion, closeTime, ledgerSeq,
+                   lowerBoundCloseTimeOffset))
     {
         txResult.setInnermostError(txTOO_EARLY);
         return std::nullopt;
     }
-    if (isTooLate(header, upperBoundCloseTimeOffset))
+    if (isTooLate(ledgerVersion, closeTime, ledgerSeq,
+                  upperBoundCloseTimeOffset))
     {
         txResult.setInnermostError(txTOO_LATE);
         return std::nullopt;
@@ -1671,7 +1676,8 @@ TransactionFrame::commonValid(
     uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
     Hash const& envelopeContentsHash, std::optional<FeePair> sorobanResourceFee,
     MutableTransactionResultBase& txResult,
-    DiagnosticEventManager& diagnosticEvents) const
+    DiagnosticEventManager& diagnosticEvents,
+    std::optional<uint32_t> validationLedgerSeq) const
 {
     ZoneScoped;
     ValidationType res = ValidationType::kInvalid;
@@ -1680,7 +1686,8 @@ TransactionFrame::commonValid(
                      lowerBoundCloseTimeOffset, upperBoundCloseTimeOffset, &app,
                      chargeFee, sorobanResourceFee, &txResult,
                      &diagnosticEvents, &current, &res, &cfg,
-                     &envelopeContentsHash](LedgerSnapshot const& ls) {
+                     &envelopeContentsHash,
+                     validationLedgerSeq](LedgerSnapshot const& ls) {
         if (applying &&
             (lowerBoundCloseTimeOffset != 0 || upperBoundCloseTimeOffset != 0))
         {
@@ -1693,7 +1700,7 @@ TransactionFrame::commonValid(
         auto sourceAccount = commonValidPreSeqNum(
             app, cfg, ls, chargeFee, lowerBoundCloseTimeOffset,
             upperBoundCloseTimeOffset, envelopeContentsHash, sorobanResourceFee,
-            txResult, diagnosticEvents);
+            txResult, diagnosticEvents, validationLedgerSeq);
 
         if (!sourceAccount)
         {
@@ -1721,7 +1728,11 @@ TransactionFrame::commonValid(
 
         res = ValidationType::kInvalidUpdateSeqNum;
 
-        if (isTooEarlyForAccount(header, *sourceAccount,
+        auto ledgerSeq =
+            validationLedgerSeq.value_or(header.current().ledgerSeq);
+        auto closeTime = header.current().scpValue.closeTime;
+        if (isTooEarlyForAccount(header.current().ledgerVersion, closeTime,
+                                 ledgerSeq, *sourceAccount,
                                  lowerBoundCloseTimeOffset))
         {
             txResult.setInnermostError(txBAD_MIN_SEQ_AGE_OR_GAP);
@@ -1897,7 +1908,8 @@ TransactionFrame::checkValidWithOptionallyChargedFee(
     bool chargeFee, uint64_t lowerBoundCloseTimeOffset,
     uint64_t upperBoundCloseTimeOffset, Hash const& envelopeContentsHash,
     MutableTransactionResultBase& txResult,
-    DiagnosticEventManager& diagnosticEvents, bool isOverlayValidation) const
+    DiagnosticEventManager& diagnosticEvents, bool isOverlayValidation,
+    std::optional<uint32_t> validationLedgerSeq) const
 {
     ZoneScoped;
     mCachedAccountPreProtocol8.reset();
@@ -1923,8 +1935,8 @@ TransactionFrame::checkValidWithOptionallyChargedFee(
     if (commonValid(app, sorobanConfig, signatureChecker, ls, current, false,
                     chargeFee, lowerBoundCloseTimeOffset,
                     upperBoundCloseTimeOffset, envelopeContentsHash,
-                    sorobanResourceFee, txResult,
-                    diagnosticEvents) != ValidationType::kMaybeValid)
+                    sorobanResourceFee, txResult, diagnosticEvents,
+                    validationLedgerSeq) != ValidationType::kMaybeValid)
     {
         return;
     }
@@ -1952,12 +1964,11 @@ TransactionFrame::checkValidWithOptionallyChargedFee(
 }
 
 MutableTxResultPtr
-TransactionFrame::checkValidImpl(AppConnector& app, LedgerSnapshot const& ls,
-                                 SequenceNumber current,
-                                 uint64_t lowerBoundCloseTimeOffset,
-                                 uint64_t upperBoundCloseTimeOffset,
-                                 DiagnosticEventManager& diagnosticEvents,
-                                 bool isOverlayValidation) const
+TransactionFrame::checkValidImpl(
+    AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
+    uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+    DiagnosticEventManager& diagnosticEvents, bool isOverlayValidation,
+    std::optional<uint32_t> validationLedgerSeq) const
 {
 #ifdef BUILD_TESTS
     if (app.getRunInOverlayOnlyMode())
@@ -1990,29 +2001,32 @@ TransactionFrame::checkValidImpl(AppConnector& app, LedgerSnapshot const& ls,
     checkValidWithOptionallyChargedFee(
         app, ls, current, true, lowerBoundCloseTimeOffset,
         upperBoundCloseTimeOffset, getContentsHash(), *txResult,
-        diagnosticEvents, isOverlayValidation);
+        diagnosticEvents, isOverlayValidation, validationLedgerSeq);
     return txResult;
 }
 
 MutableTxResultPtr
-TransactionFrame::checkValid(AppConnector& app, LedgerSnapshot const& ls,
-                             SequenceNumber current,
-                             uint64_t lowerBoundCloseTimeOffset,
-                             uint64_t upperBoundCloseTimeOffset,
-                             DiagnosticEventManager& diagnosticEvents) const
+TransactionFrame::checkValid(
+    AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
+    uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+    DiagnosticEventManager& diagnosticEvents,
+    std::optional<uint32_t> validationLedgerSeq) const
 {
     return checkValidImpl(app, ls, current, lowerBoundCloseTimeOffset,
-                          upperBoundCloseTimeOffset, diagnosticEvents, false);
+                          upperBoundCloseTimeOffset, diagnosticEvents, false,
+                          validationLedgerSeq);
 }
 
 MutableTxResultPtr
 TransactionFrame::checkValidForOverlay(
     AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
     uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
-    DiagnosticEventManager& diagnosticEvents) const
+    DiagnosticEventManager& diagnosticEvents,
+    std::optional<uint32_t> validationLedgerSeq) const
 {
     return checkValidImpl(app, ls, current, lowerBoundCloseTimeOffset,
-                          upperBoundCloseTimeOffset, diagnosticEvents, true);
+                          upperBoundCloseTimeOffset, diagnosticEvents, true,
+                          validationLedgerSeq);
 }
 
 void
@@ -2108,12 +2122,16 @@ TransactionFrame::commonPreApply(bool chargeFee, AppConnector& app,
                                    sorobanResourceFee->non_refundable_fee;
         txResult.initializeRefundableFeeTracker(initialFeeRefund);
     }
+
+    // Pass in nullopt, we always use the header ledgerSeq in the apply path for
+    // validation.
     LedgerTxn ltxTx(ltx);
     LedgerSnapshot lsTx(ltxTx);
     auto cv =
         commonValid(app, sorobanConfig, *signatureChecker, lsTx, 0, true,
                     chargeFee, 0, 0, envelopeContentsHash, sorobanResourceFee,
-                    txResult, meta.getDiagnosticEventManager());
+                    txResult, meta.getDiagnosticEventManager(),
+                    /*validationLedgerSeq=*/std::nullopt);
     if (cv >= ValidationType::kInvalidUpdateSeqNum)
     {
         processSeqNum(ltxTx);

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -57,8 +57,9 @@ class TransactionFrame : public TransactionFrameBase
     maybeAdoptFailedReplayResult(MutableTransactionResultBase& txResult) const;
 
     MutableTxResultPtr checkValidImpl(
-        AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
-        uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+        AppConnector& app, CheckValidLedgerViewWrapper const& ledgerView,
+        SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
+        uint64_t upperBoundCloseTimeOffset,
         DiagnosticEventManager& diagnosticEvents, bool isOverlayValidation,
         std::optional<uint32_t> validationLedgerSeq = std::nullopt) const;
 
@@ -109,8 +110,8 @@ class TransactionFrame : public TransactionFrameBase
     // If check passes, returns the source account. Otherwise returns nullopt.
     std::optional<LedgerEntryWrapper>
     commonValidPreSeqNum(AppConnector& app, SorobanNetworkConfig const* cfg,
-                         LedgerSnapshot const& ls, bool chargeFee,
-                         uint64_t lowerBoundCloseTimeOffset,
+                         CheckValidLedgerViewWrapper const& ledgerView,
+                         bool chargeFee, uint64_t lowerBoundCloseTimeOffset,
                          uint64_t upperBoundCloseTimeOffset,
                          Hash const& envelopeContentsHash,
                          std::optional<FeePair> sorobanResourceFee,
@@ -121,17 +122,16 @@ class TransactionFrame : public TransactionFrameBase
     virtual bool isBadSeq(LedgerHeaderWrapper const& header,
                           int64_t seqNum) const;
 
-    ValidationType
-    commonValid(AppConnector& app, SorobanNetworkConfig const* cfg,
-                SignatureChecker& signatureChecker, LedgerSnapshot const& ls,
-                SequenceNumber current, bool applying, bool chargeFee,
-                uint64_t lowerBoundCloseTimeOffset,
-                uint64_t upperBoundCloseTimeOffset,
-                Hash const& envelopeContentsHash,
-                std::optional<FeePair> sorobanResourceFee,
-                MutableTransactionResultBase& txResult,
-                DiagnosticEventManager& diagnosticEvents,
-                std::optional<uint32_t> validationLedgerSeq) const;
+    ValidationType commonValid(
+        AppConnector& app, SorobanNetworkConfig const* cfg,
+        SignatureChecker& signatureChecker,
+        CheckValidLedgerViewWrapper const& ledgerView, SequenceNumber current,
+        bool applying, bool chargeFee, uint64_t lowerBoundCloseTimeOffset,
+        uint64_t upperBoundCloseTimeOffset, Hash const& envelopeContentsHash,
+        std::optional<FeePair> sorobanResourceFee,
+        MutableTransactionResultBase& txResult,
+        DiagnosticEventManager& diagnosticEvents,
+        std::optional<uint32_t> validationLedgerSeq) const;
 
     void removeOneTimeSignerFromAllSourceAccounts(AbstractLedgerTxn& ltx) const;
 
@@ -246,27 +246,29 @@ class TransactionFrame : public TransactionFrameBase
                                        uint32_t ledgerVersion) const override;
 
     bool checkOperationSignatures(
-        SignatureChecker& signatureChecker, LedgerSnapshot const& ls,
+        SignatureChecker& signatureChecker,
+        CheckValidLedgerViewWrapper const& ledgerView,
         MutableTransactionResultBase* txResult) const override;
 
     void checkValidWithOptionallyChargedFee(
-        AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
-        bool chargeFee, uint64_t lowerBoundCloseTimeOffset,
-        uint64_t upperBoundCloseTimeOffset, Hash const& envelopeContentsHash,
-        MutableTransactionResultBase& result,
-        DiagnosticEventManager& diagnosticEvents,
-        bool isOverlayValidation,
-        std::optional<uint32_t> validationLedgerSeq = std::nullopt) const;
-    MutableTxResultPtr
-    checkValid(AppConnector& app, LedgerSnapshot const& ls,
-               SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
-               uint64_t upperBoundCloseTimeOffset,
-               DiagnosticEventManager& diagnosticEvents,
-               std::optional<uint32_t> validationLedgerSeq =
-                   std::nullopt) const override;
-    MutableTxResultPtr checkValidForOverlay(
-        AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
+        AppConnector& app, CheckValidLedgerViewWrapper const& ledgerView,
+        SequenceNumber current, bool chargeFee,
         uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+        Hash const& envelopeContentsHash, MutableTransactionResultBase& result,
+        DiagnosticEventManager& diagnosticEvents, bool isOverlayValidation,
+        std::optional<uint32_t> validationLedgerSeq = std::nullopt) const;
+    MutableTxResultPtr checkValid(AppConnector& app,
+                                  CheckValidLedgerViewWrapper const& ledgerView,
+                                  SequenceNumber current,
+                                  uint64_t lowerBoundCloseTimeOffset,
+                                  uint64_t upperBoundCloseTimeOffset,
+                                  DiagnosticEventManager& diagnosticEvents,
+                                  std::optional<uint32_t> validationLedgerSeq =
+                                      std::nullopt) const override;
+    MutableTxResultPtr checkValidForOverlay(
+        AppConnector& app, CheckValidLedgerViewWrapper const& ledgerView,
+        SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
+        uint64_t upperBoundCloseTimeOffset,
         DiagnosticEventManager& diagnosticEvents,
         std::optional<uint32_t> validationLedgerSeq =
             std::nullopt) const override;

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -56,13 +56,11 @@ class TransactionFrame : public TransactionFrameBase
     bool
     maybeAdoptFailedReplayResult(MutableTransactionResultBase& txResult) const;
 
-    MutableTxResultPtr checkValidImpl(AppConnector& app,
-                                      LedgerSnapshot const& ls,
-                                      SequenceNumber current,
-                                      uint64_t lowerBoundCloseTimeOffset,
-                                      uint64_t upperBoundCloseTimeOffset,
-                                      DiagnosticEventManager& diagnosticEvents,
-                                      bool isOverlayValidation) const;
+    MutableTxResultPtr checkValidImpl(
+        AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
+        uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+        DiagnosticEventManager& diagnosticEvents, bool isOverlayValidation,
+        std::optional<uint32_t> validationLedgerSeq = std::nullopt) const;
 
   protected:
 #ifdef BUILD_TESTS
@@ -96,12 +94,15 @@ class TransactionFrame : public TransactionFrameBase
         kMaybeValid
     };
 
-    virtual bool isTooEarly(LedgerHeaderWrapper const& header,
+    virtual bool isTooEarly(uint32_t ledgerVersion, uint64_t closeTime,
+                            uint32_t ledgerSeq,
                             uint64_t lowerBoundCloseTimeOffset) const;
-    virtual bool isTooLate(LedgerHeaderWrapper const& header,
+    virtual bool isTooLate(uint32_t ledgerVersion, uint64_t closeTime,
+                           uint32_t ledgerSeq,
                            uint64_t upperBoundCloseTimeOffset) const;
 
-    bool isTooEarlyForAccount(LedgerHeaderWrapper const& header,
+    bool isTooEarlyForAccount(uint32_t ledgerVersion, uint64_t closeTime,
+                              uint32_t ledgerSeq,
                               LedgerEntryWrapper const& sourceAccount,
                               uint64_t lowerBoundCloseTimeOffset) const;
 
@@ -114,22 +115,23 @@ class TransactionFrame : public TransactionFrameBase
                          Hash const& envelopeContentsHash,
                          std::optional<FeePair> sorobanResourceFee,
                          MutableTransactionResultBase& txResult,
-                         DiagnosticEventManager& diagnosticEvents) const;
+                         DiagnosticEventManager& diagnosticEvents,
+                         std::optional<uint32_t> validationLedgerSeq) const;
 
     virtual bool isBadSeq(LedgerHeaderWrapper const& header,
                           int64_t seqNum) const;
 
-    ValidationType commonValid(AppConnector& app,
-                               SorobanNetworkConfig const* cfg,
-                               SignatureChecker& signatureChecker,
-                               LedgerSnapshot const& ls, SequenceNumber current,
-                               bool applying, bool chargeFee,
-                               uint64_t lowerBoundCloseTimeOffset,
-                               uint64_t upperBoundCloseTimeOffset,
-                               Hash const& envelopeContentsHash,
-                               std::optional<FeePair> sorobanResourceFee,
-                               MutableTransactionResultBase& txResult,
-                               DiagnosticEventManager& diagnosticEvents) const;
+    ValidationType
+    commonValid(AppConnector& app, SorobanNetworkConfig const* cfg,
+                SignatureChecker& signatureChecker, LedgerSnapshot const& ls,
+                SequenceNumber current, bool applying, bool chargeFee,
+                uint64_t lowerBoundCloseTimeOffset,
+                uint64_t upperBoundCloseTimeOffset,
+                Hash const& envelopeContentsHash,
+                std::optional<FeePair> sorobanResourceFee,
+                MutableTransactionResultBase& txResult,
+                DiagnosticEventManager& diagnosticEvents,
+                std::optional<uint32_t> validationLedgerSeq) const;
 
     void removeOneTimeSignerFromAllSourceAccounts(AbstractLedgerTxn& ltx) const;
 
@@ -253,16 +255,21 @@ class TransactionFrame : public TransactionFrameBase
         uint64_t upperBoundCloseTimeOffset, Hash const& envelopeContentsHash,
         MutableTransactionResultBase& result,
         DiagnosticEventManager& diagnosticEvents,
-        bool isOverlayValidation) const;
+        bool isOverlayValidation,
+        std::optional<uint32_t> validationLedgerSeq = std::nullopt) const;
     MutableTxResultPtr
     checkValid(AppConnector& app, LedgerSnapshot const& ls,
                SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
                uint64_t upperBoundCloseTimeOffset,
-               DiagnosticEventManager& diagnosticEvents) const override;
+               DiagnosticEventManager& diagnosticEvents,
+               std::optional<uint32_t> validationLedgerSeq =
+                   std::nullopt) const override;
     MutableTxResultPtr checkValidForOverlay(
         AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
         uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
-        DiagnosticEventManager& diagnosticEvents) const override;
+        DiagnosticEventManager& diagnosticEvents,
+        std::optional<uint32_t> validationLedgerSeq =
+            std::nullopt) const override;
     bool checkSorobanResources(
         SorobanNetworkConfig const& cfg, uint32_t ledgerVersion,
         DiagnosticEventManager& diagnosticEvents) const override;

--- a/src/transactions/TransactionFrameBase.h
+++ b/src/transactions/TransactionFrameBase.h
@@ -6,9 +6,9 @@
 
 #include <optional>
 
+#include "ledger/ImmutableLedgerView.h"
 #include "ledger/LedgerEntryScope.h"
 #include "ledger/LedgerHashUtils.h"
-#include "ledger/LedgerStateSnapshot.h"
 #include "ledger/NetworkConfig.h"
 #include "main/Config.h"
 #include "overlay/StellarXDR.h"
@@ -177,19 +177,18 @@ class TransactionFrameBase
     // ledgerSeq from the snapshot header. This is used for pre-consensus
     // validation where the snapshot reflects LCL but checks must evaluate
     // against the next ledger.
-    virtual MutableTxResultPtr
-    checkValid(AppConnector& app, LedgerSnapshot const& ls,
-               SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
-               uint64_t upperBoundCloseTimeOffset,
-               DiagnosticEventManager& diagnosticEvents,
-               std::optional<uint32_t> validationLedgerSeq =
-                   std::nullopt) const = 0;
-    virtual MutableTxResultPtr checkValidForOverlay(
-        AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
-        uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+    virtual MutableTxResultPtr checkValid(
+        AppConnector& app, CheckValidLedgerViewWrapper const& ledgerView,
+        SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
+        uint64_t upperBoundCloseTimeOffset,
         DiagnosticEventManager& diagnosticEvents,
-        std::optional<uint32_t> validationLedgerSeq =
-            std::nullopt) const = 0;
+        std::optional<uint32_t> validationLedgerSeq = std::nullopt) const = 0;
+    virtual MutableTxResultPtr checkValidForOverlay(
+        AppConnector& app, CheckValidLedgerViewWrapper const& ledgerView,
+        SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
+        uint64_t upperBoundCloseTimeOffset,
+        DiagnosticEventManager& diagnosticEvents,
+        std::optional<uint32_t> validationLedgerSeq = std::nullopt) const = 0;
     virtual bool
     checkSorobanResources(SorobanNetworkConfig const& cfg,
                           uint32_t ledgerVersion,
@@ -211,7 +210,7 @@ class TransactionFrameBase
     // populating signature cache in the background).
     virtual bool
     checkOperationSignatures(SignatureChecker& signatureChecker,
-                             LedgerSnapshot const& ls,
+                             CheckValidLedgerViewWrapper const& ledgerView,
                              MutableTransactionResultBase* txResult) const = 0;
 
     // Validate all transaction-level signatures

--- a/src/transactions/TransactionFrameBase.h
+++ b/src/transactions/TransactionFrameBase.h
@@ -172,15 +172,24 @@ class TransactionFrameBase
         SorobanMetrics& sorobanMetrics, Hash const& sorobanBasePrngSeed,
         TxEffects& effects) const = 0;
 
+    // When validationLedgerSeq is set, ledger sequence precondition
+    // checks use this value instead of the
+    // ledgerSeq from the snapshot header. This is used for pre-consensus
+    // validation where the snapshot reflects LCL but checks must evaluate
+    // against the next ledger.
     virtual MutableTxResultPtr
     checkValid(AppConnector& app, LedgerSnapshot const& ls,
                SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
                uint64_t upperBoundCloseTimeOffset,
-               DiagnosticEventManager& diagnosticEvents) const = 0;
+               DiagnosticEventManager& diagnosticEvents,
+               std::optional<uint32_t> validationLedgerSeq =
+                   std::nullopt) const = 0;
     virtual MutableTxResultPtr checkValidForOverlay(
         AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
         uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
-        DiagnosticEventManager& diagnosticEvents) const = 0;
+        DiagnosticEventManager& diagnosticEvents,
+        std::optional<uint32_t> validationLedgerSeq =
+            std::nullopt) const = 0;
     virtual bool
     checkSorobanResources(SorobanNetworkConfig const& cfg,
                           uint32_t ledgerVersion,

--- a/src/transactions/test/FrozenLedgerKeysTests.cpp
+++ b/src/transactions/test/FrozenLedgerKeysTests.cpp
@@ -97,9 +97,9 @@ bypassAndUnbypassTxHashes(Application& app, std::vector<Hash> const& toBypass,
 UnorderedSet<LedgerKey>
 loadFrozenKeysFromLedger(Application& app)
 {
-    LedgerSnapshot ls(app);
+    CheckValidLedgerViewWrapper ledgerView(app);
     auto configKey = configSettingKey(CONFIG_SETTING_FROZEN_LEDGER_KEYS);
-    auto entry = ls.load(configKey);
+    auto entry = ledgerView.load(configKey);
     REQUIRE(entry);
 
     auto const& frozenKeys =
@@ -122,9 +122,9 @@ loadFrozenKeysFromLedger(Application& app)
 UnorderedSet<Hash>
 loadFreezeBypassTxsFromLedger(Application& app)
 {
-    LedgerSnapshot ls(app);
+    CheckValidLedgerViewWrapper ledgerView(app);
     auto configKey = configSettingKey(CONFIG_SETTING_FREEZE_BYPASS_TXS);
-    auto entry = ls.load(configKey);
+    auto entry = ledgerView.load(configKey);
     REQUIRE(entry);
 
     auto const& bypassTxs =
@@ -152,9 +152,9 @@ TEST_CASE("frozen ledger keys config setting does not exist prior to p26",
         static_cast<uint32_t>(ProtocolVersion::V_25);
     auto app = createTestApplication(clock, cfg);
     auto root = app->getRoot();
-    LedgerSnapshot ls(*app);
+    CheckValidLedgerViewWrapper ledgerView(*app);
     auto configKey = configSettingKey(CONFIG_SETTING_FROZEN_LEDGER_KEYS);
-    auto entry = ls.load(configKey);
+    auto entry = ledgerView.load(configKey);
     REQUIRE(!entry);
 }
 
@@ -168,9 +168,9 @@ TEST_CASE("freeze bypass txs config setting does not exist prior to p26",
         static_cast<uint32_t>(ProtocolVersion::V_25);
     auto app = createTestApplication(clock, cfg);
     auto root = app->getRoot();
-    LedgerSnapshot ls(*app);
+    CheckValidLedgerViewWrapper ledgerView(*app);
     auto configKey = configSettingKey(CONFIG_SETTING_FREEZE_BYPASS_TXS);
-    auto entry = ls.load(configKey);
+    auto entry = ledgerView.load(configKey);
     REQUIRE(!entry);
 }
 
@@ -539,8 +539,9 @@ TEST_CASE("freeze bypass tx hash allows frozen key access at validation time",
 
     auto checkFrozen = [&](TransactionTestFramePtr& tx,
                            bool expectInnerFrozenResult) {
-        LedgerSnapshot ls(*app);
-        auto result = tx->checkValid(app->getAppConnector(), ls, 0, 0, 0);
+        CheckValidLedgerViewWrapper ledgerView(*app);
+        auto result =
+            tx->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0);
         REQUIRE(!result->isSuccess());
         if (expectInnerFrozenResult)
         {
@@ -556,8 +557,9 @@ TEST_CASE("freeze bypass tx hash allows frozen key access at validation time",
     };
 
     auto checkValid = [&](TransactionTestFramePtr& tx) {
-        LedgerSnapshot ls(*app);
-        auto result = tx->checkValid(app->getAppConnector(), ls, 0, 0, 0);
+        CheckValidLedgerViewWrapper ledgerView(*app);
+        auto result =
+            tx->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0);
         REQUIRE(result->isSuccess());
     };
 
@@ -709,8 +711,9 @@ TEST_CASE("frozen ledger keys in Soroban footprint",
         auto tx = createUploadWasmTx(*app, a1, 1000, DEFAULT_TEST_RESOURCE_FEE,
                                      resources);
 
-        LedgerSnapshot ls(*app);
-        auto result = tx->checkValid(app->getAppConnector(), ls, 0, 0, 0);
+        CheckValidLedgerViewWrapper ledgerView(*app);
+        auto result =
+            tx->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0);
         REQUIRE(!result->isSuccess());
         REQUIRE(result->getResultCode() == txFROZEN_KEY_ACCESSED);
 
@@ -732,8 +735,9 @@ TEST_CASE("source account frozen", "[frozenledgerkeys][tx]")
         root->create("A2", lm.getLastMinBalance(10) + 10 * lm.getLastTxFee());
 
     auto checkTx = [&](TransactionTestFramePtr& tx) {
-        LedgerSnapshot ls(*app);
-        auto result = tx->checkValid(app->getAppConnector(), ls, 0, 0, 0);
+        CheckValidLedgerViewWrapper ledgerView(*app);
+        auto result =
+            tx->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0);
         REQUIRE(!result->isSuccess());
         REQUIRE(result->getResultCode() == txFROZEN_KEY_ACCESSED);
     };
@@ -867,8 +871,9 @@ TEST_CASE("source account frozen", "[frozenledgerkeys][tx]")
 
         unfreezeKey(*app, a1Key);
 
-        LedgerSnapshot ls(*app);
-        auto result = tx->checkValid(app->getAppConnector(), ls, 0, 0, 0);
+        CheckValidLedgerViewWrapper ledgerView(*app);
+        auto result =
+            tx->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0);
         REQUIRE(result->isSuccess());
     }
 }
@@ -903,8 +908,9 @@ TEST_CASE("source trustline frozen", "[frozenledgerkeys][tx]")
     auto checkAccessesFrozenKey = [&](Operation const& op) {
         auto tx = transactionFromOperations(*app, a1.getSecretKey(),
                                             a1.nextSequenceNumber(), {op});
-        LedgerSnapshot ls(*app);
-        auto result = tx->checkValid(app->getAppConnector(), ls, 0, 0, 0);
+        CheckValidLedgerViewWrapper ledgerView(*app);
+        auto result =
+            tx->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0);
         REQUIRE(!result->isSuccess());
         REQUIRE(result->getResultCode() == txFROZEN_KEY_ACCESSED);
     };
@@ -1018,8 +1024,9 @@ TEST_CASE("operation destination frozen", "[frozenledgerkeys][tx]")
         auto tx =
             transactionFromOperations(*app, sourceAccount.getSecretKey(),
                                       sourceAccount.nextSequenceNumber(), {op});
-        LedgerSnapshot ls(*app);
-        auto result = tx->checkValid(app->getAppConnector(), ls, 0, 0, 0);
+        CheckValidLedgerViewWrapper ledgerView(*app);
+        auto result =
+            tx->checkValid(app->getAppConnector(), ledgerView, 0, 0, 0);
         REQUIRE(!result->isSuccess());
         REQUIRE(result->getResultCode() == txFROZEN_KEY_ACCESSED);
     };
@@ -2227,9 +2234,9 @@ TEST_CASE("frozen offers are transparent to DEX matching - randomized",
                     tx->addSignature(taker.getSecretKey());
 
                     {
-                        LedgerSnapshot ls(*app);
-                        auto result =
-                            tx->checkValid(app->getAppConnector(), ls, 0, 0, 0);
+                        CheckValidLedgerViewWrapper ledgerView(*app);
+                        auto result = tx->checkValid(app->getAppConnector(),
+                                                     ledgerView, 0, 0, 0);
                         REQUIRE(result->isSuccess());
                     }
 

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -17,8 +17,8 @@
 #include "crypto/Random.h"
 #include "crypto/SecretKey.h"
 #include "herder/Herder.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "ledger/LedgerManager.h"
-#include "ledger/LedgerStateSnapshot.h"
 #include "ledger/LedgerTxn.h"
 #include "ledger/LedgerTypeUtils.h"
 #include "ledger/test/LedgerTestUtils.h"
@@ -2210,10 +2210,10 @@ TEST_CASE("resource fee exceeds uint32", "[tx][soroban][feebump]")
                      txEnvelope.v1());
         auto tx = TransactionFrameBase::makeTransactionFromWire(
             test.getApp().getNetworkID(), txEnvelope);
-        LedgerSnapshot ls(test.getApp());
+        CheckValidLedgerViewWrapper ledgerView(test.getApp());
         auto diagnostics = DiagnosticEventManager::createDisabled();
         auto innerCheckValidResult = tx->checkValid(
-            test.getApp().getAppConnector(), ls, 0, 0, 0, diagnostics);
+            test.getApp().getAppConnector(), ledgerView, 0, 0, 0, diagnostics);
 
         int64_t feeBumpFullFee = resourceFee + inclusionFee;
         auto feeBumpTx = feeBump(test.getApp(), feeBumper, tx, feeBumpFullFee,
@@ -2222,7 +2222,7 @@ TEST_CASE("resource fee exceeds uint32", "[tx][soroban][feebump]")
         REQUIRE(feeBumpTx->getInclusionFee() == inclusionFee);
 
         auto checkValidResult = feeBumpTx->checkValid(
-            test.getApp().getAppConnector(), ls, 0, 0, 0, diagnostics);
+            test.getApp().getAppConnector(), ledgerView, 0, 0, 0, diagnostics);
         if (!checkValidResult->isSuccess())
         {
             return checkValidResult->getResultCode();
@@ -4750,12 +4750,13 @@ TEST_CASE("persistent entry archival", "[tx][soroban][archival]")
         auto lk = client.getContract().getDataKey(
             makeSymbolSCVal("key"), ContractDataDurability::PERSISTENT);
 
-        auto snap = test.getApp().getLedgerManager().copyLedgerStateSnapshot();
+        auto ledgerView =
+            test.getApp().getLedgerManager().copyImmutableLedgerView();
 
         if (evict)
         {
-            REQUIRE(snap.loadArchiveEntry(lk));
-            REQUIRE(!snap.loadArchiveEntry(getTTLKey(lk)));
+            REQUIRE(ledgerView.loadArchiveEntry(lk));
+            REQUIRE(!ledgerView.loadArchiveEntry(getTTLKey(lk)));
             {
                 LedgerTxn ltx(test.getApp().getLedgerTxnRoot());
                 REQUIRE(!ltx.load(lk));
@@ -4764,8 +4765,8 @@ TEST_CASE("persistent entry archival", "[tx][soroban][archival]")
         }
         else
         {
-            REQUIRE(!snap.loadArchiveEntry(lk));
-            REQUIRE(!snap.loadArchiveEntry(getTTLKey(lk)));
+            REQUIRE(!ledgerView.loadArchiveEntry(lk));
+            REQUIRE(!ledgerView.loadArchiveEntry(getTTLKey(lk)));
             {
                 LedgerTxn ltx(test.getApp().getLedgerTxnRoot());
                 REQUIRE(ltx.load(lk));
@@ -4829,7 +4830,7 @@ TEST_CASE("persistent entry archival", "[tx][soroban][archival]")
                 client.get("key", ContractDataDurability::PERSISTENT, 123);
 
                 auto restoredSnap =
-                    test.getApp().getLedgerManager().copyLedgerStateSnapshot();
+                    test.getApp().getLedgerManager().copyImmutableLedgerView();
 
                 // Restored entries are deleted from Hot Archive
                 REQUIRE(!restoredSnap.loadArchiveEntry(lk));
@@ -7473,7 +7474,7 @@ TEST_CASE("multiple version of same key in a single eviction scan",
         }
 
         auto evictSnap =
-            test.getApp().getLedgerManager().copyLedgerStateSnapshot();
+            test.getApp().getLedgerManager().copyImmutableLedgerView();
         REQUIRE(evictSnap.loadArchiveEntry(lk));
     };
 
@@ -7485,9 +7486,9 @@ TEST_CASE("multiple version of same key in a single eviction scan",
     // levels of the BucketList.
     test.invokeRestoreOp({lk}, 20166);
 
-    auto restoreSnap =
-        test.getApp().getLedgerManager().copyLedgerStateSnapshot();
-    auto loadRes = restoreSnap.loadLiveEntry(lk);
+    auto restoreView =
+        test.getApp().getLedgerManager().copyImmutableLedgerView();
+    auto loadRes = restoreView.loadLiveEntry(lk);
     REQUIRE(loadRes);
 
     // Evict the entry again. If we "double evict" we'll throw during ledger
@@ -7549,10 +7550,10 @@ TEST_CASE_VERSIONS("do not evict outdated keys", "[archival][soroban]")
 
         // Check the eviction results.
         // Entry should be archived and not in the live BucketList
-        auto evictionSnap = snapshotManager.copyLedgerStateSnapshot();
-        REQUIRE(!evictionSnap.loadLiveEntry(lk));
+        auto evictionView = snapshotManager.copyImmutableLedgerView();
+        REQUIRE(!evictionView.loadLiveEntry(lk));
 
-        auto hotLoad = evictionSnap.loadArchiveEntry(lk);
+        auto hotLoad = evictionView.loadArchiveEntry(lk);
         REQUIRE(hotLoad);
         REQUIRE(hotLoad->type() == HOT_ARCHIVE_ARCHIVED);
 
@@ -7573,12 +7574,12 @@ TEST_CASE_VERSIONS("do not evict outdated keys", "[archival][soroban]")
         // Restore entry and make sure the correct value is restored
         test.invokeRestoreOp({lk}, 20166);
 
-        auto restoreSnap = snapshotManager.copyLedgerStateSnapshot();
-        auto hotLoadAfterRestore = restoreSnap.loadArchiveEntry(lk);
+        auto restoreView = snapshotManager.copyImmutableLedgerView();
+        auto hotLoadAfterRestore = restoreView.loadArchiveEntry(lk);
         REQUIRE(!hotLoadAfterRestore);
 
         // Check that restored value matches what was archived
-        auto liveLoadAfterRestore = restoreSnap.loadLiveEntry(lk);
+        auto liveLoadAfterRestore = restoreView.loadLiveEntry(lk);
         REQUIRE(liveLoadAfterRestore);
 
         if (protocolVersionIsBefore(test.getLedgerVersion(),
@@ -7652,23 +7653,23 @@ TEST_CASE("disable eviction scan", "[archival][soroban]")
         REQUIRE(initialIterator == test.getNetworkCfg().evictionIterator());
     }
 
-    auto snap = snapshotManager.copyLedgerStateSnapshot();
+    auto ledgerView = snapshotManager.copyImmutableLedgerView();
     auto assertTemp = [&](bool isLive) {
-        snap = snapshotManager.copyLedgerStateSnapshot();
-        auto tempLiveLoad = snap.loadLiveEntry(temporaryKey);
+        ledgerView = snapshotManager.copyImmutableLedgerView();
+        auto tempLiveLoad = ledgerView.loadLiveEntry(temporaryKey);
         REQUIRE(static_cast<bool>(tempLiveLoad) == isLive);
 
         // Temp entries are never archived
-        REQUIRE(!snap.loadArchiveEntry(temporaryKey));
+        REQUIRE(!ledgerView.loadArchiveEntry(temporaryKey));
     };
 
     auto assertPersistent = [&](bool isLive) {
-        snap = snapshotManager.copyLedgerStateSnapshot();
+        ledgerView = snapshotManager.copyImmutableLedgerView();
 
-        auto persistentLiveLoad = snap.loadLiveEntry(persistentKey);
+        auto persistentLiveLoad = ledgerView.loadLiveEntry(persistentKey);
         REQUIRE(static_cast<bool>(persistentLiveLoad) == isLive);
 
-        auto hotArchiveLoad = snap.loadArchiveEntry(persistentKey);
+        auto hotArchiveLoad = ledgerView.loadArchiveEntry(persistentKey);
         REQUIRE(static_cast<bool>(hotArchiveLoad) != isLive);
     };
 
@@ -7692,9 +7693,9 @@ TEST_CASE("disable eviction scan", "[archival][soroban]")
     initialIterator = iteratorAfterUpgrade;
 
     // Check that exactly one entry has been evicted
-    snap = snapshotManager.copyLedgerStateSnapshot();
+    ledgerView = snapshotManager.copyImmutableLedgerView();
 
-    auto persistentLiveLoad = snap.loadLiveEntry(persistentKey);
+    auto persistentLiveLoad = ledgerView.loadLiveEntry(persistentKey);
     if (persistentLiveLoad)
     {
         // If perstent entry is live, assert that the temp entry is evicted.
@@ -8725,8 +8726,8 @@ TEST_CASE_VERSIONS("merge account then SAC payment scenarios",
             checkTx(1, r, txFAILED);
 
             // Verify that a1 no longer exists after the merge
-            LedgerSnapshot ls(test.getApp());
-            REQUIRE(!ls.getAccount(a1.getPublicKey()));
+            CheckValidLedgerViewWrapper ledgerView(test.getApp());
+            REQUIRE(!ledgerView.getAccount(a1.getPublicKey()));
 
             // Verify that b1 received a1's balance (minus merge fee)
             auto expectedBalance =
@@ -8757,8 +8758,8 @@ TEST_CASE_VERSIONS("merge account then SAC payment scenarios",
             checkTx(1, r, txFAILED);
 
             // Verify that a1 no longer exists after the merge
-            LedgerSnapshot ls(test.getApp());
-            REQUIRE(!ls.getAccount(a1.getPublicKey()));
+            CheckValidLedgerViewWrapper ledgerView(test.getApp());
+            REQUIRE(!ledgerView.getAccount(a1.getPublicKey()));
 
             // Verify that b1 received a1's balance (minus merge fee)
             auto expectedBalance =
@@ -8794,8 +8795,8 @@ TEST_CASE_VERSIONS("merge account then SAC payment scenarios",
             checkTx(1, r, txNO_ACCOUNT);
 
             // Verify that a1 no longer exists after the merge
-            LedgerSnapshot ls(test.getApp());
-            REQUIRE(!ls.getAccount(a1.getPublicKey()));
+            CheckValidLedgerViewWrapper ledgerView(test.getApp());
+            REQUIRE(!ledgerView.getAccount(a1.getPublicKey()));
 
             // Verify that b1 received a1's balance (minus the soroban
             // transactions fee which a1 paid before it was merged).
@@ -9057,7 +9058,7 @@ TEST_CASE("apply generated parallel tx sets", "[soroban][parallelapply]")
     {
         std::vector<TransactionFrameBaseConstPtr> sorobanTxs;
         auto resources = lm.maxLedgerResources(true);
-        LedgerSnapshot ls(app);
+        CheckValidLedgerViewWrapper ledgerView(app);
         for (int txId = 0; txId < MAX_TRANSACTIONS_PER_LEDGER; ++txId)
         {
             auto account = txtest::getGenesisAccount(app, accountId++);
@@ -9098,7 +9099,7 @@ TEST_CASE("apply generated parallel tx sets", "[soroban][parallelapply]")
             auto tx = invocation.withExactNonRefundableResourceFee().createTx(
                 &account);
 
-            REQUIRE(tx->checkValid(app.getAppConnector(), ls, 0, 0, 0)
+            REQUIRE(tx->checkValid(app.getAppConnector(), ledgerView, 0, 0, 0)
                         ->isSuccess());
             if (!anyGreater(tx->getResources(false, test.getLedgerVersion()),
                             resources))
@@ -9488,8 +9489,8 @@ TEST_CASE("in-memory state size tracking", "[soroban]")
         {
             auto ledgerKey = client.getContract().getDataKey(
                 makeSymbolSCVal(key), durability);
-            LedgerSnapshot ls(test.getApp());
-            auto le = ls.load(ledgerKey);
+            CheckValidLedgerViewWrapper ledgerView(test.getApp());
+            auto le = ledgerView.load(ledgerKey);
             if (le)
             {
                 // We only deal with the data entries here, so no need to use
@@ -9700,9 +9701,9 @@ TEST_CASE("readonly ttl bumps across threads and stages",
         auto startingTTL = test.getTTL(lk);
 
         // Capture the TTL entry's lastModifiedLedgerSeq before tx execution
-        LedgerSnapshot ls(test.getApp());
+        CheckValidLedgerViewWrapper ledgerView(test.getApp());
         auto ttlKey = getTTLKey(lk);
-        auto ttlEntry = ls.load(ttlKey);
+        auto ttlEntry = ledgerView.load(ttlKey);
         REQUIRE(ttlEntry);
         uint32_t ttlLastModifiedBeforeTx =
             ttlEntry.current().lastModifiedLedgerSeq;
@@ -9749,9 +9750,9 @@ TEST_CASE("readonly ttl bumps across threads and stages",
         auto startingTTL = test.getTTL(lk);
 
         // Capture the TTL entry's lastModifiedLedgerSeq before tx execution
-        LedgerSnapshot ls(test.getApp());
+        CheckValidLedgerViewWrapper ledgerView(test.getApp());
         auto ttlKey = getTTLKey(lk);
-        auto ttlEntry = ls.load(ttlKey);
+        auto ttlEntry = ledgerView.load(ttlKey);
         REQUIRE(ttlEntry);
         uint32_t ttlLastModifiedBeforeTx =
             ttlEntry.current().lastModifiedLedgerSeq;
@@ -9803,9 +9804,9 @@ TEST_CASE("readonly ttl bumps across threads and stages",
         auto startingTTL = test.getTTL(lk);
 
         // Capture the TTL entry's lastModifiedLedgerSeq before tx execution
-        LedgerSnapshot ls(test.getApp());
+        CheckValidLedgerViewWrapper ledgerView(test.getApp());
         auto ttlKey = getTTLKey(lk);
-        auto ttlEntry = ls.load(ttlKey);
+        auto ttlEntry = ledgerView.load(ttlKey);
         REQUIRE(ttlEntry);
         uint32_t ttlLastModifiedBeforeTx =
             ttlEntry.current().lastModifiedLedgerSeq;
@@ -10087,7 +10088,7 @@ TEST_CASE("autorestore from another contract", "[tx][soroban][archival]")
                         std::nullopt) == INVOKE_HOST_FUNCTION_ENTRY_ARCHIVED);
 
     auto archivedSnap =
-        test.getApp().getLedgerManager().copyLedgerStateSnapshot();
+        test.getApp().getLedgerManager().copyImmutableLedgerView();
 
     REQUIRE(archivedSnap.loadArchiveKeys({lk1, lk2}).size() == 2);
     REQUIRE(archivedSnap.loadLiveKeys({lk1, lk2}, "load").size() == 0);
@@ -10116,7 +10117,7 @@ TEST_CASE("autorestore from another contract", "[tx][soroban][archival]")
     REQUIRE(invocation.withExactNonRefundableResourceFee().invoke());
 
     auto restoredSnap =
-        test.getApp().getLedgerManager().copyLedgerStateSnapshot();
+        test.getApp().getLedgerManager().copyImmutableLedgerView();
 
     REQUIRE(restoredSnap.loadLiveKeys({lk1, lk2}, "load").size() == 2);
     REQUIRE(restoredSnap.loadArchiveKeys({lk1, lk2}).size() == 0);
@@ -10192,8 +10193,8 @@ TEST_CASE_VERSIONS("fee bump inner account merged then used as inner account "
         REQUIRE(innerRes.result.code() == txNO_ACCOUNT);
 
         // Verify that innerAccount no longer exists after the merge
-        LedgerSnapshot ls(test.getApp());
-        REQUIRE(!ls.getAccount(innerAccount.getPublicKey()));
+        CheckValidLedgerViewWrapper ledgerView(test.getApp());
+        REQUIRE(!ledgerView.getAccount(innerAccount.getPublicKey()));
 
         auto expectedDestinationBalance = startingBalance + startingBalance;
         REQUIRE(destination.getBalance() == expectedDestinationBalance);

--- a/src/transactions/test/ParallelApplyTest.cpp
+++ b/src/transactions/test/ParallelApplyTest.cpp
@@ -10,7 +10,7 @@
 
 #include <limits>
 
-#include "ledger/LedgerStateSnapshot.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "main/Application.h"
 #include "test/TestUtils.h"
 #include "test/TxTests.h"
@@ -1052,17 +1052,17 @@ applyTestTransactions(TestConfig const& testConfig, uint32_t protocolVersion,
     auto allTxs = classicTxs;
     allTxs.insert(allTxs.end(), sorobanTxs.begin(), sorobanTxs.end());
     {
-        LedgerSnapshot ls(test.getApp());
+        CheckValidLedgerViewWrapper ledgerView(test.getApp());
         auto diag = DiagnosticEventManager::createDisabled();
         for (auto const& tx : allTxs)
         {
-            bool isValid = tx->checkValid(test.getApp().getAppConnector(), ls,
-                                          0, 0, 0, diag)
+            bool isValid = tx->checkValid(test.getApp().getAppConnector(),
+                                          ledgerView, 0, 0, 0, diag)
                                ->isSuccess();
             if (!isValid)
             {
-                tx->checkValid(test.getApp().getAppConnector(), ls, 0, 0, 0,
-                               diag);
+                tx->checkValid(test.getApp().getAppConnector(), ledgerView, 0,
+                               0, 0, diag);
             }
             REQUIRE(isValid);
         }
@@ -1120,14 +1120,14 @@ applyTestTransactions(TestConfig const& testConfig, uint32_t protocolVersion,
     std::vector<std::pair<LedgerKey, std::pair<std::optional<LedgerEntry>,
                                                std::optional<LedgerEntry>>>>
         finalEntries;
-    LedgerSnapshot ls(test.getApp());
+    CheckValidLedgerViewWrapper ledgerView(test.getApp());
     auto archiveSnap =
-        test.getApp().getLedgerManager().copyLedgerStateSnapshot();
+        test.getApp().getLedgerManager().copyImmutableLedgerView();
     for (auto const& k : allKeys)
     {
         std::optional<LedgerEntry> liveEntry;
         std::optional<LedgerEntry> archivedEntry;
-        if (auto e = ls.load(k))
+        if (auto e = ledgerView.load(k))
         {
             liveEntry = e.current();
             // All the entries that were in the live state and were
@@ -1154,7 +1154,7 @@ applyTestTransactions(TestConfig const& testConfig, uint32_t protocolVersion,
         {
             LedgerKey ttlKey = getTTLKey(k);
             std::optional<LedgerEntry> liveTtlEntry;
-            if (auto e = ls.load(ttlKey))
+            if (auto e = ledgerView.load(ttlKey))
             {
                 liveTtlEntry = e.current();
             }

--- a/src/transactions/test/PaymentTests.cpp
+++ b/src/transactions/test/PaymentTests.cpp
@@ -1510,11 +1510,11 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
 
             // Since a1 has a trustline, and there is only 1 trustline, we know
             // that gateway has no trustlines.
-            LedgerSnapshot lsg(*app);
+            CheckValidLedgerViewWrapper ledgerView(*app);
             LedgerKey trustKey(TRUSTLINE);
             trustKey.trustLine().accountID = gateway.getPublicKey();
             trustKey.trustLine().asset = assetToTrustLineAsset(idr);
-            REQUIRE(!lsg.load(trustKey));
+            REQUIRE(!ledgerView.load(trustKey));
         });
     }
     SECTION("authorize flag")

--- a/src/transactions/test/SorobanTxTestUtils.cpp
+++ b/src/transactions/test/SorobanTxTestUtils.cpp
@@ -3,7 +3,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "SorobanTxTestUtils.h"
-#include "ledger/LedgerStateSnapshot.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "ledger/LedgerTypeUtils.h"
 #include "rust/RustBridge.h"
 #include "test/Catch2.h"
@@ -1369,10 +1369,10 @@ SorobanTest::createRestoreTx(SorobanResources const& resources,
 bool
 SorobanTest::isTxValid(TransactionFrameBaseConstPtr tx)
 {
-    LedgerSnapshot ls(getApp());
+    CheckValidLedgerViewWrapper ledgerView(getApp());
     auto diagnostics = DiagnosticEventManager::createDisabled();
-    auto ret =
-        tx->checkValid(getApp().getAppConnector(), ls, 0, 0, 0, diagnostics);
+    auto ret = tx->checkValid(getApp().getAppConnector(), ledgerView, 0, 0, 0,
+                              diagnostics);
     return ret->isSuccess();
 }
 
@@ -1381,10 +1381,10 @@ SorobanTest::invokeTx(TransactionFrameBaseConstPtr tx)
 {
     {
         auto diagnostics = DiagnosticEventManager::createDisabled();
-        LedgerSnapshot ls(getApp());
-        REQUIRE(
-            tx->checkValid(getApp().getAppConnector(), ls, 0, 0, 0, diagnostics)
-                ->isSuccess());
+        CheckValidLedgerViewWrapper ledgerView(getApp());
+        REQUIRE(tx->checkValid(getApp().getAppConnector(), ledgerView, 0, 0, 0,
+                               diagnostics)
+                    ->isSuccess());
     }
 
     auto resultSet = closeLedger(*mApp, {tx});
@@ -1435,17 +1435,17 @@ ExpirationStatus
 SorobanTest::getEntryExpirationStatus(LedgerKey const& key)
 {
     auto ttlKey = getTTLKey(key);
-    LedgerSnapshot ls(getApp());
-    if (auto lse = ls.load(ttlKey))
+    CheckValidLedgerViewWrapper ledgerView(getApp());
+    if (auto le = ledgerView.load(ttlKey))
     {
-        if (lse.current().data.ttl().liveUntilLedgerSeq <= getLCLSeq())
+        if (le.current().data.ttl().liveUntilLedgerSeq <= getLCLSeq())
         {
             return ExpirationStatus::EXPIRED_IN_LIVE_STATE;
         }
         return ExpirationStatus::LIVE;
     }
-    auto snap = getApp().getLedgerManager().copyLedgerStateSnapshot();
-    if (snap.loadArchiveEntry(key) != nullptr)
+    auto archiveView = getApp().getLedgerManager().copyImmutableLedgerView();
+    if (archiveView.loadArchiveEntry(key) != nullptr)
     {
         return ExpirationStatus::HOT_ARCHIVE;
     }

--- a/src/transactions/test/TransactionTestFrame.cpp
+++ b/src/transactions/test/TransactionTestFrame.cpp
@@ -86,49 +86,52 @@ TransactionTestFrame::checkValid(AppConnector& app, AbstractLedgerTxn& ltxOuter,
                                  uint64_t upperBoundCloseTimeOffset) const
 {
     LedgerTxn ltx(ltxOuter);
-    auto ls = LedgerSnapshot(ltx);
+    auto ledgerView = CheckValidLedgerViewWrapper(ltx);
     auto diagnostics = DiagnosticEventManager::createDisabled();
     mTransactionTxResult = mTransactionFrame->checkValid(
-        app, ls, current, lowerBoundCloseTimeOffset, upperBoundCloseTimeOffset,
-        diagnostics);
+        app, ledgerView, current, lowerBoundCloseTimeOffset,
+        upperBoundCloseTimeOffset, diagnostics);
     return mTransactionTxResult->clone();
 }
 
 MutableTxResultPtr
 TransactionTestFrame::checkValid(
-    AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
-    uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+    AppConnector& app, CheckValidLedgerViewWrapper const& ledgerView,
+    SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
+    uint64_t upperBoundCloseTimeOffset,
     std::optional<uint32_t> validationLedgerSeq) const
 {
     auto diagnostics = DiagnosticEventManager::createDisabled();
-    return checkValid(app, ls, current, lowerBoundCloseTimeOffset,
+    return checkValid(app, ledgerView, current, lowerBoundCloseTimeOffset,
                       upperBoundCloseTimeOffset, diagnostics,
                       validationLedgerSeq);
 }
 
 MutableTxResultPtr
 TransactionTestFrame::checkValid(
-    AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
-    uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+    AppConnector& app, CheckValidLedgerViewWrapper const& ledgerView,
+    SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
+    uint64_t upperBoundCloseTimeOffset,
     DiagnosticEventManager& diagnosticEvents,
     std::optional<uint32_t> validationLedgerSeq) const
 {
     mTransactionTxResult = mTransactionFrame->checkValid(
-        app, ls, current, lowerBoundCloseTimeOffset, upperBoundCloseTimeOffset,
-        diagnosticEvents, validationLedgerSeq);
+        app, ledgerView, current, lowerBoundCloseTimeOffset,
+        upperBoundCloseTimeOffset, diagnosticEvents, validationLedgerSeq);
     return mTransactionTxResult->clone();
 }
 
 MutableTxResultPtr
 TransactionTestFrame::checkValidForOverlay(
-    AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
-    uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+    AppConnector& app, CheckValidLedgerViewWrapper const& ledgerView,
+    SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
+    uint64_t upperBoundCloseTimeOffset,
     DiagnosticEventManager& diagnosticEvents,
     std::optional<uint32_t> validationLedgerSeq) const
 {
     mTransactionTxResult = mTransactionFrame->checkValidForOverlay(
-        app, ls, current, lowerBoundCloseTimeOffset, upperBoundCloseTimeOffset,
-        diagnosticEvents, validationLedgerSeq);
+        app, ledgerView, current, lowerBoundCloseTimeOffset,
+        upperBoundCloseTimeOffset, diagnosticEvents, validationLedgerSeq);
     return mTransactionTxResult->clone();
 }
 
@@ -252,11 +255,12 @@ TransactionTestFrame::checkSignature(SignatureChecker& signatureChecker,
 
 bool
 TransactionTestFrame::checkOperationSignatures(
-    SignatureChecker& signatureChecker, LedgerSnapshot const& ls,
+    SignatureChecker& signatureChecker,
+    CheckValidLedgerViewWrapper const& ledgerView,
     MutableTransactionResultBase* txResult) const
 {
-    return mTransactionFrame->checkOperationSignatures(signatureChecker, ls,
-                                                       txResult);
+    return mTransactionFrame->checkOperationSignatures(signatureChecker,
+                                                       ledgerView, txResult);
 }
 
 bool

--- a/src/transactions/test/TransactionTestFrame.cpp
+++ b/src/transactions/test/TransactionTestFrame.cpp
@@ -95,26 +95,27 @@ TransactionTestFrame::checkValid(AppConnector& app, AbstractLedgerTxn& ltxOuter,
 }
 
 MutableTxResultPtr
-TransactionTestFrame::checkValid(AppConnector& app, LedgerSnapshot const& ls,
-                                 SequenceNumber current,
-                                 uint64_t lowerBoundCloseTimeOffset,
-                                 uint64_t upperBoundCloseTimeOffset) const
+TransactionTestFrame::checkValid(
+    AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
+    uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+    std::optional<uint32_t> validationLedgerSeq) const
 {
     auto diagnostics = DiagnosticEventManager::createDisabled();
     return checkValid(app, ls, current, lowerBoundCloseTimeOffset,
-                      upperBoundCloseTimeOffset, diagnostics);
+                      upperBoundCloseTimeOffset, diagnostics,
+                      validationLedgerSeq);
 }
 
 MutableTxResultPtr
-TransactionTestFrame::checkValid(AppConnector& app, LedgerSnapshot const& ls,
-                                 SequenceNumber current,
-                                 uint64_t lowerBoundCloseTimeOffset,
-                                 uint64_t upperBoundCloseTimeOffset,
-                                 DiagnosticEventManager& diagnosticEvents) const
+TransactionTestFrame::checkValid(
+    AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
+    uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+    DiagnosticEventManager& diagnosticEvents,
+    std::optional<uint32_t> validationLedgerSeq) const
 {
     mTransactionTxResult = mTransactionFrame->checkValid(
         app, ls, current, lowerBoundCloseTimeOffset, upperBoundCloseTimeOffset,
-        diagnosticEvents);
+        diagnosticEvents, validationLedgerSeq);
     return mTransactionTxResult->clone();
 }
 
@@ -122,11 +123,12 @@ MutableTxResultPtr
 TransactionTestFrame::checkValidForOverlay(
     AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
     uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
-    DiagnosticEventManager& diagnosticEvents) const
+    DiagnosticEventManager& diagnosticEvents,
+    std::optional<uint32_t> validationLedgerSeq) const
 {
     mTransactionTxResult = mTransactionFrame->checkValidForOverlay(
         app, ls, current, lowerBoundCloseTimeOffset, upperBoundCloseTimeOffset,
-        diagnosticEvents);
+        diagnosticEvents, validationLedgerSeq);
     return mTransactionTxResult->clone();
 }
 

--- a/src/transactions/test/TransactionTestFrame.h
+++ b/src/transactions/test/TransactionTestFrame.h
@@ -69,10 +69,12 @@ class TransactionTestFrame : public TransactionFrameBase
                                   uint64_t lowerBoundCloseTimeOffset,
                                   uint64_t upperBoundCloseTimeOffset) const;
     MutableTxResultPtr checkValid(
-        AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
-        uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+        AppConnector& app, CheckValidLedgerViewWrapper const& ledgerView,
+        SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
+        uint64_t upperBoundCloseTimeOffset,
         std::optional<uint32_t> validationLedgerSeq = std::nullopt) const;
-    MutableTxResultPtr checkValid(AppConnector& app, LedgerSnapshot const& ls,
+    MutableTxResultPtr checkValid(AppConnector& app,
+                                  CheckValidLedgerViewWrapper const& ledgerView,
                                   SequenceNumber current,
                                   uint64_t lowerBoundCloseTimeOffset,
                                   uint64_t upperBoundCloseTimeOffset,
@@ -80,8 +82,9 @@ class TransactionTestFrame : public TransactionFrameBase
                                   std::optional<uint32_t> validationLedgerSeq =
                                       std::nullopt) const override;
     MutableTxResultPtr checkValidForOverlay(
-        AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
-        uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+        AppConnector& app, CheckValidLedgerViewWrapper const& ledgerView,
+        SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
+        uint64_t upperBoundCloseTimeOffset,
         DiagnosticEventManager& diagnosticEvents,
         std::optional<uint32_t> validationLedgerSeq =
             std::nullopt) const override;
@@ -121,7 +124,8 @@ class TransactionTestFrame : public TransactionFrameBase
                         int32_t neededWeight) const override;
 
     bool checkOperationSignatures(
-        SignatureChecker& signatureChecker, LedgerSnapshot const& ls,
+        SignatureChecker& signatureChecker,
+        CheckValidLedgerViewWrapper const& ledgerView,
         MutableTransactionResultBase* txResult) const override;
 
     bool checkAllTransactionSignatures(SignatureChecker& signatureChecker,

--- a/src/transactions/test/TransactionTestFrame.h
+++ b/src/transactions/test/TransactionTestFrame.h
@@ -68,19 +68,23 @@ class TransactionTestFrame : public TransactionFrameBase
                                   SequenceNumber current,
                                   uint64_t lowerBoundCloseTimeOffset,
                                   uint64_t upperBoundCloseTimeOffset) const;
+    MutableTxResultPtr checkValid(
+        AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
+        uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+        std::optional<uint32_t> validationLedgerSeq = std::nullopt) const;
     MutableTxResultPtr checkValid(AppConnector& app, LedgerSnapshot const& ls,
                                   SequenceNumber current,
                                   uint64_t lowerBoundCloseTimeOffset,
-                                  uint64_t upperBoundCloseTimeOffset) const;
-    MutableTxResultPtr
-    checkValid(AppConnector& app, LedgerSnapshot const& ls,
-               SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
-               uint64_t upperBoundCloseTimeOffset,
-               DiagnosticEventManager& diagnosticEvents) const override;
+                                  uint64_t upperBoundCloseTimeOffset,
+                                  DiagnosticEventManager& diagnosticEvents,
+                                  std::optional<uint32_t> validationLedgerSeq =
+                                      std::nullopt) const override;
     MutableTxResultPtr checkValidForOverlay(
         AppConnector& app, LedgerSnapshot const& ls, SequenceNumber current,
         uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
-        DiagnosticEventManager& diagnosticEvents) const override;
+        DiagnosticEventManager& diagnosticEvents,
+        std::optional<uint32_t> validationLedgerSeq =
+            std::nullopt) const override;
     bool checkSorobanResources(
         SorobanNetworkConfig const& cfg, uint32_t ledgerVersion,
         DiagnosticEventManager& diagnosticEvents) const override;

--- a/src/transactions/test/TxEnvelopeTests.cpp
+++ b/src/transactions/test/TxEnvelopeTests.cpp
@@ -2519,7 +2519,7 @@ TEST_CASE_VERSIONS("overlay validation skips ed25519 signed payload signers",
         {
             // Normal checkValid should succeed — the payload signer is valid
             LedgerTxn ltx(app->getLedgerTxnRoot());
-            auto ls = LedgerSnapshot(ltx);
+            auto ls = CheckValidLedgerViewWrapper(ltx);
             auto diagnostics = DiagnosticEventManager::createDisabled();
             auto result = tx->checkValid(app->getAppConnector(), ls, 0, 0, 0,
                                          diagnostics);
@@ -2539,7 +2539,7 @@ TEST_CASE_VERSIONS("overlay validation skips ed25519 signed payload signers",
             // authorized only via payload signer should fail overlay
             // validation
             LedgerTxn ltx(app->getLedgerTxnRoot());
-            auto ls = LedgerSnapshot(ltx);
+            auto ls = CheckValidLedgerViewWrapper(ltx);
             auto diagnostics = DiagnosticEventManager::createDisabled();
             auto result = tx->checkValidForOverlay(app->getAppConnector(), ls,
                                                    0, 0, 0, diagnostics);
@@ -2556,7 +2556,7 @@ TEST_CASE_VERSIONS("overlay validation skips ed25519 signed payload signers",
             SECTION("checkValid accepts fee bump")
             {
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                auto ls = LedgerSnapshot(ltx);
+                auto ls = CheckValidLedgerViewWrapper(ltx);
                 auto diagnostics = DiagnosticEventManager::createDisabled();
                 auto result = feeBumpTx->checkValid(app->getAppConnector(), ls,
                                                     0, 0, 0, diagnostics);
@@ -2566,7 +2566,7 @@ TEST_CASE_VERSIONS("overlay validation skips ed25519 signed payload signers",
             SECTION("checkValidForOverlay rejects fee bump")
             {
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                auto ls = LedgerSnapshot(ltx);
+                auto ls = CheckValidLedgerViewWrapper(ltx);
                 auto diagnostics = DiagnosticEventManager::createDisabled();
                 auto result = feeBumpTx->checkValidForOverlay(
                     app->getAppConnector(), ls, 0, 0, 0, diagnostics);


### PR DESCRIPTION
# Description

This completes step 4 of the [ledger state refactor](https://docs.google.com/document/d/1Argz4DHgBsMnYiQXYWvmkD5EwfpMzXZUR1SNHjdqqhk/edit?usp=sharing), namely removing `BucketSnapshotState`.  This was a pretty hacky struct, where we kept a redundant, mutable `LedgerHeader` in order to verify against ledgerSeq `lcl + 1` when doing `checkValid` in the TX queue. Commits as follows:

1. Makes the redundant `BucketSnapshotState` header const and add a `validationLedgerSeq` override to `checkValid` when set, this uses the override ledgerSeq instead of the LedgerHeader.
2. Removes `BucketSnapshotState` entirely. This also cleans up some of the snapshot interface in general. Specifically, we load the network config a lot, and this can now be done  from our `LedgerStateSnapshot`  struct.
3. Rename `LedgerSnapshot` to `LedgerReadView`. This is a lot of loc but is just a rename. We had `LedgerStateSnapshot`, which actually held the snapshot data and did loads, and another class `LedgerSnapshot`, which was just a thin compatibility wrapper around `LedgerStateSnapshot` and `LedgerTxn`. I've renamed `LedgerSnapshot` to `LedgerReadView` to separate it further and get the point across that it's really just a read-only wrapper.



# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
