### PR TITLE
Update stellar-quorum-analyzer to master and handle NoQuorum status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,7 +1998,7 @@ dependencies = [
 [[package]]
 name = "stellar-quorum-analyzer"
 version = "0.1.0"
-source = "git+https://github.com/stellar/stellar-quorum-analyzer?rev=f67e9e2f080c2cc1a332d894c42277c64845e257#f67e9e2f080c2cc1a332d894c42277c64845e257"
+source = "git+https://github.com/stellar/stellar-quorum-analyzer?rev=b422b366ede667c030c78ffe18b2010194698dbd#b422b366ede667c030c78ffe18b2010194698dbd"
 dependencies = [
  "batsat",
  "itertools 0.10.5",

--- a/src/herder/RustQuorumCheckerAdaptor.cpp
+++ b/src/herder/RustQuorumCheckerAdaptor.cpp
@@ -159,13 +159,17 @@ fromQuorumCheckerStatusJson(Json::Value const& value)
     }
 
     auto statusInt = value.asUInt();
-    if (statusInt > static_cast<unsigned>(QuorumCheckerStatus::UNKNOWN))
+    switch (statusInt)
     {
+    case static_cast<unsigned>(QuorumCheckerStatus::UNSAT):
+    case static_cast<unsigned>(QuorumCheckerStatus::SAT):
+    case static_cast<unsigned>(QuorumCheckerStatus::UNKNOWN):
+    case static_cast<unsigned>(QuorumCheckerStatus::NO_QUORUM):
+        return static_cast<QuorumCheckerStatus>(statusInt);
+    default:
         throw RustQuorumCheckerError("Invalid status value: " +
                                      std::to_string(statusInt));
     }
-
-    return static_cast<QuorumCheckerStatus>(statusInt);
 }
 
 void
@@ -252,6 +256,7 @@ QuorumCheckerMetrics::QuorumCheckerMetrics()
     , mAbortedRun(0)
     , mResultPotentialSplit(0)
     , mResultUnknown(0)
+    , mResultNoQuorum(0)
     , mCumulativeTimeMs(0)
     , mCumulativeMemByte(0)
 {
@@ -293,6 +298,12 @@ QuorumCheckerMetrics::QuorumCheckerMetrics(Json::Value const& value)
         throw RustQuorumCheckerError(
             "Metrics missing or invalid 'result_unknown_count' field");
     }
+    if (!value.isMember("result_no_quorum_count") ||
+        !value["result_no_quorum_count"].isUInt())
+    {
+        throw RustQuorumCheckerError(
+            "Metrics missing or invalid 'result_no_quorum_count' field");
+    }
     if (!value.isMember("cumulative_time_ms") ||
         !value["cumulative_time_ms"].isUInt64())
     {
@@ -310,6 +321,7 @@ QuorumCheckerMetrics::QuorumCheckerMetrics(Json::Value const& value)
     mAbortedRun = value["aborted_run_count"].asUInt64();
     mResultPotentialSplit = value["result_potential_split_count"].asUInt64();
     mResultUnknown = value["result_unknown_count"].asUInt64();
+    mResultNoQuorum = value["result_no_quorum_count"].asUInt64();
     mCumulativeTimeMs = value["cumulative_time_ms"].asUInt64();
     mCumulativeMemByte = value["cumulative_mem_byte"].asUInt64();
 }
@@ -323,6 +335,7 @@ QuorumCheckerMetrics::toJson()
     ret["aborted_run_count"] = Json::UInt64(mAbortedRun);
     ret["result_potential_split_count"] = Json::UInt64(mResultPotentialSplit);
     ret["result_unknown_count"] = Json::UInt64(mResultUnknown);
+    ret["result_no_quorum_count"] = Json::UInt64(mResultNoQuorum);
     ret["cumulative_time_ms"] = Json::UInt64(mCumulativeTimeMs);
     ret["cumulative_mem_byte"] = Json::UInt64(mCumulativeMemByte);
     return ret;
