### PR TITLE
Add CodeQL config file to only run the scan for production code

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,36 @@
+name: "Stellar Core CodeQL Config"
+
+# Restrict CodeQL analysis to production code only.
+# See: https://docs.github.com/en/code-security/reference/code-scanning/workflow-configuration-options#specifying-directories-to-scan
+#
+# `paths` lists the directories that should be scanned. For compiled languages
+# (C/C++) `paths` is advisory: CodeQL still analyzes everything that gets built,
+# but `paths-ignore` is honored to filter results.
+
+paths:
+  - .github/workflows
+  - src
+
+paths-ignore:
+  # Test directories and test data anywhere under src
+  - src/**/test
+  - src/**/testdata
+  # Simulation is a non-production test/benchmarking subsystem
+  - src/simulation
+  # Generated XDR bindings
+  - src/xdr
+  # No skipping vendored / third-party libraries for now
+  # - lib
+  # Rust vendored soroban sources (tests + fuzz harnesses)
+  - src/rust/soroban/**/fuzz
+  # Build, tooling and docs
+  - docker
+  - docs
+  - scripts
+  - performance-eval
+  - Builds
+  - m4
+  - target
+  - test-lcm
+  - test-tx-meta-baseline-current
+  - test-tx-meta-baseline-next

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,73 @@
+name: CodeQL
+
+on:
+  schedule:
+    # Run weekly on Monday at 06:00 UTC
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: c-cpp
+            build-mode: autobuild
+          - language: rust
+            build-mode: none
+          - language: python
+            build-mode: none
+          - language: actions
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Install build dependencies
+        if: matrix.language == 'c-cpp'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            git build-essential pkg-config autoconf automake libtool \
+            bison flex libpq-dev libunwind-dev parallel sed perl \
+            postgresql ccache clang-format-12 libc++-dev libc++abi-dev
+
+      - name: Install Rust toolchain
+        if: matrix.language == 'c-cpp' || matrix.language == 'rust'
+        run: ./install-rust.sh
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Configure
+        if: matrix.language == 'c-cpp'
+        run: |
+          ./autogen.sh
+          ./configure --enable-ccache --enable-sdfprefs
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
### what
Add CodeQL config file to only run the scan for production code.

### why
So we can ignore non-production files in the scan and focus on the important ones.