### PR TITLE
Introduce a thread pool for batch execution of parallel CPU-bound tasks.

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -626,6 +626,7 @@ exit /b 0
     <ClCompile Include="..\..\src\main\AppConnector.cpp" />
     <ClCompile Include="..\..\src\main\BannedAccountsPersistor.cpp" />
     <ClCompile Include="..\..\src\main\Diagnostics.cpp" />
+    <ClCompile Include="..\..\src\main\NtpProbe.cpp" />
     <ClCompile Include="..\..\src\main\QueryServer.cpp" />
     <ClCompile Include="..\..\src\main\SettingsUpgradeUtils.cpp" />
     <ClCompile Include="..\..\src\main\test\ApplicationUtilsTests.cpp" />
@@ -759,6 +760,7 @@ exit /b 0
     <ClCompile Include="..\..\src\transactions\TransactionUtils.cpp" />
     <ClCompile Include="..\..\src\transactions\TrustFlagsOpFrameBase.cpp" />
     <ClCompile Include="..\..\src\util\Backtrace.cpp" />
+    <ClCompile Include="..\..\src\util\BatchExecutor.cpp" />
     <ClCompile Include="..\..\src\util\BinaryFuseFilter.cpp" />
     <ClCompile Include="..\..\src\util\DebugMetaUtils.cpp" />
     <ClCompile Include="..\..\src\util\FileSystemException.cpp" />
@@ -1092,6 +1094,7 @@ exit /b 0
     <ClInclude Include="..\..\src\main\AppConnector.h" />
     <ClInclude Include="..\..\src\main\BannedAccountsPersistor.h" />
     <ClInclude Include="..\..\src\main\Diagnostics.h" />
+    <ClInclude Include="..\..\src\main\NtpProbe.h" />
     <ClInclude Include="..\..\src\main\QueryServer.h" />
     <ClInclude Include="..\..\src\main\SettingsUpgradeUtils.h" />
     <ClInclude Include="..\..\src\overlay\BanManager.h" />
@@ -1182,6 +1185,7 @@ exit /b 0
     <ClInclude Include="..\..\src\transactions\TransactionUtils.h" />
     <ClInclude Include="..\..\src\transactions\TrustFlagsOpFrameBase.h" />
     <ClInclude Include="..\..\src\util\Backtrace.h" />
+    <ClInclude Include="..\..\src\util\BatchExecutor.h" />
     <ClInclude Include="..\..\src\util\BinaryFuseFilter.h" />
     <ClInclude Include="..\..\src\util\BufferedAsioCerealOutputArchive.h" />
     <ClInclude Include="..\..\src\util\DebugMetaUtils.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -462,9 +462,6 @@
     <ClCompile Include="..\..\src\work\test\WorkTests.cpp">
       <Filter>work\tests</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\test\fuzz\FuzzMain.cpp">
-      <Filter>test\fuzz</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\test\fuzz\FuzzRegressionTests.cpp">
       <Filter>test\fuzz</Filter>
     </ClCompile>
@@ -1458,6 +1455,12 @@
     </ClCompile>
     <ClCompile Include="..\..\src\test\CovMark.cpp">
       <Filter>test</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\BatchExecutor.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\NtpProbe.cpp">
+      <Filter>main</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -2589,6 +2592,12 @@
     </ClInclude>
     <ClInclude Include="..\..\src\test\CovMark.h">
       <Filter>test</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\BatchExecutor.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\NtpProbe.h">
+      <Filter>main</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -40,6 +40,7 @@
 #include "transactions/TransactionFrameBase.h"
 #include "transactions/TransactionMeta.h"
 #include "transactions/TransactionUtils.h"
+#include "util/BatchExecutor.h"
 #include "util/DebugMetaUtils.h"
 #include "util/Decoder.h"
 #include "util/Fs.h"
