### PR TITLE
Overlay v2 sharding

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,9 +15,9 @@
 		// Note that these options have security implications and should be used with caution.
 		// We have them disabled currently because we don't want to allow copilot LLMs to use ptrace
 		// to escape the container sandbox.
-		// "--cap-add=SYS_PTRACE",
-		// "--security-opt",
-		// "seccomp=unconfined",
+		"--cap-add=SYS_PTRACE",
+		"--security-opt",
+		"seccomp=unconfined",
 
 		// Uncomment the next line to use a non-root user. On Linux, this will prevent
 		// new files getting created as root, but you may need to update the USER_UID

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -1034,6 +1034,12 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flagset"
@@ -2381,9 +2387,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "overload"
@@ -2460,7 +2466,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.4.2",
  "indexmap",
 ]
 
@@ -2741,12 +2747,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "readme-rustdocifier"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ad765b21a08b1a8e5cdce052719188a23772bcbefb3c439f0baaf62c56ceac"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.10.0",
+]
+
+[[package]]
+name = "reed-solomon-simd"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffef0520d30fbd4151fb20e262947ae47fb0ab276a744a19b6398438105a072"
+dependencies = [
+ "cpufeatures",
+ "fixedbitset 0.5.7",
+ "once_cell",
+ "readme-rustdocifier",
 ]
 
 [[package]]
@@ -3788,6 +3812,7 @@ dependencies = [
  "libp2p-stream",
  "lru",
  "rand 0.8.5",
+ "reed-solomon-simd",
  "serde",
  "serde_json",
  "sha2",

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -172,6 +172,22 @@ overlay.recv-transaction.max              | counter   | maximum time (microsecon
 overlay.send.<X>                          | meter     | sent message <X>
 overlay.timeout.idle                      | meter     | idle peer timeout
 overlay.timeout.straggler                 | meter     | straggler peer timeout
+overlay.txset-shard.broadcast             | meter     | txsets sent through eager sharded broadcast
+overlay.txset-shard.original-sent         | meter     | original txset shards sent eagerly
+overlay.txset-shard.recovery-sent         | meter     | recovery txset shards sent eagerly
+overlay.txset-shard.original-recv-unique  | meter     | unique original txset shards received
+overlay.txset-shard.recovery-recv-unique  | meter     | unique recovery txset shards received
+overlay.txset-shard.original-recv-redundant | meter   | redundant original txset shards received
+overlay.txset-shard.recovery-recv-redundant | meter   | redundant recovery txset shards received
+overlay.txset-shard.original-forwarded    | meter     | original txset shards forwarded through shard TTL
+overlay.txset-shard.recovery-forwarded    | meter     | recovery txset shards forwarded through shard TTL
+overlay.txset-shard.reconstruct-success-original | meter | txsets reconstructed from original shards only
+overlay.txset-shard.reconstruct-success-recovery | meter | txsets reconstructed with recovery shards
+overlay.txset-shard.reconstruct-fail-original | meter | failed reconstruction attempts using original shards only
+overlay.txset-shard.reconstruct-fail-recovery | meter | failed reconstruction attempts using recovery shards
+overlay.txset-shard.reconstruct-recovery  | timer     | time spent reconstructing txsets with recovery shards
+overlay.txset-shard.fetch-preempted       | meter     | Core txset requests satisfied by prior eager shard reconstruction
+overlay.txset-shard.eager-also-served     | meter     | eagerly sharded txsets later served as full txset responses
 process.action.queue                      | counter   | number of items waiting in internal action-queue
 process.action.overloaded                 | counter   | 0-or-1 value indicating action-queue overloading
 process.file.handles                      | counter   | number of open file handles

--- a/docs/rust-overlay/ipc.md
+++ b/docs/rust-overlay/ipc.md
@@ -66,6 +66,7 @@ are rejected with `InvalidData`.
 | 11 | `RequestTxSet`        | `[hash:32]`                                  | Fetch TX set body by hash                         |
 | 12 | `CacheTxSet`          | `[hash:32][txset_xdr]`                       | Tell overlay to cache a locally-built TX set      |
 | 13 | `RequestOverlayMetrics` | (empty)                                    | Request metrics snapshot                          |
+| 14 | `BroadcastTxSetShards` | `[hash:32]`                                | Eagerly broadcast cached TX set via shard path    |
 
 ### Overlay → Core
 

--- a/overlay/Cargo.toml
+++ b/overlay/Cargo.toml
@@ -38,6 +38,9 @@ blake2 = "0.10"
 digest = "0.10"
 sha2 = "0.10"
 
+# Erasure coding for TX set shard dissemination
+reed-solomon-simd = "3.1"
+
 # Hostname detection (for self-dial prevention in K8s)
 hostname = "0.4"
 

--- a/overlay/src/config.rs
+++ b/overlay/src/config.rs
@@ -20,6 +20,16 @@ pub struct Config {
 
     /// Log level
     pub log_level: String,
+
+    /// Target payload bytes per TX set shard. The overlay may increase this to
+    /// keep the original + recovery shard count below 256.
+    pub txset_target_shard_size: usize,
+
+    /// Recovery shards as a percentage of original shards.
+    pub txset_shard_recovery_factor_percent: usize,
+
+    /// Initial shard rebroadcast TTL.
+    pub txset_shard_ttl: u8,
 }
 
 impl Default for Config {
@@ -29,6 +39,9 @@ impl Default for Config {
             libp2p_listen_ip: "0.0.0.0".to_string(), // Bind to all interfaces for internet operation
             peer_port: 11625,
             log_level: "info".to_string(),
+            txset_target_shard_size: 1024,
+            txset_shard_recovery_factor_percent: 50,
+            txset_shard_ttl: 1,
         }
     }
 }
@@ -76,6 +89,9 @@ mod tests {
         );
         assert_eq!(config.peer_port, 11625);
         assert_eq!(config.log_level, "info");
+        assert_eq!(config.txset_target_shard_size, 1024);
+        assert_eq!(config.txset_shard_recovery_factor_percent, 50);
+        assert_eq!(config.txset_shard_ttl, 1);
     }
 
     #[test]
