### PR TITLE
Fix unified build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1440,8 +1440,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "26.1.2"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c0e58f94ff2983a09440cef6a54253349fd3c4db#c0e58f94ff2983a09440cef6a54253349fd3c4db"
+version = "27.0.0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=b03d2563f3a08d51095a19bdbb6d90364b8ce04a#b03d2563f3a08d51095a19bdbb6d90364b8ce04a"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -1548,17 +1548,17 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "26.1.2"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c0e58f94ff2983a09440cef6a54253349fd3c4db#c0e58f94ff2983a09440cef6a54253349fd3c4db"
+version = "27.0.0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=b03d2563f3a08d51095a19bdbb6d90364b8ce04a#b03d2563f3a08d51095a19bdbb6d90364b8ce04a"
 dependencies = [
  "crate-git-revision",
  "ethnum",
  "num-derive",
  "num-traits",
- "soroban-env-macros 26.1.2",
+ "soroban-env-macros 27.0.0",
  "soroban-wasmi",
  "static_assertions",
- "stellar-xdr 26.0.0",
+ "stellar-xdr 27.0.0",
  "wasmparser",
 ]
 
@@ -1772,8 +1772,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "26.1.2"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c0e58f94ff2983a09440cef6a54253349fd3c4db#c0e58f94ff2983a09440cef6a54253349fd3c4db"
+version = "27.0.0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=b03d2563f3a08d51095a19bdbb6d90364b8ce04a#b03d2563f3a08d51095a19bdbb6d90364b8ce04a"
 dependencies = [
  "ark-bls12-381 0.5.0",
  "ark-bn254 0.5.0",
@@ -1798,8 +1798,8 @@ dependencies = [
  "sec1",
  "sha2",
  "sha3",
- "soroban-builtin-sdk-macros 26.1.2",
- "soroban-env-common 26.1.2",
+ "soroban-builtin-sdk-macros 27.0.0",
+ "soroban-env-common 27.0.0",
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey 0.0.13",
@@ -1892,15 +1892,15 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "26.1.2"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c0e58f94ff2983a09440cef6a54253349fd3c4db#c0e58f94ff2983a09440cef6a54253349fd3c4db"
+version = "27.0.0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=b03d2563f3a08d51095a19bdbb6d90364b8ce04a#b03d2563f3a08d51095a19bdbb6d90364b8ce04a"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "stellar-xdr 26.0.0",
+ "stellar-xdr 27.0.0",
  "syn 2.0.39",
 ]
 
@@ -1987,7 +1987,7 @@ dependencies = [
  "soroban-env-host 24.0.0",
  "soroban-env-host 25.0.0",
  "soroban-env-host 26.0.0",
- "soroban-env-host 26.1.2",
+ "soroban-env-host 27.0.0",
  "soroban-fuzz-targets",
  "soroban-synth-wasm",
  "soroban-test-wasms",
@@ -2136,6 +2136,7 @@ version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05ff843326969bdf1ef673dcdba94c08f4a3c8f1e58d6e6ef39b1bd4f749179a"
 dependencies = [
+ "base64 0.22.1",
  "crate-git-revision",
  "escape-bytes",
  "ethnum",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -115,10 +115,10 @@ tracy-client = { version = "=0.17.0", features = [
 # unify them, perturbing the contents of the lockfile.
 
 [dependencies.soroban-env-host-p27]
-version = "=26.1.2"
+version = "=27.0.0"
 git = "https://github.com/stellar/rs-soroban-env"
 package = "soroban-env-host"
-rev = "c0e58f94ff2983a09440cef6a54253349fd3c4db"
+rev = "b03d2563f3a08d51095a19bdbb6d90364b8ce04a"
 optional = true
 
 [dependencies.soroban-env-host-p26]


### PR DESCRIPTION
This is a minimal fix to the unified build. It's required to get the fuzz build (and oss-fuzz) working.

I'll file another PR tomorrow to add a build to CI that actively defends this path. The fuzz _targets_ are all already built by CI and tested as part of unit tests but the fuzzer _integration_ (using unified build and connecting to a fuzz engine) are not currently. I'll fix that next.