### PR TITLE
Fail noisily if an unknown --enable or --disable flag is passed to configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -495,6 +495,11 @@ AM_CONDITIONAL(USE_TCMALLOC, [test -n "$have_tcmalloc"])
 AC_SUBST(libtcmalloc_CFLAGS)
 AC_SUBST(libtcmalloc_LIBS)
 
+# AC_CONFIG_SUBDIRS disables option checking so options can be forwarded to
+# recursive configures. Re-enable it for the top-level configure by default;
+# generated recursion still passes --disable-option-checking to sub-configures.
+m4_divert_text([DEFAULTS], [enable_option_checking=fatal])
+
 AC_ARG_ENABLE(tests,
     AS_HELP_STRING([--disable-tests],
         [Disable building test suite]))


### PR DESCRIPTION
If, like me, you regularly mis-spell a configure --enable-foo or --disable-foo flag and it gets silently ignored, you might enjoy this PR: it enables a thing in autoconf that catches and complains about such misspellings rather than silently ignoring them!

(Apparently this is normally the default _until_ you have sub-configures like we have, in which case it switches. But you can switch it back. Thanks robot for discovering this!)

Fixes #2635