### PR TITLE
Switch trigger timer on p28 boundary

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -201,7 +201,7 @@ scp.timing.externalized                   | timer     | time spent in ballot pro
 scp.timing.first-to-self-externalize-lag  | timer     | delay between first externalize message and local node externalizing
 scp.timing.self-to-others-externalize-lag | timer     | delay between local node externalizing and later externalize messages from other nodes
 scp.timing.ballot-blocked-on-txset        | timer     | time balloting was blocked waiting for a txset download (milliseconds)
-scp.trigger.prepare-start-fallback        | meter     | experimental trigger timer fell back from the network-close-time anchor to the local prepare-start anchor
+scp.trigger.prepare-start-fallback        | meter     | trigger timer fell back from the network-close-time anchor to the local prepare-start anchor
 scp.value.invalid                         | meter     | SCP value is invalid
 scp.value.valid                           | meter     | SCP value is valid
 scp.slot.values-referenced                | histogram | number of values referenced per consensus round

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1447,8 +1447,18 @@ HerderImpl::setupTriggerNextLedger()
 
     auto now = mApp.getClock().now();
 
+    // Starting from protocol 28 the trigger timer is anchored on the
+    // network-agreed consensus close time.
+    // FORCE_OLD_STYLE_PREPARE_START_TRIGGER_TIMER forces the older
+    // prepare-start anchor as an emergency fallback.
+    bool const useConsensusCloseTimeAnchor =
+        protocolVersionStartsFrom(
+            lcl.header.ledgerVersion,
+            CONSENSUS_CLOSE_TIME_TRIGGER_PROTOCOL_VERSION) &&
+        !mApp.getConfig().FORCE_OLD_STYLE_PREPARE_START_TRIGGER_TIMER;
+
     auto lastLedgerStartingPoint =
-        mApp.getConfig().EXPERIMENTAL_TRIGGER_TIMER
+        useConsensusCloseTimeAnchor
             ? triggerAnchorFromConsensusCloseTime(lastIndex, now, milliseconds)
             : triggerAnchorFromPrepareStart(lastIndex, now, milliseconds);
 

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -358,7 +358,7 @@ class HerderImpl : public Herder
         medida::Meter& mEnvelopeValidSig;
         medida::Meter& mEnvelopeInvalidSig;
 
-        // Marked when the experimental trigger timer falls back from the
+        // Marked when the trigger timer falls back from the
         // network-close-time anchor to the local prepare-start anchor.
         medida::Meter& mTriggerPrepareStartFallback;
 

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -9282,10 +9282,103 @@ TEST_CASE("SCP state restore with missing tx set", "[herder]")
 }
 #endif // CAP_0083
 
