### PR TITLE
Extract entries by reference from LTX.

### DIFF
--- a/src/bucket/BucketListBase.cpp
+++ b/src/bucket/BucketListBase.cpp
@@ -890,7 +890,6 @@ template void BucketListBase<HotArchiveBucket>::addBatchInternal(
 
 template void BucketListBase<LiveBucket>::addBatchInternal(
     Application& app, uint32_t currLedger, uint32_t currLedgerProtocol,
-    std::vector<LedgerEntry> const& initEntries,
-    std::vector<LedgerEntry> const& liveEntries,
-    std::vector<LedgerKey> const& deadEntries);
+    LedgerEntryRefs const& initEntries, LedgerEntryRefs const& liveEntries,
+    LedgerKeyRefs const& deadEntries);
 }

--- a/src/bucket/BucketManager.cpp
+++ b/src/bucket/BucketManager.cpp
@@ -1024,9 +1024,9 @@ BucketManager::forgetUnreferencedBuckets(HistoryArchiveState const& has)
 
 void
 BucketManager::addLiveBatch(Application& app, LedgerHeader header,
-                            std::vector<LedgerEntry> const& initEntries,
-                            std::vector<LedgerEntry> const& liveEntries,
-                            std::vector<LedgerKey> const& deadEntries)
+                            LedgerEntryRefs initEntries,
+                            LedgerEntryRefs liveEntries,
+                            LedgerKeyRefs deadEntries)
 {
     ZoneScoped;
 #ifdef BUILD_TESTS

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -7,6 +7,7 @@
 #include "bucket/BucketMergeMap.h"
 #include "history/HistoryArchive.h"
 #include "ledger/ImmutableLedgerView.h"
+#include "ledger/LedgerEntryRefs.h"
 #include "ledger/NetworkConfig.h"
 #include "main/Config.h"
 #include "util/ThreadAnnotations.h"
@@ -315,9 +316,8 @@ class BucketManager : NonMovableOrCopyable
     // `header` value should be taken from the ledger at which this batch is
     // being added.
     void addLiveBatch(Application& app, LedgerHeader header,
-                      std::vector<LedgerEntry> const& initEntries,
-                      std::vector<LedgerEntry> const& liveEntries,
-                      std::vector<LedgerKey> const& deadEntries);
+                      LedgerEntryRefs initEntries, LedgerEntryRefs liveEntries,
+                      LedgerKeyRefs deadEntries);
     void addHotArchiveBatch(Application& app, LedgerHeader header,
                             std::vector<LedgerEntry> const& archivedEntries,
                             std::vector<LedgerKey> const& restoredEntries);

--- a/src/bucket/LiveBucket.cpp
+++ b/src/bucket/LiveBucket.cpp
@@ -377,11 +377,24 @@ LiveBucket::getRangeForType(LedgerEntryType type) const
     return getIndex().getRangeForType(type);
 }
 
+#ifdef BUILD_TESTS
 std::vector<BucketEntry>
 LiveBucket::convertToBucketEntry(bool useInit,
                                  std::vector<LedgerEntry> const& initEntries,
                                  std::vector<LedgerEntry> const& liveEntries,
                                  std::vector<LedgerKey> const& deadEntries)
