### PR TITLE
Change flood de-duplication to be by NodeID (not address)

### DIFF
--- a/src/overlay/Floodgate.cpp
+++ b/src/overlay/Floodgate.cpp
@@ -21,7 +21,7 @@ Floodgate::FloodRecord::FloodRecord(uint32_t ledger, Peer::pointer peer)
     : mLedgerSeq(ledger)
 {
     if (peer)
-        mPeersTold.insert(peer->toString());
+        mPeersTold.insert(peer->getPeerID());
 }
 
 Floodgate::Floodgate(Application& app)
@@ -75,7 +75,7 @@ Floodgate::addRecord(Peer::pointer peer, Hash const& index)
     }
     else
     {
-        result->second->mPeersTold.insert(peer->toString());
+        result->second->mPeersTold.insert(peer->getPeerID());
         return false;
     }
 }
@@ -122,7 +122,7 @@ Floodgate::broadcast(std::shared_ptr<StellarMessage const> msg,
     {
         bool pullMode = msg->type() == TRANSACTION;
 
-        if (peersTold.insert(peer.second->toString()).second)
+        if (peersTold.insert(peer.second->getPeerID()).second)
         {
             if (pullMode)
             {
@@ -177,7 +177,7 @@ Floodgate::getPeersKnows(Hash const& h)
         auto const& peers = mApp.getOverlayManager().getAuthenticatedPeers();
         for (auto& p : peers)
         {
-            if (ids.find(p.second->toString()) != ids.end())
+            if (ids.find(p.second->getPeerID()) != ids.end())
             {
                 res.insert(p.second);
             }

--- a/src/overlay/Floodgate.h
+++ b/src/overlay/Floodgate.h
@@ -38,7 +38,7 @@ class Floodgate
         typedef std::shared_ptr<FloodRecord> pointer;
 
         uint32_t mLedgerSeq;
-        std::set<std::string> mPeersTold;
+        std::set<NodeID> mPeersTold;
 
         FloodRecord(uint32_t ledger, Peer::pointer peer);
     };


### PR DESCRIPTION
Changes flood de-duplication to be done by peer node ids (which are unique for each connection we have) instead of addresses (which may not be unique since addresses are constructed using the peer port from the node, not the port they connected on). This way, we can properly flood to multiple nodes behind the same public IP (e.g., k8s nodes, nodes behind NAT, etc...). I believe the only situation where this change won't flood data where the previous version would is if a node disconnects and reconnects with the same key but different IP.