### PR TITLE
Add random memo to apply-load transactions

### DIFF
--- a/src/simulation/ApplyLoad.cpp
+++ b/src/simulation/ApplyLoad.cpp
@@ -1,6 +1,7 @@
 #include "simulation/ApplyLoad.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <memory>
 #include <numeric>
@@ -30,7 +31,6 @@
 #include "util/XDRCereal.h"
 #include "util/types.h"
 #include "xdrpp/printer.h"
-#include <crypto/Random.h>
 #include <crypto/SHA.h>
 
 namespace stellar
@@ -739,6 +739,18 @@ ApplyLoad::ApplyLoad(Application& app)
         throw std::runtime_error(
             "APPLY_LOAD_LEDGER_MAX_DEPENDENT_TX_CLUSTERS cannot be zero");
     }
+
+    // Seed the classic payment memo id from the current wall-clock time (in
+    // nanoseconds) so that classic payment tx hashes differ across runs. The id
+    // is then incremented per generated payment to stay unique within a run.
+    // Nanosecond resolution makes cross-run collisions practically impossible:
+    // two runs would have to start within (number of payments) ns of each other
+    // to overlap.
+    mNextClassicPaymentMemoId = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            mApp.getClock().system_now().time_since_epoch())
+            .count());
+
     setup();
 }
 
@@ -1873,13 +1885,11 @@ ApplyLoad::generateClassicPayments(std::vector<TransactionFrameBasePtr>& txs,
         auto it = accounts.find(accountIdx);
         releaseAssert(it != accounts.end());
         it->second->loadSequenceNumber();
-        // Attach a random memo so that the generated classic payment tx hashes
-        // are non-deterministic (unique within a run and across runs). The
-        // global random engine is not randomly seeded in apply-load, so use a
-        // CSPRNG-backed source to guarantee uniqueness across runs.
-        Memo memo(MEMO_HASH);
-        auto randMemo = randomBytes(memo.hash().size());
-        std::copy(randMemo.begin(), randMemo.end(), memo.hash().begin());
+        // Attach a unique memo id so that the generated classic payment tx
+        // hashes are unique within a run and across runs (the id is seeded from
+        // wall-clock time in the constructor and incremented per payment).
+        Memo memo(MEMO_ID);
+        memo.id() = mNextClassicPaymentMemoId++;
         auto [_, tx] = mTxGenerator.paymentTransaction(
             mNumAccounts, 0, lm.getLastClosedLedgerNum() + 1, it->first, 1,
             std::nullopt, memo);

--- a/src/simulation/ApplyLoad.cpp
+++ b/src/simulation/ApplyLoad.cpp
@@ -30,6 +30,7 @@
 #include "util/XDRCereal.h"
 #include "util/types.h"
 #include "xdrpp/printer.h"
+#include <crypto/Random.h>
 #include <crypto/SHA.h>
 
 namespace stellar
@@ -1872,9 +1873,16 @@ ApplyLoad::generateClassicPayments(std::vector<TransactionFrameBasePtr>& txs,
         auto it = accounts.find(accountIdx);
         releaseAssert(it != accounts.end());
         it->second->loadSequenceNumber();
+        // Attach a random memo so that the generated classic payment tx hashes
+        // are non-deterministic (unique within a run and across runs). The
+        // global random engine is not randomly seeded in apply-load, so use a
+        // CSPRNG-backed source to guarantee uniqueness across runs.
+        Memo memo(MEMO_HASH);
+        auto randMemo = randomBytes(memo.hash().size());
+        std::copy(randMemo.begin(), randMemo.end(), memo.hash().begin());
         auto [_, tx] = mTxGenerator.paymentTransaction(
             mNumAccounts, 0, lm.getLastClosedLedgerNum() + 1, it->first, 1,
-            std::nullopt);
+            std::nullopt, memo);
         auto res =
             tx->checkValid(appConnector, ledgerView, 0, 0, 0, diagnostics);
         releaseAssert(res && res->isSuccess());

--- a/src/simulation/ApplyLoad.h
+++ b/src/simulation/ApplyLoad.h
@@ -178,6 +178,12 @@ class ApplyLoad
 
     // Counter for generating unique destination addresses for SAC payments
     uint32_t mDestCounter = 0;
+
+    // Monotonic memo id assigned to generated classic payments to keep their
+    // tx hashes unique within a run and across runs. Seeded from the wall-clock
+    // time at construction (see constructor) so that separate runs start from
+    // different values.
+    uint64_t mNextClassicPaymentMemoId = 0;
 };
 
 #ifdef BUILD_TESTS

