### PR TITLE
Extend overlay ed25519 signature verification budget to protocol

### DIFF
--- a/src/transactions/SignatureChecker.cpp
+++ b/src/transactions/SignatureChecker.cpp
@@ -28,22 +28,19 @@ SignatureChecker::SignatureChecker(
     : mProtocolVersion{protocolVersion}
     , mContentsHash{contentsHash}
     , mSignatures{signatures}
-    , mIsOverlayValidation{isOverlayValidation}
+    , mEnforceVerifyBudget{
+          isOverlayValidation ||
+          protocolVersionStartsFrom(protocolVersion,
+                                    TX_ED25519_VERIFY_BUDGET_PROTOCOL_VERSION)}
 {
     mUsedSignatures.resize(mSignatures.size());
 }
 
 bool
-SignatureChecker::isOverlayValidation() const
-{
-    return mIsOverlayValidation;
-}
-
-bool
 SignatureChecker::isOverVerificationBudget() const
 {
-    return mIsOverlayValidation &&
-           mTxEd25519Verifications >= OVERLAY_TX_ED25519_VERIFY_BUDGET;
+    return mEnforceVerifyBudget &&
+           mTxEd25519Verifications >= TX_ED25519_VERIFY_BUDGET;
 }
 
 bool

--- a/src/transactions/SignatureChecker.h
+++ b/src/transactions/SignatureChecker.h
@@ -43,8 +43,11 @@ class SignatureChecker
     void disableCacheMetricsTracking();
 #endif // BUILD_TESTS
 
-    bool isOverlayValidation() const;
-    static constexpr uint32_t OVERLAY_TX_ED25519_VERIFY_BUDGET = 1000;
+    // Maximum number of ed25519 signature verifications a single
+    // SignatureChecker will perform. Enforced during overlay validation at all
+    // protocol versions, and on all validation and apply paths starting from
+    // TX_ED25519_VERIFY_BUDGET_PROTOCOL_VERSION.
+    static constexpr uint32_t TX_ED25519_VERIFY_BUDGET = 1000;
 
     // Reset and return the counts of signature checks performed as part of
     // transaction `checkValid` or apply flow. The first element of the pair is
@@ -57,9 +60,13 @@ class SignatureChecker
     Hash const& mContentsHash;
     xdr::xvector<DecoratedSignature, 20> const& mSignatures;
     bool mTrackCacheMetrics{true};
-    bool mIsOverlayValidation{false};
+
+    // Whether this checker enforces TX_ED25519_VERIFY_BUDGET.
+    bool const mEnforceVerifyBudget;
 
     std::vector<bool> mUsedSignatures;
+
+    // Number of ed25519 verifications performed by this checker
     uint32_t mTxEd25519Verifications{0};
 
     bool isOverVerificationBudget() const;

--- a/src/util/ProtocolVersion.h
+++ b/src/util/ProtocolVersion.h
@@ -78,6 +78,9 @@ constexpr ProtocolVersion EMPTY_TX_SET_PROTOCOL_VERSION =
 constexpr ProtocolVersion INVOKE_HOST_FUNCTION_V2_PROTOCOL_VERSION =
     ProtocolVersion::V_28;
 
+constexpr ProtocolVersion TX_ED25519_VERIFY_BUDGET_PROTOCOL_VERSION =
+    ProtocolVersion::V_28;
+
 #ifdef CAP_0085_EXECUTABLE_REF
 constexpr ProtocolVersion EXTERNAL_EXECUTABLE_REF_PROTOCOL_VERSION =
     ProtocolVersion::V_28;


### PR DESCRIPTION
This PR extends the existing overlay level ed25519 signature verification budget to the protocol level. The new cap activates at the p28 protocol boundary.