### PR TITLE
Update config docs

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -269,10 +269,11 @@ BUCKETLIST_DB_PERSIST_INDEX = true
 # thread.
 BACKGROUND_OVERLAY_PROCESSING = true
 
-# EXPERIMENTAL_PARALLEL_LEDGER_APPLY (bool) default false
+# PARALLEL_LEDGER_APPLY (bool) default true
 # This causes ledger application to be done in parallel, which can lead to better
-# performance on multicore machines. Note that this is not compatible with SQLite.
-EXPERIMENTAL_PARALLEL_LEDGER_APPLY = false
+# performance on multicore machines. Note that this is not compatible with
+# in-memory SQLite.
+PARALLEL_LEDGER_APPLY = true
 
 # BACKGROUND_TX_SIG_VERIFICATION (bool) default true
 # Check signatures in the background for transactions received

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -516,10 +516,10 @@ class Config : public std::enable_shared_from_this<Config>
     // index.
     size_t BUCKETLIST_DB_INDEX_CUTOFF;
 
-    // Enable parallel processing of overlay operations (experimental)
+    // Enable parallel processing of overlay operations
     bool BACKGROUND_OVERLAY_PROCESSING;
 
-    // Enable parallel block application (experimental)
+    // Enable parallel block application
     bool PARALLEL_LEDGER_APPLY;
 
     // Disable expensive Soroban metrics for performance testing


### PR DESCRIPTION
Minor updates to `PARALLEL_LEDGER_APPLY` to reflect current non-experimental status; also, removes the `(experimental)` note from `BACKGROUND_OVERLAY_PROCESSING`'s comment