@@ -2639,42 +2640,37 @@ LedgerManagerImpl::applySorobanStageClustersInParallel(
 {
     ZoneScoped;
 
-    std::vector<std::unique_ptr<ThreadParallelApplyLedgerState>> threadStates;
-    std::vector<std::future<std::unique_ptr<ThreadParallelApplyLedgerState>>>
-        threadFutures;
-
     DeactivateScopeGuard globalStateDeactivateGuard(globalState);
 
+    std::vector<
+        std::function<std::unique_ptr<ThreadParallelApplyLedgerState>()>>
+        tasks;
+    tasks.reserve(stage.numClusters());
     for (size_t i = 0; i < stage.numClusters(); ++i)
     {
-        auto const& cluster = stage.getCluster(i);
-        auto threadStatePtr = std::make_unique<ThreadParallelApplyLedgerState>(
-            app, globalState, cluster, i);
-        threadFutures.emplace_back(std::async(
-            std::launch::async, &LedgerManagerImpl::applyThread, this,
-            std::ref(app), std::move(threadStatePtr), std::cref(cluster),
-            std::cref(config), ledgerInfo, sorobanBasePrngSeed));
+        tasks.emplace_back([this, &app, &globalState, &stage, i, &config,
+                            &ledgerInfo, &sorobanBasePrngSeed]() {
+            auto const& cluster = stage.getCluster(i);
+            auto threadStatePtr =
+                std::make_unique<ThreadParallelApplyLedgerState>(
+                    app, globalState, cluster, i);
+            return applyThread(app, std::move(threadStatePtr), cluster, config,
+                               ledgerInfo, sorobanBasePrngSeed);
+        });
     }
 
-    for (auto& threadFuture : threadFutures)
+    try
     {
-        releaseAssert(threadFuture.valid());
-        try
-        {
-            auto futureResult = threadFuture.get();
-            threadStates.emplace_back(std::move(futureResult));
-        }
-        catch (std::exception const& e)
-        {
-            printErrorAndAbort("Exception on apply thread: ", e.what());
-        }
-        catch (...)
-        {
-            printErrorAndAbort("Unknown exception on apply thread");
-        }
+        return app.getBatchExecutor().executeBatch(std::move(tasks));
     }
-    threadFutures.clear();
-    return threadStates;
+    catch (std::exception const& e)
+    {
+        printErrorAndAbort("Exception on apply thread: ", e.what());
+    }
+    catch (...)
+    {
+        printErrorAndAbort("Unknown exception on apply thread");
+    }
 }
 
 void

--- a/src/main/AppConnector.cpp
+++ b/src/main/AppConnector.cpp
@@ -169,6 +169,12 @@ AppConnector::threadIsType(Application::ThreadType type) const
     return mApp.threadIsType(type);
 }
 
+BatchExecutor&
+AppConnector::getBatchExecutor()
+{
+    return mApp.getBatchExecutor();
+}
+
 ImmutableLedgerView
 AppConnector::copyImmutableLedgerView()
 {

--- a/src/main/AppConnector.h
+++ b/src/main/AppConnector.h
@@ -22,6 +22,7 @@ class SorobanMetrics;
 class SearchableHotArchiveBucketListSnapshot;
 struct LedgerTxnDelta;
 class CapacityTrackedMessage;
+class BatchExecutor;
 
 // Helper class to isolate access to Application; all function helpers must
 // either be called from main or be thread-safe
@@ -68,6 +69,7 @@ class AppConnector
     checkScheduledAndCache(std::shared_ptr<CapacityTrackedMessage> msgTracker);
     SorobanNetworkConfig const& getLastClosedSorobanNetworkConfig() const;
     bool threadIsType(Application::ThreadType type) const;
+    BatchExecutor& getBatchExecutor();
 
     MetricsRegistry& getMetrics() const;
 

--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -37,6 +37,7 @@ class WorkScheduler;
 class BanManager;
 class BannedAccountsPersistor;
 class StatusManager;
+class BatchExecutor;
 class AbstractLedgerTxnParent;
 class BasicWork;
 enum class LoadGenMode;
@@ -269,6 +270,13 @@ class Application
                                      std::string jobName) = 0;
     virtual void postOnLedgerCloseThread(std::function<void()>&& f,
                                          std::string jobName) = 0;
