### PR TITLE
Add DISABLE_TX_META_FOR_TESTING config flag.

### DIFF
--- a/docs/apply-load-benchmark-sac.cfg
+++ b/docs/apply-load-benchmark-sac.cfg
@@ -16,6 +16,8 @@ APPLY_LOAD_TIME_WRITES = true
 # eventually, it is useful to disable these when optimizing anything besides
 # the metrics.
 DISABLE_SOROBAN_METRICS_FOR_TESTING = true
+# Disable transaction metadata collection (BUILD_TESTS forces it otherwise)
+DISABLE_TX_META_FOR_TESTING = true
 # Disable metadata output
 METADATA_OUTPUT_STREAM = ""
 # Disable metadata debug

--- a/docs/apply-load-benchmark-token.cfg
+++ b/docs/apply-load-benchmark-token.cfg
@@ -16,6 +16,8 @@ APPLY_LOAD_TIME_WRITES = true
 # eventually, it is useful to disable these when optimizing anything besides
 # the metrics.
 DISABLE_SOROBAN_METRICS_FOR_TESTING = true
+# Disable transaction metadata collection (BUILD_TESTS forces it otherwise)
+DISABLE_TX_META_FOR_TESTING = true
 # Disable metadata output
 METADATA_OUTPUT_STREAM = ""
 # Disable metadata debug

--- a/scripts/apply_load/aws/apply-load-aws-benchmark.cfg
+++ b/scripts/apply_load/aws/apply-load-aws-benchmark.cfg
@@ -17,6 +17,8 @@ APPLY_LOAD_TIME_WRITES = true
 # eventually, it is useful to disable these when optimizing anything besides
 # the metrics.
 DISABLE_SOROBAN_METRICS_FOR_TESTING = true
+# Disable transaction metadata collection (BUILD_TESTS forces it otherwise)
+DISABLE_TX_META_FOR_TESTING = true
 # Disable metadata output
 METADATA_OUTPUT_STREAM = ""
 # Disable metadata debug

--- a/scripts/apply_load/aws/apply-load-aws-ledger-limits.cfg
+++ b/scripts/apply_load/aws/apply-load-aws-ledger-limits.cfg
@@ -13,6 +13,8 @@ LOG_FILE_PATH="{log_file_path}"
 # eventually, it is useful to disable these when optimizing anything besides
 # the metrics.
 DISABLE_SOROBAN_METRICS_FOR_TESTING = false
+# Disable transaction metadata collection (BUILD_TESTS forces it otherwise)
+DISABLE_TX_META_FOR_TESTING = true
 # Disable metadata output
 METADATA_OUTPUT_STREAM = ""
 # Disable metadata debug

--- a/scripts/apply_load/aws/apply-load-aws-max-sac-tps.cfg
+++ b/scripts/apply_load/aws/apply-load-aws-max-sac-tps.cfg
@@ -17,6 +17,8 @@ APPLY_LOAD_TIME_WRITES = true
 # eventually, it is useful to disable these when optimizing anything besides
 # the metrics.
 DISABLE_SOROBAN_METRICS_FOR_TESTING = true
+# Disable transaction metadata collection (BUILD_TESTS forces it otherwise)
+DISABLE_TX_META_FOR_TESTING = true
 # Disable metadata output
 METADATA_OUTPUT_STREAM = ""
 # Disable metadata debug

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1606,8 +1606,9 @@ LedgerManagerImpl::applyLedger(LedgerCloseData const& ledgerData,
     }
 
 #ifdef BUILD_TESTS
