### PR TITLE
Add a new CI builder that builds fuzz targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
 
   complete:
     if: always()
-    needs: [static-checks, build-linux, build-mac]
+    needs: [static-checks, build-linux, build-linux-fuzz-targets, build-mac]
     runs-on:
       - namespace-profile-noble-24-04-stellar-core-x64-small
     steps:
@@ -193,6 +193,98 @@ jobs:
         if: ${{ success() && steps.check-last-tested-commit.outputs.skip != 'true' }}
         run: |
           echo "${{ github.sha }}" > "build-${{matrix.toolchain}}-${{matrix.protocol}}/.last-tested-commit-sha"
+
+
+  build-linux-fuzz-targets:
+    if: github.event.repository.visibility != 'private'
+    runs-on:
+      - namespace-profile-noble-24-04-stellar-core-x64-large;overrides.cache-tag=config-clang-libfuzzer
+    steps:
+      - name: Checkout with Namespace Git mirrors cache
+        uses: namespacelabs/nscloud-checkout-action@v7
+        with:
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Configure Namespace cache volume
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          path: |
+            ~/.cargo
+            build-clang-libfuzzer
+
+      - name: Check if commit already tested
+        id: check-last-tested-commit
+        run: |
+          LAST_TESTED_COMMIT_SHA_FILE="build-clang-libfuzzer/.last-tested-commit-sha"
+          if [ -f "$LAST_TESTED_COMMIT_SHA_FILE" ] && [ "$(cat "$LAST_TESTED_COMMIT_SHA_FILE")" = "${{ github.sha }}" ]; then
+            echo "Commit ${{ github.sha }} already tested successfully, skipping build"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Install rustup
+        if: steps.check-last-tested-commit.outputs.skip != 'true'
+        run: ./install-rust.sh
+
+      - name: Install rustup components
+        if: steps.check-last-tested-commit.outputs.skip != 'true'
+        run: rustup component add rustfmt
+
+      - uses: stellar/binaries@v50
+        if: steps.check-last-tested-commit.outputs.skip != 'true'
+        with:
+          name: cargo-cache
+          version: 0.8.3
+
+      - uses: stellar/binaries@v50
+        if: steps.check-last-tested-commit.outputs.skip != 'true'
+        with:
+          name: cargo-sweep
+          version: 0.7.0
+
+      # Restore original modification time of files based on the date of the most
+      # recent commit that modified them as mtimes affect the Go test cache.
+      - name: Restore modification time of checkout files
+        if: steps.check-last-tested-commit.outputs.skip != 'true'
+        shell: bash
+        run: |
+          # Set a base, fixed modification time of all directories.
+          # git-restore-mtime doesn't set the mtime of all directories.
+          # (see https://github.com/MestreLion/git-tools/issues/47 for details)
+          touch -m -t '201509301646' $(find . -type d -not -path '.git/*')
+          # Restore original modification time from git. git clone sets the
+          # modification time to the current time, but Go tests that access fixtures
+          # get invalidated if their modification times change.
+          #
+          # Note: git-restore-mtime needs to be baked into the image we're
+          # running on.
+          git restore-mtime
+
+      - name: Build fuzz targets
+        if: steps.check-last-tested-commit.outputs.skip != 'true'
+        run: |
+          export CC=clang
+          export CXX=clang++
+          export CFLAGS="-g -fsanitize=fuzzer-no-link,address"
+          export CXXFLAGS="-g -fsanitize=fuzzer-no-link,address"
+          export LIB_FUZZING_ENGINE="-fsanitize=fuzzer"
+          export OUT=./fuzz-out
+          rm -rf fuzz-out
+          mkdir fuzz-out
+          ./build-fuzz.sh
+
+      - name: Check that some fuzz targets were built
+        if: steps.check-last-tested-commit.outputs.skip != 'true' && hashFiles('fuzz-out/fuzz_*') == ''
+        run: exit 1
+
+      - name: Record successful test commit
+        if: ${{ success() && steps.check-last-tested-commit.outputs.skip != 'true' }}
+        run: |
+          echo "${{ github.sha }}" > "build-clang-libfuzzer/.last-tested-commit-sha"
+
+
 
   build-mac:
     if: github.event.repository.visibility != 'private'

--- a/build-fuzz.sh
+++ b/build-fuzz.sh
@@ -5,87 +5,49 @@
 
 # Build script for oss-fuzz integration.
 #
-# This script builds fuzz targets for use with libfuzzer, honggfuzz, or AFL++.
-# It follows the oss-fuzz build conventions:
-# - Uses environment variables: $CC, $CXX, $CFLAGS, $CXXFLAGS, $LIB_FUZZING_ENGINE, $OUT
-# - Produces binaries in $OUT
-# - Creates seed corpus archives as fuzz_<target>_seed_corpus.zip
-#
-# For local testing with libfuzzer:
-#   export CC=clang
-#   export CXX=clang++
-#   export CFLAGS="-g -fsanitize=fuzzer-no-link,address"
-#   export CXXFLAGS="-g -fsanitize=fuzzer-no-link,address"
-#   export LIB_FUZZING_ENGINE="-fsanitize=fuzzer"
-#   export OUT=./fuzz-out
-#   ./build-fuzz.sh
-#
-# For honggfuzz (local):
-#   export CC=hfuzz-clang
-#   export CXX=hfuzz-clang++
-#   export LIB_FUZZING_ENGINE=""  # honggfuzz provides its own
-#   export OUT=./fuzz-out
-#   ./build-fuzz.sh
-#
-# Outputs:
-#   $OUT/fuzz_tx                    - Transaction application fuzzer
-#   $OUT/fuzz_overlay               - Overlay message fuzzer
-#   $OUT/fuzz_tx_seed_corpus.zip    - Seed corpus for tx fuzzer
-#   $OUT/fuzz_overlay_seed_corpus.zip - Seed corpus for overlay fuzzer
+# This script is copy of the "build.sh" integration script
+# that OSS-fuzz uses to build fuzz targets for running on their infrastructure
+# very slightly modified to work with our CI (using ccache + cached build dirs)
 
