### PR TITLE
Add new mode to apply load for tx set validation

### DIFF
--- a/docs/apply-load-benchmark-sac.cfg
+++ b/docs/apply-load-benchmark-sac.cfg
@@ -7,6 +7,11 @@
 APPLY_LOAD_MODE="benchmark"
 APPLY_LOAD_MODEL_TX="sac"
 
+# Which timing path to use: "apply" preserves the historical apply-only
+# benchmark, while "txset-validation-and-apply" simulates a non-leader receiving
+# and validating a tx set before applying it. Tx-set creation is not measured.
+APPLY_LOAD_TIMING_PHASES = "apply"
+
 # Whether to time the write part of the apply stage. This can be
 # disabled to get less noisy results for non-write related changes,
 # but should be enabled to get more comprehensive e2e numbers.

--- a/docs/apply-load-benchmark-sac.cfg
+++ b/docs/apply-load-benchmark-sac.cfg
@@ -7,9 +7,9 @@
 APPLY_LOAD_MODE="benchmark"
 APPLY_LOAD_MODEL_TX="sac"
 
-# Which timing path to use: "apply" preserves the historical apply-only
-# benchmark, while "txset-validation-and-apply" simulates a non-leader receiving
-# and validating a tx set before applying it. Tx-set creation is not measured.
+# Which timing path to use: "apply" times only transaction application, while
+# "txset-validation-and-apply" also simulates a non-leader receiving and
+# validating a tx set before applying it. Tx-set creation is not measured.
 APPLY_LOAD_TIMING_PHASES = "apply"
 
 # Whether to time the write part of the apply stage. This can be

--- a/docs/apply-load-benchmark-token.cfg
+++ b/docs/apply-load-benchmark-token.cfg
@@ -7,6 +7,11 @@
 APPLY_LOAD_MODE="benchmark"
 APPLY_LOAD_MODEL_TX="custom_token"
 
+# Which timing path to use: "apply" times only transaction application, while
+# "txset-validation-and-apply" also simulates a non-leader receiving and
+# validating a tx set before applying it. Tx-set creation is not measured.
+APPLY_LOAD_TIMING_PHASES = "apply"
+
 # Whether to time the write part of the apply stage. This can be
 # disabled to get less noisy results for non-write related changes,
 # but should be enabled to get more comprehensive e2e numbers.

--- a/docs/apply-load-for-meta.cfg
+++ b/docs/apply-load-for-meta.cfg
@@ -9,7 +9,12 @@
 # Select the apply-load mode.
 APPLY_LOAD_MODE="ledger-limits"
 
-# Custom meta path - if not set it will be written to a temp directory and 
+# Which timing path to use: "apply" times only transaction application, while
+# "txset-validation-and-apply" also simulates a non-leader receiving and
+# validating a tx set before applying it. Tx-set creation is not measured.
+APPLY_LOAD_TIMING_PHASES = "apply"
+
+# Custom meta path - if not set it will be written to a temp directory and
 # cleaned up after running the benchmark
 METADATA_OUTPUT_STREAM='meta.xdr'
 

--- a/docs/apply-load-ledger-limits.cfg
+++ b/docs/apply-load-ledger-limits.cfg
@@ -7,6 +7,11 @@
 # Select the apply-load mode.
 APPLY_LOAD_MODE="ledger-limits"
 
+# Which timing path to use: "apply" times only transaction application, while
+# "txset-validation-and-apply" also simulates a non-leader receiving and
+# validating a tx set before applying it. Tx-set creation is not measured.
+APPLY_LOAD_TIMING_PHASES = "apply"
+
 # Medida metrics (histograms in particular) in apply path cause severe and
 # non-deterministic performance degradation. While this has to be addressed
 # eventually, it is useful to disable these when optimizing anything besides

--- a/docs/apply-load-max-sac-tps.cfg
+++ b/docs/apply-load-max-sac-tps.cfg
@@ -7,6 +7,10 @@
 # Select the apply-load mode.
 APPLY_LOAD_MODE="max-sac-tps"
 
+# Which timing path to use. The max-sac-tps search targets apply-only close
+# time, so it only supports "apply".
+APPLY_LOAD_TIMING_PHASES = "apply"
+
 # Whether to time the write part of the apply stage. This can be
 # disabled to get less noisy results for non-write related changes,
 # but should be enabled to get more comprehensive e2e numbers.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -62,6 +62,7 @@ crypto.verify.miss                        | meter     | number of signature cach
 crypto.verify.total                       | meter     | sum of both hits and misses
 crypto.verify.tx-valid-hit                | meter     | signature cache hits that occurred while validating transactions (outside of background signature validation)
 crypto.verify.tx-valid-total              | meter     | sum of both hits and misses during transaction validation (outside of background signature validation)
+herder.txset.validate                     | timer     | time spent turning a received tx set into an applicable tx set and validating it on a validity-cache miss; Tracy labels the enclosing call as a cache hit or miss
 herder.pending[-soroban]-txs.age0         | counter   | number of gen0 pending transactions
 herder.pending[-soroban]-txs.age1         | counter   | number of gen1 pending transactions
 herder.pending[-soroban]-txs.age2         | counter   | number of gen2 pending transactions

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -62,7 +62,7 @@ crypto.verify.miss                        | meter     | number of signature cach
 crypto.verify.total                       | meter     | sum of both hits and misses
 crypto.verify.tx-valid-hit                | meter     | signature cache hits that occurred while validating transactions (outside of background signature validation)
 crypto.verify.tx-valid-total              | meter     | sum of both hits and misses during transaction validation (outside of background signature validation)
-herder.txset.validate                     | timer     | time spent turning a received tx set into an applicable tx set and validating it on a validity-cache miss; Tracy labels the enclosing call as a cache hit or miss
+herder.txset.validate                     | timer     | time spent turning a received tx set into an applicable tx set and validating it on a validity-cache miss
 herder.pending[-soroban]-txs.age0         | counter   | number of gen0 pending transactions
 herder.pending[-soroban]-txs.age1         | counter   | number of gen1 pending transactions
 herder.pending[-soroban]-txs.age2         | counter   | number of gen2 pending transactions

--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -20,9 +20,11 @@ Common options can be placed at any place in the command line.
 Command options can only by placed after command.
 
 * **apply-load**: Benchmarks Soroban transaction application time using
-    synthetic transactions. The benchmark is isolated to mostly just executing
-    the transactions and thus it omits a lot of the supporting mechanisms
-    (such as overlay, SCP, mempool etc). This command will generate enough
+    synthetic transactions. The benchmark omits the overlay and mempool, but
+    each iteration reconstructs the tx set from serialized bytes and runs real
+    consensus with the node as its own single-validator quorum. It does not
+    simulate network transport, peer fetching, or multi-node timing.
+    This command will generate enough
     transactions to fill up a synthetic transaction queue (it's just a list of
     transactions with the same limits as the real queue), and then create a
     transaction set off of that to apply. This can also be used to record the
@@ -36,6 +38,20 @@ Command options can only by placed after command.
       consisting only of fast SAC transfer.
     - `APPLY_LOAD_MODE="benchmark"`: benchmarks a fixed-size ledger of model
       transactions. Use `APPLY_LOAD_MODEL_TX` to select the model transaction.
