### PR TITLE
Revert "Run soroban on large stacks"

### DIFF
--- a/src/rust/src/soroban_invoke.rs
+++ b/src/rust/src/soroban_invoke.rs
@@ -20,56 +20,22 @@ pub(crate) fn invoke_host_function(
     rent_fee_configuration: CxxRentFeeConfiguration,
     module_cache: &SorobanModuleCache,
 ) -> Result<InvokeHostFunctionOutput, Box<dyn std::error::Error>> {
-    use std::error::Error as StdError;
-    type BoxStdErr = Box<dyn StdError>;
-    type BoxStdErrSend = Box<dyn StdError + Send>;
-    type BoxStdErrSendSync = Box<dyn StdError + Send + Sync>;
-
-    fn sendable_str_err(str: &str) -> BoxStdErrSend {
-        let tmp: BoxStdErrSendSync = Box::from(str);
-        tmp as BoxStdErrSend
-    }
-
     let hm = get_host_module_for_protocol(config_max_protocol, ledger_info.protocol_version)?;
-    // Rust stacks are 2MiB by default, which is a little too small
-    // for comfort; to give ourselves a little more breathing room
-    // against unforeseen bugs we use a 100MiB stack. Unfortunately
-    // there's no easy way to enforce this at the C++ side when the
-    // initial std::async parallel-exec thread is spawned, so we
-    // have to spawn _another_ here. On linux this is fairly fast,
-    // on the order of a ten-ish microseconds.
-    let LARGE_STACK_SIZE: usize = 100 * 1024 * 1024; // 100 MiB
-    let res = std::thread::scope(|scope| {
-        std::thread::Builder::new()
-            .stack_size(LARGE_STACK_SIZE)
-            .spawn_scoped(scope, || {
-                (hm.invoke_host_function)(
-                    enable_diagnostics,
-                    instruction_limit,
-                    hf_buf,
-                    &resources_buf,
-                    restored_rw_entry_indices,
-                    source_account_buf,
-                    auth_entries,
-                    &ledger_info,
-                    ledger_entries,
-                    ttl_entries,
-                    base_prng_seed,
-                    &rent_fee_configuration,
-                    module_cache,
-                )
-                // Map non-sendable error to sendable for crossing thread boundary.
-                // This is crude but the error is going to be stringified on the
-                // bridge-crossing anyways.
-                .map_err(|e| sendable_str_err(&format!("{e}")))
-            })
-            .map_err(|_| sendable_str_err("spawn_scoped failed"))?
-            .join()
-            .map_err(|_| sendable_str_err("join failed"))?
-    });
-
-    // Map sendable error back to non-sendable -- Rust doesn't do dyn upcasts.
-    let res = res.map_err(|e: BoxStdErrSend| e as BoxStdErr);
+    let res = (hm.invoke_host_function)(
+        enable_diagnostics,
+        instruction_limit,
+        hf_buf,
+        &resources_buf,
+        restored_rw_entry_indices,
+        source_account_buf,
+        auth_entries,
+        &ledger_info,
+        ledger_entries,
+        ttl_entries,
+        base_prng_seed,
+        &rent_fee_configuration,
+        module_cache,
+    );
 
     #[cfg(feature = "testutils")]
     crate::soroban_test_extra_protocol::maybe_invoke_host_function_again_and_compare_outputs(


### PR DESCRIPTION
# Description

Revert "Run soroban on large stacks".

This reverts commit c37030dbdef696278c5a287fdcaaa89444a35efa.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