-TEST_CASE("experimental trigger timer", "[herder][!hide]")
+static bool
+triggerTimerProtocolSupported()
 {
+    return protocolVersionStartsFrom(
+        Config::CURRENT_LEDGER_PROTOCOL_VERSION,
+        CONSENSUS_CLOSE_TIME_TRIGGER_PROTOCOL_VERSION);
+}
+
+// Four top-tier validators over TCP on the real clock, with a 1s artificial
+// apply delay and a configurable nomination-emit delay so we can actually see
+// the impact of the two different timers.
+static Simulation::pointer
+makeTriggerTimerSimulation(
+    bool forcePrepareStartTimer, std::chrono::milliseconds nominationEmitDelay,
+    std::chrono::milliseconds driftClockOffset =
+        std::chrono::milliseconds::zero(),
+    std::optional<uint32_t> startingProtocol = std::nullopt)
+{
+    auto networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
+
+    auto simulation = Topologies::separateAllHighQuality(
+        4, Simulation::OVER_TCP, networkID, [&](int i) {
+            auto cfg = getTestConfig(i, Config::TESTDB_DEFAULT);
+            cfg.ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING = false;
+            cfg.FORCE_OLD_STYLE_PREPARE_START_TRIGGER_TIMER =
+                forcePrepareStartTimer;
+            cfg.ARTIFICIALLY_DELAY_LEDGER_CLOSE_FOR_TESTING =
+                std::chrono::milliseconds(1000);
+            cfg.ARTIFICIALLY_DELAY_NOMINATION_EMIT_FOR_TESTING =
+                nominationEmitDelay;
+            // Remember enough SCP slots that the tests can attribute every
+            // externalized value in their measurement windows to its
+            // proposer.
+            cfg.MAX_SLOTS_TO_REMEMBER = 24;
+            if (startingProtocol)
+            {
+                cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION = *startingProtocol;
+            }
+
+            // Drift one validator. Note: i == 0 is the Simulation's
+            // idle app (its config is generated first by the constructor),
+            // so the first real validator is i == 1.
+            if (i == 1)
+            {
+                cfg.ARTIFICIALLY_SET_SYSTEM_CLOCK_OFFSET_FOR_TESTING =
+                    driftClockOffset;
+            }
+            return cfg;
+        });
+
+    simulation->fullyConnectAllPending();
+    simulation->startAllNodes();
+    REQUIRE(simulation->getExpectedLedgerCloseTime() ==
+            std::chrono::seconds(5));
+    return simulation;
+}
+
+static uint32_t
+minLedger(std::vector<Application::pointer> const& nodes)
+{
+    return std::min_element(
+               nodes.begin(), nodes.end(),
+               [](Application::pointer const& lhs,
+                  Application::pointer const& rhs) {
+                   return lhs->getLedgerManager().getLastClosedLedgerNum() <
+                          rhs->getLedgerManager().getLastClosedLedgerNum();
+               })
+        ->get()
+        ->getLedgerManager()
+        .getLastClosedLedgerNum();
+}
+
+// Crank until every node has externalized `count` more ledgers; returns the
+// elapsed real time.
+static std::chrono::milliseconds
+closeLedgers(Simulation::pointer const& simulation, uint32_t count,
+             bool finalCrank = false)
+{
+    auto nodes = simulation->getNodes();
+    auto const expectedClose = simulation->getExpectedLedgerCloseTime();
+    auto const target = minLedger(nodes) + count;
+    auto const start = nodes.front()->getClock().now();
+    simulation->crankUntil(
+        [&]() { return simulation->haveAllExternalized(target, 1); },
+        10 * (count + 1) * expectedClose, finalCrank);
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+        nodes.front()->getClock().now() - start);
+}
+
+TEST_CASE("consensus close time trigger timer", "[herder][!hide]")
+{
+    if (!triggerTimerProtocolSupported())
+    {
+        return;
+    }
+
     constexpr uint32_t LEDGERS_TO_RUN = 10;
-    constexpr int64_t MIN_DRIFT_FALLBACKS = (LEDGERS_TO_RUN + 1) / 2;
     auto const driftOffset = std::chrono::seconds(4);
 
     struct RunResult
@@ -9293,7 +9386,8 @@ TEST_CASE("experimental trigger timer", "[herder][!hide]")
         std::chrono::milliseconds elapsed;
         int64_t totalFallbacks{0};
         int64_t driftedNodeFallbacks{0};
-        int64_t otherNodeFallbacks{0};
+        int64_t maxOtherNodeFallbacks{0};
+        int64_t driftedLedSlots{0};
         bool sawNominationTimeout{false};
     };
 
@@ -9311,68 +9405,24 @@ TEST_CASE("experimental trigger timer", "[herder][!hide]")
     };
 
     auto runSimulation =
