### PR TITLE
fix shutdown race

### DIFF
--- a/src/overlay/IPC.cpp
+++ b/src/overlay/IPC.cpp
@@ -159,6 +159,7 @@ IPCChannel::~IPCChannel()
 {
     if (mSocket >= 0)
     {
+        shutdown();
         close(mSocket);
     }
 }
@@ -196,7 +197,7 @@ IPCChannel::fromSocket(int socket)
 bool
 IPCChannel::send(IPCMessage const& msg)
 {
-    if (!mConnected)
+    if (!mConnected.load())
     {
         return false;
     }
@@ -204,7 +205,7 @@ IPCChannel::send(IPCMessage const& msg)
     bool result = ipc::sendMessage(mSocket, msg);
     if (!result)
     {
-        mConnected = false;
+        mConnected.store(false);
     }
     return result;
 }
@@ -212,7 +213,7 @@ IPCChannel::send(IPCMessage const& msg)
 std::optional<IPCMessage>
 IPCChannel::receive()
 {
-    if (!mConnected)
+    if (!mConnected.load())
     {
         return std::nullopt;
     }
@@ -220,15 +221,24 @@ IPCChannel::receive()
     auto msg = ipc::receiveMessage(mSocket);
     if (!msg)
     {
-        mConnected = false;
+        mConnected.store(false);
     }
     return msg;
+}
+
+void
+IPCChannel::shutdown()
+{
+    if (mConnected.exchange(false))
+    {
+        ::shutdown(mSocket, SHUT_RDWR);
+    }
 }
 
 bool
 IPCChannel::isConnected() const
 {
-    return mConnected;
+    return mConnected.load();
 }
 
 // ============================================================================

--- a/src/overlay/IPC.h
+++ b/src/overlay/IPC.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -155,6 +156,9 @@ class IPCChannel
     /// Receive a message. Blocks until message available or connection closed.
     std::optional<IPCMessage> receive();
 
+    /// Shut down the socket. Unblocks any concurrent receive() call.
+    void shutdown();
+
     /// Check if connection is still open
     bool isConnected() const;
 
@@ -169,7 +173,7 @@ class IPCChannel
     explicit IPCChannel(int socket);
 
     int mSocket;
-    bool mConnected;
+    std::atomic<bool> mConnected;
 };
 
 /**

--- a/src/overlay/OverlayIPC.cpp
+++ b/src/overlay/OverlayIPC.cpp
@@ -178,14 +178,20 @@ OverlayIPC::shutdown()
         mChannel->send(msg);
     }
 
-    // Close channel (will unblock reader)
-    mChannel.reset();
+    // Shut down the socket to unblock the reader thread before destroying the
+    // channel object it is using.
+    if (mChannel)
+    {
+        mChannel->shutdown();
+    }
 
     // Wait for reader thread
     if (mReaderThread.joinable())
     {
         mReaderThread.join();
     }
+
+    mChannel.reset();
 
     // Wait for overlay process
     if (mOverlayPid > 0)


### PR DESCRIPTION
This fixes a small race on shutdown that fairly reliably causes a test-hang on my (containerized, linux-in-a-vm) test setup.