+  * `APPLY_LOAD_TIMING_PHASES` selects one of two timing paths:
+    - `"apply"`: the default historical apply-only benchmark. Its close helper
+      still calls `checkValid`, but that happens before the recorded ledger-close
+      timer and leaves the caches warm, as consensus validation would on a live
+      node. Output remains in the historical format.
+    - `"txset-validation-and-apply"`: simulates a non-leader receiving the tx
+      set over the wire, validating it through local consensus, and then applying
+      it. It reports validation, ledger close, and end-to-end time. Leader-side
+      tx-set creation and signing happen before the measured span. The signature
+      verification cache is cleared before validation, then retained so apply
+      sees the warm cache produced by validation.
+    `"txset-validation-and-apply"` is not supported with
+    `APPLY_LOAD_MODE="max-sac-tps"`; that search retains its historical
+    apply-only timing objective.
   * Load generation is configured in the Core config file. The relevant settings
     all begin with `APPLY_LOAD_`. See full example configurations with
     per-setting documentation in the `docs` directory

--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -20,11 +20,11 @@ Common options can be placed at any place in the command line.
 Command options can only by placed after command.
 
 * **apply-load**: Benchmarks Soroban transaction application time using
-    synthetic transactions. The benchmark omits the overlay and mempool, but
-    each iteration reconstructs the tx set from serialized bytes and runs real
-    consensus with the node as its own single-validator quorum. It does not
-    simulate network transport, peer fetching, or multi-node timing.
-    This command will generate enough
+    synthetic transactions. By default the benchmark is isolated to mostly just
+    executing the transactions and thus it omits a lot of the supporting
+    mechanisms (such as overlay, SCP, mempool etc). It may also measure tx-set
+    validation and consensus processing via `APPLY_LOAD_TIMING_PHASES` (see
+    below). This command will generate enough
     transactions to fill up a synthetic transaction queue (it's just a list of
     transactions with the same limits as the real queue), and then create a
     transaction set off of that to apply. This can also be used to record the
@@ -39,19 +39,20 @@ Command options can only by placed after command.
     - `APPLY_LOAD_MODE="benchmark"`: benchmarks a fixed-size ledger of model
       transactions. Use `APPLY_LOAD_MODEL_TX` to select the model transaction.
   * `APPLY_LOAD_TIMING_PHASES` selects one of two timing paths:
-    - `"apply"`: the default historical apply-only benchmark. Its close helper
-      still calls `checkValid`, but that happens before the recorded ledger-close
-      timer and leaves the caches warm, as consensus validation would on a live
-      node. Output remains in the historical format.
+    - `"apply"`: the default apply-only benchmark. Its close helper still calls
+      `checkValid`, but that happens before the recorded ledger-close timer and
+      leaves the caches warm, as consensus validation would on a live node.
     - `"txset-validation-and-apply"`: simulates a non-leader receiving the tx
-      set over the wire, validating it through local consensus, and then applying
-      it. It reports validation, ledger close, and end-to-end time. Leader-side
-      tx-set creation and signing happen before the measured span. The signature
-      verification cache is cleared before validation, then retained so apply
-      sees the warm cache produced by validation.
+      set over the wire, validating it through local consensus (with the node
+      as its own single-validator quorum), and then applying it. It reports
+      validation, ledger close, and end-to-end time in addition to the
+      apply-only output. It does not simulate network transport, peer fetching,
+      or multi-node timing. Leader-side tx-set creation and signing happen
+      before the measured span. The signature verification cache is cleared
+      before validation, then retained so apply sees the warm cache produced by
+      validation.
     `"txset-validation-and-apply"` is not supported with
-    `APPLY_LOAD_MODE="max-sac-tps"`; that search retains its historical
-    apply-only timing objective.
+    `APPLY_LOAD_MODE="max-sac-tps"`; that search targets apply-only close time.
   * Load generation is configured in the Core config file. The relevant settings
     all begin with `APPLY_LOAD_`. See full example configurations with
     per-setting documentation in the `docs` directory

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -1869,8 +1869,7 @@ HerderSCPDriver::checkAndCacheTxSetValid(TxSetXDRFrame const& txSet,
     bool* pRes = mTxSetValidCache.maybeGet(key);
     if (pRes == nullptr)
     {
-        std::string zoneTxt("miss");
-        ZoneText(zoneTxt.c_str(), zoneTxt.size());
+        ZoneNamedN(txSetValidityMissZone, "txset validity cache miss", true);
         auto validationTime = mSCPMetrics.mTxSetValidation.TimeScope();
 
         // The invariant here is that we only validate tx sets nominated
@@ -1903,8 +1902,7 @@ HerderSCPDriver::checkAndCacheTxSetValid(TxSetXDRFrame const& txSet,
     }
     else
     {
-        std::string zoneTxt("hit");
-        ZoneText(zoneTxt.c_str(), zoneTxt.size());
+        ZoneNamedN(txSetValidityHitZone, "txset validity cache hit", true);
         return *pRes;
     }
 }

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -76,6 +76,8 @@ HerderSCPDriver::SCPMetrics::SCPMetrics(Application& app)
           {"scp", "timing", "self-to-others-externalize-lag"}))
     , mBallotBlockedOnTxSet(app.getMetrics().NewTimer(
           {"scp", "timing", "ballot-blocked-on-txset"}))
+    , mTxSetValidation(
+          app.getMetrics().NewTimer({"herder", "txset", "validate"}))
     , mEmptyTxSetExternalized(
           app.getMetrics().NewCounter({"scp", "empty-tx-set", "externalized"}))
     , mEmptyTxSetValueReplaced(app.getMetrics().NewCounter(
@@ -1859,12 +1861,18 @@ HerderSCPDriver::checkAndCacheTxSetValid(TxSetXDRFrame const& txSet,
                                          LedgerHeaderHistoryEntry const& lcl,
                                          uint64_t closeTimeOffset) const
 {
+    ZoneScoped;
+
     auto key = TxSetValidityKey{lcl.hash, txSet.getContentsHash(),
                                 closeTimeOffset, closeTimeOffset};
 
     bool* pRes = mTxSetValidCache.maybeGet(key);
     if (pRes == nullptr)
     {
+        std::string zoneTxt("miss");
+        ZoneText(zoneTxt.c_str(), zoneTxt.size());
+        auto validationTime = mSCPMetrics.mTxSetValidation.TimeScope();
+
         // The invariant here is that we only validate tx sets nominated
         // to be applied to the current ledger state. However, in case
         // if we receive a bad SCP value for the current state, we still
@@ -1895,6 +1903,8 @@ HerderSCPDriver::checkAndCacheTxSetValid(TxSetXDRFrame const& txSet,
     }
     else
     {
+        std::string zoneTxt("hit");
+        ZoneText(zoneTxt.c_str(), zoneTxt.size());
         return *pRes;
     }
 }

--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -268,6 +268,9 @@ class HerderSCPDriver : public SCPDriver
         // download
         medida::Timer& mBallotBlockedOnTxSet;
 
+        // Timer tracking time to check and cache a tx set
+        medida::Timer& mTxSetValidation;
+
         // Tracks how many ledgers we externalized an empty-tx-set value.
         medida::Counter& mEmptyTxSetExternalized;
 

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -464,6 +464,23 @@ parseApplyLoadModelTx(ConfigItem const& item)
         "invalid 'APPLY_LOAD_MODEL_TX', expected one of: sac, custom_token, "
         "soroswap");
 }
+
+ApplyLoadTimingPhases
+parseApplyLoadTimingPhases(ConfigItem const& item)
+{
+    auto phases = readString(item);
+    if (phases == "apply")
+    {
+        return ApplyLoadTimingPhases::APPLY_ONLY;
+    }
+    if (phases == "txset-validation-and-apply")
+    {
+        return ApplyLoadTimingPhases::TX_SET_VALIDATION_AND_APPLY;
+    }
+    throw std::invalid_argument(
+        "invalid 'APPLY_LOAD_TIMING_PHASES', expected one of: apply, "
+        "txset-validation-and-apply");
+}
 #endif
 
 template <typename T>
@@ -1866,6 +1883,11 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                  }},
                 {"APPLY_LOAD_TIME_WRITES",
                  [&]() { APPLY_LOAD_TIME_WRITES = readBool(item); }},
