### PR TITLE
Skip building invariant delta when no invariants are enabled.

### DIFF
--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -2500,7 +2500,6 @@ LedgerManagerImpl::checkAllTxBundleInvariants(
 {
     for (auto const& txBundle : stage)
     {
-        // First check the invariants
         if (txBundle.getResPayload().isSuccess())
         {
             try
@@ -2513,7 +2512,7 @@ LedgerManagerImpl::checkAllTxBundleInvariants(
                 app.checkOnOperationApply(
                     txBundle.getTx()->getRawOperations().at(0),
                     txBundle.getResPayload().getOpResultAt(0),
-                    txBundle.getEffects().getDelta(),
+                    txBundle.getEffects().getDeltaForInvariants(),
                     txBundle.getEffects()
                         .getMeta()
                         .getOperationMetaBuilderAt(0)
@@ -2526,13 +2525,6 @@ LedgerManagerImpl::checkAllTxBundleInvariants(
                     "Invariant failure while applying operations: ", e.what());
             }
         }
-
-        // We don't call processPostApply for post v23 transactions at the
-        // moment because processPostApply is currently a no-op for those
-        // transactions.
-
-        txBundle.getEffects().getMeta().maybeSetRefundableFeeMeta(
-            txBundle.getResPayload().getRefundableFeeTracker());
     }
 }
 
@@ -2549,7 +2541,18 @@ LedgerManagerImpl::applySorobanStage(
     auto threadStates = applySorobanStageClustersInParallel(
         app, stage, globalParState, sorobanBasePrngSeed, config, ledgerInfo);
 
-    checkAllTxBundleInvariants(app, stage, config, ledgerInfo, header);
+    if (config.invariantsEnabled())
+    {
+        checkAllTxBundleInvariants(app, stage, config, ledgerInfo, header);
+    }
+    // We don't call processPostApply for post v23 transactions at the
+    // moment because processPostApply is currently a no-op for those
+    // transactions, so just set refundable fee meta here.
+    for (auto const& txBundle : stage)
+    {
+        txBundle.getEffects().getMeta().maybeSetRefundableFeeMeta(
+            txBundle.getResPayload().getRefundableFeeTracker());
+    }
 
     globalParState.commitChangesFromThreads(app, threadStates, stage);
 }

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -2704,6 +2704,12 @@ Config::toString(SCPQuorumSet const& qset)
     return fw.write(json);
 }
 
+bool
+Config::invariantsEnabled() const
+{
+    return !INVARIANT_CHECKS.empty();
+}
+
 size_t
 Config::getSorobanByteAllowance() const
 {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -956,6 +956,8 @@ class Config : public std::enable_shared_from_this<Config>
     // function to stringify a quorum set
     std::string toString(SCPQuorumSet const& qset);
 
+    bool invariantsEnabled() const;
+
     // A special name to be used for stdin in stead of a file name in command
     // line arguments.
     static std::string const STDIN_SPECIAL_NAME;

--- a/src/transactions/ParallelApplyStage.h
+++ b/src/transactions/ParallelApplyStage.h
@@ -30,29 +30,31 @@ class TxEffects
     {
         return mMeta;
     }
+
     LedgerTxnDelta const&
-    getDelta()
+    getDeltaForInvariants()
     {
-        return mDelta;
+        return mDeltaForInvariants;
     }
 
     void
-    setDeltaEntry(LedgerKey const& key, LedgerTxnDelta::EntryDelta const& delta)
+    setDeltaEntryForInvariants(LedgerKey const& key,
+                               LedgerTxnDelta::EntryDelta const& delta)
     {
-        auto [_, inserted] = mDelta.entry.emplace(key, delta);
+        auto [_, inserted] = mDeltaForInvariants.entry.emplace(key, delta);
         releaseAssertOrThrow(inserted);
     }
 
     void
     setDeltaHeader(LedgerHeader const& header)
     {
-        mDelta.header.current = header;
-        mDelta.header.previous = header;
+        mDeltaForInvariants.header.current = header;
+        mDeltaForInvariants.header.previous = header;
     }
 
   private:
     TransactionMetaBuilder mMeta;
-    LedgerTxnDelta mDelta;
+    LedgerTxnDelta mDeltaForInvariants;
 };
 
 // TxBundle contains a transaction, its associated result payload, and its

--- a/src/transactions/ParallelApplyUtils.cpp
+++ b/src/transactions/ParallelApplyUtils.cpp
@@ -787,9 +787,8 @@ ThreadParallelApplyLedgerState::commitChangeFromSuccessfulTx(
 }
 
 void
-ThreadParallelApplyLedgerState::setEffectsDeltaFromSuccessfulTx(
-    ParallelTxSuccessVal const& res, ParallelLedgerInfo const& ledgerInfo,
-    TxEffects& effects) const
+ThreadParallelApplyLedgerState::setDeltaForInvariantsFromSuccessfulTx(
+    ParallelTxSuccessVal const& res, TxEffects& effects) const
 {
     ZoneScoped;
     for (auto const& [lk, scopedEntryOpt] : res.getModifiedEntryMap())
@@ -824,7 +823,7 @@ ThreadParallelApplyLedgerState::setEffectsDeltaFromSuccessfulTx(
                 std::make_shared<InternalLedgerEntry>(entryOpt.value());
         }
         releaseAssertOrThrow(entryDelta.current || entryDelta.previous);
-        effects.setDeltaEntry(lk, entryDelta);
+        effects.setDeltaEntryForInvariants(lk, entryDelta);
     }
 }
 

--- a/src/transactions/ParallelApplyUtils.h
+++ b/src/transactions/ParallelApplyUtils.h
@@ -161,9 +161,8 @@ class ThreadParallelApplyLedgerState
     OptionalEntryT getLiveEntryOpt(LedgerKey const& key) const;
     bool entryWasRestored(LedgerKey const& key) const;
 
-    void setEffectsDeltaFromSuccessfulTx(ParallelTxSuccessVal const& res,
-                                         ParallelLedgerInfo const& ledgerInfo,
-                                         TxEffects& effects) const;
+    void setDeltaForInvariantsFromSuccessfulTx(ParallelTxSuccessVal const& res,
+                                               TxEffects& effects) const;
 
     void commitChangesFromSuccessfulTx(ParallelTxSuccessVal const& res,
                                        TxBundle const& txBundle);

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -2277,8 +2277,11 @@ TransactionFrame::parallelApply(
 
         if (res)
         {
-            threadState.setEffectsDeltaFromSuccessfulTx(*res, ledgerInfo,
-                                                        effects);
+            if (config.invariantsEnabled())
+            {
+                threadState.setDeltaForInvariantsFromSuccessfulTx(*res,
+                                                                  effects);
+            }
             opMeta.setLedgerChangesFromSuccessfulOp(threadState, *res,
                                                     ledgerInfo.getLedgerSeq());
         }


### PR DESCRIPTION
# Description

Skip building invariant delta when no invariants are enabled.

The delta is only used for invariants, so also updated the naming to reflect that.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
