### PR TITLE
Bucket query asserts and perf fix

### DIFF
--- a/src/bucket/BucketListSnapshot.cpp
+++ b/src/bucket/BucketListSnapshot.cpp
@@ -54,26 +54,43 @@ BucketListSnapshotData<BucketT>::BucketListSnapshotData(
 }
 
 //
+// BucketSnapshotMetrics
+//
+
+template <class BucketT>
+BucketSnapshotMetrics<BucketT>::BucketSnapshotMetrics(MetricsRegistry& metrics)
+    : mPointTimers([&metrics]() {
+        UnorderedMap<LedgerEntryType, std::reference_wrapper<SimpleTimer>>
+            timers;
+        for (auto t : xdr::xdr_traits<LedgerEntryType>::enum_values())
+        {
+            auto const& label = xdr::xdr_traits<LedgerEntryType>::enum_name(
+                static_cast<LedgerEntryType>(t));
+            auto& metric = metrics.NewSimpleTimer(
+                {BucketT::METRIC_STRING, label}, std::chrono::microseconds{1});
+            timers.emplace(static_cast<LedgerEntryType>(t), metric);
+        }
+        return timers;
+    }())
+    , mBulkLoadMeter(
+          metrics.NewMeter({BucketT::METRIC_STRING, "query", "loads"}, "query"))
+{
+}
+
+//
 // SearchableBucketListSnapshot
 //
 
 template <class BucketT>
 SearchableBucketListSnapshot<BucketT>::SearchableBucketListSnapshot(
     MetricsRegistry& metrics,
+    std::shared_ptr<BucketSnapshotMetrics<BucketT> const> snapshotMetrics,
     std::shared_ptr<BucketListSnapshotData<BucketT> const> data)
     : mData(std::move(data))
     , mMetrics(metrics)
-    , mBulkLoadMeter(
-          metrics.NewMeter({BucketT::METRIC_STRING, "query", "loads"}, "query"))
+    , mSnapshotMetrics(std::move(snapshotMetrics))
 {
-    for (auto t : xdr::xdr_traits<LedgerEntryType>::enum_values())
-    {
-        auto const& label = xdr::xdr_traits<LedgerEntryType>::enum_name(
-            static_cast<LedgerEntryType>(t));
-        auto& metric = metrics.NewSimpleTimer({BucketT::METRIC_STRING, label},
-                                              std::chrono::microseconds{1});
-        mPointTimers.emplace(static_cast<LedgerEntryType>(t), metric);
-    }
+    releaseAssert(mSnapshotMetrics);
 }
 
 template <class BucketT>
