### PR TITLE
Fix race condition in rebuildInMemorySorobanStateForTesting

### DIFF
--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -896,6 +896,13 @@ LedgerManagerImpl::getInMemorySorobanStateForTesting()
 void
 LedgerManagerImpl::rebuildInMemorySorobanStateForTesting(uint32_t ledgerVersion)
 {
+    // Make sure we don't race on an in-progress compilation.
+    if (mApplyState.isCompilationRunning())
+    {
+        mApplyState.finishPendingCompilation();
+        mApplyState.markEndOfSetupPhase();
+    }
+
     mApplyState.resetToSetupPhase();
     mApplyState.getInMemorySorobanStateForTesting().clearForTesting();
     mApplyState.populateInMemorySorobanState();


### PR DESCRIPTION
# Description

Fixes a flaky test I think I ran into on an unrelated [PR](https://github.com/stellar/stellar-core/actions/runs/29378709185/job/87327140083?pr=5350). It looks like we can call the test only module cache rebuild function while a real, background module cache build is under way, causing an assert failure. This just makes sure we finish any in-progress builds before calling the test reset function.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
