### PR TITLE
Destroy parallel apply state asynchronously.

### DIFF
--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -2724,6 +2724,16 @@ LedgerManagerImpl::applySorobanStage(
     }
 
     globalParState.commitChangesFromThreads(app, threadStates, stage);
+
+    // Thread states are rather large and can take up to a few ms to be
+    // deallocated. Defer the deallocation to the background worker in order to
+    // not block the apply thread unnecessarily.
+    auto deferredThreadStates = std::make_shared<
+        std::vector<std::unique_ptr<ThreadParallelApplyLedgerState>>>(
+        std::move(threadStates));
+    app.postOnBackgroundThread(
+        [deferredThreadStates]() { deferredThreadStates->clear(); },
+        "destroy parallel apply thread states");
 }
 
 void
@@ -2733,9 +2743,10 @@ LedgerManagerImpl::applySorobanStages(AppConnector& app, AbstractLedgerTxn& ltx,
                                       Hash const& sorobanBasePrngSeed)
 {
     ZoneScoped;
-    GlobalParallelApplyLedgerState globalParState(
+    auto globalParStatePtr = std::make_unique<GlobalParallelApplyLedgerState>(
         app, mApplyState.copyApplyLedgerView(), ltx, stages,
         mApplyState.getInMemorySorobanState(), sorobanConfig);
+    auto& globalParState = *globalParStatePtr;
     // LedgerTxn is not passed into applySorobanStage, so there's no risk
     // of the header being updated while we apply the stages.
     auto const& header = ltx.loadHeader().current();
@@ -2745,6 +2756,16 @@ LedgerManagerImpl::applySorobanStages(AppConnector& app, AbstractLedgerTxn& ltx,
                           sorobanBasePrngSeed);
     }
     globalParState.commitChangesToLedgerTxn(ltx);
+
+    // Global state is rather large and can take up to a few ms to be
+    // deallocated. Defer the deallocation to the background worker in order to
+    // not block the apply thread unnecessarily.
+    auto deferredGlobalState =
+        std::make_shared<std::unique_ptr<GlobalParallelApplyLedgerState>>(
+            std::move(globalParStatePtr));
+    app.postOnBackgroundThread(
+        [deferredGlobalState]() { deferredGlobalState->reset(); },
+        "destroy parallel apply global state");
 }
 
 void


### PR DESCRIPTION
# Description

Destroy parallel apply state asynchronously.

The state data structures are rather large and nested (due to containing XDR), so when they get large de-allocation may take up to a few ms. We don't really need to block the apply thread on this de-allocation, so we can hide it in the background thread.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