-        [&](bool experimentalTriggerTimer,
+        [&](bool forcePrepareStartTimer,
             std::chrono::milliseconds nominationEmitDelay,
             std::chrono::milliseconds triggerClockOffset =
                 std::chrono::milliseconds::zero()) -> RunResult {
-        auto networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
-
-        auto simulation = Topologies::separateAllHighQuality(
-            4, Simulation::OVER_TCP, networkID, [&](int i) {
-                auto cfg = getTestConfig(i, Config::TESTDB_DEFAULT);
-                cfg.ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING = false;
-                cfg.EXPERIMENTAL_TRIGGER_TIMER = experimentalTriggerTimer;
-                cfg.ARTIFICIALLY_DELAY_LEDGER_CLOSE_FOR_TESTING =
-                    std::chrono::milliseconds(1000);
-                cfg.ARTIFICIALLY_DELAY_NOMINATION_EMIT_FOR_TESTING =
-                    nominationEmitDelay;
-
-                // Drift one validator. Note: i == 0 is the Simulation's
-                // idle app (its config is generated first by the constructor),
-                // so the first real validator is i == 1.
-                if (i == 1)
-                {
-                    cfg.ARTIFICIALLY_SET_SYSTEM_CLOCK_OFFSET_FOR_TESTING =
-                        triggerClockOffset;
-                }
-                return cfg;
-            });
-
-        simulation->fullyConnectAllPending();
-        simulation->startAllNodes();
+        auto simulation = makeTriggerTimerSimulation(
+            forcePrepareStartTimer, nominationEmitDelay, triggerClockOffset);
         auto nodes = simulation->getNodes();
-        auto const expectedClose = simulation->getExpectedLedgerCloseTime();
-        REQUIRE(expectedClose == std::chrono::seconds(5));
 
         std::vector<int64_t> fallbackCounts;
         std::transform(nodes.begin(), nodes.end(),
                        std::back_inserter(fallbackCounts), fallbackCount);
 
-        auto minLedger = [&]() {
-            return std::min_element(nodes.begin(), nodes.end(),
-                                    [](Application::pointer const& lhs,
-                                       Application::pointer const& rhs) {
-                                        return lhs->getLedgerManager()
-                                                   .getLastClosedLedgerNum() <
-                                               rhs->getLedgerManager()
-                                                   .getLastClosedLedgerNum();
-                                    })
-                ->get()
-                ->getLedgerManager()
-                .getLastClosedLedgerNum();
-        };
-
-        auto const startLedger = minLedger();
-        auto targetLedger = startLedger + LEDGERS_TO_RUN;
-        auto const startTime = nodes.front()->getClock().now();
-
-        simulation->crankUntil(
-            [&]() { return simulation->haveAllExternalized(targetLedger, 1); },
-            10 * (LEDGERS_TO_RUN + 1) * expectedClose, true);
+        auto const startLedger = minLedger(nodes);
+        auto const targetLedger = startLedger + LEDGERS_TO_RUN;
 
         RunResult result;
-        result.elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-            nodes.front()->getClock().now() - startTime);
+        result.elapsed =
+            closeLedgers(simulation, LEDGERS_TO_RUN, /*finalCrank=*/true);
 
         for (size_t i = 0; i < nodes.size(); ++i)
         {
@@ -9390,7 +9440,8 @@ TEST_CASE("experimental trigger timer", "[herder][!hide]")
             }
             else
             {
-                result.otherNodeFallbacks += delta;
+                result.maxOtherNodeFallbacks =
+                    std::max(result.maxOtherNodeFallbacks, delta);
             }
 
             auto const& driver =
@@ -9406,42 +9457,194 @@ TEST_CASE("experimental trigger timer", "[herder][!hide]")
             }
         }
 
