### PR TITLE
Adjust LTO settings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,8 @@ resolver = "2"
 members = ["src/rust"]
 
 [profile.release]
-codegen-units = 1
-lto = true
+codegen-units = 16
+lto="thin"
 # Note: setting debug=true here is only going to cause debuginfo to be
 # generated for polymorphic functions inlined from sub-crates and/or
 # functions defined in the top-level rust crate, not the soroban sub

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -344,6 +344,8 @@ $(LIBRUST_STELLAR_CORE): $(RUST_HOST_DEPFILES) $(SRC_RUST_FILES) Makefile $(RUST
 	CARGO_NET_GIT_FETCH_WITH_CLI=true \
 	$(CARGO) rustc \
 		$(CARGOFLAGS_BUILDSTD) \
+		--config 'profile.release.lto="off"' \
+		--config 'profile.release.codegen-units=16' \
 		--package stellar-core \
 		--target $(RUST_TARGET) \
 		$(RUST_PROFILE_ARG) \
@@ -420,6 +422,8 @@ $(SOROBAN_LIBS_STAMP): $(wildcard rust/soroban/p*/Cargo.lock) $(ALL_SOROBAN_GIT_
 		CARGO_TARGET_DIR=$(SOROBAN_BUILD_DIR)/$$proto/target \
 		CARGO_NET_GIT_FETCH_WITH_CLI=true \
 		$(CARGO) build \
+			--config 'profile.release.lto="thin"' \
+			--config 'profile.release.codegen-units=16' \
 			--package soroban-env-host \
 			$(RUST_PROFILE_ARG) \
 			--locked \
@@ -457,6 +461,8 @@ $(LIBRUST_STELLAR_CORE): $(RUST_HOST_DEPFILES) $(SRC_RUST_FILES) $(ALL_SOROBAN_L
 	CARGO_NET_GIT_FETCH_WITH_CLI=true \
 	$(CARGO) rustc \
 		--package stellar-core \
+		--config 'profile.release.lto="thin"' \
+		--config 'profile.release.codegen-units=16' \
 		$(RUST_PROFILE_ARG) \
 		--locked \
 		--target-dir $(abspath $(RUST_TARGET_DIR)) \


### PR DESCRIPTION
This cuts build times about in half for standard / release / non-fastdev builds. Depending on the machine, it gives up either no measurable runtime perf (on a fast macbook pro) or about 10% of soroswap benchmark median exec time (on a slower older xeon).

Consequently: I'm not certain this is a good idea yet. I think we should do more testing. But I wanted to open a PR to have something to build images off and test on other machines and workloads.