### PR TITLE
Simulate apply configs now support parallel apply

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -331,8 +331,6 @@ HerderImpl::processExternalized(uint64 slotIndex, StellarValue const& value,
     TxSetXDRFrameConstPtr externalizedSet =
         mPendingEnvelopes.getTxSet(value.txSetHash);
 
-    // save the SCP messages in the database
-    if (mApp.getConfig().MODE_STORES_HISTORY_MISC)
     {
         ZoneNamedN(updateSCPHistoryZone, "update SCP history", true);
         if (slotIndex != 0)

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1310,9 +1310,11 @@ LedgerManagerImpl::emitNextMeta()
 
 namespace
 {
+#ifdef BUILD_TESTS
 void
 maybeSimulateSleep(Config const& cfg, size_t opSize,
-                   LogSlowExecution& closeTime)
+                   LogSlowExecution& closeTime,
+                   stellar_default_random_engine& rng)
 {
     if (!cfg.OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING.empty())
     {
@@ -1324,8 +1326,7 @@ maybeSimulateSleep(Config const& cfg, size_t opSize,
         for (size_t i = 0; i < opSize; i++)
         {
             sleepFor +=
-                cfg.OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING[distribution(
-                    getGlobalRandomEngine())];
+                cfg.OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING[distribution(rng)];
         }
         std::chrono::microseconds applicationTime =
             closeTime.checkElapsedTime();
@@ -1338,6 +1339,7 @@ maybeSimulateSleep(Config const& cfg, size_t opSize,
         }
     }
 }
+#endif
 
 asio::io_context&
 getMetaIOContext(Application& app)
@@ -1660,12 +1662,9 @@ LedgerManagerImpl::applyLedger(LedgerCloseData const& ledgerData,
                                         ledgerCloseMeta);
     }
 
-    if (mApp.getConfig().MODE_STORES_HISTORY_MISC)
-    {
-        auto ledgerSeq = ltx.loadHeader().current().ledgerSeq;
-        mApp.getHistoryManager().appendTransactionSet(ledgerSeq, txSet,
-                                                      txResultSet);
-    }
+    auto ledgerSeq = ltx.loadHeader().current().ledgerSeq;
+    mApp.getHistoryManager().appendTransactionSet(ledgerSeq, txSet,
+                                                  txResultSet);
 
     ltx.loadHeader().current().txSetResultHash = xdrSha256(txResultSet);
 
@@ -1727,7 +1726,7 @@ LedgerManagerImpl::applyLedger(LedgerCloseData const& ledgerData,
         }
     }
 
-    auto ledgerSeq = ltx.loadHeader().current().ledgerSeq;
+    ledgerSeq = ltx.loadHeader().current().ledgerSeq;
 
     auto lclApplyView = mApplyState.copyApplyLedgerView();
     auto appliedLedgerState = sealLedgerTxnAndStoreInBucketsAndDB(
@@ -1895,8 +1894,10 @@ LedgerManagerImpl::applyLedger(LedgerCloseData const& ledgerData,
         mApp.postOnMainThread(std::move(cb), "advanceLedgerStateAndPublish");
     }
 
+#ifdef BUILD_TESTS
     maybeSimulateSleep(mApp.getConfig(), txSet->sizeOpTotalForLogging(),
-                       applyLedgerTime);
+                       applyLedgerTime, mApplySleepRng);
+#endif
     std::chrono::duration<double> ledgerTimeSeconds = ledgerTime.Stop();
     CLOG_DEBUG(Perf, "Applied ledger {} in {} seconds", ledgerSeq,
                ledgerTimeSeconds.count());

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -17,6 +17,7 @@
 #include "transactions/ParallelApplyStage.h"
 #include "transactions/ParallelApplyUtils.h"
 #include "transactions/TransactionFrame.h"
+#include "util/Math.h"
 #include "util/XDRStream.h"
 #include "xdr/Stellar-ledger.h"
 #include <atomic>
@@ -428,6 +429,8 @@ class LedgerManagerImpl : public LedgerManager
 #ifdef BUILD_TESTS
     std::vector<TransactionMetaFrame> mLastLedgerTxMeta;
     std::optional<LedgerCloseMetaFrame> mLastLedgerCloseMeta;
+    // Local prng for OP_APPLY_SLEEP_TIME_*_FOR_TESTING.
+    stellar_default_random_engine mApplySleepRng;
 #endif
 
     void setState(State s);

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -740,16 +740,6 @@ ApplicationImpl::validateAndLogConfig()
         }
     }
 