+        // Count the externalized values the drifted
+        // validator proposed. This indicates that the non-drifting nodes
+        // hit the fallback timer, as they were drifting relative to network
+        // time for the given slot.
+        std::optional<PublicKey> driftedKey;
+        for (auto const& node : nodes)
+        {
+            if (triggerClockOffset != std::chrono::milliseconds::zero() &&
+                node->getConfig()
+                        .ARTIFICIALLY_SET_SYSTEM_CLOCK_OFFSET_FOR_TESTING ==
+                    triggerClockOffset)
+            {
+                driftedKey = node->getConfig().NODE_SEED.getPublicKey();
+            }
+        }
+        if (driftedKey)
+        {
+            auto& scp =
+                dynamic_cast<HerderImpl&>(nodes.front()->getHerder()).getSCP();
+            for (uint32_t ledger = startLedger + 1; ledger <= targetLedger;
+                 ++ledger)
+            {
+                auto const envs = scp.getExternalizingState(ledger);
+                auto const ext = std::find_if(
+                    envs.begin(), envs.end(), [](SCPEnvelope const& e) {
+                        return e.statement.pledges.type() == SCP_ST_EXTERNALIZE;
+                    });
+                releaseAssert(ext != envs.end());
+                StellarValue sv;
+                xdr::xdr_from_opaque(
+                    ext->statement.pledges.externalize().commit.value, sv);
+                if (sv.ext.v() == STELLAR_VALUE_SIGNED &&
+                    sv.ext.lcValueSignature().nodeID == *driftedKey)
+                {
+                    ++result.driftedLedSlots;
+                }
+            }
+        }
+
         return result;
     };
 
     // New timer is faster without drift.
     {
         auto const nominationDelay = std::chrono::milliseconds(1000);
-        auto const oldTimer = runSimulation(false, nominationDelay);
-        auto const newTimer = runSimulation(true, nominationDelay);
+        auto const oldTimer = runSimulation(true, nominationDelay);
+        auto const newTimer = runSimulation(false, nominationDelay);
 
         REQUIRE(newTimer.elapsed < oldTimer.elapsed);
         REQUIRE(newTimer.totalFallbacks == 0);
     }
 
