### PR TITLE
Add CI check that protocol bumps come with an overlay version bump

### DIFF
--- a/.github/workflows/build-private.yml
+++ b/.github/workflows/build-private.yml
@@ -45,6 +45,19 @@ jobs:
     - uses: actions/checkout@v4
     - uses: stellar/actions/rust-check-git-rev-deps@main
 
+  protocol-version-check:
+    # Check that a bump of CURRENT_LEDGER_PROTOCOL_VERSION is accompanied by
+    # a bump of OVERLAY_PROTOCOL_VERSION.
+    if: github.event.repository.visibility == 'private'
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: Check protocol bump is accompanied by an overlay version bump
+      run: |
+        BASE_SHA='${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}'
+        git fetch --depth=1 origin "$BASE_SHA"
+        ./scripts/check-protocol-overlay-versions.sh "$BASE_SHA"
+
   build:
     if: github.event.repository.visibility == 'private'
     runs-on: ubuntu-latest-16-cores

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
 
   complete:
     if: always()
-    needs: [static-checks, build-linux, build-mac]
+    needs: [static-checks, protocol-version-check, build-linux, build-mac]
     runs-on:
       - namespace-profile-noble-24-04-stellar-core-x64-small
     steps:
@@ -97,6 +97,24 @@ jobs:
         run: |
           mkdir -p build-static-checks
           echo "${{ github.sha }}" > "build-static-checks/.last-tested-commit-sha"
+
+  protocol-version-check:
+    # Check that a bump of CURRENT_LEDGER_PROTOCOL_VERSION is accompanied by
+    # a bump of OVERLAY_PROTOCOL_VERSION. Only runs on events that have a
+    # base revision to compare against (not on branch pushes).
+    if: github.event.repository.visibility != 'private' && github.event_name != 'push'
+    runs-on:
+      - namespace-profile-noble-24-04-stellar-core-x64-small
+    steps:
+      - uses: namespacelabs/nscloud-checkout-action@v7
+        with:
+          fetch-depth: 1
+
+      - name: Check protocol bump is accompanied by an overlay version bump
+        run: |
+          BASE_SHA='${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}'
+          git fetch --depth=1 origin "$BASE_SHA"
+          ./scripts/check-protocol-overlay-versions.sh "$BASE_SHA"
 
   build-linux:
     if: github.event.repository.visibility != 'private'

--- a/scripts/check-protocol-overlay-versions.sh
+++ b/scripts/check-protocol-overlay-versions.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+
+# This script checks that a change that bumps the current ledger protocol
+# version (Config::CURRENT_LEDGER_PROTOCOL_VERSION in src/main/Config.cpp)
+# also bumps the maximum supported overlay protocol version
+# (OVERLAY_PROTOCOL_VERSION in the same file), so that peers can tell from
+# the overlay handshake whether a node runs software that supports the new
+# ledger protocol.
+#
+# Usage: check-protocol-overlay-versions.sh <base-rev> [<head-rev>]
+#
+# Compares src/main/Config.cpp at <head-rev> (or the working tree copy if
+# <head-rev> is omitted) against <base-rev>, and exits with a non-zero
+# status if CURRENT_LEDGER_PROTOCOL_VERSION increased without
+# OVERLAY_PROTOCOL_VERSION increasing as well.
+
+set -e
+
+SRCDIR=$(realpath $(dirname $0)/..)
+CONFIG_CPP=src/main/Config.cpp
+
+if [ $# -lt 1 ] || [ $# -gt 2 ]
+then
+    echo "usage: $0 <base-rev> [<head-rev>]" >&2
+    exit 2
+fi
+
+BASE_REV=$1
+HEAD_REV=${2:-}
+
+cd "$SRCDIR"
+
+# Print the contents of src/main/Config.cpp at revision $1, or the working
+# tree copy if $1 is empty.
+config_at()
+{
+    if [ -n "$1" ]
+    then
+        git show "$1:$CONFIG_CPP"
+    else
+        cat "$CONFIG_CPP"
+    fi
+}
+
+# extract <rev> <name> <sed-expr>: print the numeric value assigned to
+# <name> in Config.cpp at <rev>, failing unless exactly one assignment is
+# found.
+extract()
+{
+    if ! CONTENTS=$(config_at "$1")
+    then
+        echo "error: failed to read $CONFIG_CPP at ${1:-working tree}" >&2
+        exit 2
+    fi
+    VAL=$(printf '%s\n' "$CONTENTS" | sed -n "$3")
+    case "$VAL" in
+    ''|*[!0-9]*)
+        echo "error: expected exactly one numeric assignment to $2 in $CONFIG_CPP at ${1:-working tree}, got '$VAL'" >&2
+        echo "(if the definition of $2 changed shape, update $0 to match)" >&2
+        exit 2
+        ;;
+    esac
+    echo "$VAL"
+}
+
+LEDGER_EXPR='s/.*Config::CURRENT_LEDGER_PROTOCOL_VERSION[[:space:]]*=[[:space:]]*\([0-9][0-9]*\).*/\1/p'
+OVERLAY_EXPR='s/^[[:space:]]*OVERLAY_PROTOCOL_VERSION[[:space:]]*=[[:space:]]*\([0-9][0-9]*\).*/\1/p'
+
+BASE_LEDGER=$(extract "$BASE_REV" CURRENT_LEDGER_PROTOCOL_VERSION "$LEDGER_EXPR")
+BASE_OVERLAY=$(extract "$BASE_REV" OVERLAY_PROTOCOL_VERSION "$OVERLAY_EXPR")
+HEAD_LEDGER=$(extract "$HEAD_REV" CURRENT_LEDGER_PROTOCOL_VERSION "$LEDGER_EXPR")
+HEAD_OVERLAY=$(extract "$HEAD_REV" OVERLAY_PROTOCOL_VERSION "$OVERLAY_EXPR")
+
+echo "CURRENT_LEDGER_PROTOCOL_VERSION: $BASE_LEDGER -> $HEAD_LEDGER"
+echo "OVERLAY_PROTOCOL_VERSION:        $BASE_OVERLAY -> $HEAD_OVERLAY"
+
+if [ "$HEAD_LEDGER" -gt "$BASE_LEDGER" ] && [ "$HEAD_OVERLAY" -le "$BASE_OVERLAY" ]
+then
+    echo "error: CURRENT_LEDGER_PROTOCOL_VERSION was bumped from $BASE_LEDGER to $HEAD_LEDGER" >&2
+    echo "without bumping OVERLAY_PROTOCOL_VERSION (still $HEAD_OVERLAY)." >&2
+    echo "A ledger protocol bump must be accompanied by a bump of the maximum" >&2
+    echo "overlay protocol version in $CONFIG_CPP." >&2
+    exit 1
+fi
+
+echo "OK"


### PR DESCRIPTION
# Description

Adds a CI check that fails if `Config::CURRENT_LEDGER_PROTOCOL_VERSION` is bumped without also bumping `OVERLAY_PROTOCOL_VERSION` in `src/main/Config.cpp`.

- `scripts/check-protocol-overlay-versions.sh` compares both constants between the PR base and head (can also be run locally, e.g. `./scripts/check-protocol-overlay-versions.sh origin/master`).
- New `protocol-version-check` job in `build.yml`, wired into the `complete` job's `needs` so it blocks merges, and a matching standalone job in `build-private.yml`.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (`make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)