+
+    // Get the shared executor for running batches of CPU-bound tasks in
+    // parallel. This is mostly used in the apply path, though it may also be
+    // used for other CPU-bound tasks, as long as they don't overlap with the
+    // apply path (e.g. building the transaction set for the next ledger).
+    // Batches are blocking and must be run one at a time.
+    virtual BatchExecutor& getBatchExecutor() = 0;
 
     // Perform actions necessary to transition from BOOTING_STATE to other
     // states. In particular: either reload or reinitialize the database, and

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -53,6 +53,7 @@
 #include "overlay/OverlayManagerImpl.h"
 #include "process/ProcessManager.h"
 #include "transactions/SignatureChecker.h"
+#include "util/BatchExecutor.h"
 #include "util/GlobalChecks.h"
 #include "util/JitterInjection.h"
 #include "util/LogSlowExecution.h"
@@ -109,6 +110,7 @@ ApplicationImpl::ApplicationImpl(VirtualClock& clock, Config const& cfg)
               : nullptr)
     , mWorkerThreads()
     , mEvictionThread()
+    , mBatchExecutor(std::make_unique<BatchExecutor>())
     , mStopSignals(clock.getIOContext(), SIGINT)
     , mStarted(false)
     , mStopping(false)
@@ -1539,6 +1541,13 @@ ApplicationImpl::getLedgerCloseIOContext()
 {
     releaseAssert(mLedgerCloseIOContext);
     return *mLedgerCloseIOContext;
+}
+
+BatchExecutor&
+ApplicationImpl::getBatchExecutor()
+{
+    releaseAssert(mBatchExecutor);
+    return *mBatchExecutor;
 }
 
 void

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -90,6 +90,8 @@ class ApplicationImpl : public Application
     virtual asio::io_context& getOverlayIOContext() override;
     virtual asio::io_context& getLedgerCloseIOContext() override;
 