+    constexpr int64_t FALLBACK_SLACK = 1;
+
     // One node drifting ahead falls back.
     {
-        auto const nodeAhead =
-            runSimulation(true, std::chrono::milliseconds::zero(), driftOffset);
-        REQUIRE(nodeAhead.driftedNodeFallbacks >= MIN_DRIFT_FALLBACKS);
-        // Fallback must be specific to the drifted node: in-sync nodes should
-        // stay on the network-close-time anchor.
-        REQUIRE(nodeAhead.otherNodeFallbacks == 0);
+        auto const nodeAhead = runSimulation(
+            false, std::chrono::milliseconds::zero(), driftOffset);
+        REQUIRE(nodeAhead.driftedNodeFallbacks >=
+                LEDGERS_TO_RUN - nodeAhead.driftedLedSlots - FALLBACK_SLACK);
+
+        // Note: When the drifting node leads the round, non-drifting nodes
+        // may fall back.
+        REQUIRE(nodeAhead.maxOtherNodeFallbacks <=
+                nodeAhead.driftedLedSlots + FALLBACK_SLACK);
     }
 
     // One node drifting behind falls back.
     {
         auto const nodeBehind = runSimulation(
-            true, std::chrono::milliseconds::zero(), -driftOffset);
-        REQUIRE(nodeBehind.driftedNodeFallbacks >= MIN_DRIFT_FALLBACKS);
-        REQUIRE(nodeBehind.otherNodeFallbacks == 0);
+            false, std::chrono::milliseconds::zero(), -driftOffset);
+        REQUIRE(nodeBehind.driftedNodeFallbacks >=
+                LEDGERS_TO_RUN - nodeBehind.driftedLedSlots - FALLBACK_SLACK);
+
+        // Note: When the drifting node leads the round, non-drifting nodes
+        // may fall back.
+        REQUIRE(nodeBehind.maxOtherNodeFallbacks <=
+                nodeBehind.driftedLedSlots + FALLBACK_SLACK);
     }
 
     // Long nomination does not cause timer fallback
     {
         auto const nominationDelay = std::chrono::milliseconds(5000);
-        auto const slowNomination = runSimulation(true, nominationDelay);
+        auto const slowNomination = runSimulation(false, nominationDelay);
         REQUIRE(slowNomination.sawNominationTimeout);
         REQUIRE(slowNomination.totalFallbacks == 0);
+    }
+}
+
+TEST_CASE("trigger timer switches anchor at protocol 28 upgrade",
+          "[herder][upgrades][!hide]")
+{
+    if (!triggerTimerProtocolSupported())
+    {
+        return;
+    }
+
+    auto const upgradeVersion =
+        static_cast<uint32_t>(CONSENSUS_CLOSE_TIME_TRIGGER_PROTOCOL_VERSION);
+
+    // With a delayed nomination emit, the prepare-start timer paces ledgers
+    // at roughly expectedClose + nominationEmitDelay (nomination happens
+    // before the anchor point), while the consensus-close-time timer absorbs
+    // the nomination delay and paces at expectedClose. This delta helps us
+    // measure the timer change after the upgrade.
+    constexpr uint32_t LEDGERS_TO_MEASURE = 8;
+    auto const nominationEmitDelay = std::chrono::milliseconds(1000);
+
+    struct RunResult
+    {
+        std::chrono::milliseconds preUpgrade;
+        std::chrono::milliseconds postUpgrade;
+    };
+
+    auto runSimulation = [&](bool forcePrepareStartTimer) -> RunResult {
+        // Start the network one protocol before the trigger-timer switch.
+        auto simulation = makeTriggerTimerSimulation(
+            forcePrepareStartTimer, nominationEmitDelay,
+            std::chrono::milliseconds::zero(), upgradeVersion - 1);
+        auto nodes = simulation->getNodes();
+        auto const expectedClose = simulation->getExpectedLedgerCloseTime();
+
+        auto lclVersion = [](Application::pointer const& node) {
+            return node->getLedgerManager()
+                .getLastClosedLedgerHeader()
+                .header.ledgerVersion;
+        };
+
+        // Measure the cadence on the pre-28 protocol.
+        simulation->crankUntil(
+            [&]() { return simulation->haveAllExternalized(3, 1); },
+            10 * expectedClose, false);
+        auto const preUpgrade = closeLedgers(simulation, LEDGERS_TO_MEASURE);
+        for (auto const& node : nodes)
+        {
+            REQUIRE(lclVersion(node) == upgradeVersion - 1);
+        }
+
+        // Upgrade to protocol 28
+        Upgrades::UpgradeParameters scheduledUpgrades;
+        scheduledUpgrades.mUpgradeTime =
+            VirtualClock::from_time_t(nodes[0]
+                                          ->getLedgerManager()
+                                          .getLastClosedLedgerHeader()
+                                          .header.scpValue.closeTime);
+        scheduledUpgrades.mProtocolVersion = upgradeVersion;
+        for (auto const& node : nodes)
+        {
+            node->getHerder().setUpgrades(scheduledUpgrades);
+        }
+
+        // Crank until every node has closed the upgrade ledger, then one
+        // more ledger so the measured window is fully post-upgrade.
+        simulation->crankUntil(
+            [&]() {
+                return std::all_of(nodes.begin(), nodes.end(),
+                                   [&](Application::pointer const& node) {
+                                       return lclVersion(node) ==
+                                              upgradeVersion;
+                                   });
+            },
+            10 * expectedClose, false);
+        closeLedgers(simulation, 1);
+
+        auto const postUpgrade = closeLedgers(simulation, LEDGERS_TO_MEASURE);
+        for (auto const& node : nodes)
+        {
+            REQUIRE(lclVersion(node) == upgradeVersion);
+        }
+
+        return {preUpgrade, postUpgrade};
+    };
+
+    // Expected cadence saving is nominationEmitDelay per ledger; splitting
+    // pass/fail at half of it tolerates scheduling noise in both directions.
+    auto const cadenceMargin = LEDGERS_TO_MEASURE * nominationEmitDelay / 2;
+
+    // Crossing the boundary switches to the consensus-close-time anchor:
+    // post-upgrade ledgers close significantly faster.
+    {
+        auto const result = runSimulation(false);
+        REQUIRE(result.postUpgrade + cadenceMargin < result.preUpgrade);
+    }
+
+    // The override flag keeps the prepare-start anchor after the upgrade, so
+    // the cadence does not improve.
+    {
+        auto const result = runSimulation(true);
+        REQUIRE(result.postUpgrade + cadenceMargin > result.preUpgrade);
     }
 }

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -179,7 +179,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     DISABLE_SOROBAN_METRICS_FOR_TESTING = false;
     DISABLE_TX_META_FOR_TESTING = false;
     BACKGROUND_TX_SIG_VERIFICATION = true;
