### PR TITLE
Tracy import chrome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ compile_commands.json
 # tracy binaries
 /tracy-capture
 /tracy-gui
+/tracy-import-chrome
 
 # test output
 stellar-core-test-*

--- a/Makefile.am
+++ b/Makefile.am
@@ -65,6 +65,21 @@ tracy-csvexport: $(TRACY_CSVEXPORT_BUILD)/csvexport-release
 bin_PROGRAMS += tracy-csvexport
 endif # USE_TRACY_CSVEXPORT
 
+if USE_TRACY_IMPORT_CHROME
+TRACY_IMPORT_CHROME_DIR=$(top_srcdir)/lib/tracy/import-chrome
+TRACY_IMPORT_CHROME_SOURCE=$(TRACY_IMPORT_CHROME_DIR)/src
+TRACY_IMPORT_CHROME_BUILD=$(TRACY_IMPORT_CHROME_DIR)/build/unix
+
+$(TRACY_IMPORT_CHROME_BUILD)/import-chrome-release: $(wildcard $(TRACY_IMPORT_CHROME_SOURCE)/*.*)
+	$(MAKE) -C $(TRACY_IMPORT_CHROME_BUILD) release CC="$(CC)" CXX="$(CXX)" CXXFLAGS="$(CXXFLAGS) -DNO_PARALLEL_SORT=1" CFLAGS="$(CFLAGS)" TRACY_NO_ISA_EXTENSIONS=1 TRACY_NO_LTO=1 LEGACY=1
+
+tracy-import-chrome: $(TRACY_IMPORT_CHROME_BUILD)/import-chrome-release
+	cp -v $< $@
+
+bin_PROGRAMS += tracy-import-chrome
+endif # USE_TRACY_IMPORT_CHROME
+
+
 EXTRA_DIST = stellar-core.supp test/testnet/multitail.conf	\
 	test/testnet/run-test.sh README.md make-mks
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -68,6 +68,21 @@ tracy-csvexport: $(TRACY_CSVEXPORT_BUILD)/csvexport-release
 bin_PROGRAMS += tracy-csvexport
 endif # USE_TRACY_CSVEXPORT
 
+if USE_TRACY_IMPORT_CHROME
+TRACY_IMPORT_CHROME_DIR=$(top_srcdir)/lib/tracy/import-chrome
+TRACY_IMPORT_CHROME_SOURCE=$(TRACY_IMPORT_CHROME_DIR)/src
+TRACY_IMPORT_CHROME_BUILD=$(TRACY_IMPORT_CHROME_DIR)/build/unix
+
+$(TRACY_IMPORT_CHROME_BUILD)/import-chrome-release: $(wildcard $(TRACY_IMPORT_CHROME_SOURCE)/*.*)
+	$(MAKE) -C $(TRACY_IMPORT_CHROME_BUILD) release CC="$(CC)" CXX="$(CXX)" CXXFLAGS="$(CXXFLAGS) -DNO_PARALLEL_SORT=1" CFLAGS="$(CFLAGS)" TRACY_NO_ISA_EXTENSIONS=1 TRACY_NO_LTO=1 LEGACY=1
+
+tracy-import-chrome: $(TRACY_IMPORT_CHROME_BUILD)/import-chrome-release
+	cp -v $< $@
+
+bin_PROGRAMS += tracy-import-chrome
+endif # USE_TRACY_IMPORT_CHROME
+
+
 EXTRA_DIST = stellar-core.supp test/testnet/multitail.conf	\
 	test/testnet/run-test.sh README.md make-mks
 

--- a/configure.ac
+++ b/configure.ac
@@ -538,6 +538,11 @@ AC_ARG_ENABLE(tracy-csvexport,
         [Enable 'tracy' profiler/tracer csvexport program]))
 AM_CONDITIONAL(USE_TRACY_CSVEXPORT, [test x$enable_tracy_csvexport = xyes])
 
+AC_ARG_ENABLE(tracy-import-chrome,
+    AS_HELP_STRING([--enable-tracy-import-chrome],
+        [Enable 'tracy' profiler/tracer chrome-trace-format importer]))
+AM_CONDITIONAL(USE_TRACY_IMPORT_CHROME, [test x$enable_tracy_import_chrome = xyes])
+
 AC_ARG_ENABLE(spdlog,
     AS_HELP_STRING([--disable-spdlog],
         [Disable spdlog]))

--- a/configure.ac
+++ b/configure.ac
@@ -571,6 +571,11 @@ AC_ARG_ENABLE(tracy-csvexport,
         [Enable 'tracy' profiler/tracer csvexport program]))
 AM_CONDITIONAL(USE_TRACY_CSVEXPORT, [test x$enable_tracy_csvexport = xyes])
 
+AC_ARG_ENABLE(tracy-import-chrome,
+    AS_HELP_STRING([--enable-tracy-import-chrome],
+        [Enable 'tracy' profiler/tracer chrome-trace-format importer]))
+AM_CONDITIONAL(USE_TRACY_IMPORT_CHROME, [test x$enable_tracy_import_chrome = xyes])
+
 AC_ARG_ENABLE(spdlog,
     AS_HELP_STRING([--disable-spdlog],
         [Disable spdlog]))


### PR DESCRIPTION
This just adds another one of the tracy tools to the build -- this one can import chrome trace format traces to tracy format. This is a fairly common tracing format lots of other tools (eg. uftrace) output.