-    if (getHistoryArchiveManager().publishEnabled())
-    {
-        if (!mConfig.MODE_STORES_HISTORY_MISC)
-        {
-            throw std::invalid_argument(
-                "Core is not configured to store history, but "
-                "some history archives are writable");
-        }
-    }
-
     if (mConfig.QUORUM_SET.threshold == 0)
     {
         throw std::invalid_argument("Quorum not configured");

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -1578,13 +1578,6 @@ run(CommandLineArgs const& args)
                 // First, craft and validate the configuration
                 cfg = configOption.getConfig();
                 cfg.DISABLE_BUCKET_GC = disableBucketGC;
-
-                if (!cfg.OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING.empty() ||
-                    !cfg.OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING.empty())
-                {
-                    cfg.MODE_STORES_HISTORY_MISC = false;
-                }
-
                 maybeSetMetadataOutputStream(cfg, stream);
                 cfg.FORCE_SCP =
                     cfg.NODE_IS_VALIDATOR ? !waitForConsensus : false;

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -125,12 +125,8 @@ Config::Config() : NODE_SEED(SecretKey::random())
     // fill in defaults
 
     // non configurable
-    MODE_STORES_HISTORY_MISC = true;
     MODE_DOES_CATCHUP = true;
     MODE_AUTO_STARTS_OVERLAY = true;
-    OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING =
-        std::vector<std::chrono::microseconds>();
-    OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING = std::vector<uint32>();
     LOADGEN_BYTE_COUNT_FOR_TESTING = {};
     LOADGEN_BYTE_COUNT_DISTRIBUTION_FOR_TESTING = {};
     LOADGEN_WASM_BYTES_FOR_TESTING = {};
@@ -150,6 +146,9 @@ Config::Config() : NODE_SEED(SecretKey::random())
         std::chrono::microseconds::zero();
 
 #ifdef BUILD_TESTS
+    OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING =
+        std::vector<std::chrono::microseconds>();
+    OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING = std::vector<uint32>();
     TESTING_MAX_SOROBAN_BYTE_ALLOWANCE = 0;
     TESTING_MAX_CLASSIC_BYTE_ALLOWANCE = 0;
     IGNORE_MESSAGE_LIMITS_FOR_TESTING = false;
@@ -342,8 +341,6 @@ Config::Config() : NODE_SEED(SecretKey::random())
 
     FILTERED_G_ADDRESSES = {};
 
-    OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING = {};
-    OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING = {};
     LOADGEN_BYTE_COUNT_FOR_TESTING = {};
     LOADGEN_BYTE_COUNT_DISTRIBUTION_FOR_TESTING = {};
     COMMANDS = {};
@@ -353,6 +350,8 @@ Config::Config() : NODE_SEED(SecretKey::random())
     STATE_SNAPSHOT_INVARIANT_LEDGER_FREQUENCY = 300; // 5 minutes
 
 #ifdef BUILD_TESTS
+    OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING = {};
+    OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING = {};
     TEST_CASES_ENABLED = false;
     CATCHUP_SKIP_KNOWN_RESULTS_FOR_TESTING = false;
     MODE_USES_IN_MEMORY_LEDGER = false;
@@ -1022,6 +1021,7 @@ Config::verifyLoadGenDistribution(std::vector<T> const& values,
     }
 }
 
+#ifdef BUILD_TESTS
 void
 Config::processOpApplySleepTimeForTestingConfigs()
 {
@@ -1058,6 +1058,7 @@ Config::processOpApplySleepTimeForTestingConfigs()
                  100 * OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING[i] / sum);
     }
 }
+#endif
 
 void
 Config::processConfig(std::shared_ptr<cpptoml::table> t)
@@ -1598,25 +1599,6 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                          "`banaccounts` HTTP endpoint instead to ban accounts "
                          "from submitting transactions to this node.");
                  }},
-                {"OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING",
-                 [&]() {
-                     // Since it doesn't make sense to sleep for a negative
-                     // amount of time, we use an unsigned integer type.
-                     auto input = readIntArray<uint32>(item);
-                     OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING.reserve(
-                         input.size());
-                     // Convert uint32 to std::chrono::microseconds
-                     std::transform(
-                         input.begin(), input.end(),
-                         std::back_inserter(
-                             OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING),
-                         [](uint32 x) { return std::chrono::microseconds(x); });
-                 }},
-                {"OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING",
-                 [&]() {
-                     OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING =
-                         readIntArray<uint32>(item);
-                 }},
                 {"LOADGEN_BYTE_COUNT_FOR_TESTING",
                  [&]() {
                      LOADGEN_BYTE_COUNT_FOR_TESTING =
@@ -1678,6 +1660,25 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                          readIntArray<uint32_t>(item);
                  }},
 #ifdef BUILD_TESTS
