### PR TITLE
Support out-of-tree checks for `make check`

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -462,6 +462,7 @@ else # !USE_POSTGRES
 TESTS=test/selftest-nopg
 endif # !USE_POSTGRES
 TESTS += test/check-nondet
+TESTS += test/check-nocstyle
 
 format: always
 if USE_CLANG_FORMAT

--- a/src/test/check-nocstyle
+++ b/src/test/check-nocstyle
@@ -7,6 +7,27 @@
 # This file just does some simple static checks that calls to C-style
 # functions maintained in C++ are not present in the codebase.
 
+# $srcdir is set by automake's test driver (pointing at src/ in the source
+# tree); fall back to . for direct invocation from src/ in the repo.
+if ! cd "${srcdir:-.}"
+then
+    echo "could not cd to ${srcdir:-.}, cannot check for cstyle functions"
+    exit 1
+fi
+
+# Check that we're in a git repo, and move to the top of the repo
+if ! git rev-parse --is-inside-work-tree > /dev/null 2>&1
+then
+    echo "not in a git repository, cannot check for cstyle functions"
+    exit 1
+fi
+topdir="$(git rev-parse --show-toplevel)"
+if ! cd "$topdir"
+then
+    echo "could not cd to the top of the git repository, cannot check for cstyle functions"
+    exit 1
+fi
+
 if git grep -w -P '(is|to)(alnum|alpha|lower|upper|digit|xdigit|cntrl|graph|space|blank|print|punct)' 'src/**/*.cpp' 'src/**/*.h'
 then
     echo

--- a/src/test/check-nondet
+++ b/src/test/check-nondet
@@ -8,6 +8,27 @@
 # nondeterminism (between runs, or between compilers / standard libraries) are
 # not present in the code.
 
+# $srcdir is set by automake's test driver (pointing at src/ in the source
+# tree); fall back to . for direct invocation from src/ in the repo.
+if ! cd "${srcdir:-.}"
+then
+    echo "could not cd to ${srcdir:-.}, cannot check for nondeterminism"
+    exit 1
+fi
+
+# Check that we're in a git repo, and move to the src/ subdirectory
+if ! git rev-parse --is-inside-work-tree > /dev/null 2>&1
+then
+    echo "not in a git repository, cannot check for nondeterminism"
+    exit 1
+fi
+topdir="$(git rev-parse --show-toplevel)"
+if ! cd "$topdir/src"
+then
+    echo "could not cd to src/ in the git repository, cannot check for nondeterminism"
+    exit 1
+fi
+
 if git grep 'std::rand()' '*.h' '*.cpp'
 then
     echo


### PR DESCRIPTION
Resolves #5220. To support out-of-tree checks, we just use the Automake `srcdir` environment variable to get into the correct directory and use some basic `git` commands to move within the repo. Also, add `check-nocstyle` to CI checks.