-set -eux
-
-# Get source directory (where this script lives)
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SRC="${SRC:-$SCRIPT_DIR}"
-
-# Create output directory
-: "${OUT:=./fuzz-out}"
+SRC_DIR="$(pwd)"
+OUT="${OUT:-$SRC_DIR/fuzz-out}"
+if [[ "$OUT" != /* ]]; then
+    OUT="$SRC_DIR/$OUT"
+fi
 mkdir -p "$OUT"
 
-# Change to source directory
-cd "$SRC"
+mkdir -p "build-clang-libfuzzer"
+cd "build-clang-libfuzzer"
 
-# Run autogen if configure doesn't exist
-if [ ! -f configure ]; then
-    ./autogen.sh
+#### ccache config
+export CCACHE_DIR="$(pwd)/.ccache"
+export CCACHE_COMPRESS=true
+export CCACHE_COMPRESSLEVEL=9
+# cache size should be large enough for a full build
+export CCACHE_MAXSIZE=800M
+export CCACHE_CPP2=true
+
+# periodically check to see if caches are old and purge them if so
+CACHE_MAX_DAYS=30
+if [ -d "${CCACHE_DIR}" ] ; then
+    if [ -n "$(find ${CCACHE_DIR} -mtime +$CACHE_MAX_DAYS -print -quit)" ] ; then
+        echo Purging old cache dirs "${CCACHE_DIR}" ./target "${HOME}/.cargo/registry" "${HOME}/.cargo/git"
+        rm -rf "${CCACHE_DIR}" ./target "${HOME}/.cargo/registry" "${HOME}/.cargo/git"
+    fi
 fi
 
-# Configure with fuzzing support
-# The --enable-fuzz flag:
-#   - Adds FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION define
-#   - Sets FUZZING_LIBS from LIB_FUZZING_ENGINE
-#   - Enables building of fuzz_* targets (via ENABLE_FUZZ in Makefile.am)
-./configure \
-    --enable-fuzz \
-    --without-postgres
+ccache -p
+ccache -s
+ccache -z
 
-# Build fuzz targets using automake rules
-# This builds fuzz_tx, fuzz_overlay, and Soroban targets with proper FUZZ_TARGET_NAME defines
-make -j"$(nproc)" fuzz-targets
+. "${HOME}/.cargo/env"
+(cd "${SRC_DIR}" && ./autogen.sh)
 
-# Install fuzz targets to $OUT
-# Install all fuzz targets (C++ and Soroban)
-for target in tx overlay soroban_expr soroban_wasmi; do
-    if [ -f "src/fuzz_$target" ]; then
-        cp "src/fuzz_$target" "$OUT/"
-    fi
-done
-
-# Generate and package seed corpus (if stellar-core supports it)
-# For now, create empty corpus directories
-mkdir -p corpus/tx corpus/overlay corpus/soroban_expr corpus/soroban_wasmi
-
-# Create corpus archives (even if empty, oss-fuzz expects them)
-# Create corpus archives for all targets (even if empty, oss-fuzz expects them)
-for target in tx overlay soroban_expr soroban_wasmi; do
-    if [ -d "corpus/$target" ] && [ "$(ls -A "corpus/$target" 2>/dev/null)" ]; then
-        (cd "corpus/$target" && zip -q "$OUT/fuzz_${target}_seed_corpus.zip" *)
-    else
-        # Create empty zip if no corpus
-        touch empty && zip -q "$OUT/fuzz_${target}_seed_corpus.zip" empty && rm empty
-    fi
-done
-
-echo "Build complete. Fuzz targets in $OUT:"
-ls -la "$OUT"
+# NB: the oss-fuzz driver injects sanitizer flags to CFLAGS, CXXFLAGS
+# and RUSTFLAGS. This overlaps with our own support for sanitizers,
+# but not fatally. It does require us to enable the unified rust
+# build.
+"${SRC_DIR}/configure" --enable-fuzz --enable-unified-rust-unsafe-for-production --disable-postgres --enable-ccache
+make -j $(nproc)
+make -C src fuzz-targets
+cp src/fuzz_* "${OUT}"


### PR DESCRIPTION
This adds a new CI builder that builds with the configuration necessary to build the fully-executable fuzz targets -- not just the fuzz-target _logic_ (which is already built and smoke-tested as part of the unit test suite) -- but the actual instrumented-for-greybox-fuzzing build, with unified-build mode, linked against a fuzz driver and ready to run.

This is the configuration that OSS-fuzz runs, and it runs a build script that's lightly adapted from the build script OSS-fuzz runs. This is intended to "keep the OSS-fuzz build building".