### PR TITLE
Properly skip publishing if checkpoints are present, but publishing is disabled

### DIFF
--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -403,6 +403,11 @@ HistoryManagerImpl::publishQueuedHistory()
         return 0;
     }
 
+    if (!mApp.getHistoryArchiveManager().publishEnabled())
+    {
+        return 0;
+    }
+
 #ifdef BUILD_TESTS
     if (!mPublicationEnabled)
     {

--- a/src/historywork/PutSnapshotFilesWork.cpp
+++ b/src/historywork/PutSnapshotFilesWork.cpp
@@ -11,6 +11,7 @@
 #include "historywork/PutFilesWork.h"
 #include "historywork/PutHistoryArchiveStateWork.h"
 #include "main/Application.h"
+#include "main/ErrorMessages.h"
 #include "util/Fs.h"
 #include "work/WorkSequence.h"
 #include <Tracy.hpp>
@@ -94,8 +95,18 @@ PutSnapshotFilesWork::doWork()
     }
 
     // Step 1: Get all archive states
-    for (auto const& archive :
-         mApp.getHistoryArchiveManager().getWritableHistoryArchives())
+    auto archives =
+        mApp.getHistoryArchiveManager().getWritableHistoryArchives();
+    if (archives.empty())
+    {
+        CLOG_ERROR(
+            History,
+            "PutSnapshotFilesWork: no writable history archives available");
+        CLOG_FATAL(History, "{}", REPORT_INTERNAL_BUG);
+        return State::WORK_FAILURE;
+    }
+
+    for (auto const& archive : archives)
     {
         mGetStateWorks.emplace_back(
             addWork<GetHistoryArchiveStateWork>(0, archive));


### PR DESCRIPTION
The bug showed up in simulations, that kept running into nodes getting delayed by a few ledgers for no good reason.  

Summary of the bug (AI-assisted):

* PutSnapshotFilesWork::doWork() busy-loops WORK_RUNNING forever when there are no writable history archives (Step 1 creates zero children, so it never reaches WORK_SUCCESS). 
* The after-upgrade node hits this condition because it restored before-upgrade's DB, which contained a queued checkpoint publish for ledger 31. Its own config has localHistory = false. WorkScheduler::scheduleOne then hogs the main thread in CRANK_TIME_SLICE = 500 ms bursts, re-posting itself indefinitely. 
* Every cross-thread post waits ~one slice, which is what causes post-on-main-thread.delay (mean 377 / max 530 ms). These delays causes the node to continue staying a few ledgers behind instead of properly catching up to the fast nodes