--- a/src/simulation/TxGenerator.cpp
+++ b/src/simulation/TxGenerator.cpp
@@ -234,7 +234,7 @@ TxGenerator::createAccounts(uint64_t start, uint64_t count, uint32_t ledgerNum,
     return ops;
 }
 
-TransactionFrameBasePtr
+TransactionFrameBaseConstPtr
 TxGenerator::createTransactionFramePtr(
     TxGenerator::TestAccountPtr from, std::vector<Operation> ops,
     std::optional<uint32_t> maxGeneratedFeeRate)
@@ -246,7 +246,7 @@ TxGenerator::createTransactionFramePtr(
     return txf;
 }
 
-TransactionFrameBasePtr
+TransactionFrameBaseConstPtr
 TxGenerator::createTransactionFramePtr(
     TxGenerator::TestAccountPtr from, std::vector<Operation> ops,
     std::optional<uint32_t> maxGeneratedFeeRate,

--- a/src/simulation/TxGenerator.cpp
+++ b/src/simulation/TxGenerator.cpp
@@ -250,19 +250,19 @@ TransactionFrameBasePtr
 TxGenerator::createTransactionFramePtr(
     TxGenerator::TestAccountPtr from, std::vector<Operation> ops,
     std::optional<uint32_t> maxGeneratedFeeRate,
-    std::optional<uint32_t> byteCount)
+    std::optional<uint32_t> byteCount, std::optional<Memo> memo)
 {
     if (byteCount.has_value())
     {
         return paddedTransactionFromOperations(
             mApp, from->getSecretKey(), from->nextSequenceNumber(), ops,
-            generateFee(maxGeneratedFeeRate, ops.size()), *byteCount);
+            generateFee(maxGeneratedFeeRate, ops.size()), *byteCount, memo);
     }
     else
     {
         return transactionFromOperations(
             mApp, from->getSecretKey(), from->nextSequenceNumber(), ops,
-            generateFee(maxGeneratedFeeRate, ops.size()));
+            generateFee(maxGeneratedFeeRate, ops.size()), memo);
     }
 }
 
@@ -270,7 +270,8 @@ std::pair<TxGenerator::TestAccountPtr, TransactionFrameBasePtr>
 TxGenerator::paymentTransaction(uint32_t numAccounts, uint32_t offset,
                                 uint32_t ledgerNum, uint64_t sourceAccount,
                                 std::optional<uint32_t> byteCount,
-                                std::optional<uint32_t> maxGeneratedFeeRate)
+                                std::optional<uint32_t> maxGeneratedFeeRate,
+                                std::optional<Memo> memo)
 {
     TxGenerator::TestAccountPtr to, from;
     uint64_t amount = 1;
@@ -281,7 +282,7 @@ TxGenerator::paymentTransaction(uint32_t numAccounts, uint32_t offset,
 
     return std::make_pair(from, createTransactionFramePtr(from, paymentOps,
                                                           maxGeneratedFeeRate,
-                                                          byteCount));
+                                                          byteCount, memo));
 }
 
 std::pair<TxGenerator::TestAccountPtr, TransactionFrameBaseConstPtr>

