### PR TITLE
Fix incorrect-reset bug in tx fuzz target (broken with bucketlistDB)

### DIFF
--- a/src/test/fuzz/targets/TxFuzzTarget.cpp
+++ b/src/test/fuzz/targets/TxFuzzTarget.cpp
@@ -716,6 +716,8 @@ TxFuzzTarget::description() const
     return "Fuzz transaction application with compact XDR operations";
 }
 
+TxFuzzTarget::~TxFuzzTarget() = default;
+
 void
 TxFuzzTarget::initialize()
 {
@@ -725,20 +727,34 @@ TxFuzzTarget::initialize()
     auto root = mApp->getRoot();
     mSourceAccountID = root->getPublicKey();
 
+    mApp->getInvariantManager().snapshotForFuzzer();
+    {
+        LedgerTxn ltxOuter(mApp->getLedgerTxnRoot());
+        applySetupLedgerState(ltxOuter);
+        storeSetupLedgerKeysAndPoolIDs(ltxOuter);
+    }
     resetTxInternalState(*mApp);
-    LedgerTxn ltxOuter(mApp->getLedgerTxnRoot());
 
-    initializeAccounts(ltxOuter);
-    initializeTrustLines(ltxOuter);
-    initializeClaimableBalances(ltxOuter);
-    initializeOffers(ltxOuter);
-    initializeLiquidityPools(ltxOuter);
-    reduceNativeBalancesAfterSetup(ltxOuter);
-    adjustTrustLineBalancesAfterSetup(ltxOuter);
-    reduceTrustLineLimitsAfterSetup(ltxOuter);
-    storeSetupLedgerKeysAndPoolIDs(ltxOuter);
+    mSetupLedgerTxn = std::make_unique<LedgerTxn>(mApp->getLedgerTxnRoot());
+    applySetupLedgerState(*mSetupLedgerTxn);
+    mApp->getInvariantManager().snapshotForFuzzer();
+    resetTxInternalState(*mApp);
+}
 
-    ltxOuter.commit();
+void
+TxFuzzTarget::applySetupLedgerState(AbstractLedgerTxn& ltxSetup)
+{
+    LedgerTxn ltx(ltxSetup);
+    initializeAccounts(ltx);
+    initializeTrustLines(ltx);
+    initializeClaimableBalances(ltx);
+    initializeOffers(ltx);
+    initializeLiquidityPools(ltx);
+    reduceNativeBalancesAfterSetup(ltx);
+    adjustTrustLineBalancesAfterSetup(ltx);
+    reduceTrustLineLimitsAfterSetup(ltx);
+
+    ltx.commit();
 
     mApp->getInvariantManager().snapshotForFuzzer();
 }
@@ -776,7 +792,7 @@ TxFuzzTarget::run(uint8_t const* data, size_t size)
     LOG_TRACE(DEFAULT_LOG, "{}",
               xdrToCerealString(ops, fmt::format("Fuzz ops ({})", ops.size())));
 
-    LedgerTxn ltx(mApp->getLedgerTxnRoot());
+    LedgerTxn ltx(*mSetupLedgerTxn);
     applyFuzzOperations(ltx, mSourceAccountID, ops.begin(), ops.end(), *mApp);
 
     return FuzzResultCode::FUZZ_SUCCESS;
@@ -785,6 +801,7 @@ TxFuzzTarget::run(uint8_t const* data, size_t size)
 void
 TxFuzzTarget::shutdown()
 {
+    mSetupLedgerTxn.reset();
     mApp.reset();
 }
 
@@ -1193,6 +1210,18 @@ TxFuzzTarget::reduceTrustLineLimitsAfterSetup(AbstractLedgerTxn& ltxOuter)
 
     applySetupOperations(ltx, mSourceAccountID, ops.begin(), ops.end(), *mApp);
     ltx.commit();
+}
+
+TEST_CASE("tx fuzz regression preserves setup ledger entries", "[fuzz][tx]")
+{
+    TxFuzzTarget target;
+    target.initialize();
+    std::vector<uint8_t> input = {
+        0x03, 0x00, 0x00, 0x01, 0x30, 0x00, 0x00, 0x01, 0x00, 0x00, 0x31,
+        0x1a, 0x00, 0x0d, 0x00, 0x16, 0x7e, 0x01, 0x01, 0x0b, 0x00, 0x00};
+    REQUIRE(target.run(input.data(), input.size()) ==
+            FuzzResultCode::FUZZ_SUCCESS);
+    target.shutdown();
 }
 
 // Register the target with the global registry

--- a/src/test/fuzz/targets/TxFuzzTarget.h
+++ b/src/test/fuzz/targets/TxFuzzTarget.h
@@ -89,6 +89,7 @@ class TxFuzzTarget : public FuzzTarget
 {
   public:
     TxFuzzTarget() = default;
+    ~TxFuzzTarget() override;
 
     std::string name() const override;
     std::string description() const override;
@@ -99,6 +100,7 @@ class TxFuzzTarget : public FuzzTarget
     std::vector<uint8_t> generateSeedInput() override;
 
   private:
+    void applySetupLedgerState(AbstractLedgerTxn& ltxOuter);
     void storeSetupLedgerKeysAndPoolIDs(AbstractLedgerTxn& ltx);
     void storeSetupPoolIDs(AbstractLedgerTxn& ltx,
                            std::vector<LedgerEntry> const& entries);
@@ -113,6 +115,7 @@ class TxFuzzTarget : public FuzzTarget
 
     VirtualClock mClock;
     std::shared_ptr<Application> mApp;
+    std::unique_ptr<LedgerTxn> mSetupLedgerTxn;
     PublicKey mSourceAccountID;
     FuzzUtils::StoredLedgerKeys mStoredLedgerKeys;
     FuzzUtils::StoredPoolIDs mStoredPoolIDs;


### PR DESCRIPTION
The fuzz_tx target was broken a while ago when we moved most LEs to the BucketlistDB: it sets up some state, and commits it (at the ltx level), and then resets the state assuming that the committed state will be reloaded/recovered from SQL. but it won't -- because only offers land in SQL anymore.

This bug was causing fairly early and constant internal errors when running the tx fuzz target, because the ledger state it was seeing was corrupt: offers made by nonexistent accounts mainly. This isn't a bug in the tx subsystem or anything, just in the fuzz target.

There are a few ways to fix this (including making a miniature copy of the BucketlistDB ledger-close / commit path just for the fuzz target) but the simplest is just to not write anything to disk and fuzz against an in-memory ltx: add 1 more level of nested ltx that we keep open in the fuzz target, and roll back to its state on each fuzzed tx. Works fine, actually runs faster, and is totally sufficient for fuzzing the tx subsystem.