### PR TITLE
Convert protocol-dependent tests to TEST_CASE_VERSIONS to catch bugs across all protocol versions

### DIFF
--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -1250,7 +1250,7 @@ dbModeName(Config::TestDbMode mode)
     }
 }
 
-TEST_CASE("History catchup", "[history][catchup][acceptance]")
+TEST_CASE_VERSIONS("History catchup", "[history][catchup][acceptance]")
 {
     auto runTest = [](bool skipKnownResults) {
         // needs REAL_TIME here, as resolve-snapshot works will fail for one of

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -2489,9 +2489,14 @@ TEST_CASE("contract errors cause transaction to fail", "[tx][soroban]")
     }
 }
 
-TEST_CASE("settings upgrade", "[tx][soroban][upgrades]")
+TEST_CASE_VERSIONS("settings upgrade", "[tx][soroban][upgrades]")
 {
     auto cfg = getTestConfig();
+    if (protocolVersionIsBefore(cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION,
+                                SOROBAN_PROTOCOL_VERSION))
+    {
+        return;
+    }
     cfg.ENABLE_SOROBAN_DIAGNOSTIC_EVENTS = true;
     SorobanTest test(cfg, /* useTestLimits*/ false);
     auto runTest = [&]() {
@@ -5256,9 +5261,14 @@ TEST_CASE("persistent entry archival", "[tx][soroban][archival]")
     }
 }
 