-    EXPERIMENTAL_TRIGGER_TIMER = false;
+    FORCE_OLD_STYLE_PREPARE_START_TRIGGER_TIMER = false;
     NTP_DRIFT_CHECK_SERVER = "pool.ntp.org";
     BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT = 14; // 2^14 == 16 kb
     BUCKETLIST_DB_INDEX_CUTOFF = 20;             // 20 mb
@@ -1230,8 +1230,11 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                  }},
                 {"BACKGROUND_TX_SIG_VERIFICATION",
                  [&]() { BACKGROUND_TX_SIG_VERIFICATION = readBool(item); }},
-                {"EXPERIMENTAL_TRIGGER_TIMER",
-                 [&]() { EXPERIMENTAL_TRIGGER_TIMER = readBool(item); }},
+                {"FORCE_OLD_STYLE_PREPARE_START_TRIGGER_TIMER",
+                 [&]() {
+                     FORCE_OLD_STYLE_PREPARE_START_TRIGGER_TIMER =
+                         readBool(item);
+                 }},
                 {"NTP_DRIFT_CHECK_SERVER",
                  [&]() { NTP_DRIFT_CHECK_SERVER = readString(item); }},
                 {"ARTIFICIALLY_DELAY_LEDGER_CLOSE_FOR_TESTING",

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -552,9 +552,11 @@ class Config : public std::enable_shared_from_this<Config>
     // also enabled.
     bool BACKGROUND_TX_SIG_VERIFICATION;
 
-    // Experimental flag to use externalized close time for trigger timer
-    // calculation instead of prepare start time.
-    bool EXPERIMENTAL_TRIGGER_TIMER;
+    // Starting from protocol 28 the trigger-next-ledger timer is anchored on
+    // the externalized consensus close time. Setting this flag to true forces
+    // the older prepare-start based timer even on protocol 28 and later. This
+    // is an emergency fallback and defaults to false.
+    bool FORCE_OLD_STYLE_PREPARE_START_TRIGGER_TIMER;
 
     // Hostname of an NTP server to periodically query in order to detect drift
     // of this node's local clock. This is detection only: core never adjusts

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -566,7 +566,6 @@ getTestConfig(int instanceNumber, Config::TestDbMode mode)
         thisConfig.MANUAL_CLOSE = true;
 
         thisConfig.TEST_CASES_ENABLED = true;
-        thisConfig.EXPERIMENTAL_TRIGGER_TIMER = true;
 
         // Never perform real NTP network I/O from the test suite.
         thisConfig.NTP_DRIFT_CHECK_SERVER = "";

--- a/src/util/ProtocolVersion.h
+++ b/src/util/ProtocolVersion.h
@@ -65,6 +65,9 @@ constexpr ProtocolVersion AUTO_RESTORE_PROTOCOL_VERSION = ProtocolVersion::V_23;
 
 constexpr ProtocolVersion FIRST_PROTOCOL_CAP71 = ProtocolVersion::V_27;
 
+constexpr ProtocolVersion CONSENSUS_CLOSE_TIME_TRIGGER_PROTOCOL_VERSION =
+    ProtocolVersion::V_28;
+
 #ifdef CAP_0083
 constexpr ProtocolVersion EMPTY_TX_SET_PROTOCOL_VERSION = ProtocolVersion::V_28;
 #else


### PR DESCRIPTION
# Description

This enables the new trigger timer on the protocol 28 boundary. While we had discussed the potential for this to be a non-protocol upgrade, and just ask operators to switch at around the same time, we've received slow response times historically from tier 1, which could leave the network in a degraded state. This is the safest way to land the change.

I've also added a flag that, when set, forces validators to use the old timer after the p28 upgrade. In the event that we see an unexpected perf issue after the upgrade, we can instruct operators to set this flag to roll back the change without a protocol upgrade. Finally, I also added an upgrade path test, and fixed some flakey asserts. Specifically, in the node drift tests, we assert that the drifting node detects it's drift and falls back to the old timer. However, if the drifting node's timer is externalized as the closeTime, the non-drifting nodes fall back, as they think they are drifting relative to the rest of the network. This is safe behavior, but the test would sometimes fail based on leader schedules.  

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
