### PR TITLE
Add more fuzz targets

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -583,10 +583,10 @@ FUZZ_LINKER_FLAGS = -Wl,--whole-archive,libfuzz_common.a,--no-whole-archive $(if
 # - Create regression test target
 
 # List of fuzz targets (lowercase names)
-FUZZ_TARGETS = tx overlay soroban_expr soroban_wasmi
+FUZZ_TARGETS = tx overlay scp parallel_tx bucketlist soroban_expr soroban_wasmi
 
 # Fuzz binaries are noinst because they're development tools
-noinst_PROGRAMS = fuzz_tx fuzz_overlay fuzz_soroban_expr fuzz_soroban_wasmi
+noinst_PROGRAMS = fuzz_tx fuzz_overlay fuzz_scp fuzz_parallel_tx fuzz_bucketlist fuzz_soroban_expr fuzz_soroban_wasmi
 
 # Each fuzz target only compiles FuzzMain.cpp (with its specific -DFUZZ_TARGET_NAME)
 # and links against the shared libfuzz_common.a library.
@@ -599,6 +599,21 @@ fuzz_overlay_SOURCES = $(FUZZ_MAIN)
 fuzz_overlay_CXXFLAGS = $(FUZZ_CXXFLAGS) -DFUZZ_TARGET_NAME=\"overlay\"
 fuzz_overlay_LDADD = $(FUZZ_LIBS)
 fuzz_overlay_LDFLAGS = $(FUZZ_LINKER_FLAGS)
+
+fuzz_scp_SOURCES = $(FUZZ_MAIN)
+fuzz_scp_CXXFLAGS = $(FUZZ_CXXFLAGS) -DFUZZ_TARGET_NAME=\"scp\"
+fuzz_scp_LDADD = $(FUZZ_LIBS)
+fuzz_scp_LDFLAGS = $(FUZZ_LINKER_FLAGS)
+
+fuzz_parallel_tx_SOURCES = $(FUZZ_MAIN)
+fuzz_parallel_tx_CXXFLAGS = $(FUZZ_CXXFLAGS) -DFUZZ_TARGET_NAME=\"parallel_tx\"
+fuzz_parallel_tx_LDADD = $(FUZZ_LIBS)
+fuzz_parallel_tx_LDFLAGS = $(FUZZ_LINKER_FLAGS)
+
+fuzz_bucketlist_SOURCES = $(FUZZ_MAIN)
+fuzz_bucketlist_CXXFLAGS = $(FUZZ_CXXFLAGS) -DFUZZ_TARGET_NAME=\"bucketlist\"
+fuzz_bucketlist_LDADD = $(FUZZ_LIBS)
+fuzz_bucketlist_LDFLAGS = $(FUZZ_LINKER_FLAGS)
 
 # Soroban fuzz targets (require --features fuzz in Rust build)
 fuzz_soroban_expr_SOURCES = $(FUZZ_MAIN)

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -49,6 +49,7 @@
 #include "simulation/ApplyLoad.h"
 #include "test/TestUtils.h"
 #include "test/fuzz/FuzzTargetRegistry.h"
+#include "test/fuzz/ScopedCatchResultCapture.h"
 #include "test/test.h"
 #endif
 
@@ -1799,6 +1800,7 @@ runFuzz(CommandLineArgs const& args)
             if (actual > 0)
             {
                 data.resize(actual);
+                ScopedCatchResultCapture catchCapture;
                 target->run(data.data(), data.size());
             }
 

--- a/src/rust/src/soroban_proto_all.rs
+++ b/src/rust/src/soroban_proto_all.rs
@@ -350,6 +350,7 @@ pub(crate) mod p28 {
     }
 }
 
+#[cfg(not(feature = "fastdev"))]
 #[path = "."]
 pub(crate) mod p27 {
     pub(crate) extern crate soroban_env_host_p27;

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -552,7 +552,8 @@ closeLedgerOn(Application& app, int day, int month, int year,
 
 TransactionResultSet
 closeLedger(Application& app, std::vector<TransactionFrameBasePtr> const& txs,
-            ParallelSorobanOrder const& parallelSorobanOrder)
+            ParallelSorobanOrder const& parallelSorobanOrder,
+            ApplyOrderTxCallback const& applyOrderTxCallback)
 {
     auto lastCloseTime = app.getLedgerManager()
                              .getLastClosedLedgerHeader()
@@ -561,12 +562,14 @@ closeLedger(Application& app, std::vector<TransactionFrameBasePtr> const& txs,
     auto nextLedgerSeq = app.getLedgerManager().getLastClosedLedgerNum() + 1;
 
     return closeLedgerOn(app, nextLedgerSeq, lastCloseTime, txs, true,
-                         emptyUpgradeSteps, parallelSorobanOrder);
+                         emptyUpgradeSteps, parallelSorobanOrder,
+                         applyOrderTxCallback);
 }
 
 TransactionResultSet
 closeLedger(Application& app, std::vector<TransactionFrameBasePtr> const& txs,
-            bool strictOrder, xdr::xvector<UpgradeType, 6> const& upgrades)
+            bool strictOrder, xdr::xvector<UpgradeType, 6> const& upgrades,
+            ApplyOrderTxCallback const& applyOrderTxCallback)
 {
     auto lastCloseTime = app.getLedgerManager()
                              .getLastClosedLedgerHeader()
@@ -575,14 +578,15 @@ closeLedger(Application& app, std::vector<TransactionFrameBasePtr> const& txs,
     auto nextLedgerSeq = app.getLedgerManager().getLastClosedLedgerNum() + 1;
 
     return closeLedgerOn(app, nextLedgerSeq, lastCloseTime, txs, strictOrder,
-                         upgrades);
+                         upgrades, {}, applyOrderTxCallback);
 }
 
 TransactionResultSet
 closeLedgerOn(Application& app, uint32 ledgerSeq, TimePoint closeTime,
               std::vector<TransactionFrameBasePtr> const& txs, bool strictOrder,
               xdr::xvector<UpgradeType, 6> const& upgrades,
-              ParallelSorobanOrder const& parallelSorobanOrder)
+              ParallelSorobanOrder const& parallelSorobanOrder,
+              ApplyOrderTxCallback const& applyOrderTxCallback)
 {
     // Ensure that parallelSorobanOrder is only used with strictOrder
     releaseAssert((parallelSorobanOrder.empty() || strictOrder));
@@ -635,6 +639,18 @@ closeLedgerOn(Application& app, uint32 ledgerSeq, TimePoint closeTime,
         // same order as they were constructed. It could also imply the txs
         // themselves maybe intentionally invalid for testing purpose.
         releaseAssert(txSet.second->checkValid(app, 0, 0));
+    }
+    if (applyOrderTxCallback)
+    {
+        size_t txIndex = 0;
+        for (auto const& phase : txSet.second->getPhasesInApplyOrder())
+        {
+            for (auto const& tx : phase)
+            {
+                applyOrderTxCallback(txIndex, tx);
+                ++txIndex;
+            }
+        }
     }
     app.getHerder().externalizeValue(txSet.first, ledgerSeq, closeTime,
                                      upgrades);

--- a/src/test/TxTests.h
+++ b/src/test/TxTests.h
@@ -8,7 +8,9 @@
 #include "herder/LedgerCloseData.h"
 #include "herder/Upgrades.h"
 #include "overlay/StellarXDR.h"
+#include "transactions/TransactionFrameBase.h"
 #include "transactions/test/TransactionTestFrame.h"
+#include <functional>
 #include <optional>
 
 namespace stellar
@@ -22,6 +24,9 @@ class TestAccount;
 
 namespace txtest
 {
+
+using ApplyOrderTxCallback =
+    std::function<void(size_t, stellar::TransactionFrameBaseConstPtr const&)>;
 
 struct ExpectedOpResult
 {
@@ -88,11 +93,13 @@ TransactionResultSet
 closeLedger(Application& app,
             std::vector<TransactionFrameBasePtr> const& txs = {},
             bool strictOrder = false,
-            xdr::xvector<UpgradeType, 6> const& upgrades = emptyUpgradeSteps);
+            xdr::xvector<UpgradeType, 6> const& upgrades = emptyUpgradeSteps,
+            ApplyOrderTxCallback const& applyOrderTxCallback = {});
 
 TransactionResultSet
 closeLedger(Application& app, std::vector<TransactionFrameBasePtr> const& txs,
-            ParallelSorobanOrder const& parallelSorobanOrder);
+            ParallelSorobanOrder const& parallelSorobanOrder,
+            ApplyOrderTxCallback const& applyOrderTxCallback = {});
 
 TransactionResultSet
 closeLedgerOn(Application& app, int day, int month, int year,
@@ -104,7 +111,8 @@ closeLedgerOn(Application& app, uint32 ledgerSeq, TimePoint closeTime,
               std::vector<TransactionFrameBasePtr> const& txs = {},
               bool strictOrder = false,
               xdr::xvector<UpgradeType, 6> const& upgrades = emptyUpgradeSteps,
-              ParallelSorobanOrder const& parallelSorobanOrder = {});
+              ParallelSorobanOrder const& parallelSorobanOrder = {},
+              ApplyOrderTxCallback const& applyOrderTxCallback = {});
 
 TransactionResultSet closeLedger(Application& app, TxSetXDRFrameConstPtr txSet);
 

--- a/src/test/fuzz/FuzzMain.cpp
+++ b/src/test/fuzz/FuzzMain.cpp
@@ -33,6 +33,7 @@
 #endif
 
 #include "test/fuzz/FuzzTargetRegistry.h"
+#include "test/fuzz/ScopedCatchResultCapture.h"
 #include "util/Logging.h"
 #include "util/Math.h"
 
@@ -95,6 +96,7 @@ LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     }
 
     // Run the target once
