### PR TITLE
Don't disable ASLR when re-running tests under LLDB, to work in CI

### DIFF
--- a/src/test/run-selftest-nopg
+++ b/src/test/run-selftest-nopg
@@ -22,6 +22,6 @@ R=$?
 if [[ $R -ne 0 ]] ; then
     echo "Test failed, rerunning with debugger"
     echo ./stellar-core test $STELLAR_CORE_TEST_PARAMS --base-instance $BASE_INSTANCE "$TESTS"
-    lldb -o 'r'  -o 'bt' -o 'exit' -- ./stellar-core test $STELLAR_CORE_TEST_PARAMS --base-instance $BASE_INSTANCE "$TESTS"
+    lldb -O 'settings set target.disable-aslr false' -o 'r'  -o 'bt' -o 'exit' -- ./stellar-core test $STELLAR_CORE_TEST_PARAMS --base-instance $BASE_INSTANCE "$TESTS"
 fi
 exit $R

--- a/src/test/run-selftest-pg
+++ b/src/test/run-selftest-pg
@@ -115,6 +115,6 @@ R=$?
 if [[ $R -ne 0 ]] ; then
     echo "Test failed, rerunning with debugger"
     echo ./stellar-core test $STELLAR_CORE_TEST_PARAMS --base-instance $BASE_INSTANCE "$TESTS"
-    lldb -o 'r'  -o 'bt' -o 'exit' -- ./stellar-core test $STELLAR_CORE_TEST_PARAMS --base-instance $BASE_INSTANCE "$TESTS"
+    lldb -O 'settings set target.disable-aslr false' -o 'r'  -o 'bt' -o 'exit' -- ./stellar-core test $STELLAR_CORE_TEST_PARAMS --base-instance $BASE_INSTANCE "$TESTS"
 fi
 exit $R


### PR DESCRIPTION
When tests fail in CI the runner tries to re-run the failing test under LLDB to get a backtrace. LLDB tries to disable ASLR on startup using personality(2) and this in turn doesn't work on most CI runners because it's a privileged operation and the container they're running in doesn't allow it, so rather than any useful backtrace diagnostics we get a failure like:

```
error: Cannot launch '/home/runner/work/stellar-core/stellar-core/build-gcc-current/src/stellar-core': personality set failed: Operation not permitted
```

This PR modifies how we run LLDB to tell it _not_ to try to disable ASLR, which means it won't fail, which means it _should_ be more likely to start and produce a backtrace.