@@ -85,6 +101,9 @@ mod tests {
             libp2p_listen_ip = "127.0.0.1"
             peer_port = 12625
             log_level = "debug"
+            txset_target_shard_size = 2048
+            txset_shard_recovery_factor_percent = 75
+            txset_shard_ttl = 2
         "#;
 
         let config = Config::from_str(toml).unwrap();
@@ -92,6 +111,9 @@ mod tests {
         assert_eq!(config.libp2p_listen_ip, "127.0.0.1");
         assert_eq!(config.peer_port, 12625);
         assert_eq!(config.log_level, "debug");
+        assert_eq!(config.txset_target_shard_size, 2048);
+        assert_eq!(config.txset_shard_recovery_factor_percent, 75);
+        assert_eq!(config.txset_shard_ttl, 2);
     }
 
     // ═══ Parse Error Cases ═══

--- a/overlay/src/ipc/messages.rs
+++ b/overlay/src/ipc/messages.rs
@@ -56,6 +56,10 @@ pub enum MessageType {
     /// Request overlay metrics snapshot (empty payload)
     RequestOverlayMetrics = 13,
 
+    /// Eagerly broadcast a locally-built TX set via the shard dissemination path.
+    /// Payload: [hash:32]
+    BroadcastTxSetShards = 14,
+
     // ═══ Overlay → Core (Critical Path) ═══
     /// Received SCP envelope from network
     ScpReceived = 100,
@@ -93,6 +97,7 @@ impl TryFrom<u32> for MessageType {
             11 => Ok(MessageType::RequestTxSet),
             12 => Ok(MessageType::CacheTxSet),
             13 => Ok(MessageType::RequestOverlayMetrics),
+            14 => Ok(MessageType::BroadcastTxSetShards),
             100 => Ok(MessageType::ScpReceived),
             101 => Ok(MessageType::TopTxsResponse),
             102 => Ok(MessageType::PeerRequestsScpState),
@@ -204,6 +209,25 @@ mod tests {
 
         assert_eq!(decoded.msg_type, MessageType::BroadcastScp);
         assert_eq!(decoded.payload, vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_broadcast_tx_set_shards_roundtrip() {
+        assert_eq!(
+            MessageType::try_from(14).unwrap(),
+            MessageType::BroadcastTxSetShards
+        );
+
+        let msg = Message::new(MessageType::BroadcastTxSetShards, vec![0x42; 32]);
+
+        let mut buf = Vec::new();
+        MessageCodec::write(&mut buf, &msg).unwrap();
+
+        let mut cursor = Cursor::new(buf);
+        let decoded = MessageCodec::read(&mut cursor).unwrap();
+
+        assert_eq!(decoded.msg_type, MessageType::BroadcastTxSetShards);
+        assert_eq!(decoded.payload, vec![0x42; 32]);
     }
 
     // ═══ Error Handling Tests ═══

--- a/overlay/src/ipc/transport.rs
+++ b/overlay/src/ipc/transport.rs
@@ -639,6 +639,30 @@ mod tests {
         assert_eq!(&response.payload[32..], &tx_set_data[..]);
     }
 
+    #[tokio::test]
+    async fn test_broadcast_tx_set_shards_message() {
+        let (overlay_side, core_side) = StdUnixStream::pair().unwrap();
+        let ipc = CoreIpc::from_stream(overlay_side).unwrap();
+
+        let mut core = core_side;
+        let payload = vec![0x42; 32];
+
+        MessageCodec::write(
+            &mut core,
+            &Message::new(MessageType::BroadcastTxSetShards, payload.clone()),
+        )
+        .unwrap();
+
+        let mut receiver = ipc.receiver;
+        let received = tokio::time::timeout(std::time::Duration::from_secs(1), receiver.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(received.msg_type, MessageType::BroadcastTxSetShards);
+        assert_eq!(received.payload, payload);
+    }
+
     // ═══ Multiple Messages in Sequence ═══
 
     #[tokio::test]

--- a/overlay/src/libp2p_overlay.rs
+++ b/overlay/src/libp2p_overlay.rs
@@ -85,6 +85,8 @@ pub enum OverlayCommand {
         data: Vec<u8>,
         to: PeerId,
     },
+    /// Broadcast a locally-built TX set through the shard dissemination path
+    BroadcastTxSetShards { hash: [u8; 32], data: Vec<u8> },
     /// Record that a peer has a specific TX set (learned from SCP message)
     RecordTxSetSource { hash: [u8; 32], peer: PeerId },
     /// Connect to a peer by address (bootstrap — PeerId unknown)
@@ -193,6 +195,19 @@ impl OverlayHandle {
         {
             warn!(
                 "Overlay command channel closed, failed to send SendTxSet: {}",
+                e
+            );
+        }
+    }
+
+    pub async fn broadcast_txset_shards(&self, hash: [u8; 32], data: Vec<u8>) {
+        if let Err(e) = self
+            .cmd_tx
+            .send(OverlayCommand::BroadcastTxSetShards { hash, data })
+            .await
+        {
+            warn!(
+                "Overlay command channel closed, failed to send BroadcastTxSetShards: {}",
                 e
             );
         }
@@ -516,6 +531,9 @@ impl StellarOverlay {
                         }
                         OverlayCommand::SendTxSet { hash, data, to } => {
                             self.send_txset_response(to, hash, data).await;
+                        }
+                        OverlayCommand::BroadcastTxSetShards { hash, data } => {
+                            self.broadcast_txset_shards(hash, data).await;
                         }
                         OverlayCommand::RecordTxSetSource { hash, peer } => {
                             let mut sources = self.state.txset_sources.write().await;
@@ -1073,6 +1091,69 @@ impl StellarOverlay {
                     e
                 );
             }
+        }
+    }
+
+    async fn broadcast_txset_shards(&mut self, hash: [u8; 32], data: Vec<u8>) {
+        let message = match crate::xdr::encode_generalized_tx_set_message(&data, &hash) {
+            Ok(message) => message,
+            Err(e) => {
+                warn!(
+                    "TXSET_SHARD_BROADCAST_DROP: Dropping invalid TxSet {:02x?}... from Core: {}",
+                    &hash[..4],
+                    e
+                );
+                return;
+            }
+        };
+
+        let streams = self.state.peer_streams.read().await;
+        let peers: Vec<_> = streams.keys().cloned().collect();
+        drop(streams);
+
+        if peers.is_empty() {
+            debug!(
+                "TXSET_SHARD_BROADCAST_SKIP: No peers to broadcast TxSet {:02x?}...",
+                &hash[..4]
+            );
+            return;
+        }
+
+        info!(
+            "TXSET_SHARD_BROADCAST: Broadcasting TxSet {:02x?}... ({} bytes) to {} peers",
+            &hash[..4],
+            data.len(),
+            peers.len()
+        );
+        self.state
+            .metrics
+            .message_broadcast
+            .fetch_add(1, Ordering::Relaxed);
+
+        for peer_id in peers {
+            let state = Arc::clone(&self.state);
+            let message = message.clone();
+            tokio::spawn(async move {
+                match send_to_peer_stream(&state, peer_id, StreamType::TxSet, &message).await {
+                    Ok(_) => {
+                        state.metrics.send_txset.fetch_add(1, Ordering::Relaxed);
+                        state.metrics.message_write.fetch_add(1, Ordering::Relaxed);
+                        state
+                            .metrics
+                            .byte_write
+                            .fetch_add(message.len() as u64, Ordering::Relaxed);
+                    }
+                    Err(e) => {
+                        state.metrics.error_write.fetch_add(1, Ordering::Relaxed);
+                        warn!(
+                            "TXSET_SHARD_SEND_FAIL: Failed to send TxSet {:02x?}... to {}: {}",
+                            &hash[..4],
+                            peer_id,
+                            e
+                        );
+                    }
+                }
+            });
         }
     }
 

--- a/overlay/src/libp2p_overlay.rs
+++ b/overlay/src/libp2p_overlay.rs
@@ -446,6 +446,7 @@ pub enum OverlayEvent {
         hash: [u8; 32],
         data: Vec<u8>,
         from: PeerId,
+        source: TxSetReceiveSource,
     },
     /// Peer is requesting a TX set (need to look up and respond)
     TxSetRequested { hash: [u8; 32], from: PeerId },
@@ -455,6 +456,12 @@ pub enum OverlayEvent {
     PeerConnected { peer_id: PeerId, addr: Multiaddr },
     /// Peer disconnected - clean up any pending requests
     PeerDisconnected { peer_id: PeerId },
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum TxSetReceiveSource {
+    Response,
+    Shard,
 }
 
 /// Commands to the overlay
@@ -1563,6 +1570,10 @@ impl StellarOverlay {
         );
         self.state
             .metrics
+            .txset_shard_broadcast
+            .fetch_add(1, Ordering::Relaxed);
+        self.state
+            .metrics
             .message_broadcast
             .fetch_add(1, Ordering::Relaxed);
 
@@ -1572,7 +1583,9 @@ impl StellarOverlay {
             for shard_offset in shard_offsets {
                 let shard = &shards[shard_offset];
                 match shard.encode() {
-                    Ok(message) => messages.push(message),
+                    Ok(message) => {
+                        messages.push((message, shard.shard_index < shard.original_shards))
+                    }
                     Err(e) => warn!(
                         "TXSET_SHARD_ENCODE_DROP: Failed to encode shard {} for TxSet {:02x?}...: {}",
                         shard.shard_index,
@@ -1590,7 +1603,7 @@ impl StellarOverlay {
             }
             let state = Arc::clone(&self.state);
             tokio::spawn(async move {
-                for message in messages {
+                for (message, is_original) in messages {
                     match send_to_peer_stream(
                         &state,
                         peer_id.clone(),
@@ -1600,12 +1613,22 @@ impl StellarOverlay {
                     .await
                     {
                         Ok(_) => {
-                            state.metrics.send_txset.fetch_add(1, Ordering::Relaxed);
                             state.metrics.message_write.fetch_add(1, Ordering::Relaxed);
                             state
                                 .metrics
                                 .byte_write
                                 .fetch_add(message.len() as u64, Ordering::Relaxed);
+                            if is_original {
+                                state
+                                    .metrics
+                                    .txset_shard_original_sent
+                                    .fetch_add(1, Ordering::Relaxed);
+                            } else {
+                                state
+                                    .metrics
+                                    .txset_shard_recovery_sent
+                                    .fetch_add(1, Ordering::Relaxed);
+                            }
                         }
                         Err(e) => {
                             state.metrics.error_write.fetch_add(1, Ordering::Relaxed);
@@ -2574,6 +2597,7 @@ async fn handle_inbound_txset_streams(mut incoming: IncomingStreams, state: Arc<
                                     hash,
                                     data: txset_data,
                                     from: peer_id,
+                                    source: TxSetReceiveSource::Response,
                                 }) {
                                     warn!(
                                         "Failed to forward TxSetReceived event from {}: {}",
@@ -2649,6 +2673,7 @@ async fn handle_txset_shard_message(state: &Arc<SharedState>, from: PeerId, data
     {
         let completed = state.completed_txset_shards.read().await;
         if completed.peek(&shard.hash).is_some() {
+            record_redundant_txset_shard(state, &shard);
             trace!(
                 "TXSET_SHARD_SKIP: TxSet {:02x?}... already reconstructed",
                 &shard.hash[..4]
@@ -2680,9 +2705,31 @@ async fn handle_txset_shard_message(state: &Arc<SharedState>, from: PeerId, data
         };
 
         if inserted {
+            record_unique_txset_shard(state, &shard);
             should_rebroadcast = shard.ttl > 0;
+            let used_recovery = accumulator.originals.len() < accumulator.original_shards;
+            let recovery_reconstruct_start = used_recovery.then(Instant::now);
             match accumulator.reconstruct() {
                 Ok(Some(txset)) => {
+                    if let Some(start) = recovery_reconstruct_start {
+                        state
+                            .metrics
+                            .txset_shard_reconstruct_recovery_sum_us
+                            .fetch_add(start.elapsed().as_micros() as u64, Ordering::Relaxed);
+                        state
+                            .metrics
+                            .txset_shard_reconstruct_recovery_count
+                            .fetch_add(1, Ordering::Relaxed);
+                        state
+                            .metrics
+                            .txset_shard_reconstruct_success_recovery
+                            .fetch_add(1, Ordering::Relaxed);
+                    } else {
+                        state
+                            .metrics
+                            .txset_shard_reconstruct_success_original
+                            .fetch_add(1, Ordering::Relaxed);
+                    }
                     info!(
                         "TXSET_SHARD_RECONSTRUCTED: Reconstructed TxSet {:02x?}... ({} bytes) from {} shards in {:?}",
                         &shard.hash[..4],
@@ -2694,13 +2741,35 @@ async fn handle_txset_shard_message(state: &Arc<SharedState>, from: PeerId, data
                     accumulators.remove(&shard.hash);
                 }
                 Ok(None) => {}
-                Err(e) => warn!(
-                    "TXSET_SHARD_DECODE_FAIL: Failed to decode TxSet {:02x?}...: {}",
-                    &shard.hash[..4],
-                    e
-                ),
+                Err(e) => {
+                    if let Some(start) = recovery_reconstruct_start {
+                        state
+                            .metrics
+                            .txset_shard_reconstruct_recovery_sum_us
+                            .fetch_add(start.elapsed().as_micros() as u64, Ordering::Relaxed);
+                        state
+                            .metrics
+                            .txset_shard_reconstruct_recovery_count
+                            .fetch_add(1, Ordering::Relaxed);
+                        state
+                            .metrics
+                            .txset_shard_reconstruct_fail_recovery
+                            .fetch_add(1, Ordering::Relaxed);
+                    } else {
+                        state
+                            .metrics
+                            .txset_shard_reconstruct_fail_original
+                            .fetch_add(1, Ordering::Relaxed);
+                    }
+                    warn!(
+                        "TXSET_SHARD_DECODE_FAIL: Failed to decode TxSet {:02x?}...: {}",
+                        &shard.hash[..4],
+                        e
+                    );
+                }
             }
         } else {
+            record_redundant_txset_shard(state, &shard);
             trace!(
                 "TXSET_SHARD_DUP: Duplicate shard {} for TxSet {:02x?}... from {}",
                 shard.shard_index,
@@ -2720,6 +2789,7 @@ async fn handle_txset_shard_message(state: &Arc<SharedState>, from: PeerId, data
             hash: shard.hash,
             data: txset,
             from,
+            source: TxSetReceiveSource::Shard,
         }) {
             warn!(
                 "TXSET_SHARD_TO_APP_FAIL: Failed to forward reconstructed TxSet {:02x?}...: {}",
@@ -2731,6 +2801,34 @@ async fn handle_txset_shard_message(state: &Arc<SharedState>, from: PeerId, data
 
     if should_rebroadcast {
         rebroadcast_txset_shard(state, &shard.with_ttl(shard.ttl - 1), from).await;
+    }
+}
+
+fn record_unique_txset_shard(state: &Arc<SharedState>, shard: &TxSetShardMessage) {
+    if shard.shard_index < shard.original_shards {
+        state
+            .metrics
+            .txset_shard_original_recv_unique
+            .fetch_add(1, Ordering::Relaxed);
+    } else {
+        state
+            .metrics
+            .txset_shard_recovery_recv_unique
+            .fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+fn record_redundant_txset_shard(state: &Arc<SharedState>, shard: &TxSetShardMessage) {
+    if shard.shard_index < shard.original_shards {
+        state
+            .metrics
+            .txset_shard_original_recv_redundant
+            .fetch_add(1, Ordering::Relaxed);
+    } else {
+        state
+            .metrics
+            .txset_shard_recovery_recv_redundant
+            .fetch_add(1, Ordering::Relaxed);
     }
 }
 
@@ -2765,17 +2863,28 @@ async fn rebroadcast_txset_shard(
         let message = message.clone();
         let hash = shard.hash;
         let shard_index = shard.shard_index;
+        let is_original = shard.shard_index < shard.original_shards;
         tokio::spawn(async move {
             match send_to_peer_stream(&state, peer_id.clone(), StreamType::TxSetShard, &message)
                 .await
             {
                 Ok(_) => {
-                    state.metrics.send_txset.fetch_add(1, Ordering::Relaxed);
                     state.metrics.message_write.fetch_add(1, Ordering::Relaxed);
                     state
                         .metrics
                         .byte_write
                         .fetch_add(message.len() as u64, Ordering::Relaxed);
+                    if is_original {
+                        state
+                            .metrics
+                            .txset_shard_original_forwarded
+                            .fetch_add(1, Ordering::Relaxed);
+                    } else {
+                        state
+                            .metrics
+                            .txset_shard_recovery_forwarded
+                            .fetch_add(1, Ordering::Relaxed);
+                    }
                 }
                 Err(e) => {
                     state.metrics.error_write.fetch_add(1, Ordering::Relaxed);
@@ -2971,6 +3080,121 @@ mod tests {
 
         let reconstructed = accumulator.reconstruct().unwrap().unwrap();
         assert_eq!(reconstructed, data);
+    }
+
+    #[tokio::test]
+    async fn test_txset_shard_metrics_original_reconstruction_and_redundant() {
+        let metrics = Arc::new(OverlayMetrics::new());
+        let keypair = Keypair::generate_ed25519();
+        let (_handle, mut events, _tx_events, overlay) =
+            create_overlay(keypair, Arc::clone(&metrics)).unwrap();
+        let state = overlay.state.clone();
+
+        let data = b"original-only reconstruction".to_vec();
+        let shards = make_txset_shards([0x31; 32], &data, TxSetShardConfig::default()).unwrap();
+        let original_count = shards[0].original_shards;
+        let peer = PeerId::random();
+
+        for shard in shards.iter().take(original_count) {
+            handle_txset_shard_message(&state, peer, shard.encode().unwrap()).await;
+        }
+
+        let event = events.recv().await.unwrap();
+        match event {
+            OverlayEvent::TxSetReceived {
+                hash,
+                data: reconstructed,
+                source,
+                ..
+            } => {
+                assert_eq!(hash, [0x31; 32]);
+                assert_eq!(reconstructed, data);
+                assert_eq!(source, TxSetReceiveSource::Shard);
+            }
+            other => panic!("unexpected event: {:?}", other),
+        }
+
+        assert_eq!(
+            metrics
+                .txset_shard_original_recv_unique
+                .load(Ordering::Relaxed),
+            original_count as u64
+        );
+        assert_eq!(
+            metrics
+                .txset_shard_reconstruct_success_original
+                .load(Ordering::Relaxed),
+            1
+        );
+
+        handle_txset_shard_message(&state, peer, shards[0].encode().unwrap()).await;
+        assert_eq!(
+            metrics
+                .txset_shard_original_recv_redundant
+                .load(Ordering::Relaxed),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn test_txset_shard_metrics_recovery_reconstruction() {
+        let metrics = Arc::new(OverlayMetrics::new());
+        let keypair = Keypair::generate_ed25519();
+        let (_handle, mut events, _tx_events, overlay) =
+            create_overlay(keypair, Arc::clone(&metrics)).unwrap();
+        let state = overlay.state.clone();
+
+        let data = b"recovery-assisted reconstruction needs parity".to_vec();
+        let config = TxSetShardConfig {
+            target_shard_size: 8,
+            recovery_factor_percent: 50,
+            initial_ttl: 0,
+        };
+        let shards = make_txset_shards([0x32; 32], &data, config).unwrap();
+        let original_count = shards[0].original_shards;
+        let peer = PeerId::random();
+
+        for shard in shards
+            .iter()
+            .filter(|shard| shard.shard_index != 1)
+            .take(original_count)
+        {
+            handle_txset_shard_message(&state, peer, shard.encode().unwrap()).await;
+        }
+
+        let event = events.recv().await.unwrap();
+        match event {
+            OverlayEvent::TxSetReceived {
+                hash,
+                data: reconstructed,
+                source,
+                ..
+            } => {
+                assert_eq!(hash, [0x32; 32]);
+                assert_eq!(reconstructed, data);
+                assert_eq!(source, TxSetReceiveSource::Shard);
+            }
+            other => panic!("unexpected event: {:?}", other),
+        }
+
+        assert_eq!(
+            metrics
+                .txset_shard_recovery_recv_unique
+                .load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            metrics
+                .txset_shard_reconstruct_success_recovery
+                .load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            metrics
+                .txset_shard_reconstruct_recovery_count
+                .load(Ordering::Relaxed),
+            1
+        );
     }
 
     #[test]

--- a/overlay/src/libp2p_overlay.rs
+++ b/overlay/src/libp2p_overlay.rs
@@ -26,6 +26,7 @@ use libp2p::{
     Multiaddr, PeerId, Stream, StreamProtocol, Swarm, SwarmBuilder,
 };
 use libp2p_stream::{Behaviour as StreamBehaviour, Control, IncomingStreams};
+use reed_solomon_simd::{ReedSolomonDecoder, ReedSolomonEncoder};
 use std::collections::{HashMap, HashSet};
 use std::io;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -38,6 +39,7 @@ use tracing::{debug, error, info, trace, warn};
 pub const SCP_PROTOCOL: StreamProtocol = StreamProtocol::new("/stellar/scp/1.0.0");
 pub const TX_PROTOCOL: StreamProtocol = StreamProtocol::new("/stellar/tx/1.0.0");
 pub const TXSET_PROTOCOL: StreamProtocol = StreamProtocol::new("/stellar/txset/1.0.0");
+pub const TXSET_SHARD_PROTOCOL: StreamProtocol = StreamProtocol::new("/stellar/txset-shard/1.0.0");
 
 /// Message frame: 4-byte length prefix + payload
 /// Max message size: 16MB (for large TX sets)
@@ -46,6 +48,391 @@ const MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
 /// Bounded channel capacity for TX events (backpressure for TX flooding)
 /// TXs that can't be queued are dropped - they'll be re-requested if needed.
 const TX_EVENT_CHANNEL_CAPACITY: usize = 10_000;
+
+const TXSET_TARGET_SHARD_SIZE: usize = 1024;
+const TXSET_SHARD_RECOVERY_FACTOR_PERCENT: usize = 50;
+const TXSET_SHARD_INITIAL_TTL: u8 = 1;
+const TXSET_MAX_TOTAL_SHARDS: usize = 255;
+const TXSET_SHARD_HEADER_LEN: usize = 32 + 2 + 2 + 2 + 4 + 8 + 1 + 4;
+
+#[derive(Clone, Copy, Debug)]
+pub struct TxSetShardConfig {
+    pub target_shard_size: usize,
+    pub recovery_factor_percent: usize,
+    pub initial_ttl: u8,
+}
+
+impl Default for TxSetShardConfig {
+    fn default() -> Self {
+        Self {
+            target_shard_size: TXSET_TARGET_SHARD_SIZE,
+            recovery_factor_percent: TXSET_SHARD_RECOVERY_FACTOR_PERCENT,
+            initial_ttl: TXSET_SHARD_INITIAL_TTL,
+        }
+    }
+}
+
+impl TxSetShardConfig {
+    fn recovery_shards(&self, original_shards: usize) -> usize {
+        (original_shards * self.recovery_factor_percent)
+            .div_ceil(100)
+            .max(1)
+    }
+
+    fn max_original_shards(&self) -> Option<usize> {
+        (2..=TXSET_MAX_TOTAL_SHARDS).rev().find(|original_shards| {
+            original_shards % 2 == 0
+                && *original_shards + self.recovery_shards(*original_shards)
+                    <= TXSET_MAX_TOTAL_SHARDS
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct TxSetShardPlan {
+    original_shards: usize,
+    recovery_shards: usize,
+    shard_size: usize,
+}
+
+fn make_even(value: usize) -> usize {
+    value + (value % 2)
+}
+
+fn plan_txset_shards(data_len: usize, config: TxSetShardConfig) -> Result<TxSetShardPlan, String> {
+    if config.target_shard_size == 0 {
+        return Err("configured target shard size must be non-zero".to_string());
+    }
+
+    let max_original_shards = config.max_original_shards().ok_or_else(|| {
+        format!(
+            "recovery factor {}% leaves no valid even original shard count under {} total shards",
+            config.recovery_factor_percent, TXSET_MAX_TOTAL_SHARDS
+        )
+    })?;
+
+    let target_shard_size = make_even(config.target_shard_size);
+    let mut shard_size = target_shard_size;
+    let mut original_shards = make_even(data_len.max(1).div_ceil(shard_size)).max(2);
+
+    if original_shards > max_original_shards {
+        original_shards = max_original_shards;
+        shard_size = make_even(data_len.max(1).div_ceil(original_shards)).max(2);
+    }
+
+    let recovery_shards = config.recovery_shards(original_shards);
+    if original_shards + recovery_shards > TXSET_MAX_TOTAL_SHARDS {
+        return Err(format!(
+            "planned shard count {} exceeds max {}",
+            original_shards + recovery_shards,
+            TXSET_MAX_TOTAL_SHARDS
+        ));
+    }
+
+    Ok(TxSetShardPlan {
+        original_shards,
+        recovery_shards,
+        shard_size,
+    })
+}
+
+#[derive(Clone, Debug)]
+struct TxSetShardMessage {
+    hash: [u8; 32],
+    original_shards: usize,
+    recovery_shards: usize,
+    shard_index: usize,
+    shard_size: usize,
+    original_len: usize,
+    ttl: u8,
+    payload: Vec<u8>,
+}
+
+impl TxSetShardMessage {
+    fn encode(&self) -> Result<Vec<u8>, String> {
+        if self.original_shards == 0 || self.recovery_shards == 0 {
+            return Err("shard counts must be non-zero".to_string());
+        }
+        if self.shard_index >= self.original_shards + self.recovery_shards {
+            return Err("shard index out of range".to_string());
+        }
+        if self.payload.len() != self.shard_size {
+            return Err(format!(
+                "payload length {} != shard size {}",
+                self.payload.len(),
+                self.shard_size
+            ));
+        }
+
+        let original_shards = u16::try_from(self.original_shards)
+            .map_err(|_| "too many original shards".to_string())?;
+        let recovery_shards = u16::try_from(self.recovery_shards)
+            .map_err(|_| "too many recovery shards".to_string())?;
+        let shard_index =
+            u16::try_from(self.shard_index).map_err(|_| "shard index too large".to_string())?;
+        let shard_size =
+            u32::try_from(self.shard_size).map_err(|_| "shard size too large".to_string())?;
+        let original_len = u64::try_from(self.original_len)
+            .map_err(|_| "original length too large".to_string())?;
+        let payload_len =
+            u32::try_from(self.payload.len()).map_err(|_| "payload too large".to_string())?;
+
+        let mut out = Vec::with_capacity(TXSET_SHARD_HEADER_LEN + self.payload.len());
+        out.extend_from_slice(&self.hash);
+        out.extend_from_slice(&original_shards.to_be_bytes());
+        out.extend_from_slice(&recovery_shards.to_be_bytes());
+        out.extend_from_slice(&shard_index.to_be_bytes());
+        out.extend_from_slice(&shard_size.to_be_bytes());
+        out.extend_from_slice(&original_len.to_be_bytes());
+        out.push(self.ttl);
+        out.extend_from_slice(&payload_len.to_be_bytes());
+        out.extend_from_slice(&self.payload);
+        Ok(out)
+    }
+
+    fn decode(data: &[u8]) -> Result<Self, String> {
+        if data.len() < TXSET_SHARD_HEADER_LEN {
+            return Err(format!("shard message too short: {}", data.len()));
+        }
+
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(&data[0..32]);
+        let original_shards = u16::from_be_bytes([data[32], data[33]]) as usize;
+        let recovery_shards = u16::from_be_bytes([data[34], data[35]]) as usize;
+        let shard_index = u16::from_be_bytes([data[36], data[37]]) as usize;
+        let shard_size = u32::from_be_bytes([data[38], data[39], data[40], data[41]]) as usize;
+        let original_len = u64::from_be_bytes([
+            data[42], data[43], data[44], data[45], data[46], data[47], data[48], data[49],
+        ]) as usize;
+        let ttl = data[50];
+        let payload_len = u32::from_be_bytes([data[51], data[52], data[53], data[54]]) as usize;
+        let payload_start = TXSET_SHARD_HEADER_LEN;
+        let payload_end = payload_start
+            .checked_add(payload_len)
+            .ok_or_else(|| "payload length overflow".to_string())?;
+
+        if original_shards == 0 || recovery_shards == 0 {
+            return Err("shard counts must be non-zero".to_string());
+        }
+        if shard_index >= original_shards + recovery_shards {
+            return Err("shard index out of range".to_string());
+        }
+        if shard_size == 0 || shard_size % 2 != 0 {
+            return Err("shard size must be a non-zero even number".to_string());
+        }
+        if payload_len != shard_size {
+            return Err(format!(
+                "payload length {} != shard size {}",
+                payload_len, shard_size
+            ));
+        }
+        if payload_end != data.len() {
+            return Err("shard payload length mismatch".to_string());
+        }
+
+        Ok(Self {
+            hash,
+            original_shards,
+            recovery_shards,
+            shard_index,
+            shard_size,
+            original_len,
+            ttl,
+            payload: data[payload_start..payload_end].to_vec(),
+        })
+    }
+
+    fn with_ttl(&self, ttl: u8) -> Self {
+        let mut next = self.clone();
+        next.ttl = ttl;
+        next
+    }
+}
+
+struct TxSetShardAccumulator {
+    original_shards: usize,
+    recovery_shards: usize,
+    shard_size: usize,
+    original_len: usize,
+    originals: HashMap<usize, Vec<u8>>,
+    recoveries: HashMap<usize, Vec<u8>>,
+    created_at: Instant,
+}
+
+impl TxSetShardAccumulator {
+    fn new(shard: &TxSetShardMessage) -> Self {
+        Self {
+            original_shards: shard.original_shards,
+            recovery_shards: shard.recovery_shards,
+            shard_size: shard.shard_size,
+            original_len: shard.original_len,
+            originals: HashMap::new(),
+            recoveries: HashMap::new(),
+            created_at: Instant::now(),
+        }
+    }
+
+    fn is_compatible(&self, shard: &TxSetShardMessage) -> bool {
+        self.original_shards == shard.original_shards
+            && self.recovery_shards == shard.recovery_shards
+            && self.shard_size == shard.shard_size
+            && self.original_len == shard.original_len
+    }
+
+    fn insert(&mut self, shard: &TxSetShardMessage) -> Result<bool, String> {
+        if !self.is_compatible(shard) {
+            return Err("shard parameters differ from accumulator".to_string());
+        }
+
+        if shard.shard_index < self.original_shards {
+            Ok(self
+                .originals
+                .insert(shard.shard_index, shard.payload.clone())
+                .is_none())
+        } else {
+            let recovery_index = shard.shard_index - self.original_shards;
+            Ok(self
+                .recoveries
+                .insert(recovery_index, shard.payload.clone())
+                .is_none())
+        }
+    }
+
+    fn has_enough_shards(&self) -> bool {
+        self.originals.len() + self.recoveries.len() >= self.original_shards
+    }
+
+    fn reconstruct(&self) -> Result<Option<Vec<u8>>, String> {
+        if !self.has_enough_shards() {
+            return Ok(None);
+        }
+
+        let mut pieces = Vec::with_capacity(self.original_shards * self.shard_size);
+        if self.originals.len() == self.original_shards {
+            for index in 0..self.original_shards {
+                let shard = self
+                    .originals
+                    .get(&index)
+                    .ok_or_else(|| format!("missing original shard {}", index))?;
+                pieces.extend_from_slice(shard);
+            }
+            pieces.truncate(self.original_len);
+            return Ok(Some(pieces));
+        }
+
+        let mut decoder =
+            ReedSolomonDecoder::new(self.original_shards, self.recovery_shards, self.shard_size)
+                .map_err(|e| format!("failed to create decoder: {}", e))?;
+        for (index, shard) in &self.originals {
+            decoder
+                .add_original_shard(*index, shard)
+                .map_err(|e| format!("failed to add original shard {}: {}", index, e))?;
+        }
+        for (index, shard) in &self.recoveries {
+            decoder
+                .add_recovery_shard(*index, shard)
+                .map_err(|e| format!("failed to add recovery shard {}: {}", index, e))?;
+        }
+
+        let result = decoder
+            .decode()
+            .map_err(|e| format!("failed to decode txset shards: {}", e))?;
+        let restored: HashMap<usize, Vec<u8>> = result
+            .restored_original_iter()
+            .map(|(index, shard)| (index, shard.to_vec()))
+            .collect();
+
+        for index in 0..self.original_shards {
+            if let Some(shard) = self.originals.get(&index) {
+                pieces.extend_from_slice(shard);
+            } else if let Some(shard) = restored.get(&index) {
+                pieces.extend_from_slice(shard);
+            } else {
+                return Ok(None);
+            }
+        }
+        pieces.truncate(self.original_len);
+        Ok(Some(pieces))
+    }
+}
+
+fn make_txset_shards(
+    hash: [u8; 32],
+    data: &[u8],
+    config: TxSetShardConfig,
+) -> Result<Vec<TxSetShardMessage>, String> {
+    let plan = plan_txset_shards(data.len(), config)?;
+    let original_shards = plan.original_shards;
+    let recovery_shards = plan.recovery_shards;
+    let shard_size = plan.shard_size;
+
+    u16::try_from(original_shards).map_err(|_| "too many original shards".to_string())?;
+    u16::try_from(recovery_shards).map_err(|_| "too many recovery shards".to_string())?;
+    u16::try_from(original_shards + recovery_shards)
+        .map_err(|_| "too many total shards".to_string())?;
+
+    let mut originals = Vec::with_capacity(original_shards);
+    for index in 0..original_shards {
+        let start = index * shard_size;
+        let end = (start + shard_size).min(data.len());
+        let mut shard = vec![0u8; shard_size];
+        if start < data.len() {
+            shard[..end - start].copy_from_slice(&data[start..end]);
+        }
+        originals.push(shard);
+    }
+
+    let mut encoder = ReedSolomonEncoder::new(original_shards, recovery_shards, shard_size)
+        .map_err(|e| format!("failed to create encoder: {}", e))?;
+    for shard in &originals {
+        encoder
+            .add_original_shard(shard)
+            .map_err(|e| format!("failed to add original shard: {}", e))?;
+    }
+    let result = encoder
+        .encode()
+        .map_err(|e| format!("failed to encode recovery shards: {}", e))?;
+    let recoveries: Vec<Vec<u8>> = result.recovery_iter().map(|shard| shard.to_vec()).collect();
+
+    let mut messages = Vec::with_capacity(original_shards + recovery_shards);
+    for (index, payload) in originals.into_iter().enumerate() {
+        messages.push(TxSetShardMessage {
+            hash,
+            original_shards,
+            recovery_shards,
+            shard_index: index,
+            shard_size,
+            original_len: data.len(),
+            ttl: config.initial_ttl,
+            payload,
+        });
+    }
+    for (index, payload) in recoveries.into_iter().enumerate() {
+        messages.push(TxSetShardMessage {
+            hash,
+            original_shards,
+            recovery_shards,
+            shard_index: original_shards + index,
+            shard_size,
+            original_len: data.len(),
+            ttl: config.initial_ttl,
+            payload,
+        });
+    }
+
+    Ok(messages)
+}
+
+fn assign_shards_to_peer_offsets(shard_count: usize, peer_count: usize) -> Vec<Vec<usize>> {
+    let mut assignments = vec![Vec::new(); peer_count];
+    if peer_count == 0 {
+        return assignments;
+    }
+    for shard_offset in 0..shard_count {
+        assignments[shard_offset % peer_count].push(shard_offset);
+    }
+    assignments
+}
 
 /// Events from the overlay to the application
 #[derive(Debug, Clone)]
@@ -111,6 +498,7 @@ struct PeerOutboundStreams {
     scp: Mutex<Option<Stream>>,
     tx: Mutex<Option<Stream>>,
     txset: Mutex<Option<Stream>>,
+    txset_shard: Mutex<Option<Stream>>,
 }
 
 impl PeerOutboundStreams {
@@ -119,6 +507,7 @@ impl PeerOutboundStreams {
             scp: Mutex::new(None),
             tx: Mutex::new(None),
             txset: Mutex::new(None),
+            txset_shard: Mutex::new(None),
         }
     }
 }
@@ -313,6 +702,12 @@ struct SharedState {
     txset_sources: RwLock<lru::LruCache<[u8; 32], PeerId>>,
     /// Pending TX set requests: hash -> (peer, request_time) to avoid duplicate fetches and track latency
     pending_txset_requests: RwLock<HashMap<[u8; 32], (PeerId, Instant)>>,
+    /// Partially received erasure-coded TX set shards.
+    txset_shards: RwLock<HashMap<[u8; 32], TxSetShardAccumulator>>,
+    /// TX sets already reconstructed through shards, used to drop duplicate shards.
+    completed_txset_shards: RwLock<lru::LruCache<[u8; 32], ()>>,
+    /// Tunables for TX set shard fanout and erasure coding.
+    txset_shard_config: TxSetShardConfig,
     /// Event sender for non-TX events (SCP, TxSet - critical path, unbounded)
     event_tx: mpsc::UnboundedSender<OverlayEvent>,
     /// Bounded TX event sender (backpressure - drops allowed)
@@ -340,6 +735,7 @@ impl SharedState {
         event_tx: mpsc::UnboundedSender<OverlayEvent>,
         tx_event_tx: mpsc::Sender<OverlayEvent>,
         control: Control,
+        txset_shard_config: TxSetShardConfig,
         metrics: Arc<OverlayMetrics>,
     ) -> Self {
         Self {
@@ -357,6 +753,11 @@ impl SharedState {
                 std::num::NonZeroUsize::new(1000).unwrap(),
             )),
             pending_txset_requests: RwLock::new(HashMap::new()),
+            txset_shards: RwLock::new(HashMap::new()),
+            completed_txset_shards: RwLock::new(lru::LruCache::new(
+                std::num::NonZeroUsize::new(1000).unwrap(),
+            )),
+            txset_shard_config,
             event_tx,
             tx_event_tx,
             tx_dropped_count: AtomicU64::new(0),
@@ -389,6 +790,22 @@ pub struct StellarOverlay {
 pub fn create_overlay(
     keypair: Keypair,
     metrics: Arc<OverlayMetrics>,
+) -> Result<
+    (
+        OverlayHandle,
+        mpsc::UnboundedReceiver<OverlayEvent>,
+        mpsc::Receiver<OverlayEvent>,
+        StellarOverlay,
+    ),
+    Box<dyn std::error::Error + Send + Sync>,
+> {
+    create_overlay_with_txset_shard_config(keypair, metrics, TxSetShardConfig::default())
+}
+
+pub fn create_overlay_with_txset_shard_config(
+    keypair: Keypair,
+    metrics: Arc<OverlayMetrics>,
+    txset_shard_config: TxSetShardConfig,
 ) -> Result<
     (
         OverlayHandle,
@@ -438,6 +855,7 @@ pub fn create_overlay(
         event_tx,
         tx_event_tx,
         control.clone(),
+        txset_shard_config,
         metrics,
     ));
 
@@ -502,12 +920,26 @@ impl StellarOverlay {
                 return;
             }
         };
+        let txset_shard_incoming = match self.control.accept(TXSET_SHARD_PROTOCOL) {
+            Ok(incoming) => incoming,
+            Err(e) => {
+                error!(
+                    "Failed to accept TxSetShard protocol streams: {:?}. Overlay cannot function.",
+                    e
+                );
+                return;
+            }
+        };
 
         // Spawn inbound stream handlers
         let state = self.state.clone();
         tokio::spawn(handle_inbound_scp_streams(scp_incoming, state.clone()));
         tokio::spawn(handle_inbound_tx_streams(tx_incoming, state.clone()));
         tokio::spawn(handle_inbound_txset_streams(txset_incoming, state.clone()));
+        tokio::spawn(handle_inbound_txset_shard_streams(
+            txset_shard_incoming,
+            state.clone(),
+        ));
 
         // Spawn INV/GETDATA housekeeping task
         tokio::spawn(inv_getdata_housekeeping_task(state.clone()));
@@ -1095,11 +1527,11 @@ impl StellarOverlay {
     }
 
     async fn broadcast_txset_shards(&mut self, hash: [u8; 32], data: Vec<u8>) {
-        let message = match crate::xdr::encode_generalized_tx_set_message(&data, &hash) {
-            Ok(message) => message,
+        let shards = match make_txset_shards(hash, &data, self.state.txset_shard_config) {
+            Ok(shards) => shards,
             Err(e) => {
                 warn!(
-                    "TXSET_SHARD_BROADCAST_DROP: Dropping invalid TxSet {:02x?}... from Core: {}",
+                    "TXSET_SHARD_BROADCAST_DROP: Failed to shard TxSet {:02x?}... from Core: {}",
                     &hash[..4],
                     e
                 );
@@ -1120,9 +1552,13 @@ impl StellarOverlay {
         }
 
         info!(
-            "TXSET_SHARD_BROADCAST: Broadcasting TxSet {:02x?}... ({} bytes) to {} peers",
+            "TXSET_SHARD_BROADCAST: Broadcasting TxSet {:02x?}... ({} bytes, {} shards: {} original + {} recovery, shard_size={}) to {} peers",
             &hash[..4],
             data.len(),
+            shards.len(),
+            shards[0].original_shards,
+            shards[0].recovery_shards,
+            shards[0].shard_size,
             peers.len()
         );
         self.state
@@ -1130,27 +1566,56 @@ impl StellarOverlay {
             .message_broadcast
             .fetch_add(1, Ordering::Relaxed);
 
-        for peer_id in peers {
+        let mut messages_by_peer = Vec::new();
+        for shard_offsets in assign_shards_to_peer_offsets(shards.len(), peers.len()) {
+            let mut messages = Vec::with_capacity(shard_offsets.len());
+            for shard_offset in shard_offsets {
+                let shard = &shards[shard_offset];
+                match shard.encode() {
+                    Ok(message) => messages.push(message),
+                    Err(e) => warn!(
+                        "TXSET_SHARD_ENCODE_DROP: Failed to encode shard {} for TxSet {:02x?}...: {}",
+                        shard.shard_index,
+                        &hash[..4],
+                        e
+                    ),
+                }
+            }
+            messages_by_peer.push(messages);
+        }
+
+        for (peer_id, messages) in peers.into_iter().zip(messages_by_peer) {
+            if messages.is_empty() {
+                continue;
+            }
             let state = Arc::clone(&self.state);
-            let message = message.clone();
             tokio::spawn(async move {
-                match send_to_peer_stream(&state, peer_id, StreamType::TxSet, &message).await {
-                    Ok(_) => {
-                        state.metrics.send_txset.fetch_add(1, Ordering::Relaxed);
-                        state.metrics.message_write.fetch_add(1, Ordering::Relaxed);
-                        state
-                            .metrics
-                            .byte_write
-                            .fetch_add(message.len() as u64, Ordering::Relaxed);
-                    }
-                    Err(e) => {
-                        state.metrics.error_write.fetch_add(1, Ordering::Relaxed);
-                        warn!(
-                            "TXSET_SHARD_SEND_FAIL: Failed to send TxSet {:02x?}... to {}: {}",
-                            &hash[..4],
-                            peer_id,
-                            e
-                        );
+                for message in messages {
+                    match send_to_peer_stream(
+                        &state,
+                        peer_id.clone(),
+                        StreamType::TxSetShard,
+                        &message,
+                    )
+                    .await
+                    {
+                        Ok(_) => {
+                            state.metrics.send_txset.fetch_add(1, Ordering::Relaxed);
+                            state.metrics.message_write.fetch_add(1, Ordering::Relaxed);
+                            state
+                                .metrics
+                                .byte_write
+                                .fetch_add(message.len() as u64, Ordering::Relaxed);
+                        }
+                        Err(e) => {
+                            state.metrics.error_write.fetch_add(1, Ordering::Relaxed);
+                            warn!(
+                                "TXSET_SHARD_SEND_FAIL: Failed to send TxSet shard {:02x?}... to {}: {}",
+                                &hash[..4],
+                                peer_id,
+                                e
+                            );
+                        }
                     }
                 }
             });
@@ -1193,7 +1658,7 @@ impl StellarOverlay {
     }
 }
 
-/// Open SCP, TX, and TxSet streams to a peer.
+/// Open SCP, TX, TxSet, and TxSetShard streams to a peer.
 /// Spawned as a background task so the swarm event loop stays unblocked —
 /// `control.open_stream()` needs the swarm to be polled to complete.
 async fn open_streams_to_peer(mut control: Control, state: Arc<SharedState>, peer_id: PeerId) {
@@ -1201,12 +1666,15 @@ async fn open_streams_to_peer(mut control: Control, state: Arc<SharedState>, pee
 
     let mut control2 = control.clone();
     let mut control3 = control.clone();
+    let mut control4 = control.clone();
 
     let scp_fut = async { control.open_stream(peer_id, SCP_PROTOCOL).await };
     let tx_fut = async { control2.open_stream(peer_id, TX_PROTOCOL).await };
     let txset_fut = async { control3.open_stream(peer_id, TXSET_PROTOCOL).await };
+    let txset_shard_fut = async { control4.open_stream(peer_id, TXSET_SHARD_PROTOCOL).await };
 
-    let (scp_result, tx_result, txset_result) = tokio::join!(scp_fut, tx_fut, txset_fut);
+    let (scp_result, tx_result, txset_result, txset_shard_result) =
+        tokio::join!(scp_fut, tx_fut, txset_fut, txset_shard_fut);
 
     let scp_stream = match scp_result {
         Ok(s) => {
@@ -1241,6 +1709,17 @@ async fn open_streams_to_peer(mut control: Control, state: Arc<SharedState>, pee
         }
     };
 
+    let txset_shard_stream = match txset_shard_result {
+        Ok(s) => {
+            debug!("Opened TxSetShard stream to {}", peer_id);
+            Some(s)
+        }
+        Err(e) => {
+            warn!("Failed to open TxSetShard stream to {}: {:?}", peer_id, e);
+            None
+        }
+    };
+
     // Store streams
     {
         let streams = state.peer_streams.read().await;
@@ -1253,6 +1732,9 @@ async fn open_streams_to_peer(mut control: Control, state: Arc<SharedState>, pee
             }
             if let Some(stream) = txset_stream {
                 *peer_streams.txset.lock().await = Some(stream);
+            }
+            if let Some(stream) = txset_shard_stream {
+                *peer_streams.txset_shard.lock().await = Some(stream);
             }
         }
     }
@@ -1280,6 +1762,7 @@ enum StreamType {
     Scp,
     Tx,
     TxSet,
+    TxSetShard,
 }
 
 impl StreamType {
@@ -1288,6 +1771,7 @@ impl StreamType {
             StreamType::Scp => SCP_PROTOCOL,
             StreamType::Tx => TX_PROTOCOL,
             StreamType::TxSet => TXSET_PROTOCOL,
+            StreamType::TxSetShard => TXSET_SHARD_PROTOCOL,
         }
     }
 }
@@ -1312,6 +1796,7 @@ async fn try_send_to_existing_stream(
         StreamType::Scp => &peer_streams.scp,
         StreamType::Tx => &peer_streams.tx,
         StreamType::TxSet => &peer_streams.txset,
+        StreamType::TxSetShard => &peer_streams.txset_shard,
     };
 
     let mut stream_guard = stream_mutex.lock().await;
@@ -1352,6 +1837,7 @@ async fn send_to_peer_stream(
             StreamType::Scp => &peer_streams.scp,
             StreamType::Tx => &peer_streams.tx,
             StreamType::TxSet => &peer_streams.txset,
+            StreamType::TxSetShard => &peer_streams.txset_shard,
         };
 
         let mut stream_guard = stream_mutex.lock().await;
@@ -2116,6 +2602,196 @@ async fn handle_inbound_txset_streams(mut incoming: IncomingStreams, state: Arc<
     }
 }
 
+async fn handle_inbound_txset_shard_streams(
+    mut incoming: IncomingStreams,
+    state: Arc<SharedState>,
+) {
+    while let Some((peer_id, mut stream)) = incoming.next().await {
+        debug!("Accepted inbound TxSetShard stream from {}", peer_id);
+        state.metrics.inbound_live.fetch_add(1, Ordering::Relaxed);
+        let state = state.clone();
+
+        tokio::spawn(async move {
+            loop {
+                match read_framed(&mut stream).await {
+                    Ok(data) => {
+                        state.metrics.message_read.fetch_add(1, Ordering::Relaxed);
+                        state
+                            .metrics
+                            .byte_read
+                            .fetch_add(data.len() as u64, Ordering::Relaxed);
+                        handle_txset_shard_message(&state, peer_id, data).await;
+                    }
+                    Err(e) => {
+                        state.metrics.error_read.fetch_add(1, Ordering::Relaxed);
+                        state.metrics.inbound_live.fetch_sub(1, Ordering::Relaxed);
+                        info!("TxSetShard stream from {} closed: {}", peer_id, e);
+                        break;
+                    }
+                }
+            }
+        });
+    }
+}
+
+async fn handle_txset_shard_message(state: &Arc<SharedState>, from: PeerId, data: Vec<u8>) {
+    let shard = match TxSetShardMessage::decode(&data) {
+        Ok(shard) => shard,
+        Err(e) => {
+            warn!(
+                "TXSET_SHARD_PARSE_ERR: Dropping malformed shard from {}: {}",
+                from, e
+            );
+            return;
+        }
+    };
+
+    {
+        let completed = state.completed_txset_shards.read().await;
+        if completed.peek(&shard.hash).is_some() {
+            trace!(
+                "TXSET_SHARD_SKIP: TxSet {:02x?}... already reconstructed",
+                &shard.hash[..4]
+            );
+            return;
+        }
+    }
+
+    let mut should_rebroadcast = false;
+    let mut reconstructed = None;
+    {
+        let mut accumulators = state.txset_shards.write().await;
+        let accumulator = accumulators
+            .entry(shard.hash)
+            .or_insert_with(|| TxSetShardAccumulator::new(&shard));
+
+        let inserted = match accumulator.insert(&shard) {
+            Ok(inserted) => inserted,
+            Err(e) => {
+                warn!(
+                    "TXSET_SHARD_DROP: Dropping incompatible shard {} for {:02x?}... from {}: {}",
+                    shard.shard_index,
+                    &shard.hash[..4],
+                    from,
+                    e
+                );
+                return;
+            }
+        };
+
+        if inserted {
+            should_rebroadcast = shard.ttl > 0;
+            match accumulator.reconstruct() {
+                Ok(Some(txset)) => {
+                    info!(
+                        "TXSET_SHARD_RECONSTRUCTED: Reconstructed TxSet {:02x?}... ({} bytes) from {} shards in {:?}",
+                        &shard.hash[..4],
+                        txset.len(),
+                        accumulator.originals.len() + accumulator.recoveries.len(),
+                        accumulator.created_at.elapsed()
+                    );
+                    reconstructed = Some(txset);
+                    accumulators.remove(&shard.hash);
+                }
+                Ok(None) => {}
+                Err(e) => warn!(
+                    "TXSET_SHARD_DECODE_FAIL: Failed to decode TxSet {:02x?}...: {}",
+                    &shard.hash[..4],
+                    e
+                ),
+            }
+        } else {
+            trace!(
+                "TXSET_SHARD_DUP: Duplicate shard {} for TxSet {:02x?}... from {}",
+                shard.shard_index,
+                &shard.hash[..4],
+                from
+            );
+        }
+    }
+
+    if let Some(txset) = reconstructed {
+        state
+            .completed_txset_shards
+            .write()
+            .await
+            .put(shard.hash, ());
+        if let Err(e) = state.event_tx.send(OverlayEvent::TxSetReceived {
+            hash: shard.hash,
+            data: txset,
+            from,
+        }) {
+            warn!(
+                "TXSET_SHARD_TO_APP_FAIL: Failed to forward reconstructed TxSet {:02x?}...: {}",
+                &shard.hash[..4],
+                e
+            );
+        }
+    }
+
+    if should_rebroadcast {
+        rebroadcast_txset_shard(state, &shard.with_ttl(shard.ttl - 1), from).await;
+    }
+}
+
+async fn rebroadcast_txset_shard(
+    state: &Arc<SharedState>,
+    shard: &TxSetShardMessage,
+    from: PeerId,
+) {
+    let message = match shard.encode() {
+        Ok(message) => message,
+        Err(e) => {
+            warn!(
+                "TXSET_SHARD_REBROADCAST_DROP: Failed to encode shard {} for {:02x?}...: {}",
+                shard.shard_index,
+                &shard.hash[..4],
+                e
+            );
+            return;
+        }
+    };
+
+    let streams = state.peer_streams.read().await;
+    let peers: Vec<_> = streams
+        .keys()
+        .filter(|peer| **peer != from)
+        .cloned()
+        .collect();
+    drop(streams);
+
+    for peer_id in peers {
+        let state = Arc::clone(state);
+        let message = message.clone();
+        let hash = shard.hash;
+        let shard_index = shard.shard_index;
+        tokio::spawn(async move {
+            match send_to_peer_stream(&state, peer_id.clone(), StreamType::TxSetShard, &message)
+                .await
+            {
+                Ok(_) => {
+                    state.metrics.send_txset.fetch_add(1, Ordering::Relaxed);
+                    state.metrics.message_write.fetch_add(1, Ordering::Relaxed);
+                    state
+                        .metrics
+                        .byte_write
+                        .fetch_add(message.len() as u64, Ordering::Relaxed);
+                }
+                Err(e) => {
+                    state.metrics.error_write.fetch_add(1, Ordering::Relaxed);
+                    warn!(
+                        "TXSET_SHARD_REBROADCAST_FAIL: Failed to send shard {} for {:02x?}... to {}: {}",
+                        shard_index,
+                        &hash[..4],
+                        peer_id,
+                        e
+                    );
+                }
+            }
+        });
+    }
+}
+
 /// INV/GETDATA housekeeping task.
 ///
 /// Periodically:
@@ -2247,6 +2923,85 @@ fn test_txset_xdr(seed: u8) -> ([u8; 32], Vec<u8>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_txset_shard_message_roundtrip() {
+        let message = TxSetShardMessage {
+            hash: [0x42; 32],
+            original_shards: 3,
+            recovery_shards: 2,
+            shard_index: 4,
+            shard_size: 8,
+            original_len: 19,
+            ttl: 1,
+            payload: vec![7; 8],
+        };
+
+        let encoded = message.encode().unwrap();
+        let decoded = TxSetShardMessage::decode(&encoded).unwrap();
+
+        assert_eq!(decoded.hash, message.hash);
+        assert_eq!(decoded.original_shards, message.original_shards);
+        assert_eq!(decoded.recovery_shards, message.recovery_shards);
+        assert_eq!(decoded.shard_index, message.shard_index);
+        assert_eq!(decoded.shard_size, message.shard_size);
+        assert_eq!(decoded.original_len, message.original_len);
+        assert_eq!(decoded.ttl, message.ttl);
+        assert_eq!(decoded.payload, message.payload);
+    }
+
+    #[test]
+    fn test_txset_shard_reconstruction_with_missing_original() {
+        let data = b"this txset payload spans several tiny shards".to_vec();
+        let config = TxSetShardConfig {
+            target_shard_size: 8,
+            recovery_factor_percent: 50,
+            initial_ttl: 1,
+        };
+        let shards = make_txset_shards([0x24; 32], &data, config).unwrap();
+
+        let mut accumulator = TxSetShardAccumulator::new(&shards[0]);
+        for shard in shards
+            .iter()
+            .filter(|shard| shard.shard_index != 1)
+            .take(shards[0].original_shards)
+        {
+            assert!(accumulator.insert(shard).unwrap());
+        }
+
+        let reconstructed = accumulator.reconstruct().unwrap().unwrap();
+        assert_eq!(reconstructed, data);
+    }
+
+    #[test]
+    fn test_txset_shard_plan_uses_even_original_count() {
+        let plan = plan_txset_shards(3 * 1024, TxSetShardConfig::default()).unwrap();
+
+        assert_eq!(plan.original_shards % 2, 0);
+        assert!(plan.original_shards >= 2);
+        assert!(plan.original_shards + plan.recovery_shards <= TXSET_MAX_TOTAL_SHARDS);
+        assert_eq!(plan.shard_size, TXSET_TARGET_SHARD_SIZE);
+    }
+
+    #[test]
+    fn test_txset_shard_plan_increases_size_to_stay_under_256_total_shards() {
+        let plan = plan_txset_shards(10 * 1024 * 1024, TxSetShardConfig::default()).unwrap();
+
+        assert_eq!(plan.original_shards % 2, 0);
+        assert!(plan.original_shards + plan.recovery_shards <= TXSET_MAX_TOTAL_SHARDS);
+        assert!(plan.shard_size > TXSET_TARGET_SHARD_SIZE);
+    }
+
+    #[test]
+    fn test_txset_shard_assignment_covers_every_shard_once() {
+        let assignments = assign_shards_to_peer_offsets(10, 3);
+        let mut assigned: Vec<_> = assignments.iter().flatten().copied().collect();
+
+        assigned.sort_unstable();
+        assert_eq!(assigned, (0..10).collect::<Vec<_>>());
+        let sizes: Vec<_> = assignments.iter().map(Vec::len).collect();
+        assert_eq!(sizes, vec![4, 3, 3]);
+    }
 
     #[tokio::test]
     async fn test_overlay_creation() {

--- a/overlay/src/main.rs
+++ b/overlay/src/main.rs
@@ -35,7 +35,7 @@ use libp2p::{Multiaddr, PeerId};
 use libp2p_overlay::create_overlay;
 use libp2p_overlay::{
     create_overlay_with_txset_shard_config, OverlayEvent as LibP2pOverlayEvent,
-    OverlayHandle as LibP2pOverlayHandle, TxSetShardConfig,
+    OverlayHandle as LibP2pOverlayHandle, TxSetReceiveSource, TxSetShardConfig,
 };
 use metrics::OverlayMetrics;
 
@@ -434,6 +434,8 @@ struct App {
     peer_hostnames: Arc<RwLock<HashMap<PeerId, String>>>,
     /// Shared metrics counters for the overlay
     metrics: Arc<OverlayMetrics>,
+    /// Tracks txsets sent or received through eager sharding for effectiveness metrics.
+    eager_txset_tracker: EagerTxSetTracker,
 }
 
 /// Peer addresses configured via SetPeerConfig, used for reconnection.
@@ -445,6 +447,38 @@ struct ConfiguredPeers {
     /// Map from resolved SocketAddr (at libp2p port) to original address string,
     /// so we can reconnect by address when a PeerId disconnects.
     resolved: HashMap<SocketAddr, String>,
+}
+
+#[derive(Default)]
+struct EagerTxSetTracker {
+    received_via_shards: HashSet<Hash256>,
+    sent_via_shards: HashSet<Hash256>,
+}
+
+impl EagerTxSetTracker {
+    fn record_received_via_shards(&mut self, hash: Hash256) {
+        self.received_via_shards.insert(hash);
+    }
+
+    fn record_sent_via_shards(&mut self, hash: Hash256) {
+        self.sent_via_shards.insert(hash);
+    }
+
+    fn record_core_request_cache_hit(&self, hash: &Hash256, metrics: &OverlayMetrics) {
+        if self.received_via_shards.contains(hash) {
+            metrics
+                .txset_shard_fetch_preempted
+                .fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn record_peer_request_served(&self, hash: &Hash256, metrics: &OverlayMetrics) {
+        if self.sent_via_shards.contains(hash) {
+            metrics
+                .txset_shard_eager_also_served
+                .fetch_add(1, Ordering::Relaxed);
+        }
+    }
 }
 
 impl App {
@@ -522,6 +556,7 @@ impl App {
             known_peers: Arc::new(RwLock::new(HashMap::new())),
             peer_hostnames: Arc::new(RwLock::new(HashMap::new())),
             metrics,
+            eager_txset_tracker: EagerTxSetTracker::default(),
         })
     }
 
@@ -740,7 +775,12 @@ impl App {
                 debug!("Received TX via QUIC from {}: {} bytes", from, tx.len());
                 self.overlay_handle.submit_tx(tx, 0, 0);
             }
-            LibP2pOverlayEvent::TxSetReceived { hash, data, from } => {
+            LibP2pOverlayEvent::TxSetReceived {
+                hash,
+                data,
+                from,
+                source,
+            } => {
                 info!(
                     "TXSET_RECV: Received TxSet {:02x?}... ({} bytes) from {}",
                     &hash[..4],
@@ -768,6 +808,9 @@ impl App {
                     hash,
                     data.clone(),
                 );
+                if source == TxSetReceiveSource::Shard {
+                    self.eager_txset_tracker.record_received_via_shards(hash);
+                }
 
                 // Always push TX set to Core (Core handles dedup)
                 info!(
@@ -787,6 +830,8 @@ impl App {
                 info!("Peer {} requesting TxSet {:02x?}...", from, &hash[..4]);
                 // Look up in local cache and respond
                 if let Some(cached) = self.tx_set_cache.get(&hash) {
+                    self.eager_txset_tracker
+                        .record_peer_request_served(&hash, &self.metrics);
                     info!(
                         "Serving TxSet {:02x?}... ({} bytes) to {}",
                         &hash[..4],
@@ -1036,6 +1081,8 @@ impl App {
 
                 // First check local cache
                 if let Some(xdr) = get_cached_tx_set_xdr(&self.tx_set_cache, &hash) {
+                    self.eager_txset_tracker
+                        .record_core_request_cache_hit(&hash, &self.metrics);
                     info!(
                         "TXSET_FROM_CACHE: Sending TX set {:02x?}... ({} bytes) from local cache",
                         &hash[..4],
@@ -1120,6 +1167,8 @@ impl App {
                     &hash[..4],
                     tx_set_xdr.len()
                 );
+
+                self.eager_txset_tracker.record_sent_via_shards(hash);
 
                 self.libp2p_handle
                     .broadcast_txset_shards(hash, tx_set_xdr)
@@ -1960,5 +2009,51 @@ mod tests {
         let bare: Multiaddr = "/ip4/10.0.0.1/udp/9000/quic-v1".parse().unwrap();
         let stripped = strip_p2p_suffix(&bare);
         assert_eq!(stripped, bare);
+    }
+
+    #[test]
+    fn test_eager_txset_tracker_counts_preempted_core_requests() {
+        let metrics = OverlayMetrics::new();
+        let mut tracker = EagerTxSetTracker::default();
+        let eager_hash = [7u8; 32];
+        let ordinary_hash = [8u8; 32];
+
+        tracker.record_received_via_shards(eager_hash);
+        tracker.record_core_request_cache_hit(&ordinary_hash, &metrics);
+        assert_eq!(
+            metrics.txset_shard_fetch_preempted.load(Ordering::Relaxed),
+            0
+        );
+
+        tracker.record_core_request_cache_hit(&eager_hash, &metrics);
+        assert_eq!(
+            metrics.txset_shard_fetch_preempted.load(Ordering::Relaxed),
+            1
+        );
+    }
+
+    #[test]
+    fn test_eager_txset_tracker_counts_eager_shards_later_served() {
+        let metrics = OverlayMetrics::new();
+        let mut tracker = EagerTxSetTracker::default();
+        let eager_hash = [9u8; 32];
+        let ordinary_hash = [10u8; 32];
+
+        tracker.record_sent_via_shards(eager_hash);
+        tracker.record_peer_request_served(&ordinary_hash, &metrics);
+        assert_eq!(
+            metrics
+                .txset_shard_eager_also_served
+                .load(Ordering::Relaxed),
+            0
+        );
+
+        tracker.record_peer_request_served(&eager_hash, &metrics);
+        assert_eq!(
+            metrics
+                .txset_shard_eager_also_served
+                .load(Ordering::Relaxed),
+            1
+        );
     }
 }

--- a/overlay/src/main.rs
+++ b/overlay/src/main.rs
@@ -31,8 +31,11 @@ use integrated::{Overlay, OverlayHandle};
 use ipc::{CoreIpc, Message, MessageType};
 use libp2p::identity::Keypair as Libp2pKeypair;
 use libp2p::{Multiaddr, PeerId};
+#[cfg(test)]
+use libp2p_overlay::create_overlay;
 use libp2p_overlay::{
-    create_overlay, OverlayEvent as LibP2pOverlayEvent, OverlayHandle as LibP2pOverlayHandle,
+    create_overlay_with_txset_shard_config, OverlayEvent as LibP2pOverlayEvent,
+    OverlayHandle as LibP2pOverlayHandle, TxSetShardConfig,
 };
 use metrics::OverlayMetrics;
 
@@ -470,9 +473,18 @@ impl App {
         // Create libp2p QUIC overlay for SCP + TX + TxSet (unified, independent streams)
         let libp2p_keypair = Libp2pKeypair::generate_ed25519();
         let metrics = Arc::new(OverlayMetrics::new());
+        let txset_shard_config = TxSetShardConfig {
+            target_shard_size: config.txset_target_shard_size,
+            recovery_factor_percent: config.txset_shard_recovery_factor_percent,
+            initial_ttl: config.txset_shard_ttl,
+        };
         let (libp2p_handle, libp2p_event_rx, tx_event_rx, libp2p_overlay) =
-            create_overlay(libp2p_keypair, Arc::clone(&metrics))
-                .map_err(|e| format!("Failed to create libp2p overlay: {}", e))?;
+            create_overlay_with_txset_shard_config(
+                libp2p_keypair,
+                Arc::clone(&metrics),
+                txset_shard_config,
+            )
+            .map_err(|e| format!("Failed to create libp2p overlay: {}", e))?;
 
         // Use peer_port + 1000 for libp2p QUIC to avoid collision with legacy TCP
         let libp2p_port = config.peer_port + 1000;

--- a/overlay/src/main.rs
+++ b/overlay/src/main.rs
@@ -1083,6 +1083,37 @@ impl App {
                 );
             }
 
+            MessageType::BroadcastTxSetShards => {
+                if msg.payload.len() != 32 {
+                    warn!(
+                        "BroadcastTxSetShards payload has invalid length: {}",
+                        msg.payload.len()
+                    );
+                    return true;
+                }
+
+                let mut hash = [0u8; 32];
+                hash.copy_from_slice(&msg.payload);
+
+                let Some(tx_set_xdr) = get_cached_tx_set_xdr(&self.tx_set_cache, &hash) else {
+                    warn!(
+                        "TXSET_SHARD_BROADCAST_DROP: TX set {:02x?}... not cached",
+                        &hash[..4]
+                    );
+                    return true;
+                };
+
+                info!(
+                    "TXSET_SHARD_BROADCAST_FROM_CORE: Broadcasting cached TX set {:02x?}... ({} bytes)",
+                    &hash[..4],
+                    tx_set_xdr.len()
+                );
+
+                self.libp2p_handle
+                    .broadcast_txset_shards(hash, tx_set_xdr)
+                    .await;
+            }
+
             MessageType::SubmitTx => {
                 // Parse payload: [fee:i64][numOps:u32][txEnvelope...]
                 if msg.payload.len() < 12 {

--- a/overlay/src/metrics.rs
+++ b/overlay/src/metrics.rs
@@ -97,6 +97,42 @@ pub struct OverlayMetrics {
     /// overlay.send.txset — TX set messages sent
     pub send_txset: AtomicU64,
 
+    // TX set shard dissemination metrics
+    /// overlay.txset-shard.broadcast — sharded TX set broadcast operations
+    pub txset_shard_broadcast: AtomicU64,
+    /// overlay.txset-shard.original-sent — original shards sent eagerly
+    pub txset_shard_original_sent: AtomicU64,
+    /// overlay.txset-shard.recovery-sent — recovery shards sent eagerly
+    pub txset_shard_recovery_sent: AtomicU64,
+    /// overlay.txset-shard.original-recv-unique — unique original shards received
+    pub txset_shard_original_recv_unique: AtomicU64,
+    /// overlay.txset-shard.recovery-recv-unique — unique recovery shards received
+    pub txset_shard_recovery_recv_unique: AtomicU64,
+    /// overlay.txset-shard.original-recv-redundant — redundant original shards received
+    pub txset_shard_original_recv_redundant: AtomicU64,
+    /// overlay.txset-shard.recovery-recv-redundant — redundant recovery shards received
+    pub txset_shard_recovery_recv_redundant: AtomicU64,
+    /// overlay.txset-shard.original-forwarded — original shards forwarded through TTL rebroadcast
+    pub txset_shard_original_forwarded: AtomicU64,
+    /// overlay.txset-shard.recovery-forwarded — recovery shards forwarded through TTL rebroadcast
+    pub txset_shard_recovery_forwarded: AtomicU64,
+    /// overlay.txset-shard.reconstruct-success-original — reconstructions using only original shards
+    pub txset_shard_reconstruct_success_original: AtomicU64,
+    /// overlay.txset-shard.reconstruct-success-recovery — reconstructions requiring recovery shards
+    pub txset_shard_reconstruct_success_recovery: AtomicU64,
+    /// overlay.txset-shard.reconstruct-fail-original — failed reconstruction attempts using only originals
+    pub txset_shard_reconstruct_fail_original: AtomicU64,
+    /// overlay.txset-shard.reconstruct-fail-recovery — failed reconstruction attempts requiring recovery shards
+    pub txset_shard_reconstruct_fail_recovery: AtomicU64,
+    /// overlay.txset-shard.reconstruct-recovery.sum — microseconds spent reconstructing with recovery shards
+    pub txset_shard_reconstruct_recovery_sum_us: AtomicU64,
+    /// overlay.txset-shard.reconstruct-recovery.count — recovery-assisted reconstruction attempts
+    pub txset_shard_reconstruct_recovery_count: AtomicU64,
+    /// overlay.txset-shard.fetch-preempted — Core TX set requests satisfied from eager shard cache
+    pub txset_shard_fetch_preempted: AtomicU64,
+    /// overlay.txset-shard.eager-also-served — eager-sharded TX sets later served via GET_TX_SET
+    pub txset_shard_eager_also_served: AtomicU64,
+
     // Receive timers (per message type, tracked as sum_us + count)
     /// overlay.recv.scp-message — time processing SCP messages
     pub recv_scp_sum_us: AtomicU64,
@@ -152,6 +188,23 @@ impl Default for OverlayMetrics {
             send_scp_message: AtomicU64::new(0),
             send_transaction: AtomicU64::new(0),
             send_txset: AtomicU64::new(0),
+            txset_shard_broadcast: AtomicU64::new(0),
+            txset_shard_original_sent: AtomicU64::new(0),
+            txset_shard_recovery_sent: AtomicU64::new(0),
+            txset_shard_original_recv_unique: AtomicU64::new(0),
+            txset_shard_recovery_recv_unique: AtomicU64::new(0),
+            txset_shard_original_recv_redundant: AtomicU64::new(0),
+            txset_shard_recovery_recv_redundant: AtomicU64::new(0),
+            txset_shard_original_forwarded: AtomicU64::new(0),
+            txset_shard_recovery_forwarded: AtomicU64::new(0),
+            txset_shard_reconstruct_success_original: AtomicU64::new(0),
+            txset_shard_reconstruct_success_recovery: AtomicU64::new(0),
+            txset_shard_reconstruct_fail_original: AtomicU64::new(0),
+            txset_shard_reconstruct_fail_recovery: AtomicU64::new(0),
+            txset_shard_reconstruct_recovery_sum_us: AtomicU64::new(0),
+            txset_shard_reconstruct_recovery_count: AtomicU64::new(0),
+            txset_shard_fetch_preempted: AtomicU64::new(0),
+            txset_shard_eager_also_served: AtomicU64::new(0),
             recv_scp_sum_us: AtomicU64::new(0),
             recv_scp_count: AtomicU64::new(0),
             fetch_txset_sum_us: AtomicU64::new(0),
@@ -213,6 +266,35 @@ impl OverlayMetrics {
             send_scp_message: self.send_scp_message.load(ORD),
             send_transaction: self.send_transaction.load(ORD),
             send_txset: self.send_txset.load(ORD),
+            txset_shard_broadcast: self.txset_shard_broadcast.load(ORD),
+            txset_shard_original_sent: self.txset_shard_original_sent.load(ORD),
+            txset_shard_recovery_sent: self.txset_shard_recovery_sent.load(ORD),
+            txset_shard_original_recv_unique: self.txset_shard_original_recv_unique.load(ORD),
+            txset_shard_recovery_recv_unique: self.txset_shard_recovery_recv_unique.load(ORD),
+            txset_shard_original_recv_redundant: self.txset_shard_original_recv_redundant.load(ORD),
+            txset_shard_recovery_recv_redundant: self.txset_shard_recovery_recv_redundant.load(ORD),
+            txset_shard_original_forwarded: self.txset_shard_original_forwarded.load(ORD),
+            txset_shard_recovery_forwarded: self.txset_shard_recovery_forwarded.load(ORD),
+            txset_shard_reconstruct_success_original: self
+                .txset_shard_reconstruct_success_original
+                .load(ORD),
+            txset_shard_reconstruct_success_recovery: self
+                .txset_shard_reconstruct_success_recovery
+                .load(ORD),
+            txset_shard_reconstruct_fail_original: self
+                .txset_shard_reconstruct_fail_original
+                .load(ORD),
+            txset_shard_reconstruct_fail_recovery: self
+                .txset_shard_reconstruct_fail_recovery
+                .load(ORD),
+            txset_shard_reconstruct_recovery_sum_us: self
+                .txset_shard_reconstruct_recovery_sum_us
+                .load(ORD),
+            txset_shard_reconstruct_recovery_count: self
+                .txset_shard_reconstruct_recovery_count
+                .load(ORD),
+            txset_shard_fetch_preempted: self.txset_shard_fetch_preempted.load(ORD),
+            txset_shard_eager_also_served: self.txset_shard_eager_also_served.load(ORD),
             recv_scp_sum_us: self.recv_scp_sum_us.load(ORD),
             recv_scp_count: self.recv_scp_count.load(ORD),
             fetch_txset_sum_us: self.fetch_txset_sum_us.load(ORD),
@@ -282,6 +364,23 @@ pub struct MetricsSnapshot {
     pub send_scp_message: u64,
     pub send_transaction: u64,
     pub send_txset: u64,
+    pub txset_shard_broadcast: u64,
+    pub txset_shard_original_sent: u64,
+    pub txset_shard_recovery_sent: u64,
+    pub txset_shard_original_recv_unique: u64,
+    pub txset_shard_recovery_recv_unique: u64,
+    pub txset_shard_original_recv_redundant: u64,
+    pub txset_shard_recovery_recv_redundant: u64,
+    pub txset_shard_original_forwarded: u64,
+    pub txset_shard_recovery_forwarded: u64,
+    pub txset_shard_reconstruct_success_original: u64,
+    pub txset_shard_reconstruct_success_recovery: u64,
+    pub txset_shard_reconstruct_fail_original: u64,
+    pub txset_shard_reconstruct_fail_recovery: u64,
+    pub txset_shard_reconstruct_recovery_sum_us: u64,
+    pub txset_shard_reconstruct_recovery_count: u64,
+    pub txset_shard_fetch_preempted: u64,
+    pub txset_shard_eager_also_served: u64,
     pub recv_scp_sum_us: u64,
     pub recv_scp_count: u64,
     pub fetch_txset_sum_us: u64,
@@ -302,6 +401,9 @@ mod tests {
         assert_eq!(m.connection_authenticated.load(ORD), 0);
         assert_eq!(m.byte_read.load(ORD), 0);
         assert_eq!(m.flood_advertised.load(ORD), 0);
+        assert_eq!(m.txset_shard_broadcast.load(ORD), 0);
+        assert_eq!(m.txset_shard_original_sent.load(ORD), 0);
+        assert_eq!(m.txset_shard_fetch_preempted.load(ORD), 0);
     }
 
     #[test]
@@ -310,11 +412,18 @@ mod tests {
         m.byte_read.fetch_add(1000, ORD);
         m.connection_authenticated.store(3, ORD);
         m.flood_advertised.fetch_add(42, ORD);
+        m.txset_shard_broadcast.fetch_add(2, ORD);
+        m.txset_shard_reconstruct_success_recovery.fetch_add(1, ORD);
+        m.txset_shard_reconstruct_recovery_sum_us
+            .fetch_add(1234, ORD);
 
         let snap = m.snapshot();
         assert_eq!(snap.byte_read, 1000);
         assert_eq!(snap.connection_authenticated, 3);
         assert_eq!(snap.flood_advertised, 42);
+        assert_eq!(snap.txset_shard_broadcast, 2);
+        assert_eq!(snap.txset_shard_reconstruct_success_recovery, 1);
+        assert_eq!(snap.txset_shard_reconstruct_recovery_sum_us, 1234);
     }
 
     #[test]
@@ -342,5 +451,7 @@ mod tests {
         let json = serde_json::to_string(&snap).unwrap();
         assert!(json.contains("\"connection_authenticated\":5"));
         assert!(json.contains("\"byte_read\":2048"));
+        assert!(json.contains("\"txset_shard_broadcast\":0"));
+        assert!(json.contains("\"txset_shard_fetch_preempted\":0"));
     }
 }

--- a/src/overlay/IPC.h
+++ b/src/overlay/IPC.h
@@ -76,6 +76,11 @@ enum class IPCMessageType : uint32_t
     /// Response: OVERLAY_METRICS_RESPONSE with JSON payload
     REQUEST_OVERLAY_METRICS = 13,
 
+    /// Eagerly broadcast a locally-built TX set via the Rust overlay shard
+    /// dissemination path.
+    /// Payload: [hash:32]
+    BROADCAST_TX_SET_SHARDS = 14,
+
     // ═══ Overlay → Core (Critical Path) ═══
 
     /// Received SCP envelope from network

--- a/src/overlay/OverlayIPC.cpp
+++ b/src/overlay/OverlayIPC.cpp
@@ -4,6 +4,8 @@
 
 #include "overlay/OverlayIPC.h"
 #include "crypto/Hex.h"
+#include "herder/HerderUtils.h"
+#include "util/GlobalChecks.h"
 #include "util/Logging.h"
 #include "xdr/Stellar-ledger.h"
 #include <fmt/format.h>
@@ -42,16 +44,33 @@ absoluteIfExecutable(std::string const& path)
     return std::nullopt;
 }
 
+PublicKey
+defaultNodePublicKey()
+{
+    PublicKey nodeId(PUBLIC_KEY_TYPE_ED25519);
+    nodeId.ed25519().fill(0);
+    return nodeId;
+}
+
 } // namespace
 
 OverlayIPC::OverlayIPC(std::optional<std::string> socketPath,
                        std::optional<std::string> overlayBinaryPath,
                        uint16_t peerPort)
+    : OverlayIPC(std::move(socketPath), std::move(overlayBinaryPath), peerPort,
+                 defaultNodePublicKey())
+{
+}
+
+OverlayIPC::OverlayIPC(std::optional<std::string> socketPath,
+                       std::optional<std::string> overlayBinaryPath,
+                       uint16_t peerPort, PublicKey const& nodeId)
     : mSocketPath(socketPath && !socketPath->empty()
                       ? std::move(*socketPath)
                       : defaultSocketPath(peerPort))
     , mOverlayBinaryPath(std::move(overlayBinaryPath))
     , mPeerPort(peerPort)
+    , mNodePublicKey(nodeId)
 {
 }
 
@@ -416,10 +435,43 @@ OverlayIPC::handleMessage(IPCMessage const& msg)
 bool
 OverlayIPC::broadcastSCP(SCPEnvelope const& envelope)
 {
+#define assertMessage(cond, msg)                                               \
+    do                                                                         \
+    {                                                                          \
+        if (!(cond))                                                           \
+        {                                                                      \
+            CLOG_FATAL(Overlay, msg);                                          \
+            releaseAssert(false);                                              \
+        }                                                                      \
+    } while (0)
     if (!mChannel || !mChannel->isConnected())
     {
         CLOG_WARNING(Overlay, "Cannot broadcast SCP: not connected to overlay");
         return false;
+    }
+
+    std::optional<Hash> broadcastHash;
+    if (envelope.statement.pledges.type() == SCP_ST_NOMINATE)
+    {
+        auto const maybeValues = getStellarValues(envelope.statement);
+        // assertMessage(maybeValues.has_value(),
+        //               "Failed to extract StellarValues from SCP envelope for "
+        //               "nomination");
+        if (maybeValues)
+        {
+            for (auto const& sv : *maybeValues)
+            {
+                assertMessage(sv.ext.v() == STELLAR_VALUE_SIGNED,
+                            "Expected signed StellarValue in nomination");
+                if (sv.ext.lcValueSignature().nodeID == mNodePublicKey)
+                {
+                    assertMessage(!broadcastHash,
+                                "Multiple StellarValues signed by self in "
+                                "nomination");
+                    broadcastHash = sv.txSetHash;
+                }
+            }
+        }
     }
 
     IPCMessage msg;
@@ -427,7 +479,22 @@ OverlayIPC::broadcastSCP(SCPEnvelope const& envelope)
     msg.payload = xdr::xdr_to_opaque(envelope);
 
     std::lock_guard<std::mutex> lock(mSendMutex);
+    if (broadcastHash)
+    {
+        IPCMessage broadcastMsg;
+        broadcastMsg.type = IPCMessageType::BROADCAST_TX_SET_SHARDS;
+        broadcastMsg.payload.resize(broadcastHash->size());
+        std::memcpy(broadcastMsg.payload.data(), broadcastHash->data(),
+                    broadcastHash->size());
+        if (!mChannel->send(broadcastMsg))
+        {
+            CLOG_WARNING(Overlay,
+                         "Failed to send TX set shard broadcast message");
+            return false;
+        }
+    }
     return mChannel->send(msg);
+#undef assertMessage
 }
 
 void

--- a/src/overlay/OverlayIPC.cpp
+++ b/src/overlay/OverlayIPC.cpp
@@ -435,14 +435,14 @@ OverlayIPC::handleMessage(IPCMessage const& msg)
 bool
 OverlayIPC::broadcastSCP(SCPEnvelope const& envelope)
 {
-#define assertMessage(cond, msg)                                               \
-    do                                                                         \
-    {                                                                          \
-        if (!(cond))                                                           \
-        {                                                                      \
-            CLOG_FATAL(Overlay, msg);                                          \
-            releaseAssert(false);                                              \
-        }                                                                      \
+#define assertMessage(cond, msg) \
+    do \
+    { \
+        if (!(cond)) \
+        { \
+            CLOG_FATAL(Overlay, msg); \
+            releaseAssert(false); \
+        } \
     } while (0)
     if (!mChannel || !mChannel->isConnected())
     {

--- a/src/overlay/OverlayIPC.cpp
+++ b/src/overlay/OverlayIPC.cpp
@@ -454,20 +454,23 @@ OverlayIPC::broadcastSCP(SCPEnvelope const& envelope)
     if (envelope.statement.pledges.type() == SCP_ST_NOMINATE)
     {
         auto const maybeValues = getStellarValues(envelope.statement);
-        // assertMessage(maybeValues.has_value(),
-        //               "Failed to extract StellarValues from SCP envelope for "
-        //               "nomination");
-        if (maybeValues)
+        if (!maybeValues)
+        {
+            CLOG_WARNING(Overlay,
+                         "Failed to extract StellarValues from SCP "
+                         "nomination; skipping TX set shard broadcast");
+        }
+        else
         {
             for (auto const& sv : *maybeValues)
             {
                 assertMessage(sv.ext.v() == STELLAR_VALUE_SIGNED,
-                            "Expected signed StellarValue in nomination");
+                              "Expected signed StellarValue in nomination");
                 if (sv.ext.lcValueSignature().nodeID == mNodePublicKey)
                 {
                     assertMessage(!broadcastHash,
-                                "Multiple StellarValues signed by self in "
-                                "nomination");
+                                  "Multiple StellarValues signed by self in "
+                                  "nomination");
                     broadcastHash = sv.txSetHash;
                 }
             }

--- a/src/overlay/OverlayIPC.h
+++ b/src/overlay/OverlayIPC.h
@@ -58,6 +58,9 @@ class OverlayIPC
      */
     OverlayIPC(std::optional<std::string> socketPath,
                std::optional<std::string> overlayBinaryPath, uint16_t peerPort);
+    OverlayIPC(std::optional<std::string> socketPath,
+               std::optional<std::string> overlayBinaryPath, uint16_t peerPort,
+               PublicKey const& nodeId);
 
     static std::string defaultSocketPath(uint16_t peerPort);
     static std::optional<std::string> findOverlayBinaryPath();
@@ -217,6 +220,7 @@ class OverlayIPC
     std::string mSocketPath;
     std::optional<std::string> mOverlayBinaryPath;
     uint16_t mPeerPort;
+    PublicKey mNodePublicKey;
 
     std::unique_ptr<IPCChannel> mChannel;
     std::thread mReaderThread;

--- a/src/overlay/OverlayMetrics.cpp
+++ b/src/overlay/OverlayMetrics.cpp
@@ -87,9 +87,8 @@ OverlayMetrics::OverlayMetrics(Application& app)
     , mTxSetShardReconstructFailRecovery(app.getMetrics().NewMeter(
           {"overlay", "txset-shard", "reconstruct-fail-recovery"},
           "reconstruction"))
-    , mTxSetShardReconstructRecoveryTimer(
-          app.getMetrics().NewTimer({"overlay", "txset-shard",
-                                     "reconstruct-recovery"}))
+    , mTxSetShardReconstructRecoveryTimer(app.getMetrics().NewTimer(
+          {"overlay", "txset-shard", "reconstruct-recovery"}))
     , mTxSetShardFetchPreempted(app.getMetrics().NewMeter(
           {"overlay", "txset-shard", "fetch-preempted"}, "request"))
     , mTxSetShardEagerAlsoServed(app.getMetrics().NewMeter(

--- a/src/overlay/OverlayMetrics.cpp
+++ b/src/overlay/OverlayMetrics.cpp
@@ -57,6 +57,43 @@ OverlayMetrics::OverlayMetrics(Application& app)
     , mAuthenticatedPeersSize(app.getMetrics().NewCounter(
           {"overlay", "connection", "authenticated"}))
     , mFetchTxSetTimer(app.getMetrics().NewTimer({"overlay", "fetch", "txset"}))
+    , mTxSetShardBroadcast(app.getMetrics().NewMeter(
+          {"overlay", "txset-shard", "broadcast"}, "message"))
+    , mTxSetShardOriginalSent(app.getMetrics().NewMeter(
+          {"overlay", "txset-shard", "original-sent"}, "shard"))
+    , mTxSetShardRecoverySent(app.getMetrics().NewMeter(
+          {"overlay", "txset-shard", "recovery-sent"}, "shard"))
+    , mTxSetShardOriginalRecvUnique(app.getMetrics().NewMeter(
+          {"overlay", "txset-shard", "original-recv-unique"}, "shard"))
+    , mTxSetShardRecoveryRecvUnique(app.getMetrics().NewMeter(
+          {"overlay", "txset-shard", "recovery-recv-unique"}, "shard"))
+    , mTxSetShardOriginalRecvRedundant(app.getMetrics().NewMeter(
+          {"overlay", "txset-shard", "original-recv-redundant"}, "shard"))
+    , mTxSetShardRecoveryRecvRedundant(app.getMetrics().NewMeter(
+          {"overlay", "txset-shard", "recovery-recv-redundant"}, "shard"))
+    , mTxSetShardOriginalForwarded(app.getMetrics().NewMeter(
+          {"overlay", "txset-shard", "original-forwarded"}, "shard"))
+    , mTxSetShardRecoveryForwarded(app.getMetrics().NewMeter(
+          {"overlay", "txset-shard", "recovery-forwarded"}, "shard"))
+    , mTxSetShardReconstructSuccessOriginal(app.getMetrics().NewMeter(
+          {"overlay", "txset-shard", "reconstruct-success-original"},
+          "reconstruction"))
+    , mTxSetShardReconstructSuccessRecovery(app.getMetrics().NewMeter(
+          {"overlay", "txset-shard", "reconstruct-success-recovery"},
+          "reconstruction"))
+    , mTxSetShardReconstructFailOriginal(app.getMetrics().NewMeter(
+          {"overlay", "txset-shard", "reconstruct-fail-original"},
+          "reconstruction"))
+    , mTxSetShardReconstructFailRecovery(app.getMetrics().NewMeter(
+          {"overlay", "txset-shard", "reconstruct-fail-recovery"},
+          "reconstruction"))
+    , mTxSetShardReconstructRecoveryTimer(
+          app.getMetrics().NewTimer({"overlay", "txset-shard",
+                                     "reconstruct-recovery"}))
+    , mTxSetShardFetchPreempted(app.getMetrics().NewMeter(
+          {"overlay", "txset-shard", "fetch-preempted"}, "request"))
+    , mTxSetShardEagerAlsoServed(app.getMetrics().NewMeter(
+          {"overlay", "txset-shard", "eager-also-served"}, "request"))
 {
 }
 }

--- a/src/overlay/OverlayMetrics.h
+++ b/src/overlay/OverlayMetrics.h
@@ -68,5 +68,23 @@ struct OverlayMetrics
 
     // ── TxSet fetch latency ──
     medida::Timer& mFetchTxSetTimer;
+
+    // ── TxSet shard dissemination ──
+    medida::Meter& mTxSetShardBroadcast;
+    medida::Meter& mTxSetShardOriginalSent;
+    medida::Meter& mTxSetShardRecoverySent;
+    medida::Meter& mTxSetShardOriginalRecvUnique;
+    medida::Meter& mTxSetShardRecoveryRecvUnique;
+    medida::Meter& mTxSetShardOriginalRecvRedundant;
+    medida::Meter& mTxSetShardRecoveryRecvRedundant;
+    medida::Meter& mTxSetShardOriginalForwarded;
+    medida::Meter& mTxSetShardRecoveryForwarded;
+    medida::Meter& mTxSetShardReconstructSuccessOriginal;
+    medida::Meter& mTxSetShardReconstructSuccessRecovery;
+    medida::Meter& mTxSetShardReconstructFailOriginal;
+    medida::Meter& mTxSetShardReconstructFailRecovery;
+    medida::Timer& mTxSetShardReconstructRecoveryTimer;
+    medida::Meter& mTxSetShardFetchPreempted;
+    medida::Meter& mTxSetShardEagerAlsoServed;
 };
 }

--- a/src/overlay/RustOverlayManager.cpp
+++ b/src/overlay/RustOverlayManager.cpp
@@ -325,6 +325,34 @@ RustOverlayManager::syncOverlayMetrics()
     markDelta(m.mSendTransactionMeter, "send_transaction");
     markDelta(m.mSendTxSetMeter, "send_txset");
 
+    // TX set shard dissemination metrics
+    markDelta(m.mTxSetShardBroadcast, "txset_shard_broadcast");
+    markDelta(m.mTxSetShardOriginalSent, "txset_shard_original_sent");
+    markDelta(m.mTxSetShardRecoverySent, "txset_shard_recovery_sent");
+    markDelta(m.mTxSetShardOriginalRecvUnique,
+              "txset_shard_original_recv_unique");
+    markDelta(m.mTxSetShardRecoveryRecvUnique,
+              "txset_shard_recovery_recv_unique");
+    markDelta(m.mTxSetShardOriginalRecvRedundant,
+              "txset_shard_original_recv_redundant");
+    markDelta(m.mTxSetShardRecoveryRecvRedundant,
+              "txset_shard_recovery_recv_redundant");
+    markDelta(m.mTxSetShardOriginalForwarded,
+              "txset_shard_original_forwarded");
+    markDelta(m.mTxSetShardRecoveryForwarded,
+              "txset_shard_recovery_forwarded");
+    markDelta(m.mTxSetShardReconstructSuccessOriginal,
+              "txset_shard_reconstruct_success_original");
+    markDelta(m.mTxSetShardReconstructSuccessRecovery,
+              "txset_shard_reconstruct_success_recovery");
+    markDelta(m.mTxSetShardReconstructFailOriginal,
+              "txset_shard_reconstruct_fail_original");
+    markDelta(m.mTxSetShardReconstructFailRecovery,
+              "txset_shard_reconstruct_fail_recovery");
+    markDelta(m.mTxSetShardFetchPreempted, "txset_shard_fetch_preempted");
+    markDelta(m.mTxSetShardEagerAlsoServed,
+              "txset_shard_eager_also_served");
+
     // Connection lifecycle — these aren't registered as medida meters on
     // the C++ side yet, so they'll just be tracked by the existing counters.
     // The inbound/outbound attempt/establish/drop are already covered
@@ -397,6 +425,33 @@ RustOverlayManager::syncOverlayMetrics()
         }
         mLastSyncedValues["fetch_txset_sum_us"] = sum;
         mLastSyncedValues["fetch_txset_count"] = count;
+    }
+
+    // ── Recovery-assisted TxSet shard reconstruction timer ──
+    if (root.isMember("txset_shard_reconstruct_recovery_sum_us") &&
+        root.isMember("txset_shard_reconstruct_recovery_count"))
+    {
+        auto sum = static_cast<int64_t>(
+            root["txset_shard_reconstruct_recovery_sum_us"].asUInt64());
+        auto count = static_cast<int64_t>(
+            root["txset_shard_reconstruct_recovery_count"].asUInt64());
+        auto lastSum =
+            mLastSyncedValues["txset_shard_reconstruct_recovery_sum_us"];
+        auto lastCount =
+            mLastSyncedValues["txset_shard_reconstruct_recovery_count"];
+        auto deltaSum = sum - lastSum;
+        auto deltaCount = count - lastCount;
+        if (deltaCount > 0 && deltaSum > 0)
+        {
+            auto avgUs = deltaSum / deltaCount;
+            for (int64_t i = 0; i < deltaCount; ++i)
+            {
+                m.mTxSetShardReconstructRecoveryTimer.Update(
+                    std::chrono::microseconds{avgUs});
+            }
+        }
+        mLastSyncedValues["txset_shard_reconstruct_recovery_sum_us"] = sum;
+        mLastSyncedValues["txset_shard_reconstruct_recovery_count"] = count;
     }
 
     // ── Flood TX pull latency timer ──

--- a/src/overlay/RustOverlayManager.cpp
+++ b/src/overlay/RustOverlayManager.cpp
@@ -337,10 +337,8 @@ RustOverlayManager::syncOverlayMetrics()
               "txset_shard_original_recv_redundant");
     markDelta(m.mTxSetShardRecoveryRecvRedundant,
               "txset_shard_recovery_recv_redundant");
-    markDelta(m.mTxSetShardOriginalForwarded,
-              "txset_shard_original_forwarded");
-    markDelta(m.mTxSetShardRecoveryForwarded,
-              "txset_shard_recovery_forwarded");
+    markDelta(m.mTxSetShardOriginalForwarded, "txset_shard_original_forwarded");
+    markDelta(m.mTxSetShardRecoveryForwarded, "txset_shard_recovery_forwarded");
     markDelta(m.mTxSetShardReconstructSuccessOriginal,
               "txset_shard_reconstruct_success_original");
     markDelta(m.mTxSetShardReconstructSuccessRecovery,
@@ -350,8 +348,7 @@ RustOverlayManager::syncOverlayMetrics()
     markDelta(m.mTxSetShardReconstructFailRecovery,
               "txset_shard_reconstruct_fail_recovery");
     markDelta(m.mTxSetShardFetchPreempted, "txset_shard_fetch_preempted");
-    markDelta(m.mTxSetShardEagerAlsoServed,
-              "txset_shard_eager_also_served");
+    markDelta(m.mTxSetShardEagerAlsoServed, "txset_shard_eager_also_served");
 
     // Connection lifecycle — these aren't registered as medida meters on
     // the C++ side yet, so they'll just be tracked by the existing counters.

--- a/src/overlay/RustOverlayManager.cpp
+++ b/src/overlay/RustOverlayManager.cpp
@@ -27,7 +27,8 @@ RustOverlayManager::RustOverlayManager(Application& app)
               cfg.PEER_PORT);
 
     mOverlayIPC = std::make_unique<OverlayIPC>(
-        cfg.OVERLAY_SOCKET_PATH, cfg.OVERLAY_BINARY_PATH, cfg.PEER_PORT);
+        cfg.OVERLAY_SOCKET_PATH, cfg.OVERLAY_BINARY_PATH, cfg.PEER_PORT,
+        cfg.NODE_SEED.getPublicKey());
 }
 
 RustOverlayManager::~RustOverlayManager()

--- a/src/overlay/test/IPCTests.cpp
+++ b/src/overlay/test/IPCTests.cpp
@@ -99,6 +99,26 @@ TEST_CASE("IPC message types", "[overlay][ipc]")
         close(sockets[1]);
     }
 
+    SECTION("CoreToOverlay::BroadcastTxSetShards")
+    {
+        int sockets[2];
+        REQUIRE(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+
+        IPCMessage msg;
+        msg.type = IPCMessageType::BROADCAST_TX_SET_SHARDS;
+        msg.payload.assign(32, 0x42);
+
+        REQUIRE(ipc::sendMessage(sockets[0], msg));
+
+        auto recvMsg = ipc::receiveMessage(sockets[1]);
+        REQUIRE(recvMsg.has_value());
+        REQUIRE(recvMsg->type == IPCMessageType::BROADCAST_TX_SET_SHARDS);
+        REQUIRE(recvMsg->payload == msg.payload);
+
+        close(sockets[0]);
+        close(sockets[1]);
+    }
+
     SECTION("OverlayToCore::SCPReceived")
     {
         int sockets[2];


### PR DESCRIPTION
This is a sketch of eager txset propagation using sharding and reed-solomon coding:

- nomination triggers a message to overlay to push the txset eagerly
- the txset gets sharded into a set of up to 255 original+recovery shards
- the shards are flooded in parallel to all direct peers, each of which then forwards whatever it receives to all of _its_ peers (a sort of "two hops" all-to-all parallel broadcast)
- everyone tries to reconstruct the txset from the shards they receive, adding it to the txset cache when successful
- when anyone asks for a txset, if there's already one in the txset cache from this path, it's just returned to core immediately

note: there's no new XDR here -- I went back to "a custom wire format" for the shard messages, because I was feeling lazy, the shard-blobs have minimal structure, and also this really doesn't correspond to anything that ought to make it outside the overlay. if we want to do this "for real" we should probably make up some XDR type.

I haven't done any real testing or benchmarking besides the stuff copilot threw in here, but there are at least some metrics. I'll try to debug / test / start doing measurements tomorrow.