--- a/src/simulation/TxGenerator.h
+++ b/src/simulation/TxGenerator.h
@@ -189,13 +189,15 @@ class TxGenerator
     TransactionFrameBaseConstPtr
     createTransactionFramePtr(TestAccountPtr from, std::vector<Operation> ops,
                               std::optional<uint32_t> maxGeneratedFeeRate,
-                              std::optional<uint32_t> byteCount);
+                              std::optional<uint32_t> byteCount,
+                              std::optional<Memo> memo = std::nullopt);
 
     std::pair<TestAccountPtr, TransactionFrameBaseConstPtr>
     paymentTransaction(uint32_t numAccounts, uint32_t offset,
                        uint32_t ledgerNum, uint64_t sourceAccount,
                        std::optional<uint32_t> byteCount,
-                       std::optional<uint32_t> maxGeneratedFeeRate);
+                       std::optional<uint32_t> maxGeneratedFeeRate,
+                       std::optional<Memo> memo = std::nullopt);
 
     std::pair<TestAccountPtr, TransactionFrameBaseConstPtr>
     createUploadWasmTransaction(

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -775,10 +775,16 @@ TransactionTestFramePtr
 paddedTransactionFromOperationsV1(Application& app, SecretKey const& from,
                                   SequenceNumber seq,
                                   std::vector<Operation> const& ops,
-                                  uint32_t fee, uint32_t desiredSize)
+                                  uint32_t fee, uint32_t desiredSize,
+                                  std::optional<Memo> memo)
 {
     TransactionEnvelope e =
         makeEnvelopeV1(app, from, seq, ops, fee, std::nullopt);
+
+    if (memo)
+    {
+        e.v1().tx.memo = *memo;
+    }
 
     uint32_t baseSize = xdr::xdr_argpack_size(e);
 
@@ -855,7 +861,7 @@ TransactionTestFramePtr
 paddedTransactionFromOperations(Application& app, SecretKey const& from,
                                 SequenceNumber seq,
                                 std::vector<Operation> const& ops, uint32_t fee,
-                                uint32_t desiredSize)
+                                uint32_t desiredSize, std::optional<Memo> memo)
 {
     auto ledgerVersion =
         app.getLedgerManager().getLastClosedLedgerHeader().header.ledgerVersion;
@@ -865,7 +871,7 @@ paddedTransactionFromOperations(Application& app, SecretKey const& from,
             "paddedTransactionFromOperations() called from pre-V23 protocol");
     }
     return paddedTransactionFromOperationsV1(app, from, seq, ops, fee,
-                                             desiredSize);
+                                             desiredSize, memo);
 }
 
 TransactionTestFramePtr

--- a/src/test/TxTests.h
+++ b/src/test/TxTests.h
@@ -144,7 +144,8 @@ transactionFromOperationsV0(Application& app, SecretKey const& from,
 // the cost to enable the sorobanData extension (~36 bytes).
 TransactionTestFramePtr paddedTransactionFromOperationsV1(
     Application& app, SecretKey const& from, SequenceNumber seq,
-    std::vector<Operation> const& ops, uint32_t fee, uint32_t desiredSize);
+    std::vector<Operation> const& ops, uint32_t fee, uint32_t desiredSize,
+    std::optional<Memo> memo = std::nullopt);
 
 TransactionTestFramePtr
 transactionFromOperationsV1(Application& app, SecretKey const& from,
@@ -157,11 +158,10 @@ transactionFromOperationsV1(Application& app, SecretKey const& from,
 // If `app` protocol version is >=23, attempts to pad to around `desiredSize`
 // (see comment on `paddedTransactionFromOperationsV1`). Otherwise, throw an
 // error.
-TransactionTestFramePtr
-paddedTransactionFromOperations(Application& app, SecretKey const& from,
-                                SequenceNumber seq,
-                                std::vector<Operation> const& ops,
-                                uint32_t fee = 0, uint32_t desiredSize = 0);
+TransactionTestFramePtr paddedTransactionFromOperations(
+    Application& app, SecretKey const& from, SequenceNumber seq,
+    std::vector<Operation> const& ops, uint32_t fee = 0,
+    uint32_t desiredSize = 0, std::optional<Memo> memo = std::nullopt);
 
 TransactionTestFramePtr
 transactionFromOperations(Application& app, SecretKey const& from,


### PR DESCRIPTION
In order to preserve the uniqueness of transaction hashes across multiple `apply-load` runs, this PR introduces a random memo to every legacy payment transaction.