### PR TITLE
Fix an over-eager determinizer hack breaking overlay fuzzer

### DIFF
--- a/src/crypto/Random.cpp
+++ b/src/crypto/Random.cpp
@@ -40,7 +40,7 @@ randomBytes(size_t length)
 #endif
 
 #ifdef MSAN_ENABLED
-    __msan_unpoison(out.key.data(), out.key.size());
+    __msan_unpoison(vec.data(), vec.size());
 #endif
     return vec;
 }

--- a/src/crypto/Random.cpp
+++ b/src/crypto/Random.cpp
@@ -4,6 +4,7 @@
 
 #include "crypto/Random.h"
 #include "lib/util/stdrandom.h"
+#include "util/GlobalChecks.h"
 #include "util/Math.h"
 
 #include <algorithm>
@@ -19,10 +20,21 @@ randomBytes(size_t length)
     std::vector<uint8_t> vec(length);
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    stellar::uniform_int_distribution<unsigned short> dist(0, 255);
-    std::generate(vec.begin(), vec.end(), [&]() {
-        return static_cast<uint8_t>(dist(stellar::getGlobalRandomEngine()));
-    });
+    if (stellar::threadIsMain())
+    {
+        // Only do this when threadIsMain because (a) we assert it
+        // inside the getGlobalRandomEngine() and (b) if we're not
+        // on main thread then thread scheduling is non-deterministic
+        // anyways and there's no point in trying to be deterministic.
+        stellar::uniform_int_distribution<unsigned short> dist(0, 255);
+        std::generate(vec.begin(), vec.end(), [&]() {
+            return static_cast<uint8_t>(dist(stellar::getGlobalRandomEngine()));
+        });
+    }
+    else
+    {
+        randombytes_buf(vec.data(), length);
+    }
 #else
     randombytes_buf(vec.data(), length);
 #endif


### PR DESCRIPTION
We have a little hack in Random.cpp that routes to the semi-deterministic global PRNG for drawing random bytes when we're in a fuzzer build. This helps reduce pointless nondeterminism, but we've also in the meantime made the global PRNG main-thread-only (sensibly!) and so this actually hits an assert.

The simplest fix -- and I think entirely adequate since this is a fuzzer-only hack anyways -- is to only do the diversion on the main thread, and let non-main threads (of which there are only a small number of callers, mostly those generating random filenames) keep using the normal-build path of accessing true entropy.