### PR TITLE
Sort entry pointers in convertToBucketEntry.

### DIFF
--- a/src/bucket/LiveBucket.cpp
+++ b/src/bucket/LiveBucket.cpp
@@ -383,34 +383,47 @@ LiveBucket::convertToBucketEntry(bool useInit,
                                  std::vector<LedgerKey> const& deadEntries)
 {
     ZoneScoped;
-    std::vector<BucketEntry> bucket;
-    bucket.reserve(initEntries.size() + liveEntries.size() +
-                   deadEntries.size());
+    size_t totalSize =
+        initEntries.size() + liveEntries.size() + deadEntries.size();
+
+    std::vector<BucketEntry> entries;
+    entries.reserve(totalSize);
+
+    std::vector<BucketEntry*> sortedEntries;
+    sortedEntries.reserve(totalSize);
 
     for (auto const& e : initEntries)
     {
-        BucketEntry ce;
+        auto& ce = entries.emplace_back();
         ce.type(useInit ? INITENTRY : LIVEENTRY);
         ce.liveEntry() = e;
-        bucket.push_back(ce);
+        sortedEntries.push_back(&ce);
     }
     for (auto const& e : liveEntries)
     {
-        BucketEntry ce;
+        auto& ce = entries.emplace_back();
         ce.type(LIVEENTRY);
         ce.liveEntry() = e;
-        bucket.push_back(ce);
+        sortedEntries.push_back(&ce);
     }
     for (auto const& e : deadEntries)
     {
-        BucketEntry ce;
+        auto& ce = entries.emplace_back();
         ce.type(DEADENTRY);
         ce.deadEntry() = e;
-        bucket.push_back(ce);
+        sortedEntries.push_back(&ce);
     }
 
     BucketEntryIdCmp<LiveBucket> cmp;
-    std::sort(bucket.begin(), bucket.end(), cmp);
+    std::sort(sortedEntries.begin(), sortedEntries.end(),
+              [&cmp](auto const& a, auto const& b) { return cmp(*a, *b); });
+
+    std::vector<BucketEntry> bucket;
+    bucket.reserve(sortedEntries.size());
+    for (auto* entry : sortedEntries)
+    {
+        bucket.emplace_back(std::move(*entry));
+    }
     releaseAssert(std::adjacent_find(
                       bucket.begin(), bucket.end(),
                       [&cmp](BucketEntry const& lhs, BucketEntry const& rhs) {


### PR DESCRIPTION
# Description

Sort entry pointers in convertToBucketEntry.

This avoids O(n log n) swaps of potentially large structs.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