@@ -337,6 +350,7 @@ QuorumCheckerMetrics::flush(MetricsRegistry& metrics)
     metrics.NewCounter({"scp", "qic", "result-potential-split"})
         .inc(mResultPotentialSplit);
     metrics.NewCounter({"scp", "qic", "result-unknown"}).inc(mResultUnknown);
+    metrics.NewCounter({"scp", "qic", "result-no-quorum"}).inc(mResultNoQuorum);
     metrics.NewMeter({"scp", "qic", "cumulative-time-ms"}, "milli-second")
         .Mark(mCumulativeTimeMs);
     metrics.NewMeter({"scp", "qic", "cumulative-mem-byte"}, "byte")
@@ -346,6 +360,7 @@ QuorumCheckerMetrics::flush(MetricsRegistry& metrics)
     mAbortedRun = 0;
     mResultPotentialSplit = 0;
     mResultUnknown = 0;
+    mResultNoQuorum = 0;
     mCumulativeTimeMs = 0;
     mCumulativeMemByte = 0;
 }
@@ -395,6 +410,10 @@ checkQuorumIntersectionInner(
         else if (status == QuorumCheckerStatus::SAT)
         {
             metrics.mResultPotentialSplit += 1;
+        }
+        else if (status == QuorumCheckerStatus::NO_QUORUM)
+        {
+            metrics.mResultNoQuorum += 1;
         }
 
         // Update time limit. Memory is a transient resource that gets reclaimed
@@ -565,10 +584,12 @@ runQuorumIntersectionCheckAsync(
 
         // Note: the ecode should match the return code from the command
         // line-running process which is just `QuorumCheckerStatus` as integer
-        // on success. However, if the command fails due to abort (if exceeding
-        // the memory limit), the ecode=1 will be returned because of the
-        // simplification of collapsing all non-WIFEXITED exits to error code 1
-        // (see `mapExitStatusToErrorCode` in ProcessManagerImpl.cpp).
+        // on success. Exceeding the time or (estimated) memory limit is now a
+        // recoverable solver error that surfaces as `UNKNOWN` (102), not a
+        // process abort. If the command dies abnormally (crash/signal, i.e. a
+        // non-WIFEXITED exit), ecode=1 is returned because of the
+        // simplification of collapsing all such exits to error code 1 (see
+        // `mapExitStatusToErrorCode` in ProcessManagerImpl.cpp).
         int ecode = ec.value();
         CLOG_DEBUG(SCP,
                    "Processing quorum intersection check result: numNodes={}, "
@@ -579,7 +600,8 @@ runQuorumIntersectionCheckAsync(
 
         if (ecode == static_cast<int>(QuorumCheckerStatus::UNSAT) ||
             ecode == static_cast<int>(QuorumCheckerStatus::SAT) ||
-            ecode == static_cast<int>(QuorumCheckerStatus::UNKNOWN))
+            ecode == static_cast<int>(QuorumCheckerStatus::UNKNOWN) ||
+            ecode == static_cast<int>(QuorumCheckerStatus::NO_QUORUM))
         {
             try
             {
@@ -587,9 +609,14 @@ runQuorumIntersectionCheckAsync(
                 hStateSP->mStatus = fromQuorumCheckerStatusJson(res["status"]);
                 QuorumCheckerMetrics metrics(res["metrics"]);
                 metrics.flush(hStateSP->mMetrics);
-                // only update the following info if we had a complete run
+                // only update the following info if we had a complete run.
+                // NO_QUORUM is a complete result (the checker definitively
+                // determined the FBAS has no quorum) so we record it too, but
+                // unlike UNSAT it is not a "good" result and must not advance
+                // mLastGoodLedger.
                 if (ecode == static_cast<int>(QuorumCheckerStatus::UNSAT) ||
-                    ecode == static_cast<int>(QuorumCheckerStatus::SAT))
+                    ecode == static_cast<int>(QuorumCheckerStatus::SAT) ||
+                    ecode == static_cast<int>(QuorumCheckerStatus::NO_QUORUM))
                 {
                     hStateSP->mNumNodes = numNodes;
                     hStateSP->mLastCheckLedger = ledger;

--- a/src/herder/RustQuorumCheckerAdaptor.h
+++ b/src/herder/RustQuorumCheckerAdaptor.h
@@ -35,6 +35,7 @@ struct QuorumCheckerMetrics
     uint64_t mAbortedRun;
     uint64_t mResultPotentialSplit;
     uint64_t mResultUnknown;
+    uint64_t mResultNoQuorum;
     uint64_t mCumulativeTimeMs;
     uint64_t mCumulativeMemByte;
     QuorumCheckerMetrics();
@@ -52,16 +53,20 @@ struct QuorumCheckerMetrics
 // - The time limit applies across all runs (all loops during criticality
 //   analysis), and is enforced by the Rust implementation, which returns an
 //   `Err` if exceeded.
-// - The memory limit is enforced by the glocal allocator, and once exceeds,
-//   will abort the program immediately.
+// - The memory limit is enforced softly inside the solver: memory usage is
+//   conservatively estimated from the solver's clause/variable counts, and the
+//   solver returns an `Err` once the estimate exceeds the limit.
 //
-// Therefore it is **crucial** this routine runs in a separate process from the
-// main stellar-core!!
+// We still run this routine in a separate process from the main stellar-core so
+// that its (potentially large) resource usage stays isolated.
 //
 // Return values:
 // - `UNSAT` if the quorum intersection check finds no non-intersecting quorums
 //   (good)
 // - `SAT` if the quorum intersection check finds quorum splits (bad!!)
+// - `NO_QUORUM` if the FBAS contains no quorum at all (a degenerate /
+//   potential-halt configuration). This is distinct from `UNSAT`: a network
+//   with no quorum does not enjoy quorum intersection.
 // - `UNKNOWN` if the quorum intersection check does not complete, likely due to
 //   exceeding solver internal limits (e.g. no. conflicts). Note: if the quorum
 //   intersection check completes, but the criticality analysis

--- a/src/herder/test/QuorumIntersectionTests.cpp
+++ b/src/herder/test/QuorumIntersectionTests.cpp
@@ -112,6 +112,24 @@ networkEnjoysQuorumIntersectionV2Wrapper(QuorumTracker::QuorumMap const& qmap,
     return state->mStatus == QuorumCheckerStatus::UNSAT;
 }
 
+// Like networkEnjoysQuorumIntersectionV2Wrapper, but returns the raw checker
+// status so tests can distinguish UNSAT (enjoys intersection) from NO_QUORUM
+// (the FBAS admits no quorum at all -- a halted/degenerate configuration).
+QuorumCheckerStatus
+quorumCheckStatusV2Wrapper(QuorumTracker::QuorumMap const& qmap,
+                           Config const& cfg)
+{
+    VirtualClock clock;
+    Application::pointer app = createTestApplication(clock, cfg);
+    auto state = std::make_shared<QuorumMapIntersectionState>(*app);
+    state->mRecalculating = true;
+    quorumIntersectionCheckerV2Wrapper(
+        *app, state, qmap, app->getProcessManager(), clock, false,
+        cfg.QUORUM_INTERSECTION_CHECKER_TIME_LIMIT_MS,
+        cfg.QUORUM_INTERSECTION_CHECKER_MEMORY_LIMIT_BYTES);
+    return state->mStatus;
+}
+
 std::set<std::set<NodeID>>
 runIntersectionCriticalGroupsCheckV2(QuorumTracker::QuorumMap const& qmap,
                                      Config const& cfg)
@@ -235,6 +253,58 @@ TEST_CASE("quorum non intersection basic 4-node",
     REQUIRE(!qic->networkEnjoysQuorumIntersection());
 
     REQUIRE(!networkEnjoysQuorumIntersectionV2Wrapper(qm, cfg));
+}
+
+TEST_CASE("quorum no-quorum threshold exceeds degree",
+          "[herder][quorumintersection]")
+{
+    QuorumTracker::QuorumMap qm;
+
+    PublicKey pkA = SecretKey::pseudoRandomForTesting().getPublicKey();
+    PublicKey pkB = SecretKey::pseudoRandomForTesting().getPublicKey();
+    PublicKey pkC = SecretKey::pseudoRandomForTesting().getPublicKey();
+    PublicKey pkD = SecretKey::pseudoRandomForTesting().getPublicKey();
+    // A "ghost" validator that is referenced by others' quorum sets but is
+    // itself absent from the quorum map, so it can never be available. With a
+    // threshold of 3 over {self, peer, ghost}, no node can ever reach its
+    // threshold, so the FBAS admits no quorum at all. This must be reported as
+    // NO_QUORUM, and is distinct from UNSAT ("enjoys quorum intersection").
+    PublicKey pkGhost = SecretKey::pseudoRandomForTesting().getPublicKey();
+
+    qm[pkA] = QuorumTracker::NodeInfo{
+        make_shared<QS>(3, VK({pkA, pkB, pkGhost}), VQ{}), 0};
+    qm[pkB] = QuorumTracker::NodeInfo{
+        make_shared<QS>(3, VK({pkA, pkB, pkGhost}), VQ{}), 0};
+    qm[pkC] = QuorumTracker::NodeInfo{
+        make_shared<QS>(3, VK({pkC, pkD, pkGhost}), VQ{}), 0};
+    qm[pkD] = QuorumTracker::NodeInfo{
+        make_shared<QS>(3, VK({pkC, pkD, pkGhost}), VQ{}), 0};
+
+    Config cfg(getTestConfig());
+
+    VirtualClock clock;
+    Application::pointer app = createTestApplication(clock, cfg);
+    auto state = std::make_shared<QuorumMapIntersectionState>(*app);
+
+    auto& noQuorumCounter =
+        state->mMetrics.NewCounter({"scp", "qic", "result-no-quorum"});
+    auto noQuorumCountBefore = noQuorumCounter.count();
+
+    state->mRecalculating = true;
+    state->mStatus = QuorumCheckerStatus::UNKNOWN;
+    quorumIntersectionCheckerV2Wrapper(
+        *app, state, qm, app->getProcessManager(), clock, false,
+        cfg.QUORUM_INTERSECTION_CHECKER_TIME_LIMIT_MS,
+        cfg.QUORUM_INTERSECTION_CHECKER_MEMORY_LIMIT_BYTES);
+
+    REQUIRE(state->mStatus == QuorumCheckerStatus::NO_QUORUM);
+    REQUIRE(noQuorumCounter.count() == noQuorumCountBefore + 1);
+    // NO_QUORUM is a complete result (records the checked ledger) but it is not
+    // a "good" result, so it does not advance mLastGoodLedger and the network
+    // does not enjoy quorum intersection.
+    REQUIRE(state->mLastCheckLedger != 0);
+    REQUIRE(state->mLastGoodLedger == 0);
+    REQUIRE(!state->enjoysQuorunIntersection());
 }
 
 TEST_CASE("quorum non intersection 6-node", "[herder][quorumintersection]")
@@ -956,8 +1026,13 @@ TEST_CASE("quorum intersection 6-org 1-node 4-null qsets",
     // for org2..org5. We know org0..org1 have threshold 67% = 3-of-4 (4 being
     // "self + 3 neighbours"); the current logic in the quorum intersection
     // checker (see buildGraph and convertSCPQuorumSet) will treat this network
-    // as _only_ having 2-nodes and will therefore declare it vacuously enjoying
-    // quorum intersection due to being halted.
+    // as _only_ having 2-nodes and therefore as a halted network with no
+    // quorum.
+    //
+    // The V1 checker declares such a halted network as vacuously enjoying
+    // quorum intersection; the V2 checker instead reports NO_QUORUM (the FBAS
+    // admits no quorum at all), which is not conflated with UNSAT ("enjoys
+    // intersection").
     //
     // (At other points in the design, and possibly again in the future if we
     // change our minds, we modeled this differently, treating the null-qset
@@ -991,7 +1066,10 @@ TEST_CASE("quorum intersection 6-org 1-node 4-null qsets",
     REQUIRE(qic->networkEnjoysQuorumIntersection());
     REQUIRE(qic->getMaxQuorumsFound() == 0);
 
-    REQUIRE(networkEnjoysQuorumIntersectionV2Wrapper(qm, cfg));
+    // V2 reports the halted network as having no quorum, rather than vacuously
+    // enjoying quorum intersection like V1.
+    REQUIRE(quorumCheckStatusV2Wrapper(qm, cfg) ==
+            QuorumCheckerStatus::NO_QUORUM);
 }
 
 TEST_CASE("quorum intersection 4-org 1-node 4-null qsets",
@@ -1008,10 +1086,11 @@ TEST_CASE("quorum intersection 4-org 1-node 4-null qsets",
     //           +-> org3 <-+
     //
     // As with the case before, this represents (to the quorum intersection
-    // checker's eyes) a halted network which vacuously enjoys quorum
-    // intersection.  But if we were using one of the other models for the
-    // meaning of a null qset, it might be different: split in the byzantine
-    // case, live and enjoying quorum intersection in the live-and-unknown case.
+    // checker's eyes) a halted network with no quorum. The V1 checker treats it
+    // as vacuously enjoying quorum intersection, while the V2 checker reports
+    // NO_QUORUM. But if we were using one of the other models for the meaning
+    // of a null qset, it might be different: split in the byzantine case, live
+    // and enjoying quorum intersection in the live-and-unknown case.
 
     auto orgs = generateOrgs(4, {1});
     auto qm = interconnectOrgsUnidir(orgs, {
@@ -1040,7 +1119,10 @@ TEST_CASE("quorum intersection 4-org 1-node 4-null qsets",
     REQUIRE(qic->networkEnjoysQuorumIntersection());
     REQUIRE(qic->getMaxQuorumsFound() == 0);
 
-    REQUIRE(networkEnjoysQuorumIntersectionV2Wrapper(qm, cfg));
+    // V2 reports the halted network as having no quorum, rather than vacuously
+    // enjoying quorum intersection like V1.
+    REQUIRE(quorumCheckStatusV2Wrapper(qm, cfg) ==
+            QuorumCheckerStatus::NO_QUORUM);
 }
 
 TEST_CASE("quorum intersection 6-org 3-node fully-connected",

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -1386,6 +1386,12 @@ runCheckQuorumIntersection(CommandLineArgs const& args)
             {
                 CLOG_WARNING(SCP, "Network does not enjoy quorum intersection");
             }
+            else if (status == QuorumCheckerStatus::NO_QUORUM)
+            {
+                CLOG_WARNING(SCP, "Network has no quorum -- the configuration "
+                                  "admits no quorum at all, which does not "
+                                  "enjoy quorum intersection");
+            }
             else
             {
                 CLOG_WARNING(SCP, "UNKNOWN result -- quorum intersection "

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -307,6 +307,12 @@ Config::Config() : NODE_SEED(SecretKey::random())
     QUORUM_INTERSECTION_CHECKER = true;
     USE_QUORUM_INTERSECTION_CHECKER_V2 = false;
     QUORUM_INTERSECTION_CHECKER_TIME_LIMIT_MS = 5000; // 5 secs
+    // NB: this budget is compared against a conservative over-estimate of the
+    // solver's memory (charged per clause/variable), not measured allocator
+    // usage. Under the current tier-1 network configuration (7 orgs) usage
+    // stays well under this limit, but the solver's encoding grows
+    // combinatorially with a vertex's degree, so if the number of tier-1
+    // organizations ever increases we will have to revisit this limit.
     QUORUM_INTERSECTION_CHECKER_MEMORY_LIMIT_BYTES =
         100 * 1024 * 1024; // 100 MiB
 

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -411,8 +411,6 @@ main(int argc, char* const* argv)
     // that would call std::terminate
     std::set_terminate(printBacktraceAndAbort);
 
-    rust_bridge::set_rust_global_memory_limit_to_unlimited();
-
     Logging::init();
     if (sodium_init() != 0)
     {

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -190,7 +190,7 @@ optional = true
 [dependencies.stellar-quorum-analyzer]
 version = "0.1.0"
 git = "https://github.com/stellar/stellar-quorum-analyzer"
-rev = "f67e9e2f080c2cc1a332d894c42277c64845e257"
+rev = "b422b366ede667c030c78ffe18b2010194698dbd"
 
 [features]
 

--- a/src/rust/src/bridge.rs
+++ b/src/rust/src/bridge.rs
@@ -181,6 +181,7 @@ pub(crate) mod rust_bridge {
         UNSAT = 0,
         SAT = 101,
         UNKNOWN = 102,
+        NO_QUORUM = 103,
     }
 
     struct QuorumSplit {
@@ -363,25 +364,27 @@ pub(crate) mod rust_bridge {
         //  - `QuorumCheckerStatus::UNKNOWN`. Solver could not finish, possibly
         //     due to reaching some internal limits (e.g. num conflicts) not
         //     including resource limits (see "Resource limits and errors")
+        //  - `QuorumCheckerStatus::NO_QUORUM` if the FBAS contains no quorum at
+        //     all (a degenerate / potential-halt configuration). The
+        //     disjoint-quorum question is vacuously unsatisfiable here, but this
+        //     must NOT be conflated with `UNSAT` ("a quorum exists and all
+        //     quorums intersect"): a network with no quorum does not enjoy
+        //     quorum intersection.
         //
         // Resource limits and errors:
         //
         // The quorum checker accepts two limits (passed via `resource_limit`),
-        // time (ms) and memory (bytes). The time limit is enforced internally
-        // via code logic, once exceeds, returns a solver error. The memory
-        // limit is enforced by a global memory allocator, and if exceeded, will
-        // abort the program. In other words, memory limit is a hard, system
-        // enforced limit.
+        // time (ms) and memory (bytes). Both are enforced internally via code
+        // logic; once exceeded, the solver returns an error. Memory is not
+        // measured directly but conservatively *estimated* from the solver's
+        // clause/variable counts, so the limit is a soft, per-solver limit
+        // rather than a hard, process-global one.
         //
         // Errors:
-        //  - if resource limits (not including memory) have been exceeded.
-        //  - any other solver error In either sucess or error case, the
+        //  - if resource limits (time or estimated memory) have been exceeded.
+        //  - any other solver error. In either success or error case, the
         // `resource_usage` will be updated with the actual resource
         // consumption.
-        //
-        // Aborts:
-        // - if the memory limit has been exceeded
-        // Abort is non-recoverable (it cannot be caught by catch_unwind)
         fn network_enjoys_quorum_intersection(
             nodes: &Vec<CxxBuf>,
             quorum_set: &Vec<CxxBuf>,
@@ -389,13 +392,6 @@ pub(crate) mod rust_bridge {
             resource_limit: &QuorumCheckerResource,
             resource_usage: &mut QuorumCheckerResource,
         ) -> Result<QuorumCheckerStatus>;
-
-        // The QI checker actually manages the memory limit using a global
-        // allocator, which winds up controlling _all_ memory allocation by
-        // rust code in the process. So we want to ensure that limit is unlimited
-        // when the process starts up -- the QI check call will limit it later,
-        // if and only if it's running as a QI-checking subprocess.
-        fn set_rust_global_memory_limit_to_unlimited();
 
         // Soroban fuzzing support - always declared but only functional with --features fuzz.
         // Panics on internal errors (which libfuzzer will catch as crashes).

--- a/src/rust/src/quorum_checker.rs
+++ b/src/rust/src/quorum_checker.rs
@@ -27,13 +27,10 @@ impl From<SolveStatus> for QuorumCheckerStatus {
         match ss {
             stellar_quorum_analyzer::SolveStatus::UNSAT => QuorumCheckerStatus::UNSAT,
             stellar_quorum_analyzer::SolveStatus::SAT(_) => QuorumCheckerStatus::SAT,
+            stellar_quorum_analyzer::SolveStatus::NoQuorum => QuorumCheckerStatus::NO_QUORUM,
             stellar_quorum_analyzer::SolveStatus::UNKNOWN => QuorumCheckerStatus::UNKNOWN,
         }
     }
-}
-
-pub(crate) fn set_rust_global_memory_limit_to_unlimited() {
-    ResourceLimiter::new(0, usize::MAX);
 }
 
 fn update_resource_usage(
@@ -53,14 +50,15 @@ pub(crate) fn network_enjoys_quorum_intersection(
     resource_limit: &QuorumCheckerResource,
     resource_usage: &mut QuorumCheckerResource,
 ) -> Result<QuorumCheckerStatus, Box<dyn std::error::Error>> {
-    // The panic handler catches any unwind-able panics, and convert it to an
-    // error (which will be converted to a C++ exception). It **cannot** catch
-    // an abort, which can happen if the `FbasAnalyzer` program exceeds the
-    // memory limit.
+    // The panic handler catches any unwind-able panics, and converts them to an
+    // error (which will be converted to a C++ exception).
     //
-    // Making the memory limit a hard limit is a design choice, because we want
-    // the memory usage of the process running quorum checker to be isolated
-    // from the main stellar-core running process.
+    // The memory limit is enforced softly, inside the solver: memory usage is
+    // conservatively estimated from the solver's clause/variable counts and,
+    // once the estimate exceeds the limit, the solver returns an error (rather
+    // than aborting the process via a global allocator, as an earlier version
+    // did). We still run the checker out-of-process so that its resource usage
+    // stays isolated from the main stellar-core process.
     let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let resource_limiter =
             ResourceLimiter::new(resource_limit.time_ms, resource_limit.mem_bytes);


### PR DESCRIPTION
# Description

### What

Bump `stellar-quorum-analyzer` from `f67e9e2f` to `b422b366` (master) and adapt the Quorum Intersection Checker V2 integration:

- Add `QuorumCheckerStatus::NO_QUORUM` (103), propagated through the subprocess exit code, `result.json`, adaptor state, a new `result-no-quorum` metric, and the CLI. It counts as a complete run but never advances `mLastGoodLedger`, so the network does not report as enjoying quorum intersection.
- Remove the now-dead `set_rust_global_memory_limit_to_unlimited()` and its stale abort-based-memory comments.
- Update the two null-qset tests to expect `NO_QUORUM`; add a no-quorum test.

### Why

The new analyzer distinguishes an FBAS with *no quorum at all* (a degenerate / potential-halt state) from `UNSAT` ("enjoys quorum intersection"), which the old version wrongly conflated. It also replaced the global-allocator hard memory limit (process abort on exceed) with a soft, estimate-based per-solver limit, making `set_rust_global_memory_limit_to_unlimited()` a no-op.

Tested: full suite passes (5,678,585 assertions / 698 cases), incl. the `[quorumintersection]` suite.

# Checklist

- [x] Reviewed the contributing document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` (v20.1.8, the repo-pinned version; via `git-clang-format` on the diff)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence — n/a
