### PR TITLE
Fix race in persist publish queue

### DIFF
--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -2027,16 +2027,29 @@ TEST_CASE("persist publish queue", "[history][publish][acceptance]")
             clock.crank(false);
         app1->start();
         auto& hm1 = app1->getHistoryManager();
-        while (hm1.getPublishSuccessCount() < 5)
-        {
-            clock.crank(true);
-        }
+        // Ledgers to add to genesis. Trimming runs lazily (at most one
+        // checkpoint per externalize), so we wait for it to catch up.
+        uint32_t const publishedCount = 30;
+        auto minScpLedger = [&]() {
+            uint32_t m = 0;
+            soci::indicator ind = soci::i_null;
+            app1->getDatabase().getRawMiscSession()
+                << "SELECT MIN(ledgerseq) FROM scphistory",
+                soci::into(m, ind);
+            return ind == soci::i_ok ? m : 0;
+        };
+        testutil::crankUntil(
+            app1,
+            [&]() {
+                return hm1.getPublishSuccessCount() >= 5 &&
+                       minScpLedger() > publishedCount;
+            },
+            std::chrono::seconds{60});
+        REQUIRE(hm1.getPublishSuccessCount() >= 5);
+        REQUIRE(minScpLedger() > publishedCount);
 
-        // Verify old history got trimmed
+        // Verify old SCP history got trimmed
         XDROutputFileStream out(app1->getClock().getIOContext(), true);
-        // Ledgers to add to genesis, maintenance keeps at least one checkpoint
-        // of data, so last ledger trimmed is (5 * 8 - 1) - 8 = 31
-        uint32_t publishedCount = 30;
         auto scp = app1->getHerderPersistence().copySCPHistoryToStream(
             app1->getDatabase().getRawMiscSession(),
             LedgerManager::GENESIS_LEDGER_SEQ, publishedCount, out);


### PR DESCRIPTION
# Description

Fixes a race in "persist publish queue" tests.

Here is a diff to repro the original failure:
```
  diff --git a/src/ledger/LedgerManagerImpl.cpp b/src/ledger/LedgerManagerImpl.cpp
  index b4dd5ee19..5f1fc9a18 100644
  --- a/src/ledger/LedgerManagerImpl.cpp
  +++ b/src/ledger/LedgerManagerImpl.cpp
  @@ -2934,6 +2934,7 @@ LedgerManagerImpl::storePersistentStateAndLedgerHeaderInDB(

       if (appendToCheckpoint)
       {
  +        std::this_thread::sleep_for(std::chrono::milliseconds(2000));
           mApp.getHistoryManager().appendLedgerHeader(header);
       }
```

I think this issue is from https://github.com/stellar/stellar-core/pull/5229. We used to purge SCP state in `newSlotExternalized`, but now it get's called post apply. `while (hm1.getPublishSuccessCount() < 5)` was a bad check, since we could increment the published count before hitting the SCP message cleanup. I think the race existed for a while, but the most recent PR delayed cleanup, so it made it more likely to occur. The race seems like it's just in the test itself.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