+    stellar::ScopedCatchResultCapture catchCapture;
     switch (gFuzzTarget->run(data, size))
     {
     case stellar::FuzzResultCode::FUZZ_SUCCESS:

--- a/src/test/fuzz/ScopedCatchResultCapture.h
+++ b/src/test/fuzz/ScopedCatchResultCapture.h
@@ -1,0 +1,210 @@
+// Copyright 2026 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#pragma once
+
+#include "test/Catch2.h"
+
+#include <stdexcept>
+#include <string>
+
+namespace stellar
+{
+
+// Standalone fuzz entry points do not run inside Catch's test runner, but many
+// test helpers used by fuzz targets contain REQUIRE/CHECK assertions. Without a
+// result capture installed, those assertions fail with Catch's internal "No
+// result capture instance" error instead of reporting the real assertion.
+//
+// Install this at non-Catch fuzz entry points, such as FuzzMain or fuzz-one,
+// around target->run(). It is intentionally a no-op when a real Catch capture
+// is already present, so smoke/corpus unit tests keep their normal reporting.
+class ScopedCatchResultCapture : public Catch::IResultCapture
+{
+  public:
+    ScopedCatchResultCapture()
+        : mPreviousCapture(Catch::getCurrentContext().getResultCapture())
+    {
+        if (mPreviousCapture == nullptr)
+        {
+            Catch::getCurrentMutableContext().setResultCapture(this);
+            mInstalled = true;
+        }
+    }
+
+    ~ScopedCatchResultCapture() override
+    {
+        if (mInstalled)
+        {
+            Catch::getCurrentMutableContext().setResultCapture(
+                mPreviousCapture);
+        }
+    }
+
+    bool
+    sectionStarted(Catch::SectionInfo const&, Catch::Counts&) override
+    {
+        return true;
+    }
+
+    void
+    sectionEnded(Catch::SectionEndInfo const&) override
+    {
+    }
+
+    void
+    sectionEndedEarly(Catch::SectionEndInfo const&) override
+    {
+    }
+
+    Catch::IGeneratorTracker&
+    acquireGeneratorTracker(Catch::StringRef,
+                            Catch::SourceLineInfo const&) override
+    {
+        throw std::runtime_error("generators are unsupported in fuzz target");
+    }
+
+#if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
+    void
+    benchmarkPreparing(std::string const&) override
+    {
+    }
+
+    void
+    benchmarkStarting(Catch::BenchmarkInfo const&) override
+    {
+    }
+
+    void
+    benchmarkEnded(Catch::BenchmarkStats<> const&) override
+    {
+    }
+
+    void
+    benchmarkFailed(std::string const&) override
+    {
+        throw std::runtime_error("benchmark failed in fuzz target");
+    }
+#endif
+
+    void
+    pushScopedMessage(Catch::MessageInfo const&) override
+    {
+    }
+
+    void
+    popScopedMessage(Catch::MessageInfo const&) override
+    {
+    }
+
+    void
+    emplaceUnscopedMessage(Catch::MessageBuilder const&) override
+    {
+    }
+
+    void
+    handleFatalErrorCondition(Catch::StringRef message) override
+    {
+        throw std::runtime_error(static_cast<std::string>(message));
+    }
+
+    void
+    handleExpr(Catch::AssertionInfo const& info,
+               Catch::ITransientExpression const& expr,
+               Catch::AssertionReaction& reaction) override
+    {
+        mLastAssertionPassed =
+            expr.getResult() != Catch::isFalseTest(info.resultDisposition);
+        if (!mLastAssertionPassed)
+        {
+            reaction.shouldThrow = true;
+        }
+    }
+
+    void
+    handleMessage(Catch::AssertionInfo const&, Catch::ResultWas::OfType result,
+                  Catch::StringRef const& message,
+                  Catch::AssertionReaction& reaction) override
+    {
+        mLastAssertionPassed = Catch::isOk(result);
+        if (!mLastAssertionPassed)
+        {
+            reaction.shouldThrow = true;
+            mLastMessage = static_cast<std::string>(message);
+        }
+    }
+
+    void
+    handleUnexpectedExceptionNotThrown(
+        Catch::AssertionInfo const&,
+        Catch::AssertionReaction& reaction) override
+    {
+        mLastAssertionPassed = false;
+        reaction.shouldThrow = true;
+    }
+
+    void
+    handleUnexpectedInflightException(
+        Catch::AssertionInfo const&, std::string const& message,
+        Catch::AssertionReaction& reaction) override
+    {
+        mLastAssertionPassed = false;
+        reaction.shouldThrow = true;
+        mLastMessage = message;
+    }
+
+    void
+    handleIncomplete(Catch::AssertionInfo const&) override
+    {
+        mLastAssertionPassed = false;
+    }
+
+    void
+    handleNonExpr(Catch::AssertionInfo const&, Catch::ResultWas::OfType result,
+                  Catch::AssertionReaction& reaction) override
+    {
+        mLastAssertionPassed = Catch::isOk(result);
+        if (!mLastAssertionPassed)
+        {
+            reaction.shouldThrow = true;
+        }
+    }
+
+    bool
+    lastAssertionPassed() override
+    {
+        return mLastAssertionPassed;
+    }
+
+    void
+    assertionPassed() override
+    {
+        mLastAssertionPassed = true;
+    }
+
+    std::string
+    getCurrentTestName() const override
+    {
+        return "fuzz target";
+    }
+
+    Catch::AssertionResult const*
+    getLastResult() const override
+    {
+        return nullptr;
+    }
+
+    void
+    exceptionEarlyReported() override
+    {
+    }
+
+  private:
+    Catch::IResultCapture* mPreviousCapture;
+    bool mInstalled{false};
+    bool mLastAssertionPassed{true};
+    std::string mLastMessage;
+};
+
+} // namespace stellar

--- a/src/test/fuzz/targets/BucketListFuzzTarget.cpp
+++ b/src/test/fuzz/targets/BucketListFuzzTarget.cpp
@@ -1,0 +1,533 @@
+// Copyright 2026 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "test/fuzz/FuzzTargetRegistry.h"
+
+#include "bucket/BucketManager.h"
+#include "bucket/HotArchiveBucketList.h"
+#include "bucket/LiveBucketList.h"
+#include "bucket/test/BucketTestUtils.h"
+#include "crypto/SHA.h"
+#include "ledger/ImmutableLedgerView.h"
+#include "main/Application.h"
+#include "test/Catch2.h"
+#include "test/fuzz/FuzzUtils.h"
+#include "test/test.h"
+#include "transactions/TransactionUtils.h"
+
+#include <algorithm>
+#include <map>
+#include <set>
+
+namespace stellar
+{
+namespace
+{
+
+// This harness fuzzes the bucket-list storage layer directly. It decodes input
+// into a small deterministic stream of live-bucket and hot-archive mutations,
+// applies them with LiveBucketList::addBatch and
+// HotArchiveBucketList::addBatch, and checks the resulting ApplyLedgerView
+// against a local model. It is meant to catch bucket-list bugs such as stale
+// reads after shadowing, lost updates, bad delete/restore tombstone handling,
+// live/archive cross-contamination, and merge-order mistakes across bucket
+// levels.
+//
+// It does not emulate the production Soroban expiration pipeline. In
+// production, persistent entries move into the hot archive only after higher
+// level ledger-close logic interprets paired TTL entries and decides that live
+// entries have expired. This target starts below that abstraction boundary: an
+// ARCHIVE_UPSERT means "the higher layer has already decided this entry should
+// be archived." For that reason the model intentionally avoids TTL entries and
+// cannot catch bugs in TTL extension, expiration discovery, or the live-to-
+// archive decision process. Those belong in a higher-level Soroban archival
+// lifecycle harness.
+
+constexpr size_t MAX_OPS = 128;
+constexpr uint8_t KEY_SLOT_COUNT = 16;
+constexpr size_t MAX_BATCH_CHANGES = 8;
+
+enum class BucketOpKind : uint8_t
+{
+    LIVE_UPSERT = 0,
+    LIVE_DELETE = 1,
+    ARCHIVE_UPSERT = 2,
+    ARCHIVE_RESTORE = 3,
+    FLUSH = 4,
+    CHECKPOINT = 5
+};
+
+struct BucketOp
+{
+    BucketOpKind kind;
+    uint8_t keySlot;
+    uint8_t valueVariant;
+};
+
+struct PendingBatch
+{
+    std::vector<LedgerEntry> initEntries;
+    std::vector<LedgerEntry> liveEntries;
+    std::vector<LedgerKey> deadEntries;
+    std::vector<LedgerEntry> archiveEntries;
+    std::vector<LedgerKey> restoredArchiveEntries;
+    std::set<LedgerKey, LedgerEntryIdCmp> keys;
+
+    bool
+    empty() const
+    {
+        return initEntries.empty() && liveEntries.empty() &&
+               deadEntries.empty() && archiveEntries.empty() &&
+               restoredArchiveEntries.empty();
+    }
+
+    size_t
+    size() const
+    {
+        return initEntries.size() + liveEntries.size() + deadEntries.size() +
+               archiveEntries.size() + restoredArchiveEntries.size();
+    }
+
+    bool
+    hasKey(LedgerKey const& key) const
+    {
+        return keys.find(key) != keys.end();
+    }
+
+    void
+    noteKey(LedgerKey const& key)
+    {
+        keys.insert(key);
+    }
+
+    void
+    clear()
+    {
+        initEntries.clear();
+        liveEntries.clear();
+        deadEntries.clear();
+        archiveEntries.clear();
+        restoredArchiveEntries.clear();
+        keys.clear();
+    }
+};
+
+struct ExpectedState
+{
+    std::map<LedgerKey, LedgerEntry, LedgerEntryIdCmp> live;
+    std::set<LedgerKey, LedgerEntryIdCmp> deletedLive;
+    std::map<LedgerKey, LedgerEntry, LedgerEntryIdCmp> archive;
+    std::set<LedgerKey, LedgerEntryIdCmp> restoredArchive;
+};
+
+class ByteCursor
+{
+  public:
+    ByteCursor(uint8_t const* data, size_t size) : mData(data), mSize(size)
+    {
+    }
+
+    bool
+    empty() const
+    {
+        return mPos >= mSize;
+    }
+
+    uint8_t
+    nextU8()
+    {
+        releaseAssert(!empty());
+        return mData[mPos++];
+    }
+
+  private:
+    uint8_t const* mData;
+    size_t mSize;
+    size_t mPos{0};
+};
+
+LedgerHeader
+makeHeader(uint32_t seq, uint32_t protocolVersion)
+{
+    LedgerHeader h;
+    h.ledgerSeq = seq;
+    h.ledgerVersion = protocolVersion;
+    return h;
+}
+
+LedgerEntry
+makeContractCodeEntry(uint8_t keySlot, uint8_t valueVariant, uint32_t seq)
+{
+    auto code = "bucketlist-fuzz-" + std::to_string(keySlot) + "-" +
+                std::to_string(valueVariant);
+
+    LedgerEntry e;
+    e.lastModifiedLedgerSeq = seq;
+    e.data.type(CONTRACT_CODE);
+    auto& contractCode = e.data.contractCode();
+    contractCode.ext.v(0);
+    contractCode.hash =
+        sha256("bucketlist-fuzz-key-" + std::to_string(keySlot));
+    contractCode.code.assign(code.begin(), code.end());
+    e.ext.v(0);
+    return e;
+}
+
+LedgerKey
+makeContractDataKey(uint8_t keySlot)
+{
+    LedgerKey k(CONTRACT_DATA);
+    auto& contractData = k.contractData();
+    contractData.contract.type(SC_ADDRESS_TYPE_CONTRACT);
+    contractData.contract.contractId() = sha256("bucketlist-fuzz-contract");
+    contractData.key =
+        makeSymbolSCVal("bucketlist-fuzz-key-" + std::to_string(keySlot));
+    contractData.durability = PERSISTENT;
+    return k;
+}
+
+LedgerEntry
+makeContractDataEntry(uint8_t keySlot, uint8_t valueVariant, uint32_t seq)
+{
+    LedgerEntry e;
+    e.lastModifiedLedgerSeq = seq;
+    e.data.type(CONTRACT_DATA);
+    auto& contractData = e.data.contractData();
+    contractData.ext.v(0);
+    contractData.contract.type(SC_ADDRESS_TYPE_CONTRACT);
+    contractData.contract.contractId() = sha256("bucketlist-fuzz-contract");
+    contractData.key =
+        makeSymbolSCVal("bucketlist-fuzz-key-" + std::to_string(keySlot));
+    contractData.durability = PERSISTENT;
+    contractData.val = makeU64SCVal(valueVariant & 0x7f);
+    e.ext.v(0);
+    return e;
+}
+
+bool
+useContractData(uint8_t valueVariant)
+{
+    return (valueVariant & 0x80) != 0;
+}
+
+LedgerEntry
+makeEntry(uint8_t keySlot, uint8_t valueVariant, uint32_t seq)
+{
+    if (useContractData(valueVariant))
+    {
+        return makeContractDataEntry(keySlot, valueVariant, seq);
+    }
+    return makeContractCodeEntry(keySlot, valueVariant, seq);
+}
+
+LedgerKey
+keyForSlot(uint8_t keySlot, bool contractData)
+{
+    if (contractData)
+    {
+        return makeContractDataKey(keySlot);
+    }
+
+    LedgerKey k(CONTRACT_CODE);
+    k.contractCode().hash =
+        sha256("bucketlist-fuzz-key-" + std::to_string(keySlot));
+    return k;
+}
+
+LedgerKey
+keyForOp(BucketOp const& op)
+{
+    return keyForSlot(op.keySlot, useContractData(op.valueVariant));
+}
+
+std::vector<BucketOp>
+decodeOps(uint8_t const* data, size_t size)
+{
+    ByteCursor cursor(data, size);
+    std::vector<BucketOp> ops;
+    ops.reserve(std::min(MAX_OPS, size / 3));
+    while (!cursor.empty() && ops.size() < MAX_OPS)
+    {
+        auto kind = static_cast<BucketOpKind>(cursor.nextU8() % 6);
+        if (cursor.empty())
+        {
+            break;
+        }
+        auto keySlot = static_cast<uint8_t>(cursor.nextU8() % KEY_SLOT_COUNT);
+        if (cursor.empty())
+        {
+            break;
+        }
+        auto valueVariant = cursor.nextU8();
+        ops.push_back({kind, keySlot, valueVariant});
+    }
+    return ops;
+}
+
+void
+checkExpectedState(Application& app, ExpectedState const& expected)
+{
+    auto applyView = app.getLedgerManager().copyApplyLedgerView();
+    for (auto const& [key, entry] : expected.live)
+    {
+        auto loaded = applyView.loadLiveEntry(key);
+        if (!loaded)
+        {
+            throw std::runtime_error("bucketlist live entry missing");
+        }
+        if (*loaded != entry)
+        {
+            throw std::runtime_error("bucketlist live entry stale");
+        }
+        if (applyView.loadArchiveEntry(key))
+        {
+            throw std::runtime_error("bucketlist live entry also archived");
+        }
+    }
+
+    for (auto const& key : expected.deletedLive)
+    {
+        if (expected.live.find(key) == expected.live.end() &&
+            applyView.loadLiveEntry(key))
+        {
+            throw std::runtime_error("bucketlist deleted live entry present");
+        }
+    }
+
+    for (auto const& [key, entry] : expected.archive)
+    {
+        auto loaded = applyView.loadArchiveEntry(key);
+        if (!loaded)
+        {
+            throw std::runtime_error("bucketlist archive entry missing");
+        }
+        if (loaded->type() != HOT_ARCHIVE_ARCHIVED ||
+            loaded->archivedEntry() != entry)
+        {
+            throw std::runtime_error("bucketlist archive entry stale");
+        }
+        if (applyView.loadLiveEntry(key))
+        {
+            throw std::runtime_error("bucketlist archive entry also live");
+        }
+    }
+
+    for (auto const& key : expected.restoredArchive)
+    {
+        if (expected.archive.find(key) == expected.archive.end() &&
+            applyView.loadArchiveEntry(key))
+        {
+            throw std::runtime_error(
+                "bucketlist restored archive entry present");
+        }
+    }
+
+    for (uint8_t keySlot = 0; keySlot < KEY_SLOT_COUNT; ++keySlot)
+    {
+        for (bool contractData : {false, true})
+        {
+            auto key = keyForSlot(keySlot, contractData);
+            if (expected.live.find(key) == expected.live.end() &&
+                expected.deletedLive.find(key) == expected.deletedLive.end() &&
+                applyView.loadLiveEntry(key))
+            {
+                throw std::runtime_error(
+                    "bucketlist absent live entry present");
+            }
+            if (expected.archive.find(key) == expected.archive.end() &&
+                expected.restoredArchive.find(key) ==
+                    expected.restoredArchive.end() &&
+                applyView.loadArchiveEntry(key))
+            {
+                throw std::runtime_error(
+                    "bucketlist absent archive entry present");
+            }
+        }
+    }
+}
+
+void
+flushBatch(Application& app, PendingBatch& pending,
+           ExpectedState const& expected, uint32_t& ledgerSeq,
+           uint32_t protocolVersion)
+{
+    if (pending.empty())
+    {
+        return;
+    }
+
+    auto header = makeHeader(ledgerSeq, protocolVersion);
+    auto& bm = app.getBucketManager();
+    bm.getLiveBucketList().addBatch(app, header.ledgerSeq, header.ledgerVersion,
+                                    pending.initEntries, pending.liveEntries,
+                                    pending.deadEntries);
+    bm.getHotArchiveBucketList().addBatch(
+        app, header.ledgerSeq, header.ledgerVersion, pending.archiveEntries,
+        pending.restoredArchiveEntries);
+    app.getLedgerManager().updateCanonicalStateForTesting(header);
+    pending.clear();
+    checkExpectedState(app, expected);
+    ++ledgerSeq;
+}
+
+class BucketListFuzzTarget : public FuzzTarget
+{
+  public:
+    std::string
+    name() const override
+    {
+        return "bucketlist";
+    }
+
+    std::string
+    description() const override
+    {
+        return "Fuzz live/hot-archive bucketlist transitions with snapshot "
+               "invariant checks";
+    }
+
+    void
+    initialize() override
+    {
+        reinitializeAllGlobalStateForFuzzing(1);
+    }
+
+    FuzzResultCode
+    run(uint8_t const* data, size_t size) override
+    {
+        if (data == nullptr || size < 3 || size > maxInputSize())
+        {
+            return FuzzResultCode::FUZZ_REJECTED;
+        }
+
+        auto ops = decodeOps(data, size);
+        if (ops.empty())
+        {
+            return FuzzResultCode::FUZZ_REJECTED;
+        }
+
+        VirtualClock clock;
+        auto cfg = getFuzzConfig(601);
+        auto app =
+            createTestApplication<BucketTestUtils::BucketTestApplication>(clock,
+                                                                          cfg);
+        auto protocolVersion = BucketTestUtils::getAppLedgerVersion(*app);
+        auto ledgerSeq = app->getLedgerManager().getLastClosedLedgerNum() + 1;
+
+        PendingBatch pending;
+        ExpectedState expected;
+        for (auto const& op : ops)
+        {
+            auto key = keyForOp(op);
+            if (pending.hasKey(key))
+            {
+                flushBatch(*app, pending, expected, ledgerSeq, protocolVersion);
+            }
+
+            switch (op.kind)
+            {
+            case BucketOpKind::LIVE_UPSERT:
+            {
+                auto isUpdate = expected.live.find(key) != expected.live.end();
+                auto entry = makeEntry(op.keySlot, op.valueVariant, ledgerSeq);
+                if (isUpdate)
+                {
+                    pending.liveEntries.push_back(entry);
+                }
+                else
+                {
+                    pending.initEntries.push_back(entry);
+                }
+                expected.live[key] = entry;
+                expected.deletedLive.erase(key);
+                expected.archive.erase(key);
+                expected.restoredArchive.insert(key);
+                pending.restoredArchiveEntries.push_back(key);
+                pending.noteKey(key);
+                break;
+            }
+            case BucketOpKind::LIVE_DELETE:
+                pending.deadEntries.push_back(key);
+                expected.live.erase(key);
+                expected.deletedLive.insert(key);
+                pending.noteKey(key);
+                break;
+            case BucketOpKind::ARCHIVE_UPSERT:
+            {
+                auto entry = makeEntry(op.keySlot, op.valueVariant, ledgerSeq);
+                pending.archiveEntries.push_back(entry);
+                expected.archive[key] = entry;
+                expected.restoredArchive.erase(key);
+                expected.live.erase(key);
+                expected.deletedLive.insert(key);
+                pending.deadEntries.push_back(key);
+                pending.noteKey(key);
+                break;
+            }
+            case BucketOpKind::ARCHIVE_RESTORE:
+                pending.restoredArchiveEntries.push_back(key);
+                expected.archive.erase(key);
+                expected.restoredArchive.insert(key);
+                pending.noteKey(key);
+                break;
+            case BucketOpKind::FLUSH:
+                flushBatch(*app, pending, expected, ledgerSeq, protocolVersion);
+                break;
+            case BucketOpKind::CHECKPOINT:
+                flushBatch(*app, pending, expected, ledgerSeq, protocolVersion);
+                checkExpectedState(*app, expected);
+                break;
+            }
+
+            if (pending.size() >= MAX_BATCH_CHANGES)
+            {
+                flushBatch(*app, pending, expected, ledgerSeq, protocolVersion);
+            }
+        }
+
+        flushBatch(*app, pending, expected, ledgerSeq, protocolVersion);
+        checkExpectedState(*app, expected);
+        app->gracefulStop();
+
+        return FuzzResultCode::FUZZ_SUCCESS;
+    }
+
+    void
+    shutdown() override
+    {
+    }
+
+    size_t
+    maxInputSize() const override
+    {
+        return 4 * 1024;
+    }
+
+    std::vector<uint8_t>
+    generateSeedInput() override
+    {
+        return {
+            static_cast<uint8_t>(BucketOpKind::LIVE_UPSERT),     0, 10,
+            static_cast<uint8_t>(BucketOpKind::FLUSH),           0, 0,
+            static_cast<uint8_t>(BucketOpKind::LIVE_UPSERT),     0, 11,
+            static_cast<uint8_t>(BucketOpKind::LIVE_UPSERT),     1, 20,
+            static_cast<uint8_t>(BucketOpKind::FLUSH),           0, 0,
+            static_cast<uint8_t>(BucketOpKind::LIVE_DELETE),     0, 0,
+            static_cast<uint8_t>(BucketOpKind::ARCHIVE_UPSERT),  2, 30,
+            static_cast<uint8_t>(BucketOpKind::FLUSH),           0, 0,
+            static_cast<uint8_t>(BucketOpKind::LIVE_UPSERT),     0, 12,
+            static_cast<uint8_t>(BucketOpKind::ARCHIVE_RESTORE), 2, 0,
+            static_cast<uint8_t>(BucketOpKind::LIVE_UPSERT),     3, 0x81,
+            static_cast<uint8_t>(BucketOpKind::ARCHIVE_UPSERT),  4, 0x82,
+            static_cast<uint8_t>(BucketOpKind::CHECKPOINT),      0, 0,
+        };
+    }
+};
+
+REGISTER_FUZZ_TARGET(BucketListFuzzTarget, "bucketlist",
+                     "Fuzz live/hot-archive bucketlist transitions with "
+                     "snapshot invariant checks");
+
+} // namespace
+} // namespace stellar

--- a/src/test/fuzz/targets/ParallelTxFuzzTarget.cpp
+++ b/src/test/fuzz/targets/ParallelTxFuzzTarget.cpp
@@ -1,0 +1,911 @@
+// Copyright 2026 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "test/fuzz/FuzzTargetRegistry.h"
+
+#include "ledger/LedgerTxn.h"
+#include "test/Catch2.h"
+#include "test/TestUtils.h"
+#include "test/TxTests.h"
+#include "test/fuzz/FuzzUtils.h"
+#include "transactions/TransactionMeta.h"
+#include "transactions/test/SorobanTxTestUtils.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace stellar
+{
+namespace
+{
+
+// This harness fuzzes Soroban intra-ledger parallel apply at the ledger-close
+// level. It builds a fixed-size deterministic ledger of real storage-contract
+// transactions, runs the same transaction set with different
+// mLedgerMaxDependentTxClusters settings, and compares the serial and parallel
+// outcomes. The oracle checks order-independent result codes, normalized write
+// effects in transaction metadata, final contract-storage snapshots, and the
+// values returned by HAS/GET operations in actual apply order.
+//
+// The target is meant to catch applyParallelPhase bugs such as bad dependency
+// clustering, stale reads between transactions, lost or misordered writes,
+// divergent metadata, or different final storage state under parallel apply. It
+// deliberately keeps the workload narrow: current-protocol Soroban storage
+// operations generated from deterministic fuzz bytes. It does not try to fuzz
+// transaction validation, fee/resource accounting in general, arbitrary host
+// functions, protocol-upgrade behavior, or non-Soroban ledger entries. Those
+// are either above this comparison point or would make the differential oracle
+// much less precise.
+
+constexpr size_t MIN_TX_COUNT = 32;
+constexpr size_t MAX_TX_COUNT = 32;
+constexpr uint32_t SHARED_STORAGE_KEY_COUNT = 16;
+constexpr uint32_t TOTAL_STORAGE_KEY_COUNT =
+    SHARED_STORAGE_KEY_COUNT + static_cast<uint32_t>(MAX_TX_COUNT);
+constexpr size_t ENCODED_TX_PLAN_SIZE = 15;
+constexpr int SERIAL_CONFIG_INSTANCE = 701;
+constexpr int PARALLEL_CONFIG_INSTANCE = 702;
+
+class ByteCursor
+{
+  public:
+    ByteCursor(uint8_t const* data, size_t size) : mData(data), mSize(size)
+    {
+    }
+
+    uint8_t
+    nextU8()
+    {
+        auto out = mData[mPos % mSize];
+        ++mPos;
+        return out;
+    }
+
+    uint64_t
+    nextU64()
+    {
+        uint64_t out = 0;
+        for (size_t i = 0; i < 8; ++i)
+        {
+            out = (out << 8) | nextU8();
+        }
+        return out;
+    }
+
+  private:
+    uint8_t const* mData;
+    size_t mSize;
+    size_t mPos{0};
+};
+
+enum class DependencyShape : uint8_t
+{
+    INDEPENDENT = 0,
+    READ_READ = 1,
+    READ_WRITE = 2,
+    WRITE_WRITE = 3
+};
+
+enum class StorageAction : uint8_t
+{
+    HAS = 0,
+    GET = 1,
+    PUT = 2,
+    DEL = 3,
+    RESIZE = 4
+};
+
+struct TxPlan
+{
+    DependencyShape dependencyShape;
+    StorageAction preferredAction;
+    uint32_t sharedKeyId;
+    uint64_t value;
+    uint32_t resizeKiloBytes;
+    uint32_t instructions;
+    uint32_t readBytes;
+    uint32_t writeBytes;
+};
+
+struct ScenarioPlan
+{
+    std::vector<TxPlan> txPlans;
+};
+
+struct RunResult
+{
+    std::vector<Hash> submittedTxHashes;
+    std::vector<Hash> applyOrderTxHashes;
+    TransactionResultSet applyResults;
+    std::vector<xdr::opaque_vec<>> txMeta;
+    std::vector<xdr::opaque_vec<>> storageSnapshot;
+};
+
+struct ModeledStorageValue
+{
+    bool exists{true};
+    uint64_t value{0};
+};
+
+void
+appendOpaque(xdr::opaque_vec<>& out, xdr::opaque_vec<> const& opaque)
+{
+    out.insert(out.end(), opaque.begin(), opaque.end());
+}
+
+std::vector<xdr::opaque_vec<>>
+sortedResultCodes(TransactionResultSet const& results)
+{
+    // Different dependent-cluster limits can produce different generalized
+    // tx-set layouts, so result order and Soroban success hashes are not stable
+    // enough to compare directly. Compare only the order-independent pieces
+    // that say whether each transaction/operation succeeded in the same way.
+    std::vector<xdr::opaque_vec<>> out;
+    out.reserve(results.results.size());
+    for (auto const& result : results.results)
+    {
+        auto opaque = xdr::xdr_to_opaque(result.transactionHash);
+        appendOpaque(opaque, xdr::xdr_to_opaque(result.result.result.code()));
+        if (result.result.result.code() == txSUCCESS ||
+            result.result.result.code() == txFAILED)
+        {
+            for (auto const& opResult : result.result.result.results())
+            {
+                appendOpaque(opaque, xdr::xdr_to_opaque(opResult.code()));
+                if (opResult.code() == opINNER)
+                {
+                    appendOpaque(opaque,
+                                 xdr::xdr_to_opaque(opResult.tr().type()));
+                    switch (opResult.tr().type())
+                    {
+                    case INVOKE_HOST_FUNCTION:
+                        appendOpaque(opaque, xdr::xdr_to_opaque(
+                                                 opResult.tr()
+                                                     .invokeHostFunctionResult()
+                                                     .code()));
+                        break;
+                    case EXTEND_FOOTPRINT_TTL:
+                        appendOpaque(opaque, xdr::xdr_to_opaque(
+                                                 opResult.tr()
+                                                     .extendFootprintTTLResult()
+                                                     .code()));
+                        break;
+                    case RESTORE_FOOTPRINT:
+                        appendOpaque(
+                            opaque,
+                            xdr::xdr_to_opaque(
+                                opResult.tr().restoreFootprintResult().code()));
+                        break;
+                    default:
+                        break;
+                    }
+                }
+            }
+        }
+        out.emplace_back(std::move(opaque));
+    }
+    std::sort(out.begin(), out.end());
+    return out;
+}
+
+xdr::opaque_vec<>
+normalizedChange(LedgerEntryChange const& change)
+{
+    xdr::opaque_vec<> out;
+    auto isStorageDataEntry = [](LedgerEntry const& entry) {
+        return entry.data.type() == CONTRACT_DATA &&
+               entry.data.contractData().key.type() == SCV_SYMBOL;
+    };
+    auto isStorageDataKey = [](LedgerKey const& key) {
+        return key.type() == CONTRACT_DATA &&
+               key.contractData().key.type() == SCV_SYMBOL;
+    };
+
+    switch (change.type())
+    {
+    case LEDGER_ENTRY_CREATED:
+        if (!isStorageDataEntry(change.created()))
+        {
+            break;
+        }
+        out.emplace_back(1);
+        appendOpaque(out, xdr::xdr_to_opaque(change.created()));
+        break;
+    case LEDGER_ENTRY_UPDATED:
+        if (!isStorageDataEntry(change.updated()))
+        {
+            break;
+        }
+        out.emplace_back(1);
+        appendOpaque(out, xdr::xdr_to_opaque(change.updated()));
+        break;
+    case LEDGER_ENTRY_REMOVED:
+        if (!isStorageDataKey(change.removed()))
+        {
+            break;
+        }
+        out.emplace_back(2);
+        appendOpaque(out, xdr::xdr_to_opaque(change.removed()));
+        break;
+    case LEDGER_ENTRY_RESTORED:
+        if (!isStorageDataEntry(change.restored()))
+        {
+            break;
+        }
+        out.emplace_back(1);
+        appendOpaque(out, xdr::xdr_to_opaque(change.restored()));
+        break;
+    case LEDGER_ENTRY_STATE:
+        break;
+    }
+    return out;
+}
+
+std::vector<xdr::opaque_vec<>>
+sortedTxMetaPairs(TransactionResultSet const& results,
+                  std::vector<TransactionMetaFrame> const& txMeta)
+{
+    if (results.results.size() != txMeta.size())
+    {
+        throw std::runtime_error("parallel_tx metadata count mismatch");
+    }
+
+    std::vector<xdr::opaque_vec<>> out;
+    out.reserve(txMeta.size());
+    for (size_t i = 0; i < txMeta.size(); ++i)
+    {
+        auto opaque = xdr::xdr_to_opaque(results.results.at(i).transactionHash);
+        if (txtest::isSuccessResult(results.results.at(i).result))
+        {
+            // Keep this oracle focused on write effects. Return values for
+            // shared-key reads are order-sensitive when legal cluster packing
+            // changes transaction order, and getLastClosedLedgerTxMeta() does
+            // not give us a transaction hash to pair metadata independently of
+            // result ordering. Storage-entry changes still catch lost writes
+            // without turning legal shared-key ordering into fuzz failures.
+            std::vector<xdr::opaque_vec<>> changes;
+            for (size_t opIdx = 0; opIdx < txMeta.at(i).getNumOperations();
+                 ++opIdx)
+            {
+                for (auto const& change :
+                     txMeta.at(i).getLedgerEntryChangesAtOp(opIdx))
+                {
+                    auto normalized = normalizedChange(change);
+                    if (!normalized.empty())
+                    {
+                        changes.emplace_back(std::move(normalized));
+                    }
+                }
+            }
+            std::sort(changes.begin(), changes.end());
+            for (auto const& change : changes)
+            {
+                appendOpaque(opaque, change);
+            }
+        }
+        out.emplace_back(std::move(opaque));
+    }
+    std::sort(out.begin(), out.end());
+    return out;
+}
+
+std::optional<size_t>
+findTxIndex(std::vector<Hash> const& hashes, Hash const& hash)
+{
+    auto it = std::find(hashes.begin(), hashes.end(), hash);
+    if (it == hashes.end())
+    {
+        return std::nullopt;
+    }
+    return static_cast<size_t>(std::distance(hashes.begin(), it));
+}
+
+bool
+successfulResultByHash(TransactionResultSet const& results, Hash const& hash)
+{
+    for (auto const& result : results.results)
+    {
+        if (result.transactionHash == hash)
+        {
+            return txtest::isSuccessResult(result.result);
+        }
+    }
+    throw std::runtime_error("parallel_tx missing apply result");
+}
+
+std::string storageKeyName(uint32_t keyId);
+
+std::vector<xdr::opaque_vec<>>
+snapshotStorage(Application& app,
+                txtest::ContractStorageTestClient& storageClient)
+{
+    // Shared keys intentionally create READ_WRITE/WRITE_WRITE dependencies.
+    // Their final values can depend on legal transaction order choices, so the
+    // final-state oracle checks only independent keys. Shared-key write effects
+    // are covered above through per-transaction metadata changes.
+    std::vector<xdr::opaque_vec<>> out;
+    out.reserve(MAX_TX_COUNT);
+
+    LedgerTxn ltx(app.getLedgerTxnRoot());
+    auto& contract = storageClient.getContract();
+    for (uint32_t keyId = SHARED_STORAGE_KEY_COUNT;
+         keyId < TOTAL_STORAGE_KEY_COUNT; ++keyId)
+    {
+        auto lk = contract.getDataKey(makeSymbolSCVal(storageKeyName(keyId)),
+                                      ContractDataDurability::PERSISTENT);
+        auto entry = ltx.load(lk);
+        xdr::opaque_vec<> opaque;
+        if (entry)
+        {
+            opaque = xdr::xdr_to_opaque(entry.current());
+            opaque.insert(opaque.begin(), 1);
+        }
+        else
+        {
+            opaque.emplace_back(0);
+        }
+        out.emplace_back(std::move(opaque));
+    }
+
+    return out;
+}
+
+ScenarioPlan
+decodeScenario(uint8_t const* data, size_t size)
+{
+    ByteCursor cursor(data, size);
+    ScenarioPlan scenario;
+    auto nTx = static_cast<size_t>(
+        MIN_TX_COUNT + (cursor.nextU8() % (MAX_TX_COUNT - MIN_TX_COUNT + 1)));
+    scenario.txPlans.reserve(nTx);
+
+    for (size_t i = 0; i < nTx; ++i)
+    {
+        TxPlan plan;
+        plan.dependencyShape =
+            static_cast<DependencyShape>(cursor.nextU8() % 4);
+        plan.preferredAction = static_cast<StorageAction>(cursor.nextU8() % 5);
+        plan.sharedKeyId = cursor.nextU8() % SHARED_STORAGE_KEY_COUNT;
+        plan.value = cursor.nextU64();
+        plan.resizeKiloBytes = 1 + (cursor.nextU8() % 3);
+        plan.instructions =
+            5'000'000 + static_cast<uint32_t>(cursor.nextU8()) * 20'000;
+        plan.readBytes = 20'000 + static_cast<uint32_t>(cursor.nextU8()) * 128;
+        plan.writeBytes = 20'000 + static_cast<uint32_t>(cursor.nextU8()) * 512;
+
+        scenario.txPlans.emplace_back(plan);
+    }
+
+    return scenario;
+}
+
+size_t
+requiredInputSize(uint8_t nTxByte)
+{
+    auto nTx = static_cast<size_t>(
+        MIN_TX_COUNT + (nTxByte % (MAX_TX_COUNT - MIN_TX_COUNT + 1)));
+    return 1 + nTx * ENCODED_TX_PLAN_SIZE;
+}
+
+uint32_t
+storageKeyId(TxPlan const& plan, size_t txIndex)
+{
+    if (plan.dependencyShape == DependencyShape::INDEPENDENT)
+    {
+        return SHARED_STORAGE_KEY_COUNT + static_cast<uint32_t>(txIndex);
+    }
+    return plan.sharedKeyId;
+}
+
+std::string
+storageKeyName(uint32_t keyId)
+{
+    return "key" + std::to_string(keyId);
+}
+
+uint64_t
+initialStorageValue(uint32_t keyId)
+{
+    return 10'000 + keyId;
+}
+
+uint64_t
+resizeStorageValue(TxPlan const& plan)
+{
+    return plan.resizeKiloBytes;
+}
+
+bool
+shouldReadOnly(TxPlan const& plan, size_t txIndex)
+{
+    switch (plan.dependencyShape)
+    {
+    case DependencyShape::READ_READ:
+        return true;
+    case DependencyShape::READ_WRITE:
+        return (txIndex % 2) == 0;
+    case DependencyShape::INDEPENDENT:
+    case DependencyShape::WRITE_WRITE:
+        return false;
+    }
+    return false;
+}
+
+StorageAction
+storageAction(TxPlan const& plan, size_t txIndex)
+{
+    if (shouldReadOnly(plan, txIndex))
+    {
+        return plan.preferredAction == StorageAction::HAS ? StorageAction::HAS
+                                                          : StorageAction::GET;
+    }
+
+    if (plan.dependencyShape == DependencyShape::READ_WRITE ||
+        plan.dependencyShape == DependencyShape::WRITE_WRITE)
+    {
+        return StorageAction::PUT;
+    }
+
+    switch (plan.preferredAction)
+    {
+    case StorageAction::DEL:
+    case StorageAction::RESIZE:
+        return plan.preferredAction;
+    case StorageAction::HAS:
+    case StorageAction::GET:
+    case StorageAction::PUT:
+        return StorageAction::PUT;
+    }
+    return StorageAction::PUT;
+}
+
+void
+checkExpectedReturnValue(TransactionMetaFrame const& meta, StorageAction action,
+                         ModeledStorageValue const& expectedValue)
+{
+    auto const& returnValue = meta.getReturnValue();
+    switch (action)
+    {
+    case StorageAction::HAS:
+        if (returnValue.type() != SCV_BOOL ||
+            returnValue.b() != expectedValue.exists)
+        {
+            throw std::runtime_error("parallel_tx stale HAS result");
+        }
+        break;
+    case StorageAction::GET:
+        if (!expectedValue.exists || returnValue.type() != SCV_U64 ||
+            returnValue.u64() != expectedValue.value)
+        {
+            throw std::runtime_error("parallel_tx stale GET result");
+        }
+        break;
+    case StorageAction::PUT:
+    case StorageAction::DEL:
+    case StorageAction::RESIZE:
+        break;
+    }
+}
+
+void
+checkReadReturnOracle(ScenarioPlan const& scenario,
+                      std::vector<Hash> const& submittedTxHashes,
+                      std::vector<Hash> const& applyOrderTxHashes,
+                      TransactionResultSet const& results,
+                      std::vector<TransactionMetaFrame> const& txMeta)
+{
+    if (applyOrderTxHashes.size() != txMeta.size() ||
+        results.results.size() != txMeta.size())
+    {
+        throw std::runtime_error("parallel_tx apply order count mismatch");
+    }
+
+    std::vector<ModeledStorageValue> storage(TOTAL_STORAGE_KEY_COUNT);
+    for (uint32_t keyId = 0; keyId < TOTAL_STORAGE_KEY_COUNT; ++keyId)
+    {
+        storage.at(keyId).value = initialStorageValue(keyId);
+    }
+
+    for (size_t applyIndex = 0; applyIndex < applyOrderTxHashes.size();
+         ++applyIndex)
+    {
+        auto txIndex =
+            findTxIndex(submittedTxHashes, applyOrderTxHashes.at(applyIndex));
+        if (!txIndex)
+        {
+            throw std::runtime_error("parallel_tx unknown apply-order tx");
+        }
+
+        if (!successfulResultByHash(results, applyOrderTxHashes.at(applyIndex)))
+        {
+            continue;
+        }
+
+        auto const& plan = scenario.txPlans.at(*txIndex);
+        auto action = storageAction(plan, *txIndex);
+        auto keyId = storageKeyId(plan, *txIndex);
+        auto const expectedValue = storage.at(keyId);
+        checkExpectedReturnValue(txMeta.at(applyIndex), action, expectedValue);
+
+        switch (action)
+        {
+        case StorageAction::PUT:
+            storage.at(keyId).exists = true;
+            storage.at(keyId).value = plan.value;
+            break;
+        case StorageAction::DEL:
+            storage.at(keyId).exists = false;
+            break;
+        case StorageAction::RESIZE:
+            storage.at(keyId).exists = true;
+            storage.at(keyId).value = resizeStorageValue(plan);
+            break;
+        case StorageAction::HAS:
+        case StorageAction::GET:
+            break;
+        }
+    }
+}
+
+txtest::SorobanInvocationSpec
+withCommonResources(txtest::SorobanInvocationSpec spec, TxPlan const& plan,
+                    uint32_t writeBytes, size_t txIndex)
+{
+    return spec.setInstructions(plan.instructions)
+        .setReadBytes(plan.readBytes)
+        .setWriteBytes(writeBytes)
+        .setInclusionFee(1000 + static_cast<uint32_t>(txIndex))
+        .setRefundableResourceFee(50'000'000);
+}
+
+TransactionFrameBasePtr
+makeStorageTx(txtest::ContractStorageTestClient& storageClient,
+              TxPlan const& plan, StorageAction action, std::string const& key,
+              TestAccount& source, size_t txIndex)
+{
+    auto const durability = ContractDataDurability::PERSISTENT;
+    auto& contract = storageClient.getContract();
+
+    switch (action)
+    {
+    case StorageAction::HAS:
+    {
+        auto spec = withCommonResources(
+            storageClient.readKeySpec(key, durability), plan, 0, txIndex);
+        return contract
+            .prepareInvocation("has_persistent", {makeSymbolSCVal(key)}, spec)
+            .withExactNonRefundableResourceFee()
+            .createTx(&source);
+    }
+    case StorageAction::GET:
+    {
+        auto spec = withCommonResources(
+            storageClient.readKeySpec(key, durability), plan, 0, txIndex);
+        return contract
+            .prepareInvocation("get_persistent", {makeSymbolSCVal(key)}, spec)
+            .withExactNonRefundableResourceFee()
+            .createTx(&source);
+    }
+    case StorageAction::PUT:
+    {
+        auto spec =
+            withCommonResources(storageClient.writeKeySpec(key, durability),
+                                plan, plan.writeBytes, txIndex);
+        return storageClient.putInvocation(key, durability, plan.value, spec)
+            .withExactNonRefundableResourceFee()
+            .createTx(&source);
+    }
+    case StorageAction::DEL:
+    {
+        auto spec = withCommonResources(
+            storageClient.writeKeySpec(key, durability), plan, 0, txIndex);
+        return storageClient.delInvocation(key, durability, spec)
+            .withExactNonRefundableResourceFee()
+            .createTx(&source);
+    }
+    case StorageAction::RESIZE:
+    {
+        auto extendTo = 100 + static_cast<uint32_t>(plan.value % 1000);
+        auto threshold = 1 + static_cast<uint32_t>(plan.value % extendTo);
+        auto writeBytes =
+            std::max(plan.writeBytes, plan.resizeKiloBytes * 1024 + 200);
+        auto spec =
+            withCommonResources(storageClient.writeKeySpec(key, durability),
+                                plan, writeBytes, txIndex);
+        return storageClient
+            .resizeStorageAndExtendInvocation(key, plan.resizeKiloBytes,
+                                              threshold, extendTo, spec)
+            .withExactNonRefundableResourceFee()
+            .createTx(&source);
+    }
+    }
+
+    throw std::runtime_error("unknown storage action");
+}
+
+std::vector<TestAccount>
+getSourceAccounts(Application& app, size_t count)
+{
+    std::vector<TestAccount> accounts;
+    accounts.reserve(count);
+    for (uint32_t i = 0; i < count; ++i)
+    {
+        accounts.push_back(txtest::getGenesisAccount(app, i));
+    }
+    return accounts;
+}
+
+void
+seedStorage(txtest::SorobanTest& test,
+            txtest::ContractStorageTestClient& storageClient,
+            std::vector<TestAccount>& accounts)
+{
+    std::vector<TransactionFrameBasePtr> setupTxs;
+    setupTxs.reserve(TOTAL_STORAGE_KEY_COUNT);
+
+    for (uint32_t keyId = 0; keyId < TOTAL_STORAGE_KEY_COUNT; ++keyId)
+    {
+        auto key = storageKeyName(keyId);
+        auto spec =
+            storageClient.writeKeySpec(key, ContractDataDurability::PERSISTENT)
+                .setInclusionFee(1000)
+                .setRefundableResourceFee(50'000'000);
+        setupTxs.push_back(
+            storageClient
+                .putInvocation(key, ContractDataDurability::PERSISTENT,
+                               initialStorageValue(keyId), spec)
+                .withExactNonRefundableResourceFee()
+                .createTx(&accounts.at(keyId)));
+    }
+
+    auto results = txtest::closeLedger(test.getApp(), setupTxs, true);
+    if (results.results.size() != setupTxs.size())
+    {
+        throw std::runtime_error("parallel_tx setup result count mismatch");
+    }
+
+    for (auto const& result : results.results)
+    {
+        if (!txtest::isSuccessResult(result.result))
+        {
+            throw std::runtime_error("parallel_tx setup transaction failed");
+        }
+    }
+}
+
+RunResult
+runScenario(uint32_t dependentClusterLimit, int configInstance,
+            ScenarioPlan const& scenario)
+{
+    auto cfg = getFuzzConfig(configInstance);
+    cfg.GENESIS_TEST_ACCOUNT_COUNT = TOTAL_STORAGE_KEY_COUNT + MAX_TX_COUNT;
+    cfg.LEDGER_PROTOCOL_VERSION = Config::CURRENT_LEDGER_PROTOCOL_VERSION;
+    cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION =
+        Config::CURRENT_LEDGER_PROTOCOL_VERSION;
+    cfg.TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE = true;
+
+    txtest::SorobanTest test(cfg, false);
+    modifySorobanNetworkConfig(
+        test.getApp(),
+        [dependentClusterLimit](SorobanNetworkConfig& sorobanCfg) {
+            sorobanCfg.mLedgerMaxDependentTxClusters = dependentClusterLimit;
+            sorobanCfg.mLedgerMaxTxCount = 1000;
+        });
+
+    txtest::ContractStorageTestClient storageClient(test, 10'000'000);
+
+    auto accounts = getSourceAccounts(
+        test.getApp(), TOTAL_STORAGE_KEY_COUNT + scenario.txPlans.size());
+    seedStorage(test, storageClient, accounts);
+
+    std::vector<TransactionFrameBasePtr> txs;
+    txs.reserve(scenario.txPlans.size());
+    for (size_t i = 0; i < scenario.txPlans.size(); ++i)
+    {
+        auto const& plan = scenario.txPlans.at(i);
+        auto action = storageAction(plan, i);
+        auto& source = accounts.at(TOTAL_STORAGE_KEY_COUNT + i);
+        auto keyId = storageKeyId(plan, i);
+        auto key = storageKeyName(keyId);
+        txs.push_back(
+            makeStorageTx(storageClient, plan, action, key, source, i));
+    }
+
+    RunResult out;
+    out.submittedTxHashes.reserve(txs.size());
+    for (auto const& tx : txs)
+    {
+        out.submittedTxHashes.push_back(tx->getContentsHash());
+    }
+
+    out.applyOrderTxHashes.reserve(txs.size());
+    auto applyOrderTxCallback = [&out](size_t txIndex,
+                                       TransactionFrameBaseConstPtr const& tx) {
+        if (txIndex != out.applyOrderTxHashes.size())
+        {
+            throw std::runtime_error("parallel_tx apply order index gap");
+        }
+        out.applyOrderTxHashes.push_back(tx->getContentsHash());
+    };
+
+    out.applyResults = txtest::closeLedger(
+        test.getApp(), txs, false, emptyUpgradeSteps, applyOrderTxCallback);
+    checkReadReturnOracle(
+        scenario, out.submittedTxHashes, out.applyOrderTxHashes,
+        out.applyResults,
+        test.getApp().getLedgerManager().getLastClosedLedgerTxMeta());
+    out.txMeta = sortedTxMetaPairs(
+        out.applyResults,
+        test.getApp().getLedgerManager().getLastClosedLedgerTxMeta());
+    out.storageSnapshot = snapshotStorage(test.getApp(), storageClient);
+    return out;
+}
+
+class ParallelTxFuzzTarget : public FuzzTarget
+{
+  public:
+    std::string
+    name() const override
+    {
+        return "parallel_tx";
+    }
+
+    std::string
+    description() const override
+    {
+        return "Fuzz Soroban applyParallelPhase equivalence across real "
+               "storage-contract workloads";
+    }
+
+    void
+    initialize() override
+    {
+        reinitializeAllGlobalStateForFuzzing(1);
+    }
+
+    FuzzResultCode
+    run(uint8_t const* data, size_t size) override
+    {
+        if (data == nullptr || size == 0 || size > maxInputSize())
+        {
+            return FuzzResultCode::FUZZ_REJECTED;
+        }
+
+        if (size < requiredInputSize(data[0]))
+        {
+            return FuzzResultCode::FUZZ_REJECTED;
+        }
+        auto scenario = decodeScenario(data, size);
+
+        auto serial = runScenario(/* dependentClusterLimit */ 1,
+                                  SERIAL_CONFIG_INSTANCE, scenario);
+        auto parallel = runScenario(/* dependentClusterLimit */ 8,
+                                    PARALLEL_CONFIG_INSTANCE, scenario);
+
+        if (serial.submittedTxHashes != parallel.submittedTxHashes)
+        {
+            throw std::runtime_error("parallel_tx submitted tx order mismatch");
+        }
+
+        if (sortedResultCodes(serial.applyResults) !=
+            sortedResultCodes(parallel.applyResults))
+        {
+            throw std::runtime_error("parallel_tx apply result mismatch");
+        }
+
+        if (serial.txMeta != parallel.txMeta)
+        {
+            throw std::runtime_error("parallel_tx metadata mismatch");
+        }
+
+        if (serial.storageSnapshot != parallel.storageSnapshot)
+        {
+            throw std::runtime_error("parallel_tx storage snapshot mismatch");
+        }
+
+        return FuzzResultCode::FUZZ_SUCCESS;
+    }
+
+    void
+    shutdown() override
+    {
+    }
+
+    size_t
+    maxInputSize() const override
+    {
+        return 8 * 1024;
+    }
+
+    std::vector<uint8_t>
+    generateSeedInput() override
+    {
+        std::vector<uint8_t> seed;
+        seed.reserve(1 + MAX_TX_COUNT * 15);
+        seed.push_back(0);
+
+        auto appendU64 = [&seed](uint64_t v) {
+            for (int shift = 56; shift >= 0; shift -= 8)
+            {
+                seed.push_back(static_cast<uint8_t>(v >> shift));
+            }
+        };
+
+        auto appendPlan =
+            [&seed, &appendU64](DependencyShape shape, StorageAction action,
+                                uint8_t sharedKeyId, uint64_t value,
+                                uint8_t resizeKiloBytes, uint8_t instructions,
+                                uint8_t readBytes, uint8_t writeBytes) {
+                seed.push_back(static_cast<uint8_t>(shape));
+                seed.push_back(static_cast<uint8_t>(action));
+                seed.push_back(sharedKeyId);
+                appendU64(value);
+                seed.push_back(resizeKiloBytes - 1);
+                seed.push_back(instructions);
+                seed.push_back(readBytes);
+                seed.push_back(writeBytes);
+            };
+
+        for (size_t i = 0; i < MAX_TX_COUNT; ++i)
+        {
+            switch (i % 8)
+            {
+            case 0:
+                appendPlan(DependencyShape::READ_READ, StorageAction::HAS,
+                           static_cast<uint8_t>(i % SHARED_STORAGE_KEY_COUNT),
+                           100 + i, 1, i, i, i);
+                break;
+            case 1:
+                appendPlan(
+                    DependencyShape::READ_READ, StorageAction::GET,
+                    static_cast<uint8_t>((i - 1) % SHARED_STORAGE_KEY_COUNT),
+                    100 + i, 1, i, i, i);
+                break;
+            case 2:
+                appendPlan(DependencyShape::READ_WRITE, StorageAction::GET,
+                           static_cast<uint8_t>(i % SHARED_STORAGE_KEY_COUNT),
+                           100 + i, 1, i, i, i);
+                break;
+            case 3:
+                appendPlan(
+                    DependencyShape::READ_WRITE, StorageAction::PUT,
+                    static_cast<uint8_t>((i - 1) % SHARED_STORAGE_KEY_COUNT),
+                    100 + i, 1, i, i, i);
+                break;
+            case 4:
+                appendPlan(DependencyShape::WRITE_WRITE, StorageAction::PUT,
+                           static_cast<uint8_t>(i % SHARED_STORAGE_KEY_COUNT),
+                           100 + i, 1, i, i, i);
+                break;
+            case 5:
+                appendPlan(
+                    DependencyShape::WRITE_WRITE, StorageAction::PUT,
+                    static_cast<uint8_t>((i - 1) % SHARED_STORAGE_KEY_COUNT),
+                    100 + i, 1, i, i, i);
+                break;
+            case 6:
+                appendPlan(DependencyShape::INDEPENDENT, StorageAction::PUT, 0,
+                           100 + i, 1, i, i, i);
+                break;
+            case 7:
+                appendPlan(DependencyShape::INDEPENDENT, StorageAction::RESIZE,
+                           0, 100 + i, 2, i, i, i);
+                break;
+            }
+        }
+
+        return seed;
+    }
+};
+
+REGISTER_FUZZ_TARGET(ParallelTxFuzzTarget, "parallel_tx",
+                     "Fuzz Soroban applyParallelPhase equivalence across real "
+                     "storage-contract workloads");
+
+} // namespace
+} // namespace stellar

--- a/src/test/fuzz/targets/SCPFuzzTarget.cpp
+++ b/src/test/fuzz/targets/SCPFuzzTarget.cpp
@@ -1,0 +1,1266 @@
+// Copyright 2026 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "test/fuzz/FuzzTargetRegistry.h"
+
+#include "crypto/SHA.h"
+#include "crypto/SecretKey.h"
+#include "scp/SCP.h"
+#include "scp/SCPDriver.h"
+#include "test/Catch2.h"
+#include "test/TxTests.h"
+
+#include <algorithm>
+#include <array>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace stellar
+{
+namespace
+{
+
+constexpr size_t MAX_ACTIONS = 64;
+constexpr size_t ACTION_ENCODED_SIZE = 8;
+constexpr size_t NODE_COUNT = 3;
+constexpr uint8_t SLOT_COUNT = 32;
+constexpr uint8_t VALUE_COUNT = 16;
+constexpr uint8_t ACTION_KIND_COUNT = 11;
+
+enum class FuzzValueState : uint8_t
+{
+    AVAILABLE_VALID = 0,
+    AVAILABLE_INVALID = 1,
+    FETCHING = 2,
+    MAYBE_VALID = 3,
+    FETCH_FAILED = 4
+};
+
+enum class ScenarioActionKind : uint8_t
+{
+    INJECT_NOMINATE = 0,
+    INJECT_PREPARE = 1,
+    INJECT_CONFIRM = 2,
+    INJECT_EXTERNALIZE = 3,
+    RUN_TIMERS = 4,
+    DELIVER_QUEUED = 5,
+    DROP_QUEUED = 6,
+    DRAIN_QUEUE = 7,
+    SET_VALUE_STATE = 8,
+    SET_LOCAL_QSET = 9,
+    COOPERATIVE_CONVERGE = 10
+};
+
+struct ScenarioAction
+{
+    ScenarioActionKind kind;
+    uint8_t nodeIndex;
+    uint8_t slotIndex;
+    uint8_t valueIndex;
+    uint8_t ballotCounter;
+    uint8_t shape;
+    uint8_t qSetChoice;
+    uint8_t timerCallbacks;
+};
+
+struct QueuedEnvelope
+{
+    size_t fromNode;
+    SCPEnvelope envelope;
+};
+
+struct ScenarioSummary
+{
+    size_t queuedCount{};
+    size_t deliveredCount{};
+    size_t droppedCount{};
+    Hash digest{};
+
+    bool
+    operator==(ScenarioSummary const& other) const
+    {
+        return queuedCount == other.queuedCount &&
+               deliveredCount == other.deliveredCount &&
+               droppedCount == other.droppedCount && digest == other.digest;
+    }
+};
+
+size_t
+targetNodeForAction(ScenarioAction const& action)
+{
+    return (action.shape >> 2) % NODE_COUNT;
+}
+
+uint8_t
+valueIndex(Value const& value)
+{
+    if (value.empty())
+    {
+        return 0;
+    }
+    return value[0] % VALUE_COUNT;
+}
+
+std::vector<Value>
+statementValues(SCPStatement const& st)
+{
+    std::vector<Value> values;
+    switch (st.pledges.type())
+    {
+    case SCP_ST_NOMINATE:
+    {
+        auto const& nominate = st.pledges.nominate();
+        values.insert(values.end(), nominate.votes.begin(),
+                      nominate.votes.end());
+        values.insert(values.end(), nominate.accepted.begin(),
+                      nominate.accepted.end());
+        break;
+    }
+    case SCP_ST_PREPARE:
+    {
+        auto const& prepare = st.pledges.prepare();
+        values.push_back(prepare.ballot.value);
+        if (prepare.prepared)
+        {
+            values.push_back(prepare.prepared->value);
+        }
+        if (prepare.preparedPrime)
+        {
+            values.push_back(prepare.preparedPrime->value);
+        }
+        break;
+    }
+    case SCP_ST_CONFIRM:
+        values.push_back(st.pledges.confirm().ballot.value);
+        break;
+    case SCP_ST_EXTERNALIZE:
+        values.push_back(st.pledges.externalize().commit.value);
+        break;
+    }
+    return values;
+}
+
+Hash
+statementQSetHash(SCPStatement const& st)
+{
+    switch (st.pledges.type())
+    {
+    case SCP_ST_PREPARE:
+        return st.pledges.prepare().quorumSetHash;
+    case SCP_ST_CONFIRM:
+        return st.pledges.confirm().quorumSetHash;
+    case SCP_ST_EXTERNALIZE:
+        return st.pledges.externalize().commitQuorumSetHash;
+    case SCP_ST_NOMINATE:
+        return st.pledges.nominate().quorumSetHash;
+    }
+    releaseAssert(false);
+}
+
+class ByteCursor
+{
+  public:
+    ByteCursor(uint8_t const* data, size_t size) : mData(data), mSize(size)
+    {
+    }
+
+    bool
+    empty() const
+    {
+        return mPos >= mSize;
+    }
+
+    size_t
+    remaining() const
+    {
+        return mSize - mPos;
+    }
+
+    uint8_t
+    nextU8(uint8_t defaultValue = 0)
+    {
+        if (empty())
+        {
+            return defaultValue;
+        }
+        return mData[mPos++];
+    }
+
+  private:
+    uint8_t const* mData;
+    size_t mSize;
+    size_t mPos{0};
+};
+
+class FuzzSCPDriver : public SCPDriver
+{
+  public:
+    explicit FuzzSCPDriver(size_t nodeIndex, NodeID const& localNode,
+                           SCPQuorumSet const& localQSet,
+                           std::array<FuzzValueState, VALUE_COUNT>* values)
+        : mNodeIndex(nodeIndex)
+        , mSCP(*this, localNode, true, localQSet)
+        , mValueStates(values)
+    {
+        mKnownQSets[sha256(xdr::xdr_to_opaque(localQSet))] =
+            std::make_shared<SCPQuorumSet>(localQSet);
+    }
+
+    void
+    signEnvelope(SCPEnvelope&) override
+    {
+    }
+
+#ifdef CAP_0083
+    Value
+    makeEmptyTxSetValueFromValue(Value const& v) const override
+    {
+        return v;
+    }
+#endif
+
+    SCPQuorumSetPtr
+    getQSet(Hash const& qSetHash) override
+    {
+        auto it = mKnownQSets.find(qSetHash);
+        if (it == mKnownQSets.end())
+        {
+            return nullptr;
+        }
+        return it->second;
+    }
+
+    void
+    rememberQSet(SCPQuorumSet const& qSet)
+    {
+        mKnownQSets[sha256(xdr::xdr_to_opaque(qSet))] =
+            std::make_shared<SCPQuorumSet>(qSet);
+    }
+
+    std::optional<std::chrono::milliseconds>
+    getTxSetDownloadWaitTime(Value const& value) const override
+    {
+        if (valueState(value) == FuzzValueState::FETCHING)
+        {
+            return std::chrono::milliseconds(100);
+        }
+        return std::nullopt;
+    }
+
+    Value
+    makeEmptyTxSetValueFromValue(Value const& value) const override
+    {
+        return value;
+    }
+
+    std::chrono::milliseconds
+    getTxSetDownloadTimeout() const override
+    {
+        return std::chrono::milliseconds(200);
+    }
+
+    bool
+    isEnvelopeReady(SCPEnvelope const& envelope) const override
+    {
+        for (auto const& value : statementValues(envelope.statement))
+        {
+            if (valueState(value) == FuzzValueState::FETCHING)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    void
+    emitEnvelope(SCPEnvelope const& envelope) override
+    {
+        mEmitted.push_back(envelope);
+    }
+
+    ValidationLevel
+    validateValue(uint64, Value const& value, bool) const override
+    {
+        switch (valueState(value))
+        {
+        case FuzzValueState::AVAILABLE_VALID:
+            return kFullyValidatedValue;
+        case FuzzValueState::AVAILABLE_INVALID:
+        case FuzzValueState::FETCH_FAILED:
+            return kInvalidValue;
+        case FuzzValueState::FETCHING:
+        case FuzzValueState::MAYBE_VALID:
+            return kMaybeValidNotCurrentValue;
+        }
+        releaseAssert(false);
+    }
+
+    bool
+    isEmptyTxSetValue(Value const&) const override
+    {
+        return false;
+    }
+
+    bool
+    isParallelTxSetDownloadEnabled() const override
+    {
+        return false;
+    }
+
+    bool
+    protocolAllowsEmptyTxSetValues() const override
+    {
+        return false;
+    }
+
+    Hash
+    getHashOf(std::vector<xdr::opaque_vec<>> const& vals) const override
+    {
+        SHA256 hasher;
+        for (auto const& v : vals)
+        {
+            hasher.add(v);
+        }
+        return hasher.finish();
+    }
+
+    ValueWrapperPtr
+    combineCandidates(uint64, ValueWrapperPtrSet const& candidates) override
+    {
+        if (candidates.empty())
+        {
+            Value v;
+            v.push_back(0);
+            return wrapValue(v);
+        }
+        return *candidates.begin();
+    }
+
+    bool
+    hasUpgrades(Value const&) override
+    {
+        return false;
+    }
+
+    ValueWrapperPtr
+    stripAllUpgrades(Value const& v) override
+    {
+        return wrapValue(v);
+    }
+
+    uint32_t
+    getUpgradeNominationTimeoutLimit() const override
+    {
+        return std::numeric_limits<uint32_t>::max();
+    }
+
+    void
+    setupTimer(uint64 slotIndex, int timerID, std::chrono::milliseconds timeout,
+               std::function<void()> cb) override
+    {
+        if (cb)
+        {
+            stopTimer(slotIndex, timerID);
+            mTimers.push_back(
+                {slotIndex, timerID,
+                 mLogicalTime + static_cast<uint64_t>(timeout.count()),
+                 mNextTimerSequence++, false, std::move(cb)});
+        }
+    }
+
+    void
+    stopTimer(uint64 slotIndex, int timerID) override
+    {
+        for (auto& timer : mTimers)
+        {
+            if (timer.slotIndex == slotIndex && timer.timerID == timerID)
+            {
+                timer.canceled = true;
+            }
+        }
+    }
+
+    std::chrono::milliseconds
+    computeTimeout(uint32 roundNumber, bool) override
+    {
+        return std::chrono::milliseconds(20 + roundNumber);
+    }
+
+    void
+    advanceTime(uint64_t ticks)
+    {
+        mLogicalTime += ticks;
+    }
+
+    void
+    runPendingTimers(size_t maxCallbacks, bool latestFirst = false)
+    {
+        size_t n = 0;
+        while (n < maxCallbacks)
+        {
+            auto timerIt = mTimers.end();
+            for (auto it = mTimers.begin(); it != mTimers.end(); ++it)
+            {
+                if (it->canceled || it->deadline > mLogicalTime)
+                {
+                    continue;
+                }
+                if (timerIt == mTimers.end())
+                {
+                    timerIt = it;
+                }
+                else if (latestFirst &&
+                         std::tie(it->deadline, it->sequence) >
+                             std::tie(timerIt->deadline, timerIt->sequence))
+                {
+                    timerIt = it;
+                }
+                else if (!latestFirst &&
+                         std::tie(it->deadline, it->sequence) <
+                             std::tie(timerIt->deadline, timerIt->sequence))
+                {
+                    timerIt = it;
+                }
+            }
+
+            if (timerIt == mTimers.end())
+            {
+                break;
+            }
+
+            auto cb = std::move(timerIt->callback);
+            timerIt->canceled = true;
+            cb();
+            ++n;
+        }
+    }
+
+    void
+    blockEnvelope(SCPEnvelope const& envelope)
+    {
+        mBlockedEnvelopes.push_back(envelope);
+    }
+
+    size_t
+    blockedCount() const
+    {
+        return mBlockedEnvelopes.size();
+    }
+
+    size_t
+    activeTimerCount() const
+    {
+        return static_cast<size_t>(
+            std::count_if(mTimers.begin(), mTimers.end(),
+                          [](auto const& t) { return !t.canceled; }));
+    }
+
+    uint64_t
+    highestSlot() const
+    {
+        return const_cast<SCP&>(mSCP).getHighestKnownSlotIndex();
+    }
+
+    std::vector<SCPEnvelope>
+    takeReadyBlocked(size_t maxEnvelopes)
+    {
+        std::vector<SCPEnvelope> ready;
+        for (auto it = mBlockedEnvelopes.begin();
+             it != mBlockedEnvelopes.end() && ready.size() < maxEnvelopes;)
+        {
+            if (isEnvelopeReady(*it))
+            {
+                ready.push_back(*it);
+                it = mBlockedEnvelopes.erase(it);
+            }
+            else
+            {
+                ++it;
+            }
+        }
+        return ready;
+    }
+
+    size_t
+    nodeIndex() const
+    {
+        return mNodeIndex;
+    }
+
+    std::vector<SCPEnvelope> const&
+    emitted() const
+    {
+        return mEmitted;
+    }
+
+    bool
+    hasEmittedBallotForSlot(uint64_t slotIndex) const
+    {
+        return std::any_of(
+            mEmitted.begin(), mEmitted.end(), [&](SCPEnvelope const& envelope) {
+                return envelope.statement.slotIndex == slotIndex &&
+                       envelope.statement.pledges.type() != SCP_ST_NOMINATE;
+            });
+    }
+
+    std::map<uint64_t, Value> const&
+    externalized() const
+    {
+        return mExternalized;
+    }
+
+    struct Summary
+    {
+        uint64_t highestSlot{};
+        size_t emittedCount{};
+        size_t externalizedCount{};
+        size_t blockedCount{};
+        size_t activeTimerCount{};
+        Hash digest{};
+
+        bool
+        operator==(Summary const& other) const
+        {
+            return highestSlot == other.highestSlot &&
+                   emittedCount == other.emittedCount &&
+                   externalizedCount == other.externalizedCount &&
+                   blockedCount == other.blockedCount &&
+                   activeTimerCount == other.activeTimerCount &&
+                   digest == other.digest;
+        }
+    };
+
+    Summary
+    summarize() const
+    {
+        SHA256 hasher;
+        for (auto const& env : mEmitted)
+        {
+            hasher.add(xdr::xdr_to_opaque(env.statement));
+        }
+        for (auto const& env : mBlockedEnvelopes)
+        {
+            hasher.add(xdr::xdr_to_opaque(env.statement));
+        }
+        for (auto const& [slot, val] : mExternalized)
+        {
+            xdr::opaque_vec<> slotBytes;
+            slotBytes.resize(sizeof(slot));
+            std::memcpy(slotBytes.data(), &slot, sizeof(slot));
+            hasher.add(slotBytes);
+            hasher.add(val);
+        }
+
+        Summary s;
+        s.highestSlot = highestSlot();
+        s.emittedCount = mEmitted.size();
+        s.externalizedCount = mExternalized.size();
+        s.blockedCount = mBlockedEnvelopes.size();
+        s.activeTimerCount = activeTimerCount();
+        s.digest = hasher.finish();
+        return s;
+    }
+
+    size_t mNodeIndex;
+    SCP mSCP;
+
+  private:
+    FuzzValueState
+    valueState(Value const& value) const
+    {
+        return (*mValueStates)[valueIndex(value)];
+    }
+
+    void
+    valueExternalized(uint64 slotIndex, Value const& value) override
+    {
+        auto existing = mExternalized.find(slotIndex);
+        if (existing != mExternalized.end() && existing->second != value)
+        {
+            throw std::runtime_error(
+                "SCP fuzz node externalized conflicting values");
+        }
+        mExternalized[slotIndex] = value;
+    }
+
+    std::map<Hash, SCPQuorumSetPtr> mKnownQSets;
+    std::vector<SCPEnvelope> mEmitted;
+    std::map<uint64_t, Value> mExternalized;
+    std::vector<SCPEnvelope> mBlockedEnvelopes;
+    std::array<FuzzValueState, VALUE_COUNT>* mValueStates;
+
+    struct PendingTimer
+    {
+        uint64_t slotIndex;
+        int timerID;
+        uint64_t deadline;
+        uint64_t sequence;
+        bool canceled;
+        std::function<void()> callback;
+    };
+
+    uint64_t mLogicalTime{0};
+    uint64_t mNextTimerSequence{0};
+    std::vector<PendingTimer> mTimers;
+};
+
+Hash
+getQSetHash(SCPQuorumSet const& qSet)
+{
+    return sha256(xdr::xdr_to_opaque(qSet));
+}
+
+Value
+makeValue(uint8_t valueIndex, uint8_t variant)
+{
+    Value v;
+    v.push_back(valueIndex % VALUE_COUNT);
+    v.push_back(variant);
+    return v;
+}
+
+SCPBallot
+makeBallot(uint8_t counter, Value const& value)
+{
+    SCPBallot ballot;
+    ballot.counter = 1 + (counter % 8);
+    ballot.value = value;
+    return ballot;
+}
+
+Hash
+qSetHashForChoice(std::vector<Hash> const& qSetHashes, uint8_t qSetChoice)
+{
+    if ((qSetChoice % 5) == 0)
+    {
+        return sha256("scp-fuzz-unknown-qset-" + std::to_string(qSetChoice));
+    }
+    return qSetHashes[qSetChoice % qSetHashes.size()];
+}
+
+std::vector<ScenarioAction>
+decodeScenario(uint8_t const* data, size_t size)
+{
+    ByteCursor cursor(data, size);
+    std::vector<ScenarioAction> actions;
+    while (cursor.remaining() >= ACTION_ENCODED_SIZE &&
+           actions.size() < MAX_ACTIONS)
+    {
+        ScenarioAction action;
+        action.kind = static_cast<ScenarioActionKind>(cursor.nextU8() %
+                                                      ACTION_KIND_COUNT);
+        action.nodeIndex = cursor.nextU8() % NODE_COUNT;
+        action.slotIndex = cursor.nextU8() % SLOT_COUNT;
+        action.valueIndex = cursor.nextU8() % VALUE_COUNT;
+        action.ballotCounter = cursor.nextU8();
+        action.shape = cursor.nextU8();
+        action.qSetChoice = cursor.nextU8();
+        action.timerCallbacks = cursor.nextU8();
+        actions.push_back(action);
+    }
+    return actions;
+}
+
+void
+addUint64(SHA256& hasher, uint64_t value)
+{
+    xdr::opaque_vec<> bytes;
+    bytes.resize(sizeof(value));
+    std::memcpy(bytes.data(), &value, sizeof(value));
+    hasher.add(bytes);
+}
+
+void
+appendAction(std::vector<uint8_t>& out, ScenarioActionKind kind,
+             uint8_t nodeIndex, uint8_t slotIndex, uint8_t valueIndex,
+             uint8_t ballotCounter, uint8_t shape, uint8_t qSetChoice,
+             uint8_t timerCallbacks)
+{
+    out.push_back(static_cast<uint8_t>(kind));
+    out.push_back(nodeIndex);
+    out.push_back(slotIndex);
+    out.push_back(valueIndex);
+    out.push_back(ballotCounter);
+    out.push_back(shape);
+    out.push_back(qSetChoice);
+    out.push_back(timerCallbacks);
+}
+
+SCPEnvelope
+makeEnvelopeFromAction(ScenarioAction const& action,
+                       std::vector<Hash> const& qSetHashes,
+                       std::array<NodeID, NODE_COUNT> const& nodes)
+{
+    auto qSetHash = qSetHashForChoice(qSetHashes, action.qSetChoice);
+    auto value = makeValue(action.valueIndex, action.shape);
+    auto otherValue = makeValue(action.valueIndex + 1, action.shape ^ 0xff);
+    auto ballot = makeBallot(action.ballotCounter, value);
+
+    SCPEnvelope env;
+    auto& st = env.statement;
+    st.nodeID = nodes[action.nodeIndex % nodes.size()];
+    st.slotIndex = static_cast<uint64_t>(1 + (action.slotIndex % SLOT_COUNT));
+
+    switch (action.kind)
+    {
+    case ScenarioActionKind::INJECT_NOMINATE:
+    {
+        st.pledges.type(SCP_ST_NOMINATE);
+        auto& nominate = st.pledges.nominate();
+        nominate.quorumSetHash = qSetHash;
+        nominate.votes.emplace_back(value);
+        if ((action.shape & 0x01) != 0)
+        {
+            nominate.votes.emplace_back(otherValue);
+            std::sort(nominate.votes.begin(), nominate.votes.end());
+        }
+        if ((action.shape & 0x02) != 0)
+        {
+            nominate.accepted.emplace_back(value);
+        }
+        break;
+    }
+    case ScenarioActionKind::INJECT_PREPARE:
+    {
+        st.pledges.type(SCP_ST_PREPARE);
+        auto& prepare = st.pledges.prepare();
+        prepare.quorumSetHash = qSetHash;
+        prepare.ballot = ballot;
+        if ((action.shape & 0x01) != 0)
+        {
+            prepare.prepared.activate() = ballot;
+        }
+        if ((action.shape & 0x02) != 0 && ballot.counter > 1)
+        {
+            prepare.preparedPrime.activate() =
+                makeBallot(ballot.counter - 2, otherValue);
+        }
+        if ((action.shape & 0x04) != 0)
+        {
+            prepare.nC = 1;
+            prepare.nH = ballot.counter;
+        }
+        else
+        {
+            prepare.nC = 0;
+            prepare.nH = 0;
+        }
+        break;
+    }
+    case ScenarioActionKind::INJECT_CONFIRM:
+    {
+        st.pledges.type(SCP_ST_CONFIRM);
+        auto& confirm = st.pledges.confirm();
+        confirm.ballot = ballot;
+        confirm.nPrepared = ballot.counter;
+        confirm.nCommit = 1;
+        confirm.nH = ballot.counter;
+        confirm.quorumSetHash = qSetHash;
+        break;
+    }
+    case ScenarioActionKind::INJECT_EXTERNALIZE:
+    {
+        st.pledges.type(SCP_ST_EXTERNALIZE);
+        auto& externalize = st.pledges.externalize();
+        externalize.commit = ballot;
+        externalize.nH = ballot.counter;
+        externalize.commitQuorumSetHash = qSetHash;
+        break;
+    }
+    case ScenarioActionKind::RUN_TIMERS:
+    case ScenarioActionKind::DELIVER_QUEUED:
+    case ScenarioActionKind::DROP_QUEUED:
+    case ScenarioActionKind::DRAIN_QUEUE:
+    case ScenarioActionKind::SET_VALUE_STATE:
+    case ScenarioActionKind::SET_LOCAL_QSET:
+    case ScenarioActionKind::COOPERATIVE_CONVERGE:
+        releaseAssert(false);
+    }
+
+    env.signature.clear();
+    return env;
+}
+
+class FuzzSCPNetwork
+{
+  public:
+    FuzzSCPNetwork()
+    {
+        auto const v0 = txtest::getAccount("scp-fuzz-v0");
+        auto const v1 = txtest::getAccount("scp-fuzz-v1");
+        auto const v2 = txtest::getAccount("scp-fuzz-v2");
+
+        mNodes = {v0.getPublicKey(), v1.getPublicKey(), v2.getPublicKey()};
+
+        buildQSetCatalog();
+
+        for (size_t i = 0; i < NODE_COUNT; ++i)
+        {
+            mDrivers.emplace_back(std::make_unique<FuzzSCPDriver>(
+                i, mNodes[i], mQSets[0], &mValueStates));
+            for (auto const& qSet : mQSets)
+            {
+                mDrivers.back()->rememberQSet(qSet);
+            }
+            mEmittedSeen.push_back(0);
+        }
+    }
+
+    void
+    run(std::vector<ScenarioAction> const& actions)
+    {
+        for (auto const& action : actions)
+        {
+            runAction(action);
+            harvestEmitted();
+            checkSafety();
+        }
+        advanceAllTime(1000);
+        runAllTimers(32);
+        harvestEmitted();
+        drainQueue(64);
+        checkSafety();
+    }
+
+    ScenarioSummary
+    summarize() const
+    {
+        SHA256 hasher;
+        for (auto const& driver : mDrivers)
+        {
+            auto nodeBytes = xdr::xdr_to_opaque(mNodes[driver->nodeIndex()]);
+            hasher.add(nodeBytes);
+            auto driverSummary = driver->summarize();
+            addUint64(hasher, driverSummary.highestSlot);
+            addUint64(hasher, driverSummary.emittedCount);
+            addUint64(hasher, driverSummary.externalizedCount);
+            addUint64(hasher, driverSummary.blockedCount);
+            addUint64(hasher, driverSummary.activeTimerCount);
+            hasher.add(xdr::xdr_to_opaque(driverSummary.digest));
+        }
+        for (auto const& queued : mQueue)
+        {
+            addUint64(hasher, queued.fromNode);
+            hasher.add(xdr::xdr_to_opaque(queued.envelope.statement));
+        }
+
+        ScenarioSummary summary;
+        summary.queuedCount = mQueue.size();
+        summary.deliveredCount = mDeliveredCount;
+        summary.droppedCount = mDroppedCount;
+        summary.digest = hasher.finish();
+        return summary;
+    }
+
+  private:
+    void
+    runAction(ScenarioAction const& action)
+    {
+        switch (action.kind)
+        {
+        case ScenarioActionKind::RUN_TIMERS:
+            advanceAllTime(1 + action.timerCallbacks);
+            runAllTimers(1 + (action.timerCallbacks % 16),
+                         (action.shape & 0x80) != 0);
+            break;
+        case ScenarioActionKind::DELIVER_QUEUED:
+            deliverQueued(action);
+            break;
+        case ScenarioActionKind::DROP_QUEUED:
+            dropQueued(action);
+            break;
+        case ScenarioActionKind::DRAIN_QUEUE:
+            drainQueue(1 + (action.timerCallbacks % 16));
+            break;
+        case ScenarioActionKind::SET_VALUE_STATE:
+            setValueState(action);
+            retryReadyBlocked(1 + (action.timerCallbacks % 16));
+            break;
+        case ScenarioActionKind::SET_LOCAL_QSET:
+            setLocalQSet(action);
+            break;
+        case ScenarioActionKind::COOPERATIVE_CONVERGE:
+            cooperativeConverge(action);
+            break;
+        default:
+            injectEnvelope(action);
+            break;
+        }
+    }
+
+    void
+    buildQSetCatalog()
+    {
+        SCPQuorumSet flatTwoOfThree;
+        flatTwoOfThree.threshold = 2;
+        flatTwoOfThree.validators = {mNodes[0], mNodes[1], mNodes[2]};
+
+        SCPQuorumSet flatThreeOfThree;
+        flatThreeOfThree.threshold = 3;
+        flatThreeOfThree.validators = {mNodes[0], mNodes[1], mNodes[2]};
+
+        SCPQuorumSet inner;
+        inner.threshold = 1;
+        inner.validators = {mNodes[1], mNodes[2]};
+
+        SCPQuorumSet nested;
+        nested.threshold = 2;
+        nested.validators = {mNodes[0]};
+        nested.innerSets = {inner};
+
+        mQSets = {flatTwoOfThree, flatThreeOfThree, nested};
+        for (auto const& qSet : mQSets)
+        {
+            mQSetHashes.push_back(getQSetHash(qSet));
+        }
+    }
+
+    void
+    injectEnvelope(ScenarioAction const& action)
+    {
+        auto env = makeEnvelopeFromAction(action, mQSetHashes, mNodes);
+        auto target = targetNodeForAction(action);
+        // receiveEnvelope models peer traffic. Avoid synthetic histories that
+        // could not arrive from a peer in this local node's current slot state.
+        if (env.statement.nodeID == mNodes[target])
+        {
+            return;
+        }
+        if (env.statement.pledges.type() != SCP_ST_NOMINATE &&
+            !mDrivers[target]->hasEmittedBallotForSlot(env.statement.slotIndex))
+        {
+            return;
+        }
+        deliverTo(*mDrivers[target], env);
+        mDrivers[target]->advanceTime(action.timerCallbacks);
+        mDrivers[target]->runPendingTimers(action.timerCallbacks % 4,
+                                           (action.shape & 0x80) != 0);
+    }
+
+    void
+    setValueState(ScenarioAction const& action)
+    {
+        mValueStates[action.valueIndex % VALUE_COUNT] =
+            static_cast<FuzzValueState>(action.shape % 5);
+    }
+
+    void
+    setLocalQSet(ScenarioAction const& action)
+    {
+        auto target = targetNodeForAction(action);
+        auto const& qSet = mQSets[action.qSetChoice % mQSets.size()];
+        mDrivers[target]->mSCP.updateLocalQuorumSet(qSet);
+    }
+
+    void
+    cooperativeConverge(ScenarioAction const& action)
+    {
+        auto slot = static_cast<uint64_t>(100 + action.slotIndex);
+        auto value = makeValue(action.valueIndex, action.shape);
+        auto previousValue = makeValue(0, 0);
+
+        mValueStates[valueIndex(value)] = FuzzValueState::AVAILABLE_VALID;
+        for (auto& driver : mDrivers)
+        {
+            driver->mSCP.updateLocalQuorumSet(mQSets[0]);
+            driver->mSCP.nominate(slot, driver->wrapValue(value),
+                                  previousValue);
+        }
+        harvestEmitted();
+
+        for (size_t i = 0; i < 64; ++i)
+        {
+            drainQueue(64);
+            advanceAllTime(100);
+            runAllTimers(8);
+            harvestEmitted();
+            if (allExternalized(slot))
+            {
+                checkSafety();
+                return;
+            }
+        }
+
+        throw std::runtime_error(
+            "SCP fuzz cooperative convergence did not externalize");
+    }
+
+    bool
+    allExternalized(uint64_t slot) const
+    {
+        for (auto const& driver : mDrivers)
+        {
+            if (driver->externalized().find(slot) ==
+                driver->externalized().end())
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    void
+    retryReadyBlocked(size_t maxRetries)
+    {
+        size_t retries = 0;
+        for (auto& driver : mDrivers)
+        {
+            auto ready = driver->takeReadyBlocked(maxRetries - retries);
+            for (auto const& env : ready)
+            {
+                deliverTo(*driver, env);
+                ++retries;
+                if (retries >= maxRetries)
+                {
+                    return;
+                }
+            }
+        }
+    }
+
+    void
+    harvestEmitted()
+    {
+        for (size_t i = 0; i < mDrivers.size(); ++i)
+        {
+            auto const& emitted = mDrivers[i]->emitted();
+            while (mEmittedSeen[i] < emitted.size() &&
+                   mQueue.size() < MAX_ACTIONS * NODE_COUNT)
+            {
+                auto const& env = emitted[mEmittedSeen[i]++];
+                if (env.statement.nodeID != mNodes[i])
+                {
+                    throw std::runtime_error(
+                        "SCP fuzz emitted envelope from wrong node");
+                }
+                if (std::find(mQSetHashes.begin(), mQSetHashes.end(),
+                              statementQSetHash(env.statement)) ==
+                    mQSetHashes.end())
+                {
+                    throw std::runtime_error(
+                        "SCP fuzz emitted envelope with unknown qset");
+                }
+                mQueue.push_back({i, env});
+            }
+        }
+    }
+
+    void
+    deliverQueued(ScenarioAction const& action)
+    {
+        if (mQueue.empty())
+        {
+            return;
+        }
+        auto index = action.valueIndex % mQueue.size();
+        auto queued = mQueue[index];
+        if ((action.qSetChoice & 0x02) == 0)
+        {
+            mQueue.erase(mQueue.begin() + static_cast<ptrdiff_t>(index));
+        }
+        if ((action.qSetChoice & 0x01) != 0)
+        {
+            for (auto& driver : mDrivers)
+            {
+                deliverTo(*driver, queued.envelope);
+            }
+        }
+        else
+        {
+            deliverTo(*mDrivers[targetNodeForAction(action)], queued.envelope);
+        }
+    }
+
+    void
+    dropQueued(ScenarioAction const& action)
+    {
+        if (mQueue.empty())
+        {
+            return;
+        }
+        auto index = action.valueIndex % mQueue.size();
+        mQueue.erase(mQueue.begin() + static_cast<ptrdiff_t>(index));
+        ++mDroppedCount;
+    }
+
+    void
+    drainQueue(size_t maxDeliveries)
+    {
+        size_t n = 0;
+        while (!mQueue.empty() && n < maxDeliveries)
+        {
+            ScenarioAction action{};
+            action.valueIndex = 0;
+            action.qSetChoice = 1;
+            deliverQueued(action);
+            harvestEmitted();
+            ++n;
+        }
+    }
+
+    void
+    deliverTo(FuzzSCPDriver& driver, SCPEnvelope const& envelope)
+    {
+        if (!driver.isEnvelopeReady(envelope))
+        {
+            driver.blockEnvelope(envelope);
+            return;
+        }
+        auto wrapped = driver.wrapEnvelope(envelope);
+        driver.mSCP.receiveEnvelope(wrapped);
+        ++mDeliveredCount;
+    }
+
+    void
+    advanceAllTime(uint64_t ticks)
+    {
+        for (auto& driver : mDrivers)
+        {
+            driver->advanceTime(ticks);
+        }
+    }
+
+    void
+    runAllTimers(size_t maxCallbacksPerNode, bool latestFirst = false)
+    {
+        for (auto& driver : mDrivers)
+        {
+            driver->runPendingTimers(maxCallbacksPerNode, latestFirst);
+        }
+    }
+
+    void
+    checkSafety() const
+    {
+        std::map<uint64_t, Value> externalized;
+        for (size_t i = 0; i < mDrivers.size(); ++i)
+        {
+            auto const& driver = mDrivers[i];
+            if (driver->highestSlot() < mHighestSeen[i])
+            {
+                throw std::runtime_error(
+                    "SCP fuzz highest known slot regressed");
+            }
+            mHighestSeen[i] = driver->highestSlot();
+            for (auto const& [slot, value] : driver->externalized())
+            {
+                auto [it, inserted] = externalized.emplace(slot, value);
+                if (!inserted && it->second != value)
+                {
+                    throw std::runtime_error(
+                        "SCP fuzz nodes externalized conflicting values");
+                }
+            }
+        }
+    }
+
+    std::array<NodeID, NODE_COUNT> mNodes;
+    std::vector<SCPQuorumSet> mQSets;
+    std::vector<Hash> mQSetHashes;
+    std::array<FuzzValueState, VALUE_COUNT> mValueStates{};
+    mutable std::array<uint64_t, NODE_COUNT> mHighestSeen{};
+    std::vector<std::unique_ptr<FuzzSCPDriver>> mDrivers;
+    std::vector<size_t> mEmittedSeen;
+    std::vector<QueuedEnvelope> mQueue;
+    size_t mDeliveredCount{0};
+    size_t mDroppedCount{0};
+};
+
+ScenarioSummary
+runScenario(std::vector<ScenarioAction> const& actions)
+{
+    FuzzSCPNetwork network;
+    network.run(actions);
+    return network.summarize();
+}
+
+class SCPFuzzTarget : public FuzzTarget
+{
+  public:
+    std::string
+    name() const override
+    {
+        return "scp";
+    }
+
+    std::string
+    description() const override
+    {
+        return "Fuzz SCP with deterministic multi-node simulation, value "
+               "readiness, qset variation, safety, liveness, and replay "
+               "checks";
+    }
+
+    void
+    initialize() override
+    {
+        reinitializeAllGlobalStateForFuzzing(1);
+    }
+
+    FuzzResultCode
+    run(uint8_t const* data, size_t size) override
+    {
+        if (data == nullptr || size == 0 || size > maxInputSize())
+        {
+            return FuzzResultCode::FUZZ_REJECTED;
+        }
+
+        auto actions = decodeScenario(data, size);
+        if (actions.empty())
+        {
+            return FuzzResultCode::FUZZ_REJECTED;
+        }
+
+        auto s1 = runScenario(actions);
+        auto s2 = runScenario(actions);
+        if (!(s1 == s2))
+        {
+            throw std::runtime_error("SCP fuzz replay was non-deterministic");
+        }
+
+        return FuzzResultCode::FUZZ_SUCCESS;
+    }
+
+    void
+    shutdown() override
+    {
+    }
+
+    size_t
+    maxInputSize() const override
+    {
+        return 32 * 1024;
+    }
+
+    std::vector<uint8_t>
+    generateSeedInput() override
+    {
+        std::vector<uint8_t> out;
+        appendAction(out, ScenarioActionKind::SET_VALUE_STATE, 0, 0, 2, 0,
+                     static_cast<uint8_t>(FuzzValueState::FETCHING), 0, 0);
+        appendAction(out, ScenarioActionKind::INJECT_NOMINATE, 1, 0, 2, 1, 3, 1,
+                     0);
+        appendAction(out, ScenarioActionKind::SET_VALUE_STATE, 0, 0, 2, 0,
+                     static_cast<uint8_t>(FuzzValueState::AVAILABLE_VALID), 0,
+                     4);
+        appendAction(out, ScenarioActionKind::INJECT_PREPARE, 1, 1, 3, 3, 7,
+                     0x80, 0);
+        appendAction(out, ScenarioActionKind::INJECT_CONFIRM, 2, 1, 4, 4, 0, 0,
+                     0);
+        appendAction(out, ScenarioActionKind::RUN_TIMERS, 0, 0, 0, 0, 0, 1, 8);
+        appendAction(out, ScenarioActionKind::COOPERATIVE_CONVERGE, 0, 2, 5, 1,
+                     0, 0, 0);
+        return out;
+    }
+};
+
+REGISTER_FUZZ_TARGET(SCPFuzzTarget, "scp",
+                     "Fuzz SCP with deterministic multi-node simulation, value "
+                     "readiness, qset variation, safety, liveness, and replay "
+                     "checks");
+
+} // namespace
+} // namespace stellar


### PR DESCRIPTION
This adds 3 new fuzz targets: one for SCP, the bucketlist, and the soroban parallel-exec phase.

These are LLM-authored with a _decent_ amount of supervision and guidance on my part, but they could contain bugs or shortcomings. They seem to work, they make sense to me at a high level, and being limited to fuzz targets it doesn't seem particularly terrible if there _are_ bugs or shortcomings. But there might be some.
