### PR TITLE
Relax invariants in recordStorageChanges for optimization.

### DIFF
--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -609,9 +609,15 @@ class InvokeHostFunctionApplyHelper : virtual LedgerAccessHelper
     recordStorageChanges(InvokeHostFunctionOutput const& out)
     {
         ZoneScoped;
-        // Create or update every entry returned.
+        // Every modified entry is either a newly created entry or an updated
+        // entry. Gather the modified entry keys in order to identify deleted
+        // entries (that don't exist in the modified entry list but do exist in
+        // the read-write footprint).
         UnorderedSet<LedgerKey> createdAndModifiedKeys;
-        UnorderedSet<LedgerKey> createdKeys;
+        uint32_t numCreatedSorobanEntries = 0;
+        uint32_t numCreatedTTLEntries = 0;
+        bool const allowClassicCreations = protocolVersionStartsFrom(
+            getLedgerVersion(), ProtocolVersion::V_26);
         for (auto const& buf : out.modified_ledger_entries)
         {
             LedgerEntry le;
@@ -628,13 +634,13 @@ class InvokeHostFunctionApplyHelper : virtual LedgerAccessHelper
 
             createdAndModifiedKeys.insert(lk);
 
-            uint32_t keySize = static_cast<uint32_t>(xdr::xdr_size(lk));
             uint32_t entrySize = static_cast<uint32_t>(buf.data.size());
 
             // ttlEntry write fees come out of refundableFee, already
             // accounted for by the host
             if (lk.type() != TTL)
             {
+                uint32_t keySize = static_cast<uint32_t>(xdr::xdr_size(lk));
                 mMetrics.noteWriteEntry(isContractCodeEntry(lk), keySize,
                                         entrySize);
                 if (mResources.writeBytes < mMetrics.mLedgerWriteByte)
@@ -653,33 +659,29 @@ class InvokeHostFunctionApplyHelper : virtual LedgerAccessHelper
 
             if (upsertLedgerEntry(lk, le))
             {
-                createdKeys.insert(lk);
+                if (isSorobanEntry(lk))
+                {
+                    ++numCreatedSorobanEntries;
+                }
+                else if (lk.type() == TTL)
+                {
+                    ++numCreatedTTLEntries;
+                }
+                else if (allowClassicCreations)
+                {
+                    releaseAssertOrThrow(lk.type() == ACCOUNT ||
+                                         lk.type() == TRUSTLINE);
+                }
+                else
+                {
+                    releaseAssertOrThrow(false);
+                }
             }
         }
 
-        // Check that each newly created ContractCode or ContractData entry also
-        // creates a ttlEntry. Starting from protocol 26 (CAP-73), the Stellar
-        // Asset Contract can also create classic entries (ACCOUNT, TRUSTLINE).
-        for (auto const& key : createdKeys)
-        {
-            if (isSorobanEntry(key))
-            {
-                auto ttlKey = getTTLKey(key);
-                releaseAssertOrThrow(createdKeys.find(ttlKey) !=
-                                     createdKeys.end());
-            }
-            else if (protocolVersionStartsFrom(getLedgerVersion(),
-                                               ProtocolVersion::V_26))
-            {
-                releaseAssertOrThrow(key.type() == TTL ||
-                                     key.type() == ACCOUNT ||
-                                     key.type() == TRUSTLINE);
-            }
-            else
-            {
-                releaseAssertOrThrow(key.type() == TTL);
-            }
-        }
+        // Verify that each newly created Soroban entry has a corresponding
+        // newly created TTL entry (1:1 pairing guaranteed by the host).
+        releaseAssertOrThrow(numCreatedSorobanEntries == numCreatedTTLEntries);
 
         // Erase every entry not returned.
         // NB: The entries that haven't been touched are passed through


### PR DESCRIPTION
# Description

Relax invariants in recordStorageChanges for optimization.

Instead of checking that created TTL keys belong to the specific entries, we just ensure that the expected entry counts match. This should be a pretty reasonable tradeoff - it seems like it would be pretty hard to create a mismatched TTL entry (vs missing it entirely). The benefit is that we avoid building a whole separate set and making lookups based on TTL keys (a SHA-256 per key).

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