+                {"OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING",
+                 [&]() {
+                     // Since it doesn't make sense to sleep for a negative
+                     // amount of time, we use an unsigned integer type.
+                     auto input = readIntArray<uint32>(item);
+                     OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING.reserve(
+                         input.size());
+                     // Convert uint32 to std::chrono::microseconds
+                     std::transform(
+                         input.begin(), input.end(),
+                         std::back_inserter(
+                             OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING),
+                         [](uint32 x) { return std::chrono::microseconds(x); });
+                 }},
+                {"OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING",
+                 [&]() {
+                     OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING =
+                         readIntArray<uint32>(item);
+                 }},
                 {"APPLY_LOAD_MODE",
                  [&]() { APPLY_LOAD_MODE = parseApplyLoadMode(item); }},
                 {"APPLY_LOAD_MODEL_TX",
@@ -1953,12 +1954,6 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             }
         }
 
-        if (!OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING.empty() ||
-            !OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING.empty())
-        {
-            processOpApplySleepTimeForTestingConfigs();
-        }
-
         if (FLOW_CONTROL_SEND_MORE_BATCH_SIZE > PEER_FLOOD_READING_CAPACITY)
         {
             std::string msg =
@@ -1976,6 +1971,12 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
         }
 
 #ifdef BUILD_TESTS
+        if (!OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING.empty() ||
+            !OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING.empty())
+        {
+            processOpApplySleepTimeForTestingConfigs();
+        }
+
         if (!IGNORE_MESSAGE_LIMITS_FOR_TESTING &&
             getSorobanByteAllowance() + getClassicByteAllowance() >
                 MAX_TX_SET_ALLOWANCE)

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -294,19 +294,6 @@ class Config : public std::enable_shared_from_this<Config>
     // Timeout before publishing externalized values to archive
     std::chrono::seconds PUBLISH_TO_ARCHIVE_DELAY;
 
-    // Config parameters that force transaction application during ledger
-    // close to sleep for a certain amount of time.
-    // The probability that it sleeps for
-    // OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING[i] microseconds is
-    // OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING[i] divided by
-    // (OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING[0] +
-    // OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING[1] + ...) for each i. These
-    // options are only for consensus and overlay simulation testing. These two
-    // must be used together.
-    std::vector<std::chrono::microseconds>
-        OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING;
-    std::vector<uint32> OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING;
-
     // Config parameters that LoadGen uses to decide the number of bytes to
     // include in each payment transaction for testing only. The probability
     // that transactions will contain COUNT[i] bytes is
@@ -344,6 +331,19 @@ class Config : public std::enable_shared_from_this<Config>
     std::vector<uint32_t> LOADGEN_INSTRUCTIONS_DISTRIBUTION_FOR_TESTING;
 
 #ifdef BUILD_TESTS
+    // Config parameters that force transaction application during ledger
+    // close to sleep for a certain amount of time.
+    // The probability that it sleeps for
+    // OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING[i] microseconds is
+    // OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING[i] divided by
+    // (OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING[0] +
+    // OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING[1] + ...) for each i. These
+    // options are only for consensus and overlay simulation testing. These two
+    // must be used together.
+    std::vector<std::chrono::microseconds>
+        OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING;
+    std::vector<uint32> OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING;
+
     // apply-load-specific configuration parameters:
     ApplyLoadMode APPLY_LOAD_MODE = ApplyLoadMode::LIMIT_BASED;
     ApplyLoadModelTx APPLY_LOAD_MODEL_TX = ApplyLoadModelTx::SAC;
@@ -541,10 +541,6 @@ class Config : public std::enable_shared_from_this<Config>
     // NODE_IS_VALIDATOR=true, this value is ignored and indexes are never
     // persisted.
     bool BUCKETLIST_DB_PERSIST_INDEX;
-
-    // A config parameter that stores historical data, such as transactions,
-    // fees, and scp history in the database
-    bool MODE_STORES_HISTORY_MISC;
 
     // A config parameter that controls whether core automatically catches up
     // when it has buffered enough input; if false an out-of-sync node will
@@ -933,6 +929,7 @@ class Config : public std::enable_shared_from_this<Config>
     // This exposes the node seed in the config, so make sure to only use in
     // test workloads (such as apply-load).
     std::string const& getLoadedConfigToml() const;
+    void processOpApplySleepTimeForTestingConfigs();
 #endif
 
     // fixes values of connection-relates settings
@@ -962,8 +959,6 @@ class Config : public std::enable_shared_from_this<Config>
     // A special name to be used for stdin in stead of a file name in command
     // line arguments.
     static std::string const STDIN_SPECIAL_NAME;
-
-    void processOpApplySleepTimeForTestingConfigs();
 
     std::chrono::seconds HISTOGRAM_WINDOW_SIZE;
 


### PR DESCRIPTION
This change is needed to properly simulate apply time in overlay-only mode with Soroban tx profiles. We haven't used these flags in a while, so they broke overtime. This change fixes them, and also performs some cleanup (such as removing obsolete MODE_STORES_HISTORY mode).