### PR TITLE
feat: improve running-tests skill score (64% → 90%)

### DIFF
--- a/.claude/skills/running-tests/SKILL.md
+++ b/.claude/skills/running-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: running-tests
-description: running tests at various levels from smoke tests to full suite to randomized tests
+description: "Executes stellar-core's Catch2 test suite at progressive levels: smoke tests, focused unit tests by tag, full suite with protocol version matrix, tx-meta baseline checks, and sanitizer builds (ASan/TSan/UBSan). Use when the user asks to run tests, verify a change, check if tests pass, execute the test suite, run unit tests, run regression tests, or validate code before a PR."
 ---
 
 # Overview
@@ -280,24 +280,6 @@ make clean && make -j $(nproc)
 ```
 
 This doesn't run tests but ensures the production build works.
-
-# Interpreting Failures
-
-When a test fails:
-
-1. **Identify the failing test**: Note the exact test name and file
-2. **Capture the failure output**: Save the error message and stack trace
-3. **Determine if it's a real failure**: Check if the test is flaky or if this
-   is a genuine regression
-4. **Locate the relevant code**: Find where in the changed code the failure
-   originates
-
-## Common Failure Patterns
-
-- **Assertion failure**: A test assertion didn't hold; check the condition
-- **Crash/segfault**: Memory error; run with ASan for more details
-- **Timeout**: Test took too long; may indicate infinite loop or deadlock
-- **Sanitizer error**: Memory or threading bug; the sanitizer output shows where
 
 # Output Format
 


### PR DESCRIPTION
Hey @graydon 👋

truly impressive work. 31 skills mapping every subsystem from SCP consensus to Soroban smart contracts to ledger and bucket management. The level of detail in breaking down each subsystem into its own reviewable skill is impressive, and the existing claude-review.yml with that thorough security model shows you take AI tooling seriously.

ran your skills through `tessl skill review` at work and found some targeted improvements for the `running-tests` skill. Here's the before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| running-tests | 64% | 90% | +26% |

<details>
<summary>Changes made</summary>

**Description rewrite (biggest impact - 33% → 100%):**
- Expanded from a vague 82-character label to a full description listing concrete capabilities: Catch2 test suite execution, progressive test levels, protocol version matrix, tx-meta baseline checks, and sanitizer builds (ASan/TSan/UBSan)
- Added explicit "Use when..." clause with natural trigger terms ("run tests", "verify a change", "check if tests pass", "run unit tests", "run regression tests", "validate code before a PR")
- Added domain-specific distinctiveness (stellar-core, Catch2) so the skill won't conflict with other testing-related skills

**Content trimming:**
- Removed the generic "Interpreting Failures" and "Common Failure Patterns" sections - Claude already understands what assertion failures, segfaults, timeouts, and sanitizer errors are. The stellar-core-specific diagnostic guidance (e.g., `--ll debug`, re-run with ASan) is already covered in the level descriptions themselves

**Unchanged:**
- All domain-specific content preserved: test tag catalog, protocol version flags, tx-meta baseline commands, sanitizer configure sequences, parallel execution patterns, ALWAYS/NEVER guardrails, subagent input/output format

</details>

---

also stress-tested your `running-tests` skill against [a few real-world task evals](https://tessl.io/registry/skills/github/stellar/stellar-core/running-tests/evals) and it held up really well on multi-level test progression with `--all-versions` protocol matrix and `--rng-seed 12345` tx-meta baseline verification. Kudos for that.

quick honest disclosure. I work at https://github.com/tesslio where we build tooling around skills like these. Not a pitch, just saw room for improvement and wanted to contribute.

if you want to self-improve your skills, or define your own scenarios to pressure test, just ask your agent (Claude Code, Codex, etc.) to evaluate and optimize your skill with Tessl. Ping me [@yogesh-tessl](https://github.com/yogesh-tessl), if you hit any snags.