+{
+    auto initRefs = toRefs(initEntries);
+    auto liveRefs = toRefs(liveEntries);
+    auto deadRefs = toRefs(deadEntries);
+    return convertToBucketEntry(useInit, initRefs, liveRefs, deadRefs);
+}
+#endif
+
+std::vector<BucketEntry>
+LiveBucket::convertToBucketEntry(bool useInit, LedgerEntryRefs initEntries,
+                                 LedgerEntryRefs liveEntries,
+                                 LedgerKeyRefs deadEntries)
 {
     ZoneScoped;
     size_t totalSize =
@@ -393,21 +406,21 @@ LiveBucket::convertToBucketEntry(bool useInit,
     std::vector<BucketEntry*> sortedEntries;
     sortedEntries.reserve(totalSize);
 
-    for (auto const& e : initEntries)
+    for (LedgerEntry const& e : initEntries)
     {
         auto& ce = entries.emplace_back();
         ce.type(useInit ? INITENTRY : LIVEENTRY);
         ce.liveEntry() = e;
         sortedEntries.push_back(&ce);
     }
-    for (auto const& e : liveEntries)
+    for (LedgerEntry const& e : liveEntries)
     {
         auto& ce = entries.emplace_back();
         ce.type(LIVEENTRY);
         ce.liveEntry() = e;
         sortedEntries.push_back(&ce);
     }
-    for (auto const& e : deadEntries)
+    for (LedgerKey const& e : deadEntries)
     {
         auto& ce = entries.emplace_back();
         ce.type(DEADENTRY);
@@ -433,12 +446,27 @@ LiveBucket::convertToBucketEntry(bool useInit,
     return bucket;
 }
 
+#ifdef BUILD_TESTS
 std::shared_ptr<LiveBucket>
 LiveBucket::fresh(BucketManager& bucketManager, uint32_t protocolVersion,
                   std::vector<LedgerEntry> const& initEntries,
                   std::vector<LedgerEntry> const& liveEntries,
                   std::vector<LedgerKey> const& deadEntries,
                   bool countMergeEvents, asio::io_context& ctx, bool doFsync)
+{
+    auto initRefs = toRefs(initEntries);
+    auto liveRefs = toRefs(liveEntries);
+    auto deadRefs = toRefs(deadEntries);
+    return fresh(bucketManager, protocolVersion, initRefs, liveRefs, deadRefs,
+                 countMergeEvents, ctx, doFsync);
+}
+#endif
+
+std::shared_ptr<LiveBucket>
+LiveBucket::fresh(BucketManager& bucketManager, uint32_t protocolVersion,
+                  LedgerEntryRefs initEntries, LedgerEntryRefs liveEntries,
+                  LedgerKeyRefs deadEntries, bool countMergeEvents,
+                  asio::io_context& ctx, bool doFsync)
 {
     ZoneScoped;
     // When building fresh buckets after protocol version 10 (i.e. version
@@ -480,10 +508,9 @@ LiveBucket::fresh(BucketManager& bucketManager, uint32_t protocolVersion,
 std::shared_ptr<LiveBucket>
 LiveBucket::freshInMemoryOnly(BucketManager& bucketManager,
                               uint32_t protocolVersion,
-                              std::vector<LedgerEntry> const& initEntries,
-                              std::vector<LedgerEntry> const& liveEntries,
-                              std::vector<LedgerKey> const& deadEntries,
-                              bool countMergeEvents)
+                              LedgerEntryRefs initEntries,
+                              LedgerEntryRefs liveEntries,
+                              LedgerKeyRefs deadEntries, bool countMergeEvents)
 {
     ZoneScoped;
     // When building fresh buckets after protocol version 10 (i.e. version

--- a/src/bucket/LiveBucket.h
+++ b/src/bucket/LiveBucket.h
@@ -7,6 +7,7 @@
 #include "bucket/BucketBase.h"
 #include "bucket/BucketUtils.h"
 #include "bucket/LiveBucketIndex.h"
+#include "ledger/LedgerEntryRefs.h"
 
 namespace medida
 {
@@ -83,10 +84,16 @@ class LiveBucket : public BucketBase<LiveBucket, LiveBucketIndex>,
                                       uint32_t protocolVersion);
 
     static std::vector<BucketEntry>
+    convertToBucketEntry(bool useInit, LedgerEntryRefs initEntries,
+                         LedgerEntryRefs liveEntries,
+                         LedgerKeyRefs deadEntries);
+#ifdef BUILD_TESTS
+    static std::vector<BucketEntry>
     convertToBucketEntry(bool useInit,
                          std::vector<LedgerEntry> const& initEntries,
                          std::vector<LedgerEntry> const& liveEntries,
                          std::vector<LedgerKey> const& deadEntries);
+#endif
 
     template <typename InputSource>
     static void mergeCasesWithEqualKeys(
@@ -118,20 +125,25 @@ class LiveBucket : public BucketBase<LiveBucket, LiveBucketIndex>,
     // be sorted, hashed, and adopted in the provided BucketManager.
     static std::shared_ptr<LiveBucket>
     fresh(BucketManager& bucketManager, uint32_t protocolVersion,
+          LedgerEntryRefs initEntries, LedgerEntryRefs liveEntries,
+          LedgerKeyRefs deadEntries, bool countMergeEvents,
+          asio::io_context& ctx, bool doFsync);
+#ifdef BUILD_TESTS
+    static std::shared_ptr<LiveBucket>
+    fresh(BucketManager& bucketManager, uint32_t protocolVersion,
           std::vector<LedgerEntry> const& initEntries,
           std::vector<LedgerEntry> const& liveEntries,
           std::vector<LedgerKey> const& deadEntries, bool countMergeEvents,
           asio::io_context& ctx, bool doFsync);
+#endif
 
     // Create a fresh bucket that exists only in memory, without writing to
     // disk, calculating a hash, or indexing. This should only be used for
     // "level -1" snap buckets that are immediately merged into level 0.
     static std::shared_ptr<LiveBucket>
     freshInMemoryOnly(BucketManager& bucketManager, uint32_t protocolVersion,
-                      std::vector<LedgerEntry> const& initEntries,
-                      std::vector<LedgerEntry> const& liveEntries,
-                      std::vector<LedgerKey> const& deadEntries,
-                      bool countMergeEvents);
+                      LedgerEntryRefs initEntries, LedgerEntryRefs liveEntries,
+                      LedgerKeyRefs deadEntries, bool countMergeEvents);
 
     // Returns true if the given BucketEntry should be dropped in the bottom
     // level bucket (i.e. DEADENTRY)

--- a/src/bucket/LiveBucketList.cpp
+++ b/src/bucket/LiveBucketList.cpp
@@ -14,9 +14,8 @@ namespace stellar
 void
 LiveBucketList::addBatch(Application& app, uint32_t currLedger,
                          uint32_t currLedgerProtocol,
-                         std::vector<LedgerEntry> const& initEntries,
-                         std::vector<LedgerEntry> const& liveEntries,
-                         std::vector<LedgerKey> const& deadEntries)
+                         LedgerEntryRefs initEntries,
+                         LedgerEntryRefs liveEntries, LedgerKeyRefs deadEntries)
 {
     ZoneScoped;
     addBatchInternal(app, currLedger, currLedgerProtocol, initEntries,
@@ -25,6 +24,21 @@ LiveBucketList::addBatch(Application& app, uint32_t currLedger,
     // Initialize caches for any new buckets we might have added
     maybeInitializeCaches(app.getConfig());
 }
+
+#ifdef BUILD_TESTS
+void
+LiveBucketList::addBatch(Application& app, uint32_t currLedger,
+                         uint32_t currLedgerProtocol,
+                         std::vector<LedgerEntry> const& initEntries,
+                         std::vector<LedgerEntry> const& liveEntries,
+                         std::vector<LedgerKey> const& deadEntries)
+{
+    auto initRefs = toRefs(initEntries);
+    auto liveRefs = toRefs(liveEntries);
+    auto deadRefs = toRefs(deadEntries);
+    addBatch(app, currLedger, currLedgerProtocol, initRefs, liveRefs, deadRefs);
+}
+#endif
 
 BucketEntryCounters
 LiveBucketList::sumBucketEntryCounters() const

--- a/src/bucket/LiveBucketList.h
+++ b/src/bucket/LiveBucketList.h
@@ -46,10 +46,15 @@ class LiveBucketList : public BucketListBase<LiveBucket>
     // and `currProtocolVersion` values should be taken from the ledger at which
     // this batch is being added.
     void addBatch(Application& app, uint32_t currLedger,
+                  uint32_t currLedgerProtocol, LedgerEntryRefs initEntries,
+                  LedgerEntryRefs liveEntries, LedgerKeyRefs deadEntries);
+#ifdef BUILD_TESTS
+    void addBatch(Application& app, uint32_t currLedger,
                   uint32_t currLedgerProtocol,
                   std::vector<LedgerEntry> const& initEntries,
                   std::vector<LedgerEntry> const& liveEntries,
                   std::vector<LedgerKey> const& deadEntries);
+#endif
 
     BucketEntryCounters sumBucketEntryCounters() const;
 

--- a/src/bucket/test/BucketTestUtils.cpp
+++ b/src/bucket/test/BucketTestUtils.cpp
@@ -37,15 +37,27 @@ getAppLedgerVersion(Application::pointer app)
 
 void
 addLiveBatchAndUpdateSnapshot(Application& app, LedgerHeader header,
-                              std::vector<LedgerEntry> const& initEntries,
-                              std::vector<LedgerEntry> const& liveEntries,
-                              std::vector<LedgerKey> const& deadEntries)
+                              LedgerEntryRefs initEntries,
+                              LedgerEntryRefs liveEntries,
+                              LedgerKeyRefs deadEntries)
 {
     auto& liveBl = app.getBucketManager().getLiveBucketList();
     liveBl.addBatch(app, header.ledgerSeq, header.ledgerVersion, initEntries,
                     liveEntries, deadEntries);
 
     app.getLedgerManager().updateCanonicalStateForTesting(header);
+}
+
+void
+addLiveBatchAndUpdateSnapshot(Application& app, LedgerHeader header,
+                              std::vector<LedgerEntry> const& initEntries,
+                              std::vector<LedgerEntry> const& liveEntries,
+                              std::vector<LedgerKey> const& deadEntries)
+{
+    auto initRefs = toRefs(initEntries);
+    auto liveRefs = toRefs(liveEntries);
+    auto deadRefs = toRefs(deadEntries);
+    addLiveBatchAndUpdateSnapshot(app, header, initRefs, liveRefs, deadRefs);
 }
 
 void
@@ -181,8 +193,8 @@ LedgerManagerForBucketTests::finalizeLedgerTxnChanges(
     if (mUseTestEntries)
     {
         // Seal the ltx but throw its entries away.
-        std::vector<LedgerEntry> init, live;
-        std::vector<LedgerKey> dead;
+        LedgerEntryRefVec init, live;
+        LedgerKeyRefVec dead;
 
         // Any V20 features must be behind initialLedgerVers check, see comment
         // in LedgerManagerImpl::ledgerClosed
@@ -262,7 +274,7 @@ LedgerManagerForBucketTests::finalizeLedgerTxnChanges(
         // Seal the ltx and collect its entries, but don't load Soroban
         // config yet -- test entries (including network config like eviction
         // iterator) are added directly to the BucketList below, not via ltx.
-        ltx.getAllEntries(init, live, dead);
+        ltx.sealAndBorrowAllEntries(init, live, dead);
 
         // Add dead entries from ltx to entries that will be added to BucketList
         // so we can test background eviction properly
@@ -280,7 +292,7 @@ LedgerManagerForBucketTests::finalizeLedgerTxnChanges(
             // When the actual entries have the same key as test entries, we
             // override the actual entries with the test entries (here we
             // just don't add the actual entries if they're already present).
-            for (auto const& liveEntry : live)
+            for (LedgerEntry const& liveEntry : live)
             {
                 if (std::find_if(mTestLiveEntries.begin(),
                                  mTestLiveEntries.end(),
@@ -295,12 +307,15 @@ LedgerManagerForBucketTests::finalizeLedgerTxnChanges(
         }
 
         // Use the testing values.
+        auto testInitRefs = toRefs(mTestInitEntries);
+        auto testLiveRefs = toRefs(mTestLiveEntries);
+        auto testDeadRefs = toRefs(mTestDeadEntries);
         mApplyState.addAnyContractsToModuleCache(lh.ledgerVersion,
-                                                 mTestInitEntries);
+                                                 testInitRefs);
         mApplyState.addAnyContractsToModuleCache(lh.ledgerVersion,
-                                                 mTestLiveEntries);
-        mApp.getBucketManager().addLiveBatch(
-            mApp, lh, mTestInitEntries, mTestLiveEntries, mTestDeadEntries);
+                                                 testLiveRefs);
+        mApp.getBucketManager().addLiveBatch(mApp, lh, testInitRefs,
+                                             testLiveRefs, testDeadRefs);
 
         // Load the final Soroban config AFTER addLiveBatch so that test
         // entries (e.g. stateArchivalSettings with eviction iterator) are
@@ -325,8 +340,7 @@ LedgerManagerForBucketTests::finalizeLedgerTxnChanges(
         }
 
         mApplyState.updateInMemorySorobanState(
-            mTestInitEntries, mTestLiveEntries, mTestDeadEntries, lh,
-            finalSorobanConfig);
+            testInitRefs, testLiveRefs, testDeadRefs, lh, finalSorobanConfig);
 
         mUseTestEntries = false;
         mAlsoAddActualEntries = false;

--- a/src/bucket/test/BucketTestUtils.h
+++ b/src/bucket/test/BucketTestUtils.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "ledger/LedgerEntryRefs.h"
 #include "test/TestUtils.h"
 #include "xdr/Stellar-ledger.h"
 
@@ -12,6 +13,10 @@ namespace stellar
 namespace BucketTestUtils
 {
 
+void addLiveBatchAndUpdateSnapshot(Application& app, LedgerHeader header,
+                                   LedgerEntryRefs initEntries,
+                                   LedgerEntryRefs liveEntries,
+                                   LedgerKeyRefs deadEntries);
 void addLiveBatchAndUpdateSnapshot(Application& app, LedgerHeader header,
                                    std::vector<LedgerEntry> const& initEntries,
                                    std::vector<LedgerEntry> const& liveEntries,
@@ -124,5 +129,6 @@ class BucketTestApplication : public TestApplication
         return std::make_unique<LedgerManagerForBucketTests>(*this);
     }
 };
-}
-}
+
+} // namespace BucketTestUtils
+} // namespace stellar

--- a/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
+++ b/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
@@ -111,10 +111,10 @@ struct BucketListGenerator
             mLiveKeys.insert(LedgerEntryKey(le));
         }
 
-        std::vector<LedgerEntry> initEntries, liveEntries;
-        std::vector<LedgerKey> deadEntries;
+        LedgerEntryRefVec initEntries, liveEntries;
+        LedgerKeyRefVec deadEntries;
         auto header = ltx.loadHeader().current();
-        ltx.getAllEntries(initEntries, liveEntries, deadEntries);
+        ltx.sealAndBorrowAllEntries(initEntries, liveEntries, deadEntries);
         BucketTestUtils::addLiveBatchAndUpdateSnapshot(
             *app, header, initEntries, liveEntries, deadEntries);
         ltx.commit();

--- a/src/ledger/InMemorySorobanState.cpp
+++ b/src/ledger/InMemorySorobanState.cpp
@@ -484,9 +484,8 @@ InMemorySorobanState::initializeStateFromSnapshot(
 
 void
 InMemorySorobanState::updateState(
-    std::vector<LedgerEntry> const& initEntries,
-    std::vector<LedgerEntry> const& liveEntries,
-    std::vector<LedgerKey> const& deadEntries, LedgerHeader const& lh,
+    LedgerEntryRefs initEntries, LedgerEntryRefs liveEntries,
+    LedgerKeyRefs deadEntries, LedgerHeader const& lh,
     std::optional<SorobanNetworkConfig const> const& sorobanConfig,
     SorobanMetrics& metrics)
 {
@@ -500,7 +499,7 @@ InMemorySorobanState::updateState(
     {
         releaseAssertOrThrow(sorobanConfig.has_value());
         uint32_t ledgerVersion = lh.ledgerVersion;
-        for (auto const& entry : initEntries)
+        for (LedgerEntry const& entry : initEntries)
         {
             if (entry.data.type() == CONTRACT_DATA)
             {
@@ -516,7 +515,7 @@ InMemorySorobanState::updateState(
             }
         }
 
-        for (auto const& entry : liveEntries)
+        for (LedgerEntry const& entry : liveEntries)
         {
             if (entry.data.type() == CONTRACT_DATA)
             {
@@ -532,7 +531,7 @@ InMemorySorobanState::updateState(
             }
         }
 
-        for (auto const& key : deadEntries)
+        for (LedgerKey const& key : deadEntries)
         {
             if (key.type() == CONTRACT_DATA)
             {

--- a/src/ledger/InMemorySorobanState.h
+++ b/src/ledger/InMemorySorobanState.h
@@ -10,6 +10,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "ledger/LedgerEntryRefs.h"
 #include "ledger/LedgerTypeUtils.h"
 #include "util/types.h"
 #include "xdr/Stellar-ledger-entries.h"
@@ -444,10 +445,8 @@ class InMemorySorobanState
     // Update the map with entries from a ledger close. ledgerSeq must be
     // exactly mLastClosedLedgerSeq + 1.
     void
-    updateState(std::vector<LedgerEntry> const& initEntries,
-                std::vector<LedgerEntry> const& liveEntries,
-                std::vector<LedgerKey> const& deadEntries,
-                LedgerHeader const& lh,
+    updateState(LedgerEntryRefs initEntries, LedgerEntryRefs liveEntries,
+                LedgerKeyRefs deadEntries, LedgerHeader const& lh,
                 std::optional<SorobanNetworkConfig const> const& sorobanConfig,
                 SorobanMetrics& metrics);
 

--- a/src/ledger/LedgerEntryRefs.h
+++ b/src/ledger/LedgerEntryRefs.h
@@ -1,0 +1,70 @@
+// Copyright 2026 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#pragma once
+
+#include "xdr/Stellar-ledger-entries.h"
+
+#include <functional>
+#include <span>
+#include <vector>
+
+namespace stellar
+{
+
+using LedgerEntryRef = std::reference_wrapper<LedgerEntry const>;
+using LedgerKeyRef = std::reference_wrapper<LedgerKey const>;
+using LedgerEntryRefVec = std::vector<LedgerEntryRef>;
+using LedgerKeyRefVec = std::vector<LedgerKeyRef>;
+
+// Non-owning views over ledger entries and keys.
+//
+// These are std::span with two deliberate modifications:
+//
+//  - No default constructor. The functions taking these are overloaded
+//    against ones taking `std::vector<LedgerEntry> const&` (in tests only), and
+//    a default-constructible span would make the existing `f({})` call sites
+//    ambiguous.
+//
+//  - Construction from an rvalue vector is deleted, so a view can never be
+//    built from a temporary that dies before it is read. Callers holding
+//    entries by value must therefore keep the result of `toRefs` in a named
+//    local for as long as they use the view.
+struct LedgerEntryRefs : std::span<LedgerEntryRef const>
+{
+    LedgerEntryRefs(LedgerEntryRefVec const& entries)
+        : std::span<LedgerEntryRef const>(entries)
+    {
+    }
+    LedgerEntryRefs(LedgerEntryRefVec&&) = delete;
+};
+
+struct LedgerKeyRefs : std::span<LedgerKeyRef const>
+{
+    LedgerKeyRefs(LedgerKeyRefVec const& keys)
+        : std::span<LedgerKeyRef const>(keys)
+    {
+    }
+    LedgerKeyRefs(LedgerKeyRefVec&&) = delete;
+};
+
+#ifdef BUILD_TESTS
+// Returns a vector of references to the entries in the input vector.
+// This is a helper for test-only wrappers that accept ledger entries/keys by
+// value for convenience, but need to pass them to functions that take
+// reference-based views.
+template <typename T>
+std::vector<std::reference_wrapper<T const>>
+toRefs(std::vector<T> const& values)
+{
+    std::vector<std::reference_wrapper<T const>> res;
+    res.reserve(values.size());
+    for (auto const& v : values)
+    {
+        res.push_back(v);
+    }
+    return res;
+}
+#endif
+} // namespace stellar

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -342,9 +342,8 @@ LedgerManagerImpl::ApplyState::isCompilationRunning() const
 
 void
 LedgerManagerImpl::ApplyState::updateInMemorySorobanState(
-    std::vector<LedgerEntry> const& initEntries,
-    std::vector<LedgerEntry> const& liveEntries,
-    std::vector<LedgerKey> const& deadEntries, LedgerHeader const& lh,
+    LedgerEntryRefs initEntries, LedgerEntryRefs liveEntries,
+    LedgerKeyRefs deadEntries, LedgerHeader const& lh,
     std::optional<SorobanNetworkConfig const> const& sorobanConfig)
 {
     releaseAssert(mPhase == Phase::SETTING_UP_STATE ||
@@ -3150,8 +3149,6 @@ LedgerManagerImpl::finalizeLedgerTxnChanges(
 {
     ZoneScoped;
     // `ledgerApplied` protects this call with a mutex
-    std::vector<LedgerEntry> initEntries, liveEntries;
-    std::vector<LedgerKey> deadEntries;
 
     EvictedStateVectors evictedState;
     std::vector<LedgerKey> restoredHotArchiveKeys;
@@ -3261,8 +3258,16 @@ LedgerManagerImpl::finalizeLedgerTxnChanges(
         finalSorobanConfig =
             std::make_optional(SorobanNetworkConfig::loadFromLedger(ltx));
     }
-    // NB: getAllEntries seals the ltx.
-    ltx.getAllEntries(initEntries, liveEntries, deadEntries);
+
+    // NB: these are borrowed from `ltx`, which stays for the remainder of this
+    // call. Make sure to not store these references anywhere out of scope of
+    // this function (e.g. via async tasks that are not joined before
+    // returning from this function).
+    // sealAndBorrowAllEntries seals the ltx, so the borrowed references are
+    // guaranteed to be immutable.
+    LedgerEntryRefVec initEntries, liveEntries;
+    LedgerKeyRefVec deadEntries;
+    ltx.sealAndBorrowAllEntries(initEntries, liveEntries, deadEntries);
 
     // Launch async task to update in-memory Soroban state. This is independent
     // from both addHotArchiveBatch and addLiveBatch, so all can run in
@@ -3386,11 +3391,11 @@ LedgerManagerImpl::ApplyState::evictFromModuleCache(
 
 void
 LedgerManagerImpl::ApplyState::addAnyContractsToModuleCache(
-    uint32_t ledgerVersion, std::vector<LedgerEntry> const& le)
+    uint32_t ledgerVersion, LedgerEntryRefs le)
 {
     ZoneScoped;
     assertWritablePhase();
-    for (auto const& e : le)
+    for (LedgerEntry const& e : le)
     {
         if (e.data.type() == CONTRACT_CODE)
         {

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -237,9 +237,8 @@ class LedgerManagerImpl : public LedgerManager
         // Non-const mutating methods, must always be called from the applying
         // thread (either main or parallel apply thread).
         void updateInMemorySorobanState(
-            std::vector<LedgerEntry> const& initEntries,
-            std::vector<LedgerEntry> const& liveEntries,
-            std::vector<LedgerKey> const& deadEntries, LedgerHeader const& lh,
+            LedgerEntryRefs initEntries, LedgerEntryRefs liveEntries,
+            LedgerKeyRefs deadEntries, LedgerHeader const& lh,
             std::optional<SorobanNetworkConfig const> const& sorobanConfig);
 
         // Note: These are const getters, but should still only be called in the
@@ -268,7 +267,7 @@ class LedgerManagerImpl : public LedgerManager
         // Adds all contracts in the provided set of LEs to the module cache.
         // This should be called as entries are added to the live bucketlist.
         void addAnyContractsToModuleCache(uint32_t ledgerVersion,
-                                          std::vector<LedgerEntry> const& le);
+                                          LedgerEntryRefs le);
 
         // Populates all live Soroban state into the cache from the provided
         // snapshot.

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -1616,21 +1616,21 @@ LedgerTxn::Impl::queryInflationWinners(size_t maxWinners, int64_t minVotes)
 }
 
 void
-LedgerTxn::getAllEntries(std::vector<LedgerEntry>& initEntries,
-                         std::vector<LedgerEntry>& liveEntries,
-                         std::vector<LedgerKey>& deadEntries)
+LedgerTxn::sealAndBorrowAllEntries(LedgerEntryRefVec& initEntries,
+                                   LedgerEntryRefVec& liveEntries,
+                                   LedgerKeyRefVec& deadEntries)
 {
-    getImpl()->getAllEntries(initEntries, liveEntries, deadEntries);
+    getImpl()->sealAndBorrowAllEntries(initEntries, liveEntries, deadEntries);
 }
 
 void
-LedgerTxn::Impl::getAllEntries(std::vector<LedgerEntry>& initEntries,
-                               std::vector<LedgerEntry>& liveEntries,
-                               std::vector<LedgerKey>& deadEntries)
+LedgerTxn::Impl::sealAndBorrowAllEntries(LedgerEntryRefVec& initEntries,
+                                         LedgerEntryRefVec& liveEntries,
+                                         LedgerKeyRefVec& deadEntries)
 {
-    abortIfWrongThread("getAllEntries");
-    std::vector<LedgerEntry> resInit, resLive;
-    std::vector<LedgerKey> resDead;
+    abortIfWrongThread("sealAndBorrowAllEntries");
+    LedgerEntryRefVec resInit, resLive;
+    LedgerKeyRefVec resDead;
     resInit.reserve(mEntry.size());
     resLive.reserve(mEntry.size());
     resDead.reserve(mEntry.size());

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -6,6 +6,7 @@
 
 #include "bucket/LiveBucketList.h"
 #include "ledger/InternalLedgerEntry.h"
+#include "ledger/LedgerEntryRefs.h"
 #include "ledger/LedgerTxnEntry.h"
 #include "ledger/LedgerTxnHeader.h"
 #include "util/UnorderedMap.h"
@@ -653,7 +654,7 @@ class AbstractLedgerTxn : public AbstractLedgerTxnParent
     virtual void updateWithoutLoading(InternalLedgerEntry const& entry) = 0;
     virtual void eraseWithoutLoading(InternalLedgerKey const& key) = 0;
 
-    // getChanges, getDelta, and getAllEntries are used to
+    // getChanges, getDelta, and sealAndBorrowAllEntries are used to
     // extract information about changes contained in the AbstractLedgerTxn
     // in different formats. These functions also cause the AbstractLedgerTxn
     // to enter the sealed state, simultaneously updating last modified if
@@ -666,17 +667,17 @@ class AbstractLedgerTxn : public AbstractLedgerTxnParent
     //     to the LedgerHeader) in a format convenient for answering queries
     //     about how specific entries and the header have changed. To be used
     //     for invariants.
-    // - getAllEntries
-    //     extracts a list of keys that were created (init), updated (live) or
-    //     deleted (dead) in this AbstractLedgerTxn. All these are to be
-    //     inserted into the BucketList.
+    // - sealAndBorrowAllEntries
+    //     seals the LTX, then returns lists of references to keys that were
+    //     created (init), updated (live) or deleted (dead) in this
+    //     AbstractLedgerTxn. All these are to be inserted into the BucketList.
     //
     // All of these functions throw if the AbstractLedgerTxn has a child.
     virtual LedgerEntryChanges getChanges() = 0;
     virtual LedgerTxnDelta getDelta() = 0;
-    virtual void getAllEntries(std::vector<LedgerEntry>& initEntries,
-                               std::vector<LedgerEntry>& liveEntries,
-                               std::vector<LedgerKey>& deadEntries) = 0;
+    virtual void sealAndBorrowAllEntries(LedgerEntryRefVec& initEntries,
+                                         LedgerEntryRefVec& liveEntries,
+                                         LedgerKeyRefVec& deadEntries) = 0;
 
     // Returns all TTL keys that have been modified (create, update, and
     // delete), but does not cause the AbstractLedgerTxn or update last
@@ -814,9 +815,9 @@ class LedgerTxn : public AbstractLedgerTxn
     std::vector<InflationWinner>
     queryInflationWinners(size_t maxWinners, int64_t minBalance) override;
 
-    void getAllEntries(std::vector<LedgerEntry>& initEntries,
-                       std::vector<LedgerEntry>& liveEntries,
-                       std::vector<LedgerKey>& deadEntries) override;
+    void sealAndBorrowAllEntries(LedgerEntryRefVec& initEntries,
+                                 LedgerEntryRefVec& liveEntries,
+                                 LedgerKeyRefVec& deadEntries) override;
     LedgerKeySet getAllKeysWithoutSealing() const override;
 
     UnorderedMap<LedgerKey, LedgerEntry>

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -427,10 +427,10 @@ class LedgerTxn::Impl
     std::vector<InflationWinner> queryInflationWinners(size_t maxWinners,
                                                        int64_t minBalance);
 
-    // getAllEntries has the strong exception safety guarantee
-    void getAllEntries(std::vector<LedgerEntry>& initEntries,
-                       std::vector<LedgerEntry>& liveEntries,
-                       std::vector<LedgerKey>& deadEntries);
+    // sealAndBorrowAllEntries has the strong exception safety guarantee
+    void sealAndBorrowAllEntries(LedgerEntryRefVec& initEntries,
+                                 LedgerEntryRefVec& liveEntries,
+                                 LedgerKeyRefVec& deadEntries);
     // getRestoredHotArchiveKeys and getRestoredLiveBucketListKeys
     // have the strong exception safety guarantee
     UnorderedMap<LedgerKey, LedgerEntry> getRestoredHotArchiveKeys() const;

--- a/src/ledger/test/LedgerTxnTests.cpp
+++ b/src/ledger/test/LedgerTxnTests.cpp
@@ -1013,9 +1013,9 @@ TEST_CASE("LedgerTxn eraseWithoutLoading", "[ledgertxn]")
         {
             LedgerTxn ltx1(app->getLedgerTxnRoot());
             REQUIRE(ltx1.create(le));
-            std::vector<LedgerEntry> init, live;
-            std::vector<LedgerKey> dead;
-            ltx1.getAllEntries(init, live, dead);
+            LedgerEntryRefVec init, live;
+            LedgerKeyRefVec dead;
+            ltx1.sealAndBorrowAllEntries(init, live, dead);
             REQUIRE_THROWS_AS(ltx1.eraseWithoutLoading(key),
                               std::runtime_error);
         }
@@ -2657,9 +2657,9 @@ TEST_CASE("LedgerTxn unsealHeader", "[ledgertxn]")
     SECTION("fails if header is active")
     {
         LedgerTxn ltx(app->getLedgerTxnRoot());
-        std::vector<LedgerEntry> init, live;
-        std::vector<LedgerKey> dead;
-        ltx.getAllEntries(init, live, dead);
+        LedgerEntryRefVec init, live;
+        LedgerKeyRefVec dead;
+        ltx.sealAndBorrowAllEntries(init, live, dead);
         ltx.unsealHeader([&ltx, &doNothing](LedgerHeader&) {
             REQUIRE_THROWS_AS(ltx.unsealHeader(doNothing), std::runtime_error);
         });
@@ -2668,9 +2668,9 @@ TEST_CASE("LedgerTxn unsealHeader", "[ledgertxn]")
     SECTION("deactivates header on completion")
     {
         LedgerTxn ltx(app->getLedgerTxnRoot());
-        std::vector<LedgerEntry> init, live;
-        std::vector<LedgerKey> dead;
-        ltx.getAllEntries(init, live, dead);
+        LedgerEntryRefVec init, live;
+        LedgerKeyRefVec dead;
+        ltx.sealAndBorrowAllEntries(init, live, dead);
         REQUIRE_NOTHROW(ltx.unsealHeader(doNothing));
         REQUIRE_NOTHROW(ltx.unsealHeader(doNothing));
     }

--- a/src/simulation/ApplyLoad.cpp
+++ b/src/simulation/ApplyLoad.cpp
@@ -1574,7 +1574,17 @@ ApplyLoad::setupBucketList()
             }
         }
 
-        bl.addBatch(mApp, lh.ledgerSeq, lh.ledgerVersion, liveEntries, {}, {});
+        LedgerEntryRefVec initEntryRefs;
+        LedgerEntryRefVec liveEntryRefs;
+        LedgerKeyRefVec deadEntryRefs;
+        liveEntryRefs.reserve(liveEntries.size());
+        for (auto const& le : liveEntries)
+        {
+            liveEntryRefs.emplace_back(le);
+        }
+
+        bl.addBatch(mApp, lh.ledgerSeq, lh.ledgerVersion, initEntryRefs,
+                    liveEntryRefs, deadEntryRefs);
         if (mTotalHotArchiveEntries > 0)
         {
             hotArchiveBl.addBatch(mApp, lh.ledgerSeq, lh.ledgerVersion,

--- a/src/test/fuzz/targets/TxFuzzTarget.cpp
+++ b/src/test/fuzz/targets/TxFuzzTarget.cpp
@@ -864,17 +864,20 @@ TxFuzzTarget::storeSetupPoolIDs(AbstractLedgerTxn& ltx,
 void
 TxFuzzTarget::storeSetupLedgerKeysAndPoolIDs(AbstractLedgerTxn& ltx)
 {
-    std::vector<LedgerEntry> init, live;
-    std::vector<LedgerKey> dead;
-    ltx.getAllEntries(init, live, dead);
+    LedgerEntryRefVec initRefs, live;
+    LedgerKeyRefVec dead;
+    ltx.sealAndBorrowAllEntries(initRefs, live, dead);
 
+    // sealAndBorrowAllEntries borrows from `ltx`; copy the init entries out so
+    // they can be sorted and handed to storeSetupPoolIDs.
+    std::vector<LedgerEntry> init(initRefs.begin(), initRefs.end());
     std::sort(init.begin(), init.end());
 
     assert(dead.empty());
     if (live.size() == 1)
     {
-        assert(live[0].data.type() == ACCOUNT);
-        assert(live[0].data.account().accountID ==
+        assert(live[0].get().data.type() == ACCOUNT);
+        assert(live[0].get().data.account().accountID ==
                txtest::getRoot(mApp->getNetworkID()).getPublicKey());
     }
     else


### PR DESCRIPTION
# Description

Currently `getAllEntries` call seals the LTX and unnecessarily copies every entry, which adds up to a few ms if thousands of entries are involved.

With this change we just return the references to all the entries. Since this call is used just once in the 'production' path, and the results are only used in a couple of read-only calls, it shouldn't be hard to maintain the lifetime correctness for this method.

This was inspired by an AI-generated change that parallelized the copy; there is actually no need to do the copy in the first place.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
