### PR TITLE
Cleanup publish path

### DIFF
--- a/src/history/HistoryManager.h
+++ b/src/history/HistoryManager.h
@@ -181,6 +181,8 @@ namespace stellar
 {
 class Application;
 class Bucket;
+class ImmutableLedgerData;
+using ImmutableLedgerDataPtr = std::shared_ptr<ImmutableLedgerData const>;
 class LiveBucketList;
 class Config;
 class Database;
@@ -322,15 +324,14 @@ class HistoryManager
     // a multiple of getCheckpointFrequency(). Returns true if checkpoint
     // publication of the LCL was queued, otherwise false. ledgerVers must align
     // with lcl.
-    virtual bool maybeQueueHistoryCheckpoint(uint32_t lcl,
-                                             uint32_t ledgerVers) = 0;
+    virtual bool
+    maybeQueueHistoryCheckpoint(ImmutableLedgerDataPtr ledgerState) = 0;
 
     // Checkpoint the LCL -- both the log of history from the previous
     // checkpoint to it, as well as the bucketlist of its state -- to a
     // publication-queue in the database. This should be followed shortly
-    // (typically after commit) with a call to publishQueuedHistory. ledgerVers
-    // must align with lcl.
-    virtual void queueCurrentHistory(uint32_t lcl, uint32_t ledgerVers) = 0;
+    // (typically after commit) with a call to publishQueuedHistory.
+    virtual void queueCurrentHistory(ImmutableLedgerDataPtr ledgerState) = 0;
 
     // Return the youngest ledger still in the outgoing publish queue;
     // returns 0 if the publish queue has nothing in it.

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -8,8 +8,6 @@
 #include "util/asio.h"
 
 #include "bucket/BucketManager.h"
-#include "bucket/LiveBucket.h"
-#include "bucket/LiveBucketList.h"
 #include "herder/HerderImpl.h"
 #include <cereal/archives/binary.hpp>
 #include <cereal/cereal.hpp>
@@ -24,7 +22,7 @@
 #include "historywork/PutSnapshotFilesWork.h"
 #include "historywork/ResolveSnapshotWork.h"
 #include "historywork/WriteSnapshotWork.h"
-#include "ledger/LedgerManager.h"
+#include "ledger/ImmutableLedgerView.h"
 #include "main/Application.h"
 #include "main/Config.h"
 #include "medida/meter.h"
@@ -285,9 +283,10 @@ HistoryManager::getMaxLedgerQueuedToPublish(Config const& cfg)
 }
 
 bool
-HistoryManagerImpl::maybeQueueHistoryCheckpoint(uint32_t lcl,
-                                                uint32_t ledgerVers)
+HistoryManagerImpl::maybeQueueHistoryCheckpoint(
+    ImmutableLedgerDataPtr ledgerState)
 {
+    auto lcl = ledgerState->getLastClosedLedgerHeader().header.ledgerSeq;
     if (!publishCheckpointOnLedgerClose(lcl, mApp.getConfig()))
     {
         return false;
@@ -308,36 +307,19 @@ HistoryManagerImpl::maybeQueueHistoryCheckpoint(uint32_t lcl,
         return false;
     }
 
-    queueCurrentHistory(lcl, ledgerVers);
+    queueCurrentHistory(std::move(ledgerState));
     return true;
 }
 
 void
-HistoryManagerImpl::queueCurrentHistory(uint32_t ledger, uint32_t ledgerVers)
+HistoryManagerImpl::queueCurrentHistory(ImmutableLedgerDataPtr ledgerState)
 {
     ZoneScoped;
 
-    // Only one thread can modify the bucketlist, access BL from the _same_
-    // thread
-    LiveBucketList bl = mApp.getBucketManager().getLiveBucketList();
-
-    HistoryArchiveState has;
-    if (protocolVersionStartsFrom(
-            ledgerVers,
-            LiveBucket::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
-    {
-        auto hotBl = mApp.getBucketManager().getHotArchiveBucketList();
-        has = HistoryArchiveState(ledger, bl, hotBl,
-                                  mApp.getConfig().NETWORK_PASSPHRASE);
-    }
-    else
-    {
-        has = HistoryArchiveState(ledger, bl,
-                                  mApp.getConfig().NETWORK_PASSPHRASE);
-    }
-
-    CLOG_INFO(History, "Queueing publish state for ledger {}", ledger);
-    mEnqueueTimes.emplace(ledger, std::chrono::steady_clock::now());
+    auto const& has = ledgerState->getLastClosedHistoryArchiveState();
+    CLOG_INFO(History, "Queueing publish state for ledger {}",
+              has.currentLedger);
+    mEnqueueTimes.emplace(has.currentLedger, std::chrono::steady_clock::now());
 
     // We queue history inside ledger commit, so do not finalize the file yet
     writeCheckpointFile(mApp, has, /* finalize */ false);

--- a/src/history/HistoryManagerImpl.h
+++ b/src/history/HistoryManagerImpl.h
@@ -45,10 +45,10 @@ class HistoryManagerImpl : public HistoryManager
 
     void logAndUpdatePublishStatus() override;
 
-    bool maybeQueueHistoryCheckpoint(uint32_t lcl,
-                                     uint32_t ledgerVers) override;
+    bool
+    maybeQueueHistoryCheckpoint(ImmutableLedgerDataPtr ledgerState) override;
 
-    void queueCurrentHistory(uint32_t lcl, uint32_t ledgerVers) override;
+    void queueCurrentHistory(ImmutableLedgerDataPtr ledgerState) override;
 
     void takeSnapshotAndPublish(HistoryArchiveState const& has);
 

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1707,7 +1707,6 @@ LedgerManagerImpl::applyLedger(LedgerCloseData const& ledgerData,
         }
     }
 
-    auto maybeNewVersion = ltx.loadHeader().current().ledgerVersion;
     auto ledgerSeq = ltx.loadHeader().current().ledgerSeq;
 
     auto lclApplyView = mApplyState.copyApplyLedgerView();
@@ -1815,7 +1814,7 @@ LedgerManagerImpl::applyLedger(LedgerCloseData const& ledgerData,
     // consistent with the ledger header, we must base checkpoints off the new
     // ledgerVers here and not the initial ledgerVers.
     auto& hm = mApp.getHistoryManager();
-    hm.maybeQueueHistoryCheckpoint(ledgerSeq, maybeNewVersion);
+    hm.maybeQueueHistoryCheckpoint(appliedLedgerState);
     JITTER_INJECT_DELAY();
 
     // step 2


### PR DESCRIPTION
# Description

Minor cleanup to the publish path, using the new `LedgerStateSnapshot` struct.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