-TEST_CASE("autorestore contract instance", "[tx][soroban][archival]")
+TEST_CASE_VERSIONS("autorestore contract instance", "[tx][soroban][archival]")
 {
     auto cfg = getTestConfig();
+    if (protocolVersionIsBefore(cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION,
+                                AUTO_RESTORE_PROTOCOL_VERSION))
+    {
+        return;
+    }
     cfg.ENABLE_SOROBAN_DIAGNOSTIC_EVENTS = true;
     SorobanTest test(cfg, true, [](SorobanNetworkConfig& cfg) {
         cfg.mStateArchivalSettings.minPersistentTTL =
@@ -5457,9 +5467,14 @@ TEST_CASE("autorestore contract instance", "[tx][soroban][archival]")
     }
 }
 
-TEST_CASE("autorestore with storage resize", "[tx][soroban][archival]")
+TEST_CASE_VERSIONS("autorestore with storage resize", "[tx][soroban][archival]")
 {
     auto cfg = getTestConfig();
+    if (protocolVersionIsBefore(cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION,
+                                AUTO_RESTORE_PROTOCOL_VERSION))
+    {
+        return;
+    }
     cfg.ENABLE_SOROBAN_DIAGNOSTIC_EVENTS = true;
     SorobanTest test(cfg, true, [](SorobanNetworkConfig& cfg) {
         cfg.mStateArchivalSettings.minPersistentTTL =
@@ -10458,9 +10473,14 @@ TEST_CASE_VERSIONS("validate return values", "[tx][soroban][parallelapply]")
 
 // Test that autorestore works when keys aren't explicitly written and
 // belong to another uncalled contractID.
-TEST_CASE("autorestore from another contract", "[tx][soroban][archival]")
+TEST_CASE_VERSIONS("autorestore from another contract", "[tx][soroban][archival]")
 {
     auto cfg = getTestConfig();
+    if (protocolVersionIsBefore(cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION,
+                                AUTO_RESTORE_PROTOCOL_VERSION))
+    {
+        return;
+    }
     cfg.ENABLE_SOROBAN_DIAGNOSTIC_EVENTS = true;
     SorobanTest test(cfg, true, [](SorobanNetworkConfig& sorobanCfg) {
         sorobanCfg.mStateArchivalSettings.minPersistentTTL =

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -2555,6 +2555,10 @@ TEST_CASE_VERSIONS("settings upgrade", "[tx][soroban][upgrades]")
 
             LedgerTxn ltx(test.getApp().getLedgerTxnRoot());
             auto costEntry = ltx.load(configSettingKey(type));
+            if (!costEntry)
+            {
+                continue;
+            }
             updatedEntries.emplace_back(
                 costEntry.current().data.configSetting());
         }

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -1101,7 +1101,7 @@ TEST_CASE("version test", "[tx][soroban]")
     }
 }
 
-TEST_CASE("Soroban footprint validation", "[tx][soroban]")
+TEST_CASE_VERSIONS("Soroban footprint validation", "[tx][soroban]")
 {
     auto appCfg = getTestConfig();
     if (protocolVersionIsBefore(appCfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION,
@@ -1381,7 +1381,10 @@ TEST_CASE("Soroban footprint validation", "[tx][soroban]")
             resources.footprint.readWrite.emplace_back(persistentKey);
             resources.footprint.readWrite.emplace_back(persistentKey2);
             resources.footprint.readWrite.emplace_back(persistentKey3);
-            testValidInvoke(true, std::vector<uint32_t>{0, 2});
+            testValidInvoke(protocolVersionStartsFrom(
+                                appCfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION,
+                                AUTO_RESTORE_PROTOCOL_VERSION),
+                            std::vector<uint32_t>{0, 2});
         }
 
         SECTION("entry in readOnly footprint")
@@ -5623,10 +5626,16 @@ TEST_CASE("autorestore with storage resize", "[tx][soroban][archival]")
  get-settings-upgrade-txs command to make sure the transactions have the
  proper resources set.
 */
-TEST_CASE("settings upgrade command line utils", "[tx][soroban][upgrades]")
+TEST_CASE_VERSIONS("settings upgrade command line utils",
+                   "[tx][soroban][upgrades]")
 {
     VirtualClock clock;
     auto cfg = getTestConfig(0, Config::TESTDB_IN_MEMORY);
+    if (protocolVersionIsBefore(cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION,
+                                SOROBAN_PROTOCOL_VERSION))
+    {
+        return;
+    }
     cfg.ENABLE_SOROBAN_DIAGNOSTIC_EVENTS = true;
     auto app = createTestApplication(clock, cfg);
     auto root = app->getRoot();
@@ -5683,6 +5692,12 @@ TEST_CASE("settings upgrade command line utils", "[tx][soroban][upgrades]")
 
         LedgerTxn ltx(app->getLedgerTxnRoot());
         auto entry = ltx.load(configSettingKey(type));
+        // Config setting IDs introduced by later protocols do not have ledger
+        // entries yet.
+        if (!entry)
+        {
+            continue;
+        }
 
         // Store the initial entries before we modify the cost types below
         initialEntries.emplace_back(entry.current().data.configSetting());
@@ -5940,7 +5955,7 @@ TEST_CASE("settings upgrade command line utils", "[tx][soroban][upgrades]")
     REQUIRE(ret == "");
 
     auto checkSettings = [&](xdr::xvector<ConfigSettingEntry> const& entries) {
-        auto expectedIndex = 0;
+        size_t expectedIndex = 0;
         for (auto t : xdr::xdr_traits<ConfigSettingID>::enum_values())
         {
             auto type = static_cast<ConfigSettingID>(t);
@@ -5959,11 +5974,16 @@ TEST_CASE("settings upgrade command line utils", "[tx][soroban][upgrades]")
 
             LedgerTxn ltx(app->getLedgerTxnRoot());
             auto entry = ltx.load(configSettingKey(type));
+            if (!entry)
+            {
+                continue;
+            }
 
             REQUIRE(entry.current().data.configSetting() ==
                     entries.at(expectedIndex));
             ++expectedIndex;
         }
+        REQUIRE(expectedIndex == entries.size());
     };
 
     SECTION("success")


### PR DESCRIPTION
# Description

Resolves #4783.

Converted 7 tests from TEST_CASE (latest protocol only) to TEST_CASE_VERSIONS
(all protocol versions), plus added protocol-version guards and null-entry checks
so the tests run safely across the full protocol range:

- History catchup, Soroban footprint validation, settings upgrade command line utils,
  settings upgrade, autorestore contract instance, autorestore with storage resize,
  autorestore from another contract.

Added null entry guard for ConfigSettingIDs introduced at V23 that have no ledger
entries at protocols V20-V22, preventing null-pointer dereference in settings upgrade.

# Checklist
- [x] Reviewed the contributing document
- [x] Rebased on top of master (no merge commits)
- [ ] Ran clang-format v8.0.0 (via make format)
- [ ] Compiles
- [ ] Ran all tests