### PR TITLE
Allow private addresses for testing

### DIFF
--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -77,7 +77,7 @@ static std::unordered_set<std::string> const TESTING_ONLY_OPTIONS = {
 
 // Options that should only be used for testing
 static std::unordered_set<std::string> const TESTING_SUGGESTED_OPTIONS = {
-    "ALLOW_LOCALHOST_FOR_TESTING"};
+    "ALLOW_LOCALHOST_FOR_TESTING", "ALLOW_PRIVATE_ADDRESSES_FOR_TESTING"};
 
 namespace
 {
@@ -155,6 +155,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     IGNORE_MESSAGE_LIMITS_FOR_TESTING = false;
     TESTING_IGNORE_LEDGER_TIME_UPGRADE_BOUNDS = false;
     TESTING_NOMINATE_RANDOM_VALUES = false;
+    ALLOW_PRIVATE_ADDRESSES_FOR_TESTING = false;
 #endif
 
     FORCE_SCP = false;
@@ -1278,6 +1279,10 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                  }},
                 {"IGNORE_MESSAGE_LIMITS_FOR_TESTING",
                  [&]() { IGNORE_MESSAGE_LIMITS_FOR_TESTING = readBool(item); }},
+                {"ALLOW_PRIVATE_ADDRESSES_FOR_TESTING",
+                 [&]() {
+                     ALLOW_PRIVATE_ADDRESSES_FOR_TESTING = readBool(item);
+                 }},
 #endif // BUILD_TESTS
                 {"ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING",
                  [&]() {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -922,6 +922,13 @@ class Config : public std::enable_shared_from_this<Config>
     // When set to true, ignores all message and tx set size limits for testing
     bool IGNORE_MESSAGE_LIMITS_FOR_TESTING;
 
+    // A config to allow gossiping (advertising and accepting in PEERS
+    // messages) and connecting to RFC1918 private addresses (10/8, 172.16/12,
+    // 192.168/16). Private addresses are normally filtered out of peer
+    // exchange, which disables gossip-based peer discovery in environments
+    // where every node has a private address (e.g. a Kubernetes pod network).
+    bool ALLOW_PRIVATE_ADDRESSES_FOR_TESTING;
+
     // When set, disables validation of the ledger target close time
     // bounds on config upgrades (for testing only).
     bool TESTING_IGNORE_LEDGER_TIME_UPGRADE_BOUNDS;

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -2018,7 +2018,12 @@ Peer::recvPeers(StellarMessage const& msg)
         releaseAssert(peer.ip.type() == IPv4);
         auto address = PeerBareAddress{peer};
 
-        if (address.isPrivate())
+        bool allowPrivateAddresses = false;
+#ifdef BUILD_TESTS
+        allowPrivateAddresses =
+            mAppConnector.getConfig().ALLOW_PRIVATE_ADDRESSES_FOR_TESTING;
+#endif
+        if (address.isPrivate() && !allowPrivateAddresses)
         {
             CLOG_DEBUG(Overlay, "ignoring received private address {}",
                        address.toString());

--- a/src/overlay/PeerManager.cpp
+++ b/src/overlay/PeerManager.cpp
@@ -211,8 +211,12 @@ std::vector<PeerBareAddress>
 PeerManager::getPeersToSend(size_t size, PeerBareAddress const& address)
 {
     ZoneScoped;
+    bool allowPrivate = false;
+#ifdef BUILD_TESTS
+    allowPrivate = mApp.getConfig().ALLOW_PRIVATE_ADDRESSES_FOR_TESTING;
+#endif
     auto keep = [&](PeerBareAddress const& pba) {
-        return !pba.isPrivate() && pba != address;
+        return (allowPrivate || !pba.isPrivate()) && pba != address;
     };
 
     auto peers = mOutboundPeersToSend->getRandomPeers(size, keep);


### PR DESCRIPTION
# Description

Super cluster missions where we do not specify preferred peers only currently do not work. This is because each peer IP we see during discovery phase looks like a private IP and gets dropped. This flag can be set in SSC tests to skip the check.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