-    // We always store the ledgerCloseMeta in tests so we can inspect it.
-    if (!ledgerCloseMeta)
+    // We always store the ledgerCloseMeta in tests so we can inspect it,
+    // unless explicitly disabled for benchmarking.
+    if (!ledgerCloseMeta && !mApp.getConfig().DISABLE_TX_META_FOR_TESTING)
     {
         ledgerCloseMeta = std::make_unique<LedgerCloseMetaFrame>(
             header.current().ledgerVersion);
@@ -2612,7 +2613,10 @@ LedgerManagerImpl::processResultAndMeta(
     {
         auto metaXDR = txMetaBuilder.finalize(result.isSuccess());
 #ifdef BUILD_TESTS
-        mLastLedgerTxMeta.emplace_back(metaXDR);
+        if (!mApp.getConfig().DISABLE_TX_META_FOR_TESTING)
+        {
+            mLastLedgerTxMeta.emplace_back(metaXDR);
+        }
 #endif
 
         ledgerCloseMeta->setTxProcessingMetaAndResultPair(
@@ -2621,8 +2625,11 @@ LedgerManagerImpl::processResultAndMeta(
     else
     {
 #ifdef BUILD_TESTS
-        mLastLedgerTxMeta.emplace_back(
-            txMetaBuilder.finalize(result.isSuccess()));
+        if (!mApp.getConfig().DISABLE_TX_META_FOR_TESTING)
+        {
+            mLastLedgerTxMeta.emplace_back(
+                txMetaBuilder.finalize(result.isSuccess()));
+        }
 #endif
     }
 }
@@ -2668,8 +2675,11 @@ LedgerManagerImpl::applyTransactions(
     bool enableTxMeta = ledgerCloseMeta != nullptr;
 #ifdef BUILD_TESTS
     // In tests we want to always enable tx meta because we store it in
-    // mLastLedgerTxMeta.
-    enableTxMeta = true;
+    // mLastLedgerTxMeta, unless explicitly disabled for benchmarking.
+    if (!mApp.getConfig().DISABLE_TX_META_FOR_TESTING)
+    {
+        enableTxMeta = true;
+    }
 #endif
     std::optional<SorobanNetworkConfig> sorobanConfig;
     if (protocolVersionStartsFrom(ltx.loadHeader().current().ledgerVersion,

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -172,6 +172,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     BACKGROUND_OVERLAY_PROCESSING = true;
     PARALLEL_LEDGER_APPLY = true;
     DISABLE_SOROBAN_METRICS_FOR_TESTING = false;
+    DISABLE_TX_META_FOR_TESTING = false;
     BACKGROUND_TX_SIG_VERIFICATION = true;
     BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT = 14; // 2^14 == 16 kb
     BUCKETLIST_DB_INDEX_CUTOFF = 20;             // 20 mb
@@ -1188,6 +1189,8 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                  [&]() {
                      DISABLE_SOROBAN_METRICS_FOR_TESTING = readBool(item);
                  }},
+                {"DISABLE_TX_META_FOR_TESTING",
+                 [&]() { DISABLE_TX_META_FOR_TESTING = readBool(item); }},
                 {"EXPERIMENTAL_BACKGROUND_TX_SIG_VERIFICATION",
                  [&]() {
                      CLOG_WARNING(Overlay,

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -525,6 +525,11 @@ class Config : public std::enable_shared_from_this<Config>
     // Disable expensive Soroban metrics for performance testing
     bool DISABLE_SOROBAN_METRICS_FOR_TESTING;
 
+    // Disable transaction metadata collection in test builds.
+    // This is useful for benchmarking, which is typically done in BUILD_TESTS
+    // builds.
+    bool DISABLE_TX_META_FOR_TESTING;
+
     // Batch transactions for flooding purposes (experimental).
     // Has no effect on non-test builds.
     size_t EXPERIMENTAL_TX_BATCH_MAX_SIZE;


### PR DESCRIPTION
# Description

Add DISABLE_TX_META_FOR_TESTING config flag.

BUILD_TESTS builds unconditionally populate mLastLedgerTxMeta and force-enable tx meta so tests can inspect it, but since the apply-load benchmarks are built with BUILD_TESTS as well we need a way to unconditionally disable meta.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