+    virtual BatchExecutor& getBatchExecutor() override;
+
     virtual void postOnMainThread(std::function<void()>&& f, std::string&& name,
                                   Scheduler::ActionType type) override;
     virtual void postOnBackgroundThread(std::function<void()>&& f,
@@ -238,6 +240,8 @@ class ApplicationImpl : public Application
     // higher-priority worker thread type, but for now we only need a single
     // thread for eviction scans.
     std::unique_ptr<std::thread> mEvictionThread;
+
+    std::unique_ptr<BatchExecutor> mBatchExecutor;
 
     // NOTE: It is important that this map not be updated outside of the
     // constructor. `unordered_map` is safe for multiple threads to read from,

--- a/src/transactions/ParallelApplyUtils.cpp
+++ b/src/transactions/ParallelApplyUtils.cpp
@@ -308,7 +308,8 @@ GlobalParallelApplyLedgerState::GlobalParallelApplyLedgerState(
                          mInMemorySorobanState.getLedgerSeq());
     releaseAssertOrThrow(ltx.getHeader().ledgerSeq ==
                          mLCLApplyView.getLedgerSeq() + 1);
-
+    releaseAssert(threadIsMain() ||
+                  app.threadIsType(Application::ThreadType::APPLY));
     // From now on, we will be using globalState, liveSnapshots, and the
     // hotArchive to collect all entries. Before we continue though, we need to
     // load into the globalEntryMap any classic entries that have been modified
@@ -327,9 +328,6 @@ GlobalParallelApplyLedgerState::
         AppConnector& app, AbstractLedgerTxn& ltx,
         std::vector<ApplyStage> const& stages)
 {
-    releaseAssert(threadIsMain() ||
-                  app.threadIsType(Application::ThreadType::APPLY));
-
     auto fetchInMemoryClassicEntries =
         [&](xdr::xvector<LedgerKey> const& keys) {
             for (auto const& lk : keys)
@@ -564,9 +562,6 @@ ThreadParallelApplyLedgerState::collectClusterFootprintEntriesFromGlobal(
     AppConnector& app, GlobalParallelApplyLedgerState const& global,
     Cluster const& cluster)
 {
-    releaseAssert(threadIsMain() ||
-                  app.threadIsType(Application::ThreadType::APPLY));
-
     // As part of the initialization of this thread state, we need to
     // collect all the keys that are in the global state map. For any keys
     // we need not in the global state, we will fetch them from the live
@@ -751,7 +746,6 @@ ThreadParallelApplyLedgerState::upsertEntry(
 void
 ThreadParallelApplyLedgerState::eraseEntry(LedgerKey const& key)
 {
-
     auto parAppEntry =
         ThreadParallelApplyEntry::dirty(scopeAdoptEntryOpt(std::nullopt));
     mThreadEntryMap.insert_or_assign(key, parAppEntry);

--- a/src/util/BatchExecutor.cpp
+++ b/src/util/BatchExecutor.cpp
@@ -1,0 +1,233 @@
+// Copyright 2026 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "util/BatchExecutor.h"
+#include "util/GlobalChecks.h"
+#include "util/Logging.h"
+
+#include <string>
+
+#ifdef __linux__
+#include <fstream>
+#include <pthread.h>
+#include <sched.h>
+#include <unordered_set>
+#endif
+
+namespace stellar
+{
+
+namespace
+{
+// Returns one logical CPU id per physical core, restricted to the CPUs this
+// process is actually allowed to run on. Empty on failure or on non-Linux
+// platforms.
+std::vector<unsigned>
+physicalCoreRepresentatives()
+{
+    std::vector<unsigned> res;
+#ifdef __linux__
+    cpu_set_t affinity;
+    CPU_ZERO(&affinity);
+    if (sched_getaffinity(0, sizeof(affinity), &affinity) != 0)
+    {
+        // Affinity unavailable (e.g. more than CPU_SETSIZE logical CPUs); skip
+        // pinning rather than guess.
+        return {};
+    }
+
+    // Walk the allowed CPUs in ascending order and keep the first (hence
+    // smallest) allowed sibling of each physical core. thread_siblings_list
+    // begins with the smallest sibling id, which is a stable per-core
+    // identifier independent of the affinity mask, so it lets us collapse the
+    // logical CPUs of one core down to a single representative.
+    std::unordered_set<unsigned> seenCores;
+    for (unsigned cpu = 0; cpu < CPU_SETSIZE; ++cpu)
+    {
+        if (!CPU_ISSET(cpu, &affinity))
+        {
+            continue;
+        }
+        std::ifstream in("/sys/devices/system/cpu/cpu" + std::to_string(cpu) +
+                         "/topology/thread_siblings_list");
+        // The list is formatted like "0,16" or "0-1"; the first (smallest)
+        // entry is the leading integer either way and identifies the core.
+        unsigned coreId;
+        if (!(in >> coreId))
+        {
+            // Topology is unreadable for a CPU we are allowed to use, so skip
+            // pinning rather than guess.
+            return {};
+        }
+        if (seenCores.insert(coreId).second)
+        {
+            res.push_back(cpu);
+        }
+    }
+#endif
+    return res;
+}
+} // namespace
+
+BatchExecutor::BatchExecutor()
+{
+    mPinCpus = physicalCoreRepresentatives();
+    if (mPinCpus.empty())
+    {
+        CLOG_WARNING(
+            Perf,
+            "CPU topology is unavailable, not pinning batch workers. This may "
+            "reduce the performance of the node.");
+    }
+    else
+    {
+        for (size_t i = 0; i < mPinCpus.size(); ++i)
+        {
+            CLOG_DEBUG(Perf, "Batch worker physical core {} maps to CPU {}", i,
+                       mPinCpus[i]);
+        }
+    }
+}
+
+BatchExecutor::~BatchExecutor()
+{
+    {
+        std::lock_guard<std::mutex> guard(mMutex);
+        mDestroying = true;
+    }
+    mCondition.notify_all();
+    for (auto& worker : mWorkers)
+    {
+        worker.join();
+    }
+}
+
+void
+BatchExecutor::ensureWorkers(size_t count)
+{
+    while (mWorkers.size() < count)
+    {
+        size_t index = mWorkers.size();
+        uint64_t batchId = mBatchId;
+        mWorkers.emplace_back(
+            [this, index, batchId]() { workerLoop(index, batchId); });
+        pinWorker(index);
+    }
+}
+
+void
+BatchExecutor::pinWorker(size_t index)
+{
+#ifdef __linux__
+    if (mPinCpus.empty())
+    {
+        return;
+    }
+    if (index >= mPinCpus.size())
+    {
+        CLOG_WARNING(
+            Perf,
+            "Not enough physical cores to pin batch executor worker {} - the "
+            "network configuration demands more physical cores than available. "
+            "This may reduce the performance of the node.",
+            index);
+    }
+    unsigned cpu = mPinCpus.at(index % mPinCpus.size());
+    cpu_set_t set;
+    CPU_ZERO(&set);
+    CPU_SET(cpu, &set);
+    int rc = pthread_setaffinity_np(mWorkers.at(index).native_handle(),
+                                    sizeof(set), &set);
+    if (rc != 0)
+    {
+        CLOG_WARNING(Perf, "Failed to pin batch worker {} to CPU {}: {}", index,
+                     cpu, rc);
+    }
+#else
+    (void)index;
+#endif
+}
+
+void
+BatchExecutor::runBatchImpl(size_t numTasks,
+                            std::function<void(size_t)> const& runTask)
+{
+
+    std::exception_ptr firstError;
+    {
+        std::unique_lock<std::mutex> lock(mMutex);
+        ensureWorkers(numTasks);
+
+        // Publish the batch and wake the participating workers.
+        mRunTask = &runTask;
+        mWorkersRequested = numTasks;
+        mWorkersDone = 0;
+        mFirstError = nullptr;
+        ++mBatchId;
+        mCondition.notify_all();
+
+        // Block until every participating worker has finished its task.
+        mCondition.wait(lock,
+                        [this]() { return mWorkersDone == mWorkersRequested; });
+
+        firstError = mFirstError;
+        // Drop references to caller-owned state now that the batch is done.
+        mRunTask = nullptr;
+        mFirstError = nullptr;
+    }
+    if (firstError)
+    {
+        std::rethrow_exception(firstError);
+    }
+}
+
+void
+BatchExecutor::workerLoop(size_t workerIndex, uint64_t initBatchId)
+{
+    uint64_t lastBatchId = initBatchId;
+    while (true)
+    {
+        std::function<void(size_t)> const* runTask = nullptr;
+        {
+            std::unique_lock<std::mutex> lock(mMutex);
+            mCondition.wait(lock, [this, lastBatchId]() {
+                return mDestroying || mBatchId != lastBatchId;
+            });
+            if (mDestroying)
+            {
+                return;
+            }
+            lastBatchId = mBatchId;
+            if (workerIndex >= mWorkersRequested)
+            {
+                continue;
+            }
+            runTask = mRunTask;
+        }
+
+        // Run the task outside the lock so tasks execute in parallel.
+        std::exception_ptr error;
+        try
+        {
+            (*runTask)(workerIndex);
+        }
+        catch (...)
+        {
+            error = std::current_exception();
+        }
+
+        {
+            std::lock_guard<std::mutex> guard(mMutex);
+            if (error && !mFirstError)
+            {
+                mFirstError = error;
+            }
+            if (++mWorkersDone == mWorkersRequested)
+            {
+                mCondition.notify_all();
+            }
+        }
+    }
+}
+}

--- a/src/util/BatchExecutor.h
+++ b/src/util/BatchExecutor.h
@@ -1,0 +1,126 @@
+#pragma once
+
+// Copyright 2026 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "lib/util/finally.h"
+#include "util/GlobalChecks.h"
+#include "util/NonCopyable.h"
+
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <functional>
+#include <mutex>
+#include <thread>
+#include <type_traits>
+#include <vector>
+
+namespace stellar
+{
+
+// Executes batches of CPU-bound tasks in parallel on a pool of worker threads.
+//
+// Use this to speed up trivially parallelizable compute-heavy workloads.
+//
+// The executor pins the worker threads to physical cores. It may only run
+// a single batch of tasks at a time, and there should be only a single executor
+// instance per app, or else the execution would have unexpectedly degraded
+// performance due to oversubscription of physical cores.
+class BatchExecutor : private NonMovableOrCopyable
+{
+  public:
+    BatchExecutor();
+    // Destroys the executor and joins all worker threads.
+    // No batch should be in progress - batch execution is not supposed to be
+    // async.
+    ~BatchExecutor();
+
+    // Executes every task in `tasks` in parallel and returns their results in
+    // the same order.
+    //
+    // Every task will always be executed by a separate worker thread. Passing
+    // more tasks than physical cores is allowed, but will result in performance
+    // degradation.
+    //
+    // Only a single thread may call executeBatch at a time (enforced by an
+    // assertion), but the executor may be reused for multiple batches scheduled
+    // from arbitrary threads over its lifetime.
+    //
+    // Rethrows the first exception captured from a `runTask` invocation,
+    // if any.
+    template <typename T>
+    std::vector<T> executeBatch(std::vector<std::function<T()>> tasks);
+
+  private:
+    // Runs `runTask(0)..runTask(numTasks-1)` across `numTasks` pinned workers
+    // and blocks until all complete. Rethrows the first exception captured from
+    // a `runTask` invocation, if any. Type-erased so the worker loop never
+    // depends on the task result type.
+    void runBatchImpl(size_t numTasks,
+                      std::function<void(size_t)> const& runTask);
+    // Task execution loop running on every worker thread.
+    void workerLoop(size_t index, uint64_t initialGeneration);
+    // Grows the pool to at least `count` workers, pinning each new one to a
+    // physical core if possible.
+    void ensureWorkers(size_t count);
+    // Pins worker `index` to its designated physical core. No-op on non-Linux
+    // platforms or when the CPU topology is unavailable.
+    void pinWorker(size_t index);
+
+    // Plain std::mutex (rather than the annotated wrapper) as it has to work
+    // with std::condition_variable.
+    std::mutex mMutex;
+    std::condition_variable mCondition;
+    std::vector<std::thread> mWorkers;
+    // One logical CPU per physical core; empty if pinning is unavailable. Set
+    // once in the constructor and immutable afterwards.
+    std::vector<unsigned> mPinCpus;
+
+    // Task that is being currently executed by the workers.
+    std::function<void(size_t)> const* mRunTask{nullptr};
+    size_t mWorkersRequested{0};
+    size_t mWorkersDone{0};
+    std::exception_ptr mFirstError;
+    // Index of the task batch, workers wake when it changes.
+    uint64_t mBatchId{0};
+    bool mDestroying{false};
+    // Marks that a batch is currently running, to prevent concurrent
+    // executeBatch calls.
+    std::atomic<bool> mBatchRunning{false};
+};
+
+template <typename T>
+std::vector<T>
+BatchExecutor::executeBatch(std::vector<std::function<T()>> tasks)
+{
+    // NB: The default-constructible requirement is not strictly necessary and
+    // may be lifted if necessary, but that would require a more complex
+    // implementation.
+    static_assert(std::is_default_constructible_v<T>,
+                  "BatchExecutor::executeBatch result type must be "
+                  "default-constructible");
+    static_assert(!std::is_same_v<T, bool>,
+                  "BatchExecutor::executeBatch does not support bool results");
+
+    // Only one executeBatch may be in progress at a time.
+    releaseAssert(!mBatchRunning.exchange(true));
+    auto resetRunning = gsl::finally([this]() { mBatchRunning.store(false); });
+
+    std::vector<T> results(tasks.size());
+    if (tasks.empty())
+    {
+        return results;
+    }
+    // Type-erase the typed tasks/results into a single index-based functor so
+    // the worker loop is independent of T.
+    std::function<void(size_t)> runTask = [&tasks, &results](size_t i) {
+        results[i] = tasks[i]();
+    };
+    runBatchImpl(tasks.size(), runTask);
+    return results;
+}
+}

--- a/src/util/test/BatchExecutorTests.cpp
+++ b/src/util/test/BatchExecutorTests.cpp
@@ -1,0 +1,131 @@
+// Copyright 2026 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "test/Catch2.h"
+#include "util/BatchExecutor.h"
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <stdexcept>
+
+using namespace stellar;
+
+namespace
+{
+template <typename T>
+std::vector<std::function<T()>>
+makeTasks(int n, std::function<T(int)> const& body)
+{
+    std::vector<std::function<T()>> tasks;
+    tasks.reserve(n);
+    for (int i = 0; i < n; ++i)
+    {
+        tasks.emplace_back([body, i]() { return body(i); });
+    }
+    return tasks;
+}
+}
+
+TEST_CASE("BatchExecutor basic tests", "[batchexecutor]")
+{
+    BatchExecutor exec;
+    int const batchSize = 7;
+    SECTION("empty batch is a no-op")
+    {
+        auto results = exec.executeBatch<int>({});
+        REQUIRE(results.empty());
+    }
+
+    SECTION("results are in task order")
+    {
+        auto results = exec.executeBatch(
+            makeTasks<int>(batchSize, [](int i) { return i * i; }));
+        REQUIRE(results.size() == batchSize);
+        for (int i = 0; i < batchSize; ++i)
+        {
+            REQUIRE(results[i] == i * i);
+        }
+    }
+
+    SECTION("tasks run exactly once")
+    {
+        std::vector<std::atomic<int>> counts(batchSize);
+        for (auto& c : counts)
+        {
+            c.store(0);
+        }
+        auto tasks = makeTasks<int>(
+            batchSize, [&counts](int i) { return counts[i].fetch_add(1); });
+        auto results = exec.executeBatch(std::move(tasks));
+        for (int i = 0; i < batchSize; ++i)
+        {
+            REQUIRE(counts[i].load() == 1);
+        }
+    }
+
+    SECTION("tasks run concurrently")
+    {
+        std::atomic<int> arrived{0};
+        std::atomic<bool> anyTimedOut{false};
+        auto tasks = makeTasks<int>(batchSize, [&](int i) -> int {
+            arrived.fetch_add(1);
+            auto deadline =
+                std::chrono::steady_clock::now() + std::chrono::seconds(10);
+            while (arrived.load() < batchSize)
+            {
+                if (std::chrono::steady_clock::now() > deadline)
+                {
+                    anyTimedOut.store(true);
+                    break;
+                }
+            }
+            return i;
+        });
+        auto results = exec.executeBatch(std::move(tasks));
+        REQUIRE_FALSE(anyTimedOut.load());
+        REQUIRE(arrived.load() == batchSize);
+    }
+
+    SECTION("task exceptions are rethrown after all finish")
+    {
+        std::atomic<int> ran{0};
+        auto tasks = makeTasks<int>(batchSize, [&](int i) -> int {
+            ran.fetch_add(1);
+            if (i == 2)
+            {
+                throw std::logic_error("error");
+            }
+            return i;
+        });
+        REQUIRE_THROWS_AS(exec.executeBatch(std::move(tasks)),
+                          std::logic_error);
+        REQUIRE(ran.load() == batchSize);
+
+        // Executor is still usable after a batch throws.
+        auto results = exec.executeBatch(
+            makeTasks<int>(batchSize, [](int i) { return i * i; }));
+        REQUIRE(results.size() == batchSize);
+        for (int i = 0; i < batchSize; ++i)
+        {
+            REQUIRE(results[i] == i * i);
+        }
+    }
+}
+
+TEST_CASE("BatchExecutor runs many successive batches", "[batchexecutor]")
+{
+    BatchExecutor exec;
+    uniform_int_distribution<> batchDistr(1, 25);
+    for (int round = 0; round < 100; ++round)
+    {
+        int const batchSize = batchDistr(Catch::rng());
+        auto results = exec.executeBatch(makeTasks<int>(
+            batchSize, [round](int i) { return round * 1000 + i; }));
+        for (int i = 0; i < batchSize; ++i)
+        {
+            REQUIRE(results[i] == round * 1000 + i);
+        }
+    }
+}


### PR DESCRIPTION
# Description

This introduced a new `BatchExecutor` class that uses a pool of physical CPU-pinned (if possible) workers to execute CPU-heavy workloads in parallel. Currently this is only used for the Soroban apply stage (which is already parallel), but in the followups we'll be able to use this for more apply flow stages (pre/post apply), as well as tasks outside of apply (like parallel tx set building).

Pinning the threads helps a lot with making per-thread runtime more even on machines with hyper-threading (which is probably pretty much every CPU out there). Pooling the threads is less impactful, but it helps a bit with the allocator churn.

While this is adding 'yet another' pool of workers, I've tried to make the interface invariants simple - the executor may only be used by a single thread at once, and the execution itself is blocking. Basically this is meant to be used in a similar fashion to one-off execution threads that we have now, but in a managed fashion.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
