### PR TITLE
Disable checkStellarCoreMajorVersionProtocolIdentity at startup

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -428,7 +428,15 @@ main(int argc, char* const* argv)
     try
     {
 
-        checkStellarCoreMajorVersionProtocolIdentity();
+        // Temporarily disabled: this check treats the packaged version string
+        // `stellar-core X.Y.Z (<hash>)` as a release build and enforces its
+        // major version against CURRENT_LEDGER_PROTOCOL_VERSION. But our
+        // package builder and packages do not differentiate release from
+        // non-release version strings, so non-release packages (e.g. those
+        // built during a protocol bump, where the packaged major lags the
+        // protocol) trip the check and abort at startup. Re-enable once the
+        // pipeline emits distinguishable release vs non-release versions.
+        // checkStellarCoreMajorVersionProtocolIdentity();
         rust_bridge::check_sensible_soroban_config_for_protocol(
             Config::CURRENT_LEDGER_PROTOCOL_VERSION);
 


### PR DESCRIPTION
Alternative to #5310 — instead of reverting 54a77959b, this just comments out the `checkStellarCoreMajorVersionProtocolIdentity()` call at startup, with a comment explaining why.

`checkStellarCoreMajorVersionProtocolIdentity` enforces that a release build's major version matches `CURRENT_LEDGER_PROTOCOL_VERSION`. It decides "is this a release build" from the version string. The problem: our package builder and packages do not differentiate release from non-release version strings, so a non-release package (e.g. one built during a protocol bump, where the packaged major lags the protocol — `stellar-core 26.1.1 (<hash>)` while the protocol is `27`) is treated as a release build and aborts at startup.

Commenting out the call keeps the function and its tests intact so it can be re-enabled once the pipeline emits distinguishable release vs non-release versions.

Note: this leaves `checkStellarCoreMajorVersionProtocolIdentity` defined-but-unused (it lives in an anonymous namespace), which produces a `-Wunused-function` warning. There is no blanket `-Werror`, so this does not fail the build; can add `[[maybe_unused]]` to silence it if preferred.