+                {"APPLY_LOAD_TIMING_PHASES",
+                 [&]() {
+                     APPLY_LOAD_TIMING_PHASES =
+                         parseApplyLoadTimingPhases(item);
+                 }},
 #endif // BUILD_TESTS
                 {"GENESIS_TEST_ACCOUNT_COUNT",
                  [&]() {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -83,6 +83,13 @@ enum class ApplyLoadModelTx
     CUSTOM_TOKEN,
     SOROSWAP
 };
+
+// Which apply-load timing path to use.
+enum class ApplyLoadTimingPhases
+{
+    APPLY_ONLY,
+    TX_SET_VALIDATION_AND_APPLY
+};
 #endif
 
 class Config : public std::enable_shared_from_this<Config>
@@ -425,6 +432,10 @@ class Config : public std::enable_shared_from_this<Config>
     // If set to true, database writes will count towards TPS calculation.
     // Otherwise, BucketList writes will not be counted.
     bool APPLY_LOAD_TIME_WRITES = true;
+
+    // Which apply-load timing path to use.
+    ApplyLoadTimingPhases APPLY_LOAD_TIMING_PHASES =
+        ApplyLoadTimingPhases::APPLY_ONLY;
 #endif // BUILD_TESTS
 
     // Waits for merges to complete before applying transactions during catchup

--- a/src/simulation/ApplyLoad.cpp
+++ b/src/simulation/ApplyLoad.cpp
@@ -12,8 +12,10 @@
 #include "bucket/BucketListSnapshot.h"
 #include "bucket/BucketManager.h"
 #include "bucket/test/BucketTestUtils.h"
+#include "crypto/SecretKey.h"
 #include "herder/Herder.h"
 #include "herder/HerderImpl.h"
+#include "herder/TxSetFrame.h"
 #include "ledger/ImmutableLedgerView.h"
 #include "ledger/InMemorySorobanState.h"
 #include "ledger/LedgerManager.h"
@@ -75,6 +77,40 @@ interpolatePercentile(std::vector<double> const& sortedValues,
     auto hi = static_cast<size_t>(std::ceil(rank));
     double weight = rank - lo;
     return sortedValues[lo] * (1.0 - weight) + sortedValues[hi] * weight;
+}
+
+void
+nominateAndClose(Application& app, TxSetXDRFrameConstPtr txSet,
+                 StellarValue const& value)
+{
+    auto& herder = static_cast<HerderImpl&>(app.getHerder());
+    auto const& lcl = app.getLedgerManager().getLastClosedLedgerHeader();
+    auto const ledgerSeq = lcl.header.ledgerSeq + 1;
+    herder.getPendingEnvelopes().putTxSet(txSet->getContentsHash(), ledgerSeq,
+                                          txSet);
+    herder.getHerderSCPDriver().nominate(ledgerSeq, value, txSet,
+                                         lcl.header.scpValue);
+
+    auto const deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(60);
+    size_t cranks = 0;
+    while (app.getLedgerManager().getLastClosedLedgerNum() < ledgerSeq &&
+           std::chrono::steady_clock::now() < deadline)
+    {
+        app.getClock().crank(true);
+        ++cranks;
+    }
+    if (app.getLedgerManager().getLastClosedLedgerNum() < ledgerSeq)
+    {
+        throw std::runtime_error(fmt::format(
+            FMT_STRING("nominateAndClose: SCP did not externalize ledger {} "
+                       "within 60s ({} cranks); close time {} is {}s from the "
+                       "wall clock (slip limit {}s)"),
+            ledgerSeq, cranks, value.closeTime,
+            static_cast<int64_t>(value.closeTime) -
+                static_cast<int64_t>(app.timeNow()),
+            Herder::MAX_TIME_SLIP_SECONDS.count()));
+    }
 }
 
 template <typename T>
@@ -627,6 +663,7 @@ ApplyLoad::ApplyLoad(Application& app)
     , mMode(app.getConfig().APPLY_LOAD_MODE)
     , mModelTx(app.getConfig().APPLY_LOAD_MODEL_TX)
     , mLimitsBasedTxProfile(deriveLimitBasedTxProfile(mMode, app.getConfig()))
+    , mTimingPhases(app.getConfig().APPLY_LOAD_TIMING_PHASES)
     , mTotalHotArchiveEntries(
           calculateRequiredHotArchiveEntries(app.getConfig()))
     , mTxCountUtilization(
@@ -680,7 +717,12 @@ ApplyLoad::ApplyLoad(Application& app)
     // enough samples for statistics to be meaningful.
     if (mMode == ApplyLoadMode::MAX_SAC_TPS)
     {
-
+        if (measuresTxSetValidation())
+        {
+            throw std::runtime_error(
+                "APPLY_LOAD_TIMING_PHASES=txset-validation-and-apply is not "
+                "supported with APPLY_LOAD_MODE=max-sac-tps");
+        }
         if (config.APPLY_LOAD_NUM_LEDGERS < 30)
         {
             throw std::runtime_error(
@@ -847,47 +889,141 @@ ApplyLoad::setup()
 }
 
 void
+ApplyLoad::logPhaseStats(std::string const& label,
+                         std::vector<double> const& samplesMs)
+{
+    releaseAssert(!samplesMs.empty());
+
+    double mean = std::accumulate(samplesMs.begin(), samplesMs.end(), 0.0) /
+                  samplesMs.size();
+
+    double varianceMsSq = 0.0;
+    for (auto const& sample : samplesMs)
+    {
+        double delta = sample - mean;
+        varianceMsSq += delta * delta;
+    }
+    varianceMsSq /= samplesMs.size();
+
+    std::vector<double> sortedSamples = samplesMs;
+    std::sort(sortedSamples.begin(), sortedSamples.end());
+
+    CLOG_WARNING(Perf, "mean {}: {} ms", label, mean);
+    CLOG_WARNING(Perf, "p25 {}:  {} ms", label,
+                 interpolatePercentile(sortedSamples, 25.0));
+    CLOG_WARNING(Perf, "p50 {}:  {} ms", label,
+                 interpolatePercentile(sortedSamples, 50.0));
+    CLOG_WARNING(Perf, "p75 {}:  {} ms", label,
+                 interpolatePercentile(sortedSamples, 75.0));
+    CLOG_WARNING(Perf, "p95 {}:  {} ms", label,
+                 interpolatePercentile(sortedSamples, 95.0));
+    CLOG_WARNING(Perf, "p99 {}:  {} ms", label,
+                 interpolatePercentile(sortedSamples, 99.0));
+    CLOG_WARNING(Perf, "{} stddev: {} ms", label, std::sqrt(varianceMsSq));
+}
+
+void
+ApplyLoad::logConfiguredPhaseStats() const
+{
+    if (!measuresTxSetValidation())
+    {
+        return;
+    }
+
+    CLOG_WARNING(Perf, "================================================");
+    logPhaseStats("txset validation", mPhaseValidationMs);
+
+    // Expect one cold check per tx + one StellarValue check per ledger.
+    auto const ledgerCount = static_cast<int64_t>(mPhaseValidationMs.size());
+    auto const txCount = static_cast<int64_t>(mBenchmarkTxCount);
+    CLOG_WARNING(
+        Perf,
+        "sig cache hits/misses: {}/{} (expected {} misses = {} tx sigs + {} "
+        "value sigs)",
+        mLedgerSigCacheHits, mLedgerSigCacheMisses, txCount + ledgerCount,
+        txCount, ledgerCount);
+    if (txCount > 0)
+    {
+        CLOG_WARNING(
+            Perf,
+            "tx signature cache misses per transaction: {:.4f} (expect 1.0)",
+            static_cast<double>(static_cast<int64_t>(mLedgerSigCacheMisses) -
+                                ledgerCount) /
+                static_cast<double>(txCount));
+    }
+    // Expect one cold tx set validation per ledger.
+    auto const validations =
+        mApp.getMetrics().NewTimer({"herder", "txset", "validate"}).count();
+    CLOG_WARNING(Perf, "txset validations per ledger: {:.2f}",
+                 static_cast<double>(validations) /
+                     static_cast<double>(ledgerCount));
+
+    logPhaseStats("ledger close", mPhaseLedgerCloseMs);
+    logPhaseStats("end-to-end txset+apply", mPhaseEndToEndMs);
+
+    double validationSum = std::accumulate(mPhaseValidationMs.begin(),
+                                           mPhaseValidationMs.end(), 0.0);
+    double ledgerCloseSum = std::accumulate(mPhaseLedgerCloseMs.begin(),
+                                            mPhaseLedgerCloseMs.end(), 0.0);
+    double e2eSum = std::accumulate(mPhaseEndToEndMs.begin(),
+                                    mPhaseEndToEndMs.end(), 0.0);
+    if (e2eSum > 0.0)
+    {
+        CLOG_WARNING(Perf, "txset validation share of end-to-end: {:.2f}%",
+                     validationSum / e2eSum * 100.0);
+        CLOG_WARNING(Perf, "ledger close share of end-to-end: {:.2f}%",
+                     ledgerCloseSum / e2eSum * 100.0);
+        CLOG_WARNING(Perf,
+                     "other receive/consensus/externalize overhead share "
+                     "of end-to-end: {:.2f}%",
+                     (e2eSum - validationSum - ledgerCloseSum) / e2eSum *
+                         100.0);
+    }
+    CLOG_WARNING(Perf, "================================================");
+}
+
+void
+ApplyLoad::recordSorobanUtilization(ApplicableTxSetFrame const& txSet,
+                                    uint32_t ledgerVersion)
+{
+    auto ledgerResources = mApp.getLedgerManager().maxLedgerResources(true);
+    auto txSetResources =
+        txSet.getPhases()
+            .at(static_cast<size_t>(TxSetPhase::SOROBAN))
+            .getTotalResources(ledgerVersion)
+            .value();
+    auto updateUtilization = [&](medida::Histogram& histogram,
+                                 Resource::Type resource) {
+        histogram.Update(txSetResources.getVal(resource) * 1.0 /
+                         ledgerResources.getVal(resource) * 100000.0);
+    };
+    updateUtilization(mTxCountUtilization, Resource::Type::OPERATIONS);
+    updateUtilization(mInstructionUtilization, Resource::Type::INSTRUCTIONS);
+    updateUtilization(mTxSizeUtilization, Resource::Type::TX_BYTE_SIZE);
+    updateUtilization(mDiskReadByteUtilization,
+                      Resource::Type::DISK_READ_BYTES);
+    updateUtilization(mWriteByteUtilization, Resource::Type::WRITE_BYTES);
+    updateUtilization(mDiskReadEntryUtilization,
+                      Resource::Type::READ_LEDGER_ENTRIES);
+    updateUtilization(mWriteEntryUtilization,
+                      Resource::Type::WRITE_LEDGER_ENTRIES);
+    CLOG_INFO(Perf, "generated tx set resources: {}/{}",
+              txSetResources.toString(), ledgerResources.toString());
+}
+
+void
 ApplyLoad::closeLedger(std::vector<TransactionFrameBasePtr> const& txs,
                        xdr::xvector<UpgradeType, 6> const& upgrades,
-                       bool recordSorobanUtilization)
+                       bool recordUtilization)
 {
     auto txSet = makeTxSetFromTransactions(txs, mApp, 0, 0);
 
-    if (recordSorobanUtilization)
+    if (recordUtilization)
     {
-        auto ledgerResources = mApp.getLedgerManager().maxLedgerResources(true);
-        auto txSetResources =
-            txSet.second->getPhases()
-                .at(static_cast<size_t>(TxSetPhase::SOROBAN))
-                .getTotalResources(mApp.getLedgerManager()
-                                       .getLastClosedLedgerHeader()
-                                       .header.ledgerVersion)
-                .value();
-        mTxCountUtilization.Update(
-            txSetResources.getVal(Resource::Type::OPERATIONS) * 1.0 /
-            ledgerResources.getVal(Resource::Type::OPERATIONS) * 100000.0);
-        mInstructionUtilization.Update(
-            txSetResources.getVal(Resource::Type::INSTRUCTIONS) * 1.0 /
-            ledgerResources.getVal(Resource::Type::INSTRUCTIONS) * 100000.0);
-        mTxSizeUtilization.Update(
-            txSetResources.getVal(Resource::Type::TX_BYTE_SIZE) * 1.0 /
-            ledgerResources.getVal(Resource::Type::TX_BYTE_SIZE) * 100000.0);
-        mDiskReadByteUtilization.Update(
-            txSetResources.getVal(Resource::Type::DISK_READ_BYTES) * 1.0 /
-            ledgerResources.getVal(Resource::Type::DISK_READ_BYTES) * 100000.0);
-        mWriteByteUtilization.Update(
-            txSetResources.getVal(Resource::Type::WRITE_BYTES) * 1.0 /
-            ledgerResources.getVal(Resource::Type::WRITE_BYTES) * 100000.0);
-        mDiskReadEntryUtilization.Update(
-            txSetResources.getVal(Resource::Type::READ_LEDGER_ENTRIES) * 1.0 /
-            ledgerResources.getVal(Resource::Type::READ_LEDGER_ENTRIES) *
-            100000.0);
-        mWriteEntryUtilization.Update(
-            txSetResources.getVal(Resource::Type::WRITE_LEDGER_ENTRIES) * 1.0 /
-            ledgerResources.getVal(Resource::Type::WRITE_LEDGER_ENTRIES) *
-            100000.0);
-        CLOG_INFO(Perf, "generated tx set resources: {}/{}",
-                  txSetResources.toString(), ledgerResources.toString());
+        recordSorobanUtilization(
+            *txSet.second,
+            mApp.getLedgerManager().getLastClosedLedgerHeader().header
+                .ledgerVersion);
     }
     auto sv =
         mApp.getHerder().makeStellarValue(txSet.first->getContentsHash(), 1,
@@ -897,9 +1033,104 @@ ApplyLoad::closeLedger(std::vector<TransactionFrameBasePtr> const& txs,
 }
 
 void
+ApplyLoad::closeLedgerViaConsensus(
+    std::vector<TransactionFrameBasePtr> const& txs,
+    bool recordUtilization)
+{
+    releaseAssert(!txs.empty());
+    auto& herder = mApp.getHerder();
+    auto const& lcl = mApp.getLedgerManager().getLastClosedLedgerHeader();
+
+    uint64_t const closeTime = lcl.header.scpValue.closeTime + 1;
+    auto txSet = makeTxSetFromTransactions(txs, mApp, 1, 1);
+
+    if (recordUtilization)
+    {
+        recordSorobanUtilization(*txSet.second, lcl.header.ledgerVersion);
+    }
+
+    // We want to simulate a non-leader node receiving a TX set off the wire,
+    // so we build and sign outside the measured receiver-side span.
+    GeneralizedTransactionSet xdrTxSet;
+    txSet.first->toXDR(xdrTxSet);
+    auto const wireBytes = xdr::xdr_to_opaque(xdrTxSet);
+    auto const nominatedValue =
+        herder.makeStellarValue(txSet.first->getContentsHash(), closeTime, {},
+                                mApp.getConfig().NODE_SEED);
+    // Do not retain leader-side frames during the measured work.
+    xdrTxSet = GeneralizedTransactionSet{};
+    txSet.first.reset();
+    txSet.second.reset();
+
+    // Validation should see cold signatures and leave them warm for apply.
+    PubKeyUtils::clearVerifySigCache();
+    // Exclude signature checks performed while building the set.
+    mApp.syncOwnMetrics();
+    auto& metrics = mApp.getMetrics();
+    auto& sigHitMeter =
+        metrics.NewMeter({"crypto", "verify", "hit"}, "signature");
+    auto& sigMissMeter =
+        metrics.NewMeter({"crypto", "verify", "miss"}, "signature");
+    auto const sigHitsBefore = sigHitMeter.count();
+    auto const sigMissesBefore = sigMissMeter.count();
+
+    auto& validationTimer = metrics.NewTimer({"herder", "txset", "validate"});
+    // ledger.close includes apply-side prepareForApply.
+    auto& ledgerCloseTimer = metrics.NewTimer({"ledger", "ledger", "close"});
+    double const validationBefore = validationTimer.sum();
+    double const ledgerCloseBefore = ledgerCloseTimer.sum();
+
+    auto const e2eStart = std::chrono::steady_clock::now();
+
+    // Decode into a fresh frame as the overlay receive path does.
+    GeneralizedTransactionSet receivedXdr;
+    xdr::xdr_from_opaque(wireBytes, receivedXdr);
+    auto receivedTxSet = TxSetXDRFrame::makeFromWire(receivedXdr);
+
+    // Nomination through externalization and apply use production SCP paths.
+    nominateAndClose(mApp, receivedTxSet, nominatedValue);
+
+    auto const e2eEnd = std::chrono::steady_clock::now();
+    double const ledgerCloseMs = ledgerCloseTimer.sum() - ledgerCloseBefore;
+    mPhaseValidationMs.emplace_back(validationTimer.sum() - validationBefore);
+    mPhaseLedgerCloseMs.emplace_back(ledgerCloseMs);
+    mPhaseEndToEndMs.emplace_back(
+        std::chrono::duration<double, std::milli>(e2eEnd - e2eStart).count());
+    mApp.syncOwnMetrics();
+    mLedgerSigCacheHits += sigHitMeter.count() - sigHitsBefore;
+    mLedgerSigCacheMisses += sigMissMeter.count() - sigMissesBefore;
+    mBenchmarkTxCount += txs.size();
+}
+
+void
+ApplyLoad::closeBenchmarkLedger(
+    std::vector<TransactionFrameBasePtr> const& txs,
+    bool recordUtilization)
+{
+    if (measuresTxSetValidation())
+    {
+        closeLedgerViaConsensus(txs, recordUtilization);
+    }
+    else
+    {
+        closeLedger(txs, {}, recordUtilization);
+    }
+}
+
+void
 ApplyLoad::execute()
 {
     logExecutionEnvironmentSnapshot(mApp.getConfig());
+    if (measuresTxSetValidation())
+    {
+        mApp.getMetrics().NewTimer({"herder", "txset", "validate"}).Clear();
+        mPhaseValidationMs.clear();
+        mPhaseLedgerCloseMs.clear();
+        mPhaseEndToEndMs.clear();
+        mLedgerSigCacheHits = 0;
+        mLedgerSigCacheMisses = 0;
+        mBenchmarkTxCount = 0;
+    }
 
     switch (mMode)
     {
@@ -1450,6 +1681,8 @@ ApplyLoad::benchmarkLimits()
               getWriteEntryUtilization().max() / 1000.0);
 
     CLOG_INFO(Perf, "Tx Success Rate: {:f}%", successRate() * 100);
+
+    logConfiguredPhaseStats();
 }
 
 double
@@ -1562,9 +1795,8 @@ ApplyLoad::benchmarkLimitsIteration()
         mApp.getMetrics().NewTimer({"ledger", "ledger", "close"});
 
     double timeBefore = ledgerCloseTime.sum();
-    closeLedger(txs, {}, /* recordSorobanUtilization */ true);
+    closeBenchmarkLedger(txs, /* recordSorobanUtilization */ true);
     double timeAfter = ledgerCloseTime.sum();
-
     double closeTime = timeAfter - timeBefore;
     CLOG_INFO(Perf, "Limits benchmark time: {:.2f}ms", closeTime);
     return closeTime;
@@ -1754,38 +1986,15 @@ ApplyLoad::benchmarkModelTx()
 
     releaseAssert(!closeTimes.empty());
 
-    double avgCloseTimeMs =
-        std::accumulate(closeTimes.begin(), closeTimes.end(), 0.0) /
-        closeTimes.size();
-
-    double varianceMsSq = 0.0;
-    for (auto const& closeTime : closeTimes)
-    {
-        double delta = closeTime - avgCloseTimeMs;
-        varianceMsSq += delta * delta;
-    }
-    varianceMsSq /= closeTimes.size();
-
-    std::vector<double> sortedCloseTimes = closeTimes;
-    std::sort(sortedCloseTimes.begin(), sortedCloseTimes.end());
-
     CLOG_WARNING(Perf, "================================================");
-    CLOG_WARNING(
-        Perf, "Model tx benchmark stats ({} ledgers, {} tx per ledger):",
-        config.APPLY_LOAD_NUM_LEDGERS, config.APPLY_LOAD_MAX_SOROBAN_TX_COUNT);
-    CLOG_WARNING(Perf, "mean close time: {} ms", avgCloseTimeMs);
-    CLOG_WARNING(Perf, "p25 close time:  {} ms",
-                 interpolatePercentile(sortedCloseTimes, 25.0));
-    CLOG_WARNING(Perf, "p50 close time:  {} ms",
-                 interpolatePercentile(sortedCloseTimes, 50.0));
-    CLOG_WARNING(Perf, "p75 close time:  {} ms",
-                 interpolatePercentile(sortedCloseTimes, 75.0));
-    CLOG_WARNING(Perf, "p95 close time:  {} ms",
-                 interpolatePercentile(sortedCloseTimes, 95.0));
-    CLOG_WARNING(Perf, "p99 close time:  {} ms",
-                 interpolatePercentile(sortedCloseTimes, 99.0));
-    CLOG_WARNING(Perf, "close time stddev: {} ms", std::sqrt(varianceMsSq));
+    CLOG_WARNING(Perf,
+                 "Model tx benchmark stats ({} ledgers, {} tx per ledger):",
+                 config.APPLY_LOAD_NUM_LEDGERS,
+                 config.APPLY_LOAD_MAX_SOROBAN_TX_COUNT);
+    logPhaseStats("close time", closeTimes);
     CLOG_WARNING(Perf, "================================================");
+
+    logConfiguredPhaseStats();
 }
 
 double
@@ -1835,7 +2044,7 @@ ApplyLoad::benchmarkModelTxTpsSingleLedger(ApplyLoadModelTx modelTx,
     releaseAssert(
         mApp.getBucketManager().getHotArchiveBucketList().futuresAllResolved());
     double timeBefore = totalTxApplyTimer.sum();
-    closeLedger(txs);
+    closeBenchmarkLedger(txs, /* recordSorobanUtilization */ false);
     double timeAfter = totalTxApplyTimer.sum();
 
     double closeTime = timeAfter - timeBefore;

--- a/src/simulation/ApplyLoad.cpp
+++ b/src/simulation/ApplyLoad.cpp
@@ -79,6 +79,42 @@ interpolatePercentile(std::vector<double> const& sortedValues,
     return sortedValues[lo] * (1.0 - weight) + sortedValues[hi] * weight;
 }
 
+// Logs the distribution of per-ledger samples for one timing phase, expressed
+// in `unit`.
+void
+logPhaseStats(std::string const& label, std::vector<double> const& samples,
+              std::string const& unit = "ms")
+{
+    releaseAssert(!samples.empty());
+
+    double mean =
+        std::accumulate(samples.begin(), samples.end(), 0.0) / samples.size();
+
+    double variance = 0.0;
+    for (auto const& sample : samples)
+    {
+        double delta = sample - mean;
+        variance += delta * delta;
+    }
+    variance /= samples.size();
+
+    std::vector<double> sortedSamples = samples;
+    std::sort(sortedSamples.begin(), sortedSamples.end());
+
+    CLOG_WARNING(Perf, "mean {}: {} {}", label, mean, unit);
+    CLOG_WARNING(Perf, "p25 {}:  {} {}", label,
+                 interpolatePercentile(sortedSamples, 25.0), unit);
+    CLOG_WARNING(Perf, "p50 {}:  {} {}", label,
+                 interpolatePercentile(sortedSamples, 50.0), unit);
+    CLOG_WARNING(Perf, "p75 {}:  {} {}", label,
+                 interpolatePercentile(sortedSamples, 75.0), unit);
+    CLOG_WARNING(Perf, "p95 {}:  {} {}", label,
+                 interpolatePercentile(sortedSamples, 95.0), unit);
+    CLOG_WARNING(Perf, "p99 {}:  {} {}", label,
+                 interpolatePercentile(sortedSamples, 99.0), unit);
+    CLOG_WARNING(Perf, "{} stddev: {} {}", label, std::sqrt(variance), unit);
+}
+
 void
 nominateAndClose(Application& app, TxSetXDRFrameConstPtr txSet,
                  StellarValue const& value)
@@ -717,11 +753,12 @@ ApplyLoad::ApplyLoad(Application& app)
     // enough samples for statistics to be meaningful.
     if (mMode == ApplyLoadMode::MAX_SAC_TPS)
     {
-        if (measuresTxSetValidation())
+        // The TPS search targets apply-only close time, so it only supports
+        // the APPLY_ONLY timing path.
+        if (mTimingPhases != ApplyLoadTimingPhases::APPLY_ONLY)
         {
-            throw std::runtime_error(
-                "APPLY_LOAD_TIMING_PHASES=txset-validation-and-apply is not "
-                "supported with APPLY_LOAD_MODE=max-sac-tps");
+            throw std::runtime_error("APPLY_LOAD_MODE=max-sac-tps only "
+                                     "supports APPLY_LOAD_TIMING_PHASES=apply");
         }
         if (config.APPLY_LOAD_NUM_LEDGERS < 30)
         {
@@ -888,47 +925,24 @@ ApplyLoad::setup()
     }
 }
 
-void
-ApplyLoad::logPhaseStats(std::string const& label,
-                         std::vector<double> const& samplesMs)
+bool
+ApplyLoad::measuresTxSetValidation() const
 {
-    releaseAssert(!samplesMs.empty());
-
-    double mean = std::accumulate(samplesMs.begin(), samplesMs.end(), 0.0) /
-                  samplesMs.size();
-
-    double varianceMsSq = 0.0;
-    for (auto const& sample : samplesMs)
+    switch (mTimingPhases)
     {
-        double delta = sample - mean;
-        varianceMsSq += delta * delta;
+    case ApplyLoadTimingPhases::APPLY_ONLY:
+        return false;
+    case ApplyLoadTimingPhases::TX_SET_VALIDATION_AND_APPLY:
+        return true;
     }
-    varianceMsSq /= samplesMs.size();
-
-    std::vector<double> sortedSamples = samplesMs;
-    std::sort(sortedSamples.begin(), sortedSamples.end());
-
-    CLOG_WARNING(Perf, "mean {}: {} ms", label, mean);
-    CLOG_WARNING(Perf, "p25 {}:  {} ms", label,
-                 interpolatePercentile(sortedSamples, 25.0));
-    CLOG_WARNING(Perf, "p50 {}:  {} ms", label,
-                 interpolatePercentile(sortedSamples, 50.0));
-    CLOG_WARNING(Perf, "p75 {}:  {} ms", label,
-                 interpolatePercentile(sortedSamples, 75.0));
-    CLOG_WARNING(Perf, "p95 {}:  {} ms", label,
-                 interpolatePercentile(sortedSamples, 95.0));
-    CLOG_WARNING(Perf, "p99 {}:  {} ms", label,
-                 interpolatePercentile(sortedSamples, 99.0));
-    CLOG_WARNING(Perf, "{} stddev: {} ms", label, std::sqrt(varianceMsSq));
+    releaseAssertOrThrow(false);
+    return false;
 }
 
 void
-ApplyLoad::logConfiguredPhaseStats() const
+ApplyLoad::logTxSetValidationPhaseStats() const
 {
-    if (!measuresTxSetValidation())
-    {
-        return;
-    }
+    releaseAssert(measuresTxSetValidation());
 
     CLOG_WARNING(Perf, "================================================");
     logPhaseStats("txset validation", mPhaseValidationMs);
@@ -961,23 +975,37 @@ ApplyLoad::logConfiguredPhaseStats() const
     logPhaseStats("ledger close", mPhaseLedgerCloseMs);
     logPhaseStats("end-to-end txset+apply", mPhaseEndToEndMs);
 
-    double validationSum = std::accumulate(mPhaseValidationMs.begin(),
-                                           mPhaseValidationMs.end(), 0.0);
-    double ledgerCloseSum = std::accumulate(mPhaseLedgerCloseMs.begin(),
-                                            mPhaseLedgerCloseMs.end(), 0.0);
-    double e2eSum = std::accumulate(mPhaseEndToEndMs.begin(),
-                                    mPhaseEndToEndMs.end(), 0.0);
-    if (e2eSum > 0.0)
+    // Report each phase's share of its own ledger's end-to-end time as a
+    // distribution over ledgers, so per-ledger variance in the shares is
+    // visible rather than just the ratio of the totals.
+    auto const sampleCount = mPhaseEndToEndMs.size();
+    releaseAssert(mPhaseValidationMs.size() == sampleCount &&
+                  mPhaseLedgerCloseMs.size() == sampleCount);
+    std::vector<double> validationShares;
+    std::vector<double> ledgerCloseShares;
+    std::vector<double> otherShares;
+    for (size_t i = 0; i < sampleCount; ++i)
     {
-        CLOG_WARNING(Perf, "txset validation share of end-to-end: {:.2f}%",
-                     validationSum / e2eSum * 100.0);
-        CLOG_WARNING(Perf, "ledger close share of end-to-end: {:.2f}%",
-                     ledgerCloseSum / e2eSum * 100.0);
-        CLOG_WARNING(Perf,
-                     "other receive/consensus/externalize overhead share "
-                     "of end-to-end: {:.2f}%",
-                     (e2eSum - validationSum - ledgerCloseSum) / e2eSum *
-                         100.0);
+        if (mPhaseEndToEndMs[i] <= 0.0)
+        {
+            continue;
+        }
+        double validationShare =
+            mPhaseValidationMs[i] / mPhaseEndToEndMs[i] * 100.0;
+        double ledgerCloseShare =
+            mPhaseLedgerCloseMs[i] / mPhaseEndToEndMs[i] * 100.0;
+        validationShares.emplace_back(validationShare);
+        ledgerCloseShares.emplace_back(ledgerCloseShare);
+        // Everything outside validation and close: wire decoding, SCP
+        // processing, and externalization overhead.
+        otherShares.emplace_back(100.0 - validationShare - ledgerCloseShare);
+    }
+    if (!validationShares.empty())
+    {
+        CLOG_WARNING(Perf, "per-ledger phase shares of end-to-end time:");
+        logPhaseStats("txset validation share", validationShares, "%");
+        logPhaseStats("ledger close share", ledgerCloseShares, "%");
+        logPhaseStats("other consensus overhead share", otherShares, "%");
     }
     CLOG_WARNING(Perf, "================================================");
 }
@@ -987,11 +1015,10 @@ ApplyLoad::recordSorobanUtilization(ApplicableTxSetFrame const& txSet,
                                     uint32_t ledgerVersion)
 {
     auto ledgerResources = mApp.getLedgerManager().maxLedgerResources(true);
-    auto txSetResources =
-        txSet.getPhases()
-            .at(static_cast<size_t>(TxSetPhase::SOROBAN))
-            .getTotalResources(ledgerVersion)
-            .value();
+    auto txSetResources = txSet.getPhases()
+                              .at(static_cast<size_t>(TxSetPhase::SOROBAN))
+                              .getTotalResources(ledgerVersion)
+                              .value();
     auto updateUtilization = [&](medida::Histogram& histogram,
                                  Resource::Type resource) {
         histogram.Update(txSetResources.getVal(resource) * 1.0 /
@@ -1020,10 +1047,9 @@ ApplyLoad::closeLedger(std::vector<TransactionFrameBasePtr> const& txs,
 
     if (recordUtilization)
     {
-        recordSorobanUtilization(
-            *txSet.second,
-            mApp.getLedgerManager().getLastClosedLedgerHeader().header
-                .ledgerVersion);
+        recordSorobanUtilization(*txSet.second, mApp.getLedgerManager()
+                                                    .getLastClosedLedgerHeader()
+                                                    .header.ledgerVersion);
     }
     auto sv =
         mApp.getHerder().makeStellarValue(txSet.first->getContentsHash(), 1,
@@ -1034,8 +1060,7 @@ ApplyLoad::closeLedger(std::vector<TransactionFrameBasePtr> const& txs,
 
 void
 ApplyLoad::closeLedgerViaConsensus(
-    std::vector<TransactionFrameBasePtr> const& txs,
-    bool recordUtilization)
+    std::vector<TransactionFrameBasePtr> const& txs, bool recordUtilization)
 {
     releaseAssert(!txs.empty());
     auto& herder = mApp.getHerder();
@@ -1103,17 +1128,17 @@ ApplyLoad::closeLedgerViaConsensus(
 }
 
 void
-ApplyLoad::closeBenchmarkLedger(
-    std::vector<TransactionFrameBasePtr> const& txs,
-    bool recordUtilization)
+ApplyLoad::closeBenchmarkLedger(std::vector<TransactionFrameBasePtr> const& txs,
+                                bool recordUtilization)
 {
-    if (measuresTxSetValidation())
+    switch (mTimingPhases)
     {
-        closeLedgerViaConsensus(txs, recordUtilization);
-    }
-    else
-    {
+    case ApplyLoadTimingPhases::APPLY_ONLY:
         closeLedger(txs, {}, recordUtilization);
+        break;
+    case ApplyLoadTimingPhases::TX_SET_VALIDATION_AND_APPLY:
+        closeLedgerViaConsensus(txs, recordUtilization);
+        break;
     }
 }
 
@@ -1682,7 +1707,10 @@ ApplyLoad::benchmarkLimits()
 
     CLOG_INFO(Perf, "Tx Success Rate: {:f}%", successRate() * 100);
 
-    logConfiguredPhaseStats();
+    if (measuresTxSetValidation())
+    {
+        logTxSetValidationPhaseStats();
+    }
 }
 
 double
@@ -1987,14 +2015,16 @@ ApplyLoad::benchmarkModelTx()
     releaseAssert(!closeTimes.empty());
 
     CLOG_WARNING(Perf, "================================================");
-    CLOG_WARNING(Perf,
-                 "Model tx benchmark stats ({} ledgers, {} tx per ledger):",
-                 config.APPLY_LOAD_NUM_LEDGERS,
-                 config.APPLY_LOAD_MAX_SOROBAN_TX_COUNT);
+    CLOG_WARNING(
+        Perf, "Model tx benchmark stats ({} ledgers, {} tx per ledger):",
+        config.APPLY_LOAD_NUM_LEDGERS, config.APPLY_LOAD_MAX_SOROBAN_TX_COUNT);
     logPhaseStats("close time", closeTimes);
     CLOG_WARNING(Perf, "================================================");
 
-    logConfiguredPhaseStats();
+    if (measuresTxSetValidation())
+    {
+        logTxSetValidationPhaseStats();
+    }
 }
 
 double

--- a/src/simulation/ApplyLoad.h
+++ b/src/simulation/ApplyLoad.h
@@ -22,7 +22,8 @@ class ApplyLoad
     // of values is [0,1.0].
     double successRate();
 
-    // Closes a ledger with the given transactions and optional upgrades.
+    // Closes a ledger through the historical direct-externalization path.
+    // checkValid runs before the ledger-close timer, leaving its caches warm.
     // `recordSorobanUtilization` indicates whether to record utilization of
     // Soroban resources in transaction set, this should only be necessary for
     // the benchmark runs.
@@ -48,6 +49,30 @@ class ApplyLoad
     uint32_t getTotalHotArchiveEntries() const;
 
   private:
+    bool
+    measuresTxSetValidation() const
+    {
+        return mTimingPhases ==
+               ApplyLoadTimingPhases::TX_SET_VALIDATION_AND_APPLY;
+    }
+
+    // Simulates a non-leader receiving a tx set over the wire, then closes it
+    // through local consensus. Tx-set creation is outside the measured span.
+    void
+    closeLedgerViaConsensus(std::vector<TransactionFrameBasePtr> const& txs,
+                            bool recordUtilization);
+    void closeBenchmarkLedger(
+        std::vector<TransactionFrameBasePtr> const& txs,
+        bool recordUtilization);
+    void recordSorobanUtilization(ApplicableTxSetFrame const& txSet,
+                                  uint32_t ledgerVersion);
+
+    // Logs the distribution of per-ledger samples for one timing phase.
+    // Passing "close time" preserves the historical output format.
+    static void logPhaseStats(std::string const& label,
+                              std::vector<double> const& samplesMs);
+    void logConfiguredPhaseStats() const;
+
     uint32_t calculateRequiredHotArchiveEntries(Config const& cfg);
 
     void setup();
@@ -140,6 +165,20 @@ class ApplyLoad
     ApplyLoadMode mMode;
     ApplyLoadModelTx mModelTx;
     ApplyLoadTxProfile mLimitsBasedTxProfile;
+    ApplyLoadTimingPhases mTimingPhases;
+
+    // A phase is a timed portion of one ledger's receiver-side processing. We
+    // track cold tx-set validation, ledger close/application, and end-to-end
+    // time from wire decoding through the completed ledger close. Ledger close
+    // includes apply-side prepareForApply.
+    std::vector<double> mPhaseValidationMs;
+    std::vector<double> mPhaseLedgerCloseMs;
+    std::vector<double> mPhaseEndToEndMs;
+
+    // Signature cache totals and the transaction count used to interpret them.
+    uint64_t mLedgerSigCacheHits = 0;
+    uint64_t mLedgerSigCacheMisses = 0;
+    uint64_t mBenchmarkTxCount = 0;
 
     uint32_t mTotalHotArchiveEntries;
 

--- a/src/simulation/ApplyLoad.h
+++ b/src/simulation/ApplyLoad.h
@@ -22,7 +22,8 @@ class ApplyLoad
     // of values is [0,1.0].
     double successRate();
 
-    // Closes a ledger through the historical direct-externalization path.
+    // Closes a ledger through the direct-externalization path, bypassing
+    // consensus.
     // checkValid runs before the ledger-close timer, leaving its caches warm.
     // `recordSorobanUtilization` indicates whether to record utilization of
     // Soroban resources in transaction set, this should only be necessary for
@@ -49,29 +50,25 @@ class ApplyLoad
     uint32_t getTotalHotArchiveEntries() const;
 
   private:
-    bool
-    measuresTxSetValidation() const
-    {
-        return mTimingPhases ==
-               ApplyLoadTimingPhases::TX_SET_VALIDATION_AND_APPLY;
-    }
+    // Whether this run records tx-set validation phase timings (i.e. runs in
+    // the TX_SET_VALIDATION_AND_APPLY timing path).
+    bool measuresTxSetValidation() const;
 
     // Simulates a non-leader receiving a tx set over the wire, then closes it
     // through local consensus. Tx-set creation is outside the measured span.
     void
     closeLedgerViaConsensus(std::vector<TransactionFrameBasePtr> const& txs,
                             bool recordUtilization);
-    void closeBenchmarkLedger(
-        std::vector<TransactionFrameBasePtr> const& txs,
-        bool recordUtilization);
+    // Closes a benchmark ledger through the path selected by
+    // APPLY_LOAD_TIMING_PHASES.
+    void closeBenchmarkLedger(std::vector<TransactionFrameBasePtr> const& txs,
+                              bool recordUtilization);
     void recordSorobanUtilization(ApplicableTxSetFrame const& txSet,
                                   uint32_t ledgerVersion);
 
-    // Logs the distribution of per-ledger samples for one timing phase.
-    // Passing "close time" preserves the historical output format.
-    static void logPhaseStats(std::string const& label,
-                              std::vector<double> const& samplesMs);
-    void logConfiguredPhaseStats() const;
+    // Logs the phase timings recorded by closeLedgerViaConsensus. Must only
+    // be called when measuresTxSetValidation() is true.
+    void logTxSetValidationPhaseStats() const;
 
     uint32_t calculateRequiredHotArchiveEntries(Config const& cfg);
 

--- a/src/simulation/test/LoadGeneratorTests.cpp
+++ b/src/simulation/test/LoadGeneratorTests.cpp
@@ -983,8 +983,12 @@ TEST_CASE("Upgrade setup with metrics reset", "[loadgen]")
 
 TEST_CASE("apply load", "[loadgen][applyload][acceptance]")
 {
+    auto const timingPhases =
+        GENERATE(ApplyLoadTimingPhases::APPLY_ONLY,
+                 ApplyLoadTimingPhases::TX_SET_VALIDATION_AND_APPLY);
     auto cfg = getTestConfig();
     cfg.APPLY_LOAD_MODE = ApplyLoadMode::LIMIT_BASED;
+    cfg.APPLY_LOAD_TIMING_PHASES = timingPhases;
     cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE = 1000;
     cfg.USE_CONFIG_FOR_GENESIS = true;
     cfg.LEDGER_PROTOCOL_VERSION = Config::CURRENT_LEDGER_PROTOCOL_VERSION;
@@ -1053,9 +1057,20 @@ TEST_CASE("apply load", "[loadgen][applyload][acceptance]")
     auto sampleEntries = ledgerView.loadArchiveKeys(sampleKeys, "test");
     REQUIRE(sampleEntries.size() == sampleKeys.size());
 
+    auto const lclBeforeExecute =
+        app->getLedgerManager().getLastClosedLedgerNum();
     al.execute();
 
+    REQUIRE(app->getLedgerManager().getLastClosedLedgerNum() >=
+            lclBeforeExecute + cfg.APPLY_LOAD_NUM_LEDGERS);
     REQUIRE(1.0 - al.successRate() < std::numeric_limits<double>::epsilon());
+    if (timingPhases == ApplyLoadTimingPhases::TX_SET_VALIDATION_AND_APPLY)
+    {
+        // Each benchmark ledger runs at least one cold tx set validation.
+        REQUIRE(app->getMetrics()
+                    .NewTimer({"herder", "txset", "validate"})
+                    .count() >= cfg.APPLY_LOAD_NUM_LEDGERS);
+    }
 }
 
 TEST_CASE("apply load find max SAC TPS",
@@ -1101,9 +1116,13 @@ TEST_CASE("apply load find max SAC TPS",
 TEST_CASE("apply load benchmark model tx",
           "[loadgen][applyload][soroban][acceptance]")
 {
+    auto const timingPhases =
+        GENERATE(ApplyLoadTimingPhases::APPLY_ONLY,
+                 ApplyLoadTimingPhases::TX_SET_VALIDATION_AND_APPLY);
     auto cfg = getTestConfig();
     cfg.APPLY_LOAD_MODE = ApplyLoadMode::BENCHMARK_MODEL_TX;
     cfg.APPLY_LOAD_MODEL_TX = ApplyLoadModelTx::SAC;
+    cfg.APPLY_LOAD_TIMING_PHASES = timingPhases;
     cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE = 1000;
     cfg.USE_CONFIG_FOR_GENESIS = true;
     cfg.LEDGER_PROTOCOL_VERSION = Config::CURRENT_LEDGER_PROTOCOL_VERSION;
@@ -1122,13 +1141,24 @@ TEST_CASE("apply load benchmark model tx",
 
     ApplyLoad al(*app);
 
+    auto const lclBeforeExecute =
+        app->getLedgerManager().getLastClosedLedgerNum();
     al.execute();
 
+    REQUIRE(app->getLedgerManager().getLastClosedLedgerNum() >=
+            lclBeforeExecute + cfg.APPLY_LOAD_NUM_LEDGERS);
     REQUIRE(1.0 - al.successRate() < std::numeric_limits<double>::epsilon());
 
     auto& successCountMetric =
         app->getMetrics().NewCounter({"ledger", "apply-soroban", "success"});
     REQUIRE(successCountMetric.count() > 0);
+    if (timingPhases == ApplyLoadTimingPhases::TX_SET_VALIDATION_AND_APPLY)
+    {
+        // Each benchmark ledger runs at least one cold tx set validation.
+        REQUIRE(app->getMetrics()
+                    .NewTimer({"herder", "txset", "validate"})
+                    .count() >= cfg.APPLY_LOAD_NUM_LEDGERS);
+    }
 }
 
 TEST_CASE("apply load benchmark custom token",


### PR DESCRIPTION
# Description

This adds a new mode to apply load, allowing us for more "end to end" simulations. In the new mode, we time and simulate ballot phase through the end of apply, but in a single node network such that SCP state transitions occur instantly. This is useful, as it allows us to benchmark the processing overhead associated with consensus, as well as measure cache performance and dedup similar work done during tx set validation and the later application of this transaction set.

The motivation for this test was from my recent block latency experiments. I noticed how optimizations in network calls, reducing bandwidth, etc were not moving the needle on actual block latency. It turned out that consensus latency was greatly affected by CPU based bottlenecks, not just network calls. On supercluster, it's challenging to benchmark CPU costs of concensus, as you can't easily run tracy or profilers and have limited visibility to single node performance. This test allows us to much more easily measure and improve the processing heavy aspects of concensus. In overlay-v2-shared for a block with 6K SAC transfers, we saw about 300 ms of non-network "ingestion" time when receiving a tx set and 500 ms of apply. Imo this was a significant blind spot in our single node apply load tests previously.

Note that the actual number produced by this test is meaningless, as consensus without a network tells us very little about overall performance. However, the reported phase timings are very useful in identifying bottlenecks and comparing solutions. This simulates the processing done by a non-leader node. In the future, it may also be helpful to add a mode for block construction as well.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