@@ -82,9 +99,8 @@ SearchableBucketListSnapshot<BucketT>::SearchableBucketListSnapshot(
     : mData(other.mData)
     // mStreams intentionally left empty — each copy gets its own stream cache
     , mMetrics(other.mMetrics)
-    , mPointTimers(other.mPointTimers)
+    , mSnapshotMetrics(other.mSnapshotMetrics)
     , mBulkTimers(other.mBulkTimers)
-    , mBulkLoadMeter(other.mBulkLoadMeter)
 {
 }
 
@@ -98,12 +114,11 @@ SearchableBucketListSnapshot<BucketT>::operator=(
         mData = other.mData;
         mStreams.clear();
         mMetrics = other.mMetrics;
-        mPointTimers = other.mPointTimers;
+        mSnapshotMetrics = other.mSnapshotMetrics;
         mBulkTimers = other.mBulkTimers;
-        mBulkLoadMeter = other.mBulkLoadMeter;
 #ifdef BUILD_TESTS
         // Reset thread ownership so the copy can be claimed by another thread.
-        mThreadId = std::thread::id{};
+        mThreadId.store(std::thread::id{});
 #endif
     }
     return *this;
@@ -119,14 +134,13 @@ void
 SearchableBucketListSnapshot<BucketT>::threadInvariant() const
 {
 #ifdef BUILD_TESTS
-    auto current = std::this_thread::get_id();
-    if (mThreadId == std::thread::id{})
+    auto const current = std::this_thread::get_id();
+    std::thread::id unclaimed{};
+    // Atomically claim ownership on first use, so any concurrent claimant sees
+    // the CAS fail with `unclaimed` set to the owner's id and asserts.
+    if (!mThreadId.compare_exchange_strong(unclaimed, current))
     {
-        mThreadId = current;
-    }
-    else
-    {
-        releaseAssert(mThreadId == current);
+        releaseAssert(unclaimed == current);
     }
 #endif
 }
@@ -336,8 +350,8 @@ SearchableBucketListSnapshot<BucketT>::load(LedgerKey const& k) const
     releaseAssert(mData);
     threadInvariant();
 
-    auto timerIter = mPointTimers.find(k.type());
-    releaseAssert(timerIter != mPointTimers.end());
+    auto timerIter = mSnapshotMetrics->mPointTimers.find(k.type());
+    releaseAssert(timerIter != mSnapshotMetrics->mPointTimers.end());
     auto timer = timerIter->second.get().TimeScope();
 
     std::shared_ptr<typename BucketT::LoadT const> result{};
@@ -375,7 +389,7 @@ SearchableBucketListSnapshot<BucketT>::getBulkLoadTimer(
     threadInvariant();
     if (numEntries != 0)
     {
-        mBulkLoadMeter.get().Mark(numEntries);
+        mSnapshotMetrics->mBulkLoadMeter.get().Mark(numEntries);
     }
 
     auto iter = mBulkTimers.find(label);
@@ -402,8 +416,10 @@ SearchableBucketListSnapshot<BucketT>::getSnapshotData() const
 
 SearchableLiveBucketListSnapshot::SearchableLiveBucketListSnapshot(
     MetricsRegistry& metrics,
+    std::shared_ptr<BucketSnapshotMetrics<LiveBucket> const> snapshotMetrics,
     std::shared_ptr<BucketListSnapshotData<LiveBucket> const> data)
-    : SearchableBucketListSnapshot<LiveBucket>(metrics, std::move(data))
+    : SearchableBucketListSnapshot<LiveBucket>(
+          metrics, std::move(snapshotMetrics), std::move(data))
 {
 }
 
@@ -843,8 +859,11 @@ SearchableLiveBucketListSnapshot::scanForEvictionInBucket(
 
 SearchableHotArchiveBucketListSnapshot::SearchableHotArchiveBucketListSnapshot(
     MetricsRegistry& metrics,
+    std::shared_ptr<BucketSnapshotMetrics<HotArchiveBucket> const>
+        snapshotMetrics,
     std::shared_ptr<BucketListSnapshotData<HotArchiveBucket> const> data)
-    : SearchableBucketListSnapshot<HotArchiveBucket>(metrics, std::move(data))
+    : SearchableBucketListSnapshot<HotArchiveBucket>(
+          metrics, std::move(snapshotMetrics), std::move(data))
 {
 }
 
@@ -879,6 +898,8 @@ SearchableHotArchiveBucketListSnapshot::scanAllEntries(
 // Explicit template instantiations
 template struct BucketListSnapshotData<LiveBucket>;
 template struct BucketListSnapshotData<HotArchiveBucket>;
+template struct BucketSnapshotMetrics<LiveBucket>;
+template struct BucketSnapshotMetrics<HotArchiveBucket>;
 template class SearchableBucketListSnapshot<LiveBucket>;
 template class SearchableBucketListSnapshot<HotArchiveBucket>;
 

--- a/src/bucket/BucketListSnapshot.cpp
+++ b/src/bucket/BucketListSnapshot.cpp
@@ -101,8 +101,34 @@ SearchableBucketListSnapshot<BucketT>::operator=(
         mPointTimers = other.mPointTimers;
         mBulkTimers = other.mBulkTimers;
         mBulkLoadMeter = other.mBulkLoadMeter;
+#ifdef BUILD_TESTS
+        // Reset thread ownership so the copy can be claimed by another thread.
+        mThreadId = std::thread::id{};
+#endif
     }
     return *this;
+}
+
+// Bucket loads are not thread safe and a single snapshot instance should only
+// be queried by one thread. We cache the initial caller's thread id and assert
+// following queries are from the same thread. Note: this only guards the
+// bucket-loading query entry points; access to the immutable underlying
+// snapshot data is thread safe.
+template <class BucketT>
+void
+SearchableBucketListSnapshot<BucketT>::threadInvariant() const
+{
+#ifdef BUILD_TESTS
+    auto current = std::this_thread::get_id();
+    if (mThreadId == std::thread::id{})
+    {
+        mThreadId = current;
+    }
+    else
+    {
+        releaseAssert(mThreadId == current);
+    }
+#endif
 }
 
 // File streams are fairly expensive to create, so they are lazily created and
@@ -112,6 +138,7 @@ XDRInputFileStream&
 SearchableBucketListSnapshot<BucketT>::getStream(
     std::shared_ptr<BucketT const> const& bucket) const
 {
+    threadInvariant();
     BucketT const* key = bucket.get();
     auto it = mStreams.find(key);
     if (it == mStreams.end())
@@ -307,6 +334,7 @@ SearchableBucketListSnapshot<BucketT>::load(LedgerKey const& k) const
 {
     ZoneScoped;
     releaseAssert(mData);
+    threadInvariant();
 
     auto timerIter = mPointTimers.find(k.type());
     releaseAssert(timerIter != mPointTimers.end());
@@ -341,6 +369,10 @@ medida::Timer&
 SearchableBucketListSnapshot<BucketT>::getBulkLoadTimer(
     std::string const& label, size_t numEntries) const
 {
+    // mBulkTimers is per-snapshot mutable state lazily populated here, so this
+    // must be single-threaded. Enforced here as well as at the public query
+    // entry points.
+    threadInvariant();
     if (numEntries != 0)
     {
         mBulkLoadMeter.get().Mark(numEntries);
@@ -383,6 +415,7 @@ SearchableBucketListSnapshot<BucketT>::loadKeys(
 {
     ZoneScoped;
     releaseAssert(mData);
+    threadInvariant();
     auto timer = getBulkLoadTimer(label, inKeys.size()).TimeScope();
 
     auto keys = inKeys;
@@ -406,6 +439,7 @@ SearchableLiveBucketListSnapshot::loadPoolShareTrustLinesByAccountAndAsset(
 {
     ZoneScoped;
     releaseAssert(mData);
+    threadInvariant();
 
     LedgerKeySet trustlinesToLoad;
 
@@ -448,6 +482,7 @@ SearchableLiveBucketListSnapshot::loadInflationWinners(size_t maxWinners,
 {
     ZoneScoped;
     releaseAssert(mData);
+    threadInvariant();
 
     auto timer = getBulkLoadTimer("inflationWinners", 0).TimeScope();
 
@@ -548,6 +583,7 @@ SearchableLiveBucketListSnapshot::scanForEviction(
     ZoneScoped;
     releaseAssert(mData);
     releaseAssert(stats);
+    threadInvariant();
 
     auto getBucketFromIter =
         [&levels = mData->levels](
@@ -599,6 +635,7 @@ SearchableLiveBucketListSnapshot::scanForEntriesOfType(
 {
     ZoneScoped;
     releaseAssert(mData);
+    threadInvariant();
 
     auto scanBucket = [&](std::shared_ptr<LiveBucket const> const& bucket) {
         if (bucket->isEmpty())
@@ -817,6 +854,7 @@ SearchableHotArchiveBucketListSnapshot::scanAllEntries(
 {
     ZoneScoped;
     releaseAssert(mData);
+    threadInvariant();
 
     auto scanBucket =
         [&](std::shared_ptr<HotArchiveBucket const> const& bucket) {

--- a/src/bucket/BucketListSnapshot.h
+++ b/src/bucket/BucketListSnapshot.h
@@ -19,6 +19,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace medida
@@ -69,9 +70,15 @@ template <class BucketT> struct BucketListSnapshotData
 // immutable snapshot data (ledger header, list of referenced buckets, etc).
 //
 // Thread-safety:
-// - A single snapshot instance must only be used by one thread at a time.
+// - A single snapshot instance must only be used by one thread at a time. In
+//   test builds this is enforced by threadInvariant(): the first thread to
+//   issue a query claims the snapshot, and subsequent queries from a different
+//   thread trigger an assertion.
 // - The underlying snapshot data (shared via shared_ptr) is immutable and
 //   can be safely shared.
+// - To query from another thread, make a copy: copies reset the cached stream
+//   cache and (in test builds) the owning-thread id, so each copy can be
+//   claimed by a different thread.
 template <class BucketT> class SearchableBucketListSnapshot
 {
     BUCKET_TYPE_ASSERT(BucketT);
@@ -83,6 +90,19 @@ template <class BucketT> class SearchableBucketListSnapshot
     // Per-snapshot mutable stream cache
     mutable UnorderedMap<BucketT const*, std::unique_ptr<XDRInputFileStream>>
         mStreams;
+
+#ifdef BUILD_TESTS
+    // Thread id of the first thread to issue a query on this snapshot instance.
+    // Used by threadInvariant() to assert that a single snapshot is not queried
+    // concurrently from multiple threads. Reset on copy so each copy can be
+    // claimed by a different thread.
+    mutable std::thread::id mThreadId{};
+#endif
+
+    // Bucket loads are not thread safe and a single snapshot instance should
+    // only be queried by one thread. We cache the initial caller's thread id
+    // and assert following queries are from the same thread (test builds only).
+    void threadInvariant() const;
 
     std::reference_wrapper<MetricsRegistry> mMetrics;
 

--- a/src/bucket/BucketListSnapshot.h
+++ b/src/bucket/BucketListSnapshot.h
@@ -14,6 +14,7 @@
 #include "util/XDRStream.h"
 #include "xdr/Stellar-ledger-entries.h"
 
+#include <atomic>
 #include <functional>
 #include <list>
 #include <memory>
@@ -65,6 +66,24 @@ template <class BucketT> struct BucketListSnapshotData
     explicit BucketListSnapshotData(BucketListBase<BucketT> const& bl);
 };
 
+// Pre-resolved metric references for snapshot queries. Resolving a metric
+// takes the global MetricsRegistry lock, so metrics are resolved once and
+// shared across snapshots rather than re-resolved in every
+// SearchableBucketListSnapshot constructor.
+template <class BucketT> struct BucketSnapshotMetrics
+{
+    BUCKET_TYPE_ASSERT(BucketT);
+
+    // Tracks load times for each LedgerEntryType. We use
+    // SimpleTimer since medida Timer overhead is too expensive for point
+    // loads.
+    UnorderedMap<LedgerEntryType, std::reference_wrapper<SimpleTimer>> const
+        mPointTimers;
+    std::reference_wrapper<medida::Meter> const mBulkLoadMeter;
+
+    explicit BucketSnapshotMetrics(MetricsRegistry& metrics);
+};
+
 // SearchableBucketListSnapshot provides BucketList lookup functionality.
 // Each snapshot maintains its own stream cache for file I/O and a pointer to
 // immutable snapshot data (ledger header, list of referenced buckets, etc).
@@ -96,7 +115,7 @@ template <class BucketT> class SearchableBucketListSnapshot
     // Used by threadInvariant() to assert that a single snapshot is not queried
     // concurrently from multiple threads. Reset on copy so each copy can be
     // claimed by a different thread.
-    mutable std::thread::id mThreadId{};
+    mutable std::atomic<std::thread::id> mThreadId{};
 #endif
 
     // Bucket loads are not thread safe and a single snapshot instance should
@@ -106,16 +125,15 @@ template <class BucketT> class SearchableBucketListSnapshot
 
     std::reference_wrapper<MetricsRegistry> mMetrics;
 
-    // Tracks load times for each LedgerEntryType. We use
-    // SimpleTimer since medida Timer overhead is too expensive for point loads.
-    UnorderedMap<LedgerEntryType, std::reference_wrapper<SimpleTimer>>
-        mPointTimers;
+    // Pre-resolved point load timers and bulk load meter, shared across
+    // snapshots (see BucketSnapshotMetrics).
+    std::shared_ptr<BucketSnapshotMetrics<BucketT> const> mSnapshotMetrics;
 
     // Bulk load timers take significantly longer, so the timer overhead is
-    // comparatively negligible.
+    // comparatively negligible. Resolved lazily per label, so kept
+    // per-instance rather than in BucketSnapshotMetrics.
     mutable UnorderedMap<std::string, std::reference_wrapper<medida::Timer>>
         mBulkTimers;
-    std::reference_wrapper<medida::Meter> mBulkLoadMeter;
 
     // Returns (lazily-constructed) file stream for bucket file. Note
     // this might be in some random position left over from a previous read --
@@ -156,6 +174,7 @@ template <class BucketT> class SearchableBucketListSnapshot
 
     SearchableBucketListSnapshot(
         MetricsRegistry& metrics,
+        std::shared_ptr<BucketSnapshotMetrics<BucketT> const> snapshotMetrics,
         std::shared_ptr<BucketListSnapshotData<BucketT> const> data);
 
   public:
@@ -190,6 +209,8 @@ class SearchableLiveBucketListSnapshot
 {
     SearchableLiveBucketListSnapshot(
         MetricsRegistry& metrics,
+        std::shared_ptr<BucketSnapshotMetrics<LiveBucket> const>
+            snapshotMetrics,
         std::shared_ptr<BucketListSnapshotData<LiveBucket> const> data);
 
     Loop scanForEvictionInBucket(
@@ -230,6 +251,8 @@ class SearchableHotArchiveBucketListSnapshot
 {
     SearchableHotArchiveBucketListSnapshot(
         MetricsRegistry& metrics,
+        std::shared_ptr<BucketSnapshotMetrics<HotArchiveBucket> const>
+            snapshotMetrics,
         std::shared_ptr<BucketListSnapshotData<HotArchiveBucket> const> data);
 
   public:
@@ -246,6 +269,8 @@ class SearchableHotArchiveBucketListSnapshot
 
 extern template struct BucketListSnapshotData<LiveBucket>;
 extern template struct BucketListSnapshotData<HotArchiveBucket>;
+extern template struct BucketSnapshotMetrics<LiveBucket>;
+extern template struct BucketSnapshotMetrics<HotArchiveBucket>;
 extern template class SearchableBucketListSnapshot<LiveBucket>;
 extern template class SearchableBucketListSnapshot<HotArchiveBucket>;
 

--- a/src/ledger/ImmutableLedgerView.cpp
+++ b/src/ledger/ImmutableLedgerView.cpp
@@ -225,12 +225,16 @@ ImmutableLedgerData::checkInvariant() const
 ImmutableLedgerData::ImmutableLedgerData(
     LiveBucketList const& liveBL, HotArchiveBucketList const& hotArchiveBL,
     LedgerHeaderHistoryEntry const& lcl, HistoryArchiveState const& has,
-    std::optional<SorobanNetworkConfig> sorobanConfig)
+    std::optional<SorobanNetworkConfig> sorobanConfig, MetricsRegistry& metrics)
     : mLiveBucketData(
           std::make_shared<BucketListSnapshotData<LiveBucket>>(liveBL))
     , mHotArchiveBucketData(
           std::make_shared<BucketListSnapshotData<HotArchiveBucket>>(
               hotArchiveBL))
+    , mLiveSnapshotMetrics(
+          std::make_shared<BucketSnapshotMetrics<LiveBucket>>(metrics))
+    , mHotArchiveSnapshotMetrics(
+          std::make_shared<BucketSnapshotMetrics<HotArchiveBucket>>(metrics))
     , mSorobanConfig(std::move(sorobanConfig))
     , mLastClosedLedgerHeader(lcl)
     , mLastClosedHistoryArchiveState(has)
@@ -275,19 +279,22 @@ ImmutableLedgerData::createAndMaybeLoadConfig(
         // Bootstrap: build a lightweight temporary state just to load config
         // from the current live bucket list.
         auto tempState = std::make_shared<ImmutableLedgerData>(
-            liveBL, hotArchiveBL, lcl, has, /*sorobanConfig*/ std::nullopt);
+            liveBL, hotArchiveBL, lcl, has, /*sorobanConfig*/ std::nullopt,
+            metrics);
         ImmutableLedgerView tempView(tempState, metrics);
         sorobanConfig = SorobanNetworkConfig::loadFromLedger(tempView);
     }
-    return std::make_shared<ImmutableLedgerData>(liveBL, hotArchiveBL, lcl, has,
-                                                 std::move(sorobanConfig));
+    return std::make_shared<ImmutableLedgerData>(
+        liveBL, hotArchiveBL, lcl, has, std::move(sorobanConfig), metrics);
 }
 
 ImmutableLedgerView::ImmutableLedgerView(ImmutableLedgerDataPtr state,
                                          MetricsRegistry& metrics)
     : mState(state)
-    , mLiveSnapshot(metrics, state->mLiveBucketData)
-    , mHotArchiveSnapshot(metrics, state->mHotArchiveBucketData)
+    , mLiveSnapshot(metrics, state->mLiveSnapshotMetrics,
+                    state->mLiveBucketData)
+    , mHotArchiveSnapshot(metrics, state->mHotArchiveSnapshotMetrics,
+                          state->mHotArchiveBucketData)
     , mMetrics(metrics)
 {
 }

--- a/src/ledger/ImmutableLedgerView.h
+++ b/src/ledger/ImmutableLedgerView.h
@@ -279,6 +279,15 @@ class ImmutableLedgerData : public NonMovableOrCopyable
     std::shared_ptr<BucketListSnapshotData<HotArchiveBucket> const> const
         mHotArchiveBucketData;
 
+    // Pre-resolved metric references shared by all views over this state.
+    // Resolving metrics takes the global registry lock, so they are resolved
+    // once here instead of in every view construction, which is on the
+    // per-transaction hot path.
+    std::shared_ptr<BucketSnapshotMetrics<LiveBucket> const> const
+        mLiveSnapshotMetrics;
+    std::shared_ptr<BucketSnapshotMetrics<HotArchiveBucket> const> const
+        mHotArchiveSnapshotMetrics;
+
     std::optional<SorobanNetworkConfig const> const mSorobanConfig;
     LedgerHeaderHistoryEntry const mLastClosedLedgerHeader;
     HistoryArchiveState const mLastClosedHistoryArchiveState;
@@ -295,7 +304,8 @@ class ImmutableLedgerData : public NonMovableOrCopyable
                         HotArchiveBucketList const& hotArchiveBL,
                         LedgerHeaderHistoryEntry const& lcl,
                         HistoryArchiveState const& has,
-                        std::optional<SorobanNetworkConfig> sorobanConfig);
+                        std::optional<SorobanNetworkConfig> sorobanConfig,
+                        MetricsRegistry& metrics);
 
     // Factory: constructs a ImmutableLedgerData, auto-loading the
     // SorobanNetworkConfig from the bucket list when the protocol requires it.

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -360,7 +360,7 @@ LedgerManagerImpl::LedgerManagerImpl(Application& app)
 
     auto initialState = std::make_shared<ImmutableLedgerData>(
         bm.getLiveBucketList(), bm.getHotArchiveBucketList(), emptyLcl,
-        emptyHas, /*sorobanConfig*/ std::nullopt);
+        emptyHas, /*sorobanConfig*/ std::nullopt, mApp.getMetrics());
 
     mApplyState.setLedgerState(initialState);
     {
@@ -2135,7 +2135,7 @@ LedgerManagerImpl::buildLedgerState(
         // Caller already loaded config (e.g. from LTX during ledger close)
         return std::make_shared<ImmutableLedgerData>(
             bm.getLiveBucketList(), bm.getHotArchiveBucketList(), lcl, has,
-            std::move(sorobanConfig));
+            std::move(sorobanConfig), mApp.getMetrics());
     }
 
     // Auto-load SorobanNetworkConfig from the BucketList


### PR DESCRIPTION
# Description

The first commit resolves https://github.com/stellar/stellar-core/issues/5067.

The 2nd commit addresses a perf issue we saw with the BucketList refactor. We build snapshot objects in parallel contents. Currently, the constructor gets a fresh set of metric references for each snapshot, acquiring a lock to do so. This changes it such that we use a single shared metrics object across all snapshots. Metrics are thread safe, so there should be no safety issue with this, and it makes the snapshot constructor much cheaper.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
