### PR TITLE
Revert "Clean up version warning"

### DIFF
--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -1175,22 +1175,16 @@ publish(Application::pointer app)
     return 0;
 }
 
-// Returns the major release version extracted from a release-version string if
-// it matches one of the supported release formats, such as vNN.X.Y,
-// vNN.X.YrcZ, vNN.X.Y-external, or the packaged form
-// `stellar-core NN.X.Y (<commit-hash>)`. If its version has some other name
+// Returns the major release version extracted from the git tag _if_ this is a
+// release-tagged version of stellar core (one that looks like vNN.X.Y or
+// vNN.X.YrcZ or vNN.X.YHOTZ). If its version has some other name structure
 // structure, return std::nullopt.
 std::optional<uint32_t>
 getStellarCoreMajorReleaseVersion(std::string const& vstr)
 {
-    std::regex releaseTagRe(
-        "^v([0-9]+)\\.[0-9]+\\.[0-9]+(rc[0-9]+|-external)?$");
-    std::regex packagedReleaseRe(
-        "^stellar-core ([0-9]+)\\.[0-9]+\\.[0-9]+(rc[0-9]+|-external)? "
-        "\\([0-9a-fA-F]+\\)$");
+    std::regex re("^v([0-9]+)\\.[0-9]+\\.[0-9]+(rc[0-9]+|HOT[0-9]+)?$");
     std::smatch match;
-    if (std::regex_match(vstr, match, releaseTagRe) ||
-        std::regex_match(vstr, match, packagedReleaseRe))
+    if (std::regex_match(vstr, match, re))
     {
         uint32_t vers = stoi(match.str(1));
         return std::make_optional<uint32_t>(vers);

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -294,13 +294,11 @@ checkXDRFileIdentity()
 void
 checkStellarCoreMajorVersionProtocolIdentity()
 {
-    // This extracts a major version number from the version string embedded in
-    // the binary if, and only if, it identifies a release build. Supported
-    // formats include source builds like vX.Y.Z, vX.Y.ZrcN,
-    // vX.Y.Z-external, and
-    // packaged builds like `stellar-core X.Y.Z (<commit-hash>)`. Other version
-    // strings return nullopt, for example git-describe versions that typically
-    // look more like `v21.0.0rc1-84-g08d89bb4a`.
+    // This extracts a major version number from the git version string embedded
+    // in the binary if, and only if, that version string has the form of a
+    // release tag: specifically vX.Y.Z, or vX.Y.ZrcN, or vX.Y.ZHOTN. Other
+    // version strings return nullopt, for example non-release-tagged versions
+    // that typically look more like `v21.0.0rc1-84-g08d89bb4a`
     auto major_release_version =
         stellar::getStellarCoreMajorReleaseVersion(STELLAR_CORE_VERSION);
     if (major_release_version)
@@ -336,12 +334,11 @@ checkStellarCoreMajorVersionProtocolIdentity()
     }
     else
     {
-        // If we are running a version that does not match a recognized release
-        // version string format, then we relax the check above and just warn.
-        LOG_WARNING(DEFAULT_LOG,
-                    "Running non-release version {} of "
-                    "stellar-core",
-                    STELLAR_CORE_VERSION);
+        // If we are running a version that does not look exactly like vX.Y.Z or
+        // vX.Y.ZrcN or vX.Y.ZHOTN, then we are running a non-release version of
+        // stellar-core and we relax the check above and just warn.
+        std::cerr << "Warning: running non-release version "
+                  << STELLAR_CORE_VERSION << " of stellar-core" << std::endl;
     }
 }
 } // namespace

--- a/src/main/test/ApplicationUtilsTests.cpp
+++ b/src/main/test/ApplicationUtilsTests.cpp
@@ -163,16 +163,9 @@ TEST_CASE("application major version numbers", "[applicationutils]")
           std::make_optional<uint32_t>(19));
     CHECK(getStellarCoreMajorReleaseVersion("v20.0.0rc1") ==
           std::make_optional<uint32_t>(20));
-    CHECK(getStellarCoreMajorReleaseVersion("v25.2.2-external") ==
-          std::make_optional<uint32_t>(25));
-    CHECK(getStellarCoreMajorReleaseVersion("v20.0.0HOT4") == std::nullopt);
-    CHECK(getStellarCoreMajorReleaseVersion(
-              "stellar-core 23.0.0 "
-              "(d5cbc0793d6eab25eac886969c5bc0f7da69d6ea)") ==
-          std::make_optional<uint32_t>(23));
+    CHECK(getStellarCoreMajorReleaseVersion("v20.0.0HOT4") ==
+          std::make_optional<uint32_t>(20));
     CHECK(getStellarCoreMajorReleaseVersion("v19.1.2-10") == std::nullopt);
-    CHECK(getStellarCoreMajorReleaseVersion("v23.0.0-1-gd5cbc0793d6e") ==
-          std::nullopt);
     CHECK(getStellarCoreMajorReleaseVersion("v19.9.0-30-g726eabdea-dirty") ==
           std::nullopt);
 }


### PR DESCRIPTION
Reverts commit 54a77959b ("Clean up version warning") and also bumps env for a recording change that does not affect core.

That commit taught `getStellarCoreMajorReleaseVersion` to treat the packaged version string `stellar-core X.Y.Z (<hash>)` as a release build, and enforce it against `CURRENT_LEDGER_PROTOCOL_VERSION` in `checkStellarCoreMajorVersionProtocolIdentity`. The problem is that release and non-release package builds do not actually use differentiated version strings — neither the package builder nor the packages themselves distinguish them. So a non-release package (e.g. one built during a protocol bump, where the packaged major lags the protocol: `stellar-core 26.1.1 (<hash>)` while the protocol is `27`) gets treated as a release build, and the identity check throws at startup instead of just warning — breaking CI on `p27-bump`.

Reverting restores the prior warn-only behavior for packaged builds, where only `vX.Y.Z`-style tags are enforced against the protocol version.

We should probably fix the underlying issue in the pipeline so release vs non-release packages carry distinguishable version strings, and then the packaged-build check can be reintroduced. It is unclear what else currently depends on (or would break from changing) the package version string format, so that needs investigation before re-landing.