### PR TITLE
Parallelize InMemoryIndex construction with bucket put loop.

### DIFF
--- a/src/bucket/BucketOutputIterator.cpp
+++ b/src/bucket/BucketOutputIterator.cpp
@@ -168,7 +168,8 @@ template <typename BucketT>
 std::shared_ptr<BucketT>
 BucketOutputIterator<BucketT>::getBucket(
     BucketManager& bucketManager, MergeKey* mergeKey,
-    std::unique_ptr<std::vector<typename BucketT::EntryT>> inMemoryState)
+    std::unique_ptr<std::vector<typename BucketT::EntryT>> inMemoryState,
+    std::shared_ptr<typename BucketT::IndexT const> preBuiltIndex)
 {
     ZoneScoped;
     if (mBuf)
@@ -219,7 +220,11 @@ BucketOutputIterator<BucketT>::getBucket(
 
     if (!index)
     {
-        if constexpr (std::is_same_v<BucketT, LiveBucket>)
+        if (preBuiltIndex)
+        {
+            index = std::move(preBuiltIndex);
+        }
+        else if constexpr (std::is_same_v<BucketT, LiveBucket>)
         {
             if (inMemoryState)
             {

--- a/src/bucket/BucketOutputIterator.h
+++ b/src/bucket/BucketOutputIterator.h
@@ -55,6 +55,8 @@ template <typename BucketT> class BucketOutputIterator
     std::shared_ptr<BucketT> getBucket(
         BucketManager& bucketManager, MergeKey* mergeKey = nullptr,
         std::unique_ptr<std::vector<typename BucketT::EntryT>> inMemoryState =
+            nullptr,
+        std::shared_ptr<typename BucketT::IndexT const> preBuiltIndex =
             nullptr);
 };
 }

--- a/src/bucket/LiveBucket.cpp
+++ b/src/bucket/LiveBucket.cpp
@@ -10,6 +10,7 @@
 #include "bucket/BucketOutputIterator.h"
 #include "bucket/BucketUtils.h"
 #include "bucket/LedgerCmp.h"
+#include <future>
 #include <medida/counter.h>
 
 namespace stellar
@@ -595,6 +596,14 @@ LiveBucket::mergeInMemory(BucketManager& bucketManager,
         bucketManager.incrMergeCounters<LiveBucket>(mc);
     }
 
+    // Start index construction on a worker thread, the inputs are all
+    // read-only from that point on.
+    auto indexFuture = std::async(
+        std::launch::async, [&bucketManager, &mergedEntries, &meta]() {
+            return std::make_shared<LiveBucketIndex const>(bucketManager,
+                                                           mergedEntries, meta);
+        });
+
     // Write merge output to a bucket and save to disk
     LiveBucketOutputIterator out(bucketManager.getTmpDir(),
                                  /*keepTombstoneEntries=*/true, meta, mc, ctx,
@@ -605,11 +614,14 @@ LiveBucket::mergeInMemory(BucketManager& bucketManager,
         out.put(e);
     }
 
+    auto preBuiltIndex = indexFuture.get();
+
     // Store the merged entries in memory in the new bucket in case this
     // bucket sees another incoming merge as level 0 curr.
     return out.getBucket(
         bucketManager, nullptr,
-        std::make_unique<std::vector<BucketEntry>>(std::move(mergedEntries)));
+        std::make_unique<std::vector<BucketEntry>>(std::move(mergedEntries)),
+        std::move(preBuiltIndex));
 }
 
 BucketEntryCounters const&


### PR DESCRIPTION
# Description

Build the LiveBucketIndex on an async worker thread while the put loop in mergeInMemory runs on the main thread. Both only read mergedEntries as const, so they need no synchronization.


# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
