### PR TITLE
Update security and protocol release notes for v26.1.0

### DIFF
--- a/docs/software/security-protocol-release-notes.md
+++ b/docs/software/security-protocol-release-notes.md
@@ -59,6 +59,14 @@ It then follows that:
 
 # List of releases
 
+## v26.1.0 (2026-05-07)
+* `Ledger` - security - Replace block on transactions using `ed25519SignedPayload` signatures with an overall cap on signature verifications stellar-core will perform per transaction.
+    * exploited: no
+    * mitigation: code fix
+* `Herder` - security - Fix a crash during validation of malformed legacy transaction sets.
+    * exploited: no
+    * mitigation: code fix
+
 ## v26.0.1 (2026-04-03)
 * `Ledger` - security - Block transactions using `ed25519SignedPayload` signatures.
     * exploited: no


### PR DESCRIPTION
This change updates our docs to describe the two security fixes in the v26.1.0 release.