### PR TITLE
Overlay-only mode fixes to prevent occasional banned transaction drops

### DIFF
--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -326,13 +326,8 @@ TransactionQueue::canAdd(
     ZoneScoped;
     if (isBanned(tx->getFullHash()))
     {
-#ifdef BUILD_TESTS
-        if (!mApp.getRunInOverlayOnlyMode())
-#endif
-        {
-            return AddResult(
-                TransactionQueue::AddResultCode::ADD_STATUS_TRY_AGAIN_LATER);
-        }
+        return AddResult(
+            TransactionQueue::AddResultCode::ADD_STATUS_TRY_AGAIN_LATER);
     }
     if (isFiltered(tx))
     {

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -1233,6 +1233,7 @@ LoadGenerator::maybeHandleFailedTx(TransactionFrameBaseConstPtr tx,
     if (status == TransactionQueue::AddResultCode::ADD_STATUS_ERROR &&
         code == txBAD_SEQ)
     {
+        releaseAssert(!mApp.getRunInOverlayOnlyMode());
         auto txQueueSeqNum =
             tx->isSoroban()
                 ? mApp.getHerder()
@@ -1971,7 +1972,10 @@ LoadGenerator::readTransactionFromFile(GeneratedLoadConfig const& cfg)
     auto idx = mCurrPreloadedTransaction % cfg.nAccounts;
     auto acc = mTxGenerator.getAccount(idx + cfg.offset);
     releaseAssert(acc);
-    acc->setSequenceNumber(txFrame->getSeqNum());
+    if (!mApp.getRunInOverlayOnlyMode())
+    {
+        acc->setSequenceNumber(txFrame->getSeqNum());
+    }
     ++mCurrPreloadedTransaction;
 
     // Do not provide an account

--- a/src/simulation/TxGenerator.cpp
+++ b/src/simulation/TxGenerator.cpp
@@ -149,6 +149,15 @@ TxGenerator::loadAccount(TxGenerator::TestAccountPtr acc)
     return false;
 }
 
+void
+TxGenerator::maybeLoadAccountSequenceNumber(TestAccountPtr const& account)
+{
+    if (!mApp.getRunInOverlayOnlyMode())
+    {
+        account->loadSequenceNumber();
+    }
+}
+
 std::pair<TxGenerator::TestAccountPtr, TxGenerator::TestAccountPtr>
 TxGenerator::pickAccountPair(uint32_t numAccounts, uint32_t offset,
                              uint32_t ledgerNum, uint64_t sourceAccountId)
@@ -538,8 +547,9 @@ TxGenerator::invokeSorobanLoadTransaction(
 
     // A tx created using this method may be discarded when creating the txSet,
     // so we need to refresh the TestAccount sequence number to avoid a
-    // txBAD_SEQ.
-    account->loadSequenceNumber();
+    // txBAD_SEQ. In overlay-only mode apply is skipped, so DB seqnums stay
+    // frozen and the local sequence counter is authoritative.
+    maybeLoadAccountSequenceNumber(account);
 
     auto tx = sorobanTransactionFrameFromOps(mApp.getNetworkID(), *account,
                                              {op}, {}, resources,
@@ -723,9 +733,10 @@ TxGenerator::invokeSorobanLoadTransactionV2(
 
     // A tx created using this method may be discarded when creating the txSet,
     // so we need to refresh the TestAccount sequence number to avoid a
-    // txBAD_SEQ.
+    // txBAD_SEQ. In overlay-only mode apply is skipped, so DB seqnums stay
+    // frozen and the local sequence counter is authoritative.
     auto account = findAccount(accountId, ledgerNum);
-    account->loadSequenceNumber();
+    maybeLoadAccountSequenceNumber(account);
 
     auto tx = sorobanTransactionFrameFromOps(
         mApp.getNetworkID(), *account, {op}, {}, resources,
@@ -750,7 +761,7 @@ TxGenerator::invokeSACPayment(uint32_t ledgerNum, uint64_t fromAccountId,
                               std::optional<uint32_t> maxGeneratedFeeRate)
 {
     auto fromAccount = findAccount(fromAccountId, ledgerNum);
-    fromAccount->loadSequenceNumber();
+    maybeLoadAccountSequenceNumber(fromAccount);
 
     SCVal fromVal(SCV_ADDRESS);
     fromVal.address() = makeAccountAddress(fromAccount->getPublicKey());
@@ -828,7 +839,7 @@ TxGenerator::invokeTokenTransfer(uint32_t ledgerNum, uint64_t fromAccountId,
                                  std::optional<uint32_t> maxGeneratedFeeRate)
 {
     auto fromAccount = findAccount(fromAccountId, ledgerNum);
-    fromAccount->loadSequenceNumber();
+    maybeLoadAccountSequenceNumber(fromAccount);
     auto toAccount = findAccount(toAccountId, ledgerNum);
 
     SCVal fromVal(SCV_ADDRESS);
@@ -1012,7 +1023,7 @@ TxGenerator::invokeSoroswapSwap(uint32_t ledgerNum, uint64_t fromAccountId,
     uint32_t tokenOutIdx = swapAForB ? pair.tokenBIndex : pair.tokenAIndex;
 
     auto fromAccount = findAccount(fromAccountId, ledgerNum);
-    fromAccount->loadSequenceNumber();
+    maybeLoadAccountSequenceNumber(fromAccount);
 
     auto fromVal =
         makeAddressSCVal(makeAccountAddress(fromAccount->getPublicKey()));
@@ -1676,7 +1687,7 @@ TxGenerator::invokeBatchTransfer(uint32_t ledgerNum, uint64_t sourceAccountId,
                                  std::vector<SCAddress> const& destinations)
 {
     auto sourceAccount = findAccount(sourceAccountId, ledgerNum);
-    sourceAccount->loadSequenceNumber();
+    maybeLoadAccountSequenceNumber(sourceAccount);
 
     // First invoke param: SAC contract address
     SCVal sacAddressVal(SCV_ADDRESS);

--- a/src/simulation/TxGenerator.h
+++ b/src/simulation/TxGenerator.h
@@ -291,6 +291,7 @@ class TxGenerator
 
     void updateMinBalance();
     bool isLive(LedgerKey const& lk, uint32_t ledgerNum) const;
+    void maybeLoadAccountSequenceNumber(TestAccountPtr const& account);
 
     Application& mApp;
 


### PR DESCRIPTION
A fairly obscure edge case in overlay-only loadgen mode: because we don't update seqnums in the DB, it is possible to generate transactions that are duplicates of already applied transactions. Because we ban applied transactions, and pull mode rejects banned transactions, the network ends up not pulling some new transactions at all. This causes a few transactions per run to get dropped, and trips loadgen. 

The fix is to avoid ever loading seq nums from DB during overlay-only mode, and always bump sequence number for every new transaction.