### PR TITLE
Fix fastdev divergence bug

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -228,6 +228,10 @@ jobs:
         if: steps.check-last-tested-commit.outputs.skip != 'true'
         run: ./install-rust.sh
 
+      - name: Install rust nightly and src
+        if: steps.check-last-tested-commit.outputs.skip != 'true'
+        run: rustup toolchain add nightly --component rust-src
+
       - name: Install rustup components
         if: steps.check-last-tested-commit.outputs.skip != 'true'
         run: rustup component add rustfmt

--- a/build-fuzz.sh
+++ b/build-fuzz.sh
@@ -43,11 +43,11 @@ ccache -z
 . "${HOME}/.cargo/env"
 (cd "${SRC_DIR}" && ./autogen.sh)
 
-# NB: the oss-fuzz driver injects sanitizer flags to CFLAGS, CXXFLAGS and
-# RUSTFLAGS. This overlaps with our own support for sanitizers, but not fatally.
-# Note that this requires --enable-fastdev-unsafe-for-production in order to
-# pass sanitizer flags through to rust and not provoke linking errors.
-"${SRC_DIR}/configure" --enable-fuzz --enable-fastdev-unsafe-for-production --disable-postgres --enable-ccache
+# NB: the oss-fuzz driver injects sanitizer flags to CFLAGS and CXXFLAGS. This
+# overlaps with our own support for sanitizers, but not fatally. Note that this
+# requires --enable-fastdev-unsafe-for-production in order to pass sanitizer
+# flags through to rust and not provoke linking errors.
+"${SRC_DIR}/configure" --enable-fuzz --enable-sdfprefs --enable-fastdev-unsafe-for-production --disable-postgres --enable-ccache
 make -j $(nproc)
 make -C src fuzz-targets
 cp src/fuzz_* "${OUT}"

--- a/build-fuzz.sh
+++ b/build-fuzz.sh
@@ -43,11 +43,11 @@ ccache -z
 . "${HOME}/.cargo/env"
 (cd "${SRC_DIR}" && ./autogen.sh)
 
-# NB: the oss-fuzz driver injects sanitizer flags to CFLAGS, CXXFLAGS
-# and RUSTFLAGS. This overlaps with our own support for sanitizers,
-# but not fatally. It does require us to enable the unified rust
-# build.
-"${SRC_DIR}/configure" --enable-fuzz --enable-unified-rust-unsafe-for-production --disable-postgres --enable-ccache
+# NB: the oss-fuzz driver injects sanitizer flags to CFLAGS, CXXFLAGS and
+# RUSTFLAGS. This overlaps with our own support for sanitizers, but not fatally.
+# Note that this requires --enable-fastdev-unsafe-for-production in order to
+# pass sanitizer flags through to rust and not provoke linking errors.
+"${SRC_DIR}/configure" --enable-fuzz --enable-fastdev-unsafe-for-production --disable-postgres --enable-ccache
 make -j $(nproc)
 make -C src fuzz-targets
 cp src/fuzz_* "${OUT}"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -324,14 +324,32 @@ $(SOROBAN_BUILD_DIR)/%/target/git-state.txt: $(top_srcdir)/.git/modules/src/rust
 # only work well when built this way), and use the non-unified build (with
 # separate .a files for each separate soroban version) for production builds.
 #
-# One important caveat: the $(CARGO_FEATURE_FUZZ_TARGETS) feature should _not_
-# be passed to fastdev mode. It pulls in a separate copy of the soroban host
-# with `testutils` enabled, which winds up up causing `testutils` to be enabled
-# _on the production soroban host_ as well, which causes the build to diverge if
-# run against mainnet. Leave $(CARGO_FEATURE_FUZZ_TARGETS) for the non-fastdev
-# build.
 
 if ENABLE_FASTDEV_UNSAFE_FOR_PRODUCTION
+
+# Another delicate bit: the $(CARGO_FEATURE_FUZZ_TARGETS) feature.
+#
+# It pulls in a separate copy of the soroban host with `testutils` enabled,
+# which, in fastdev mode, winds up causing `testutils` to be enabled _on the
+# production soroban host_ as well (due to cargo feature unification), which
+# will cause the build to have slightly different costs and therefore diverge if
+# run against mainnet. Because of this, we are selective about it:
+#
+#   - Regular build: turn on $(CARGO_FEATURE_FUZZ_TARGETS) for smoke-testing
+#   - Fastdev build: turn off, to avoid divergence risk
+#   - Fastdev + ENABLE_FUZZ: turn back on, to allow fuzzing
+#
+# This does mean that a fastdev + ENABLE_FUZZ build might diverge when run
+# against mainnet. But such a build is very slow, typically with multiple
+# sanitizers as well as the fuzzer instrumentation, and should not usually be
+# run against production traffic anyways. It exists just for running fuzzing
+# loops offline.
+
+if ENABLE_FUZZ
+FASTDEV_CARGO_FEATURE_FUZZ_TARGETS=$(CARGO_FEATURE_FUZZ_TARGETS)
+else
+FASTDEV_CARGO_FEATURE_FUZZ_TARGETS=
+endif
 
 # In the fastdev build, we have to pass the --target flag. This actually breaks
 # the non-unified build, so we wind up setting LIBRUST_STELLAR_CORE separately
@@ -359,6 +377,7 @@ $(LIBRUST_STELLAR_CORE): $(RUST_HOST_DEPFILES) $(SRC_RUST_FILES) Makefile $(RUST
 		--locked \
 		--target-dir $(abspath $(RUST_TARGET_DIR)) \
 		$(CARGO_FEATURE_FASTDEV) $(CARGO_FEATURE_TRACY) $(CARGO_FEATURE_NEXT) $(CARGO_FEATURE_TESTUTILS) \
+		$(FASTDEV_CARGO_FEATURE_FUZZ_TARGETS) \
 		$(CARGO_FEATURE_TCMALLOC)
 
 else # !ENABLE_FASTDEV_UNSAFE_FOR_PRODUCTION

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -146,10 +146,19 @@ stellar_core_SOURCES += $(GENERATED_XDRQUERY_SOURCES) util/xdrquery/XDRQueryPars
 BUILT_SOURCES += rust/RustBridge.h $(GENERATED_RUST_SOURCES)
 stellar_core_SOURCES += rust/RustBridge.h $(GENERATED_RUST_SOURCES)
 
+# Figure out if we ought to be passing -Zsanitizer=... RUSTFLAGS and friends
+SANITIZE_FLAGS := $(filter -fsanitize=%,$(CXXFLAGS))
+RUSTFLAGS_ASAN := $(if $(findstring address,$(SANITIZE_FLAGS)),-Zsanitizer=address,)
+RUSTFLAGS_TSAN := $(if $(findstring thread,$(SANITIZE_FLAGS)),-Zsanitizer=thread,)
+RUSTFLAGS_SANI := $(RUSTFLAGS_ASAN) $(RUSTFLAGS_TSAN)
+CARGOFLAGS_BUILDSTD := $(if $(findstring Zsanitizer,$(RUSTFLAGS_SANI)),-Zbuild-std,)
+RUSTFLAGS_CFGS := $(if $(findstring Zsanitizer,$(RUSTFLAGS_SANI)),--cfg curve25519_dalek_backend=\"serial\",)
+
+
 RUST_TOOLCHAIN_FILE=$(top_srcdir)/rust-toolchain.toml
 RUST_TOOLCHAIN_FILE_CHANNEL=$(shell sed -n 's/channel *= *"\([^"]*\)"/\1/p' $(RUST_TOOLCHAIN_FILE))
 if ENABLE_FASTDEV_UNSAFE_FOR_PRODUCTION
-RUST_TOOLCHAIN_CHANNEL=$(if $(findstring -fsanitize=,$(CXXFLAGS)),nightly,$(RUST_TOOLCHAIN_FILE_CHANNEL))
+RUST_TOOLCHAIN_CHANNEL=$(if $(findstring Zsanitizer,$(RUSTFLAGS_SANI)),nightly,$(RUST_TOOLCHAIN_FILE_CHANNEL))
 else
 RUST_TOOLCHAIN_CHANNEL=$(RUST_TOOLCHAIN_FILE_CHANNEL)
 endif
@@ -347,8 +356,21 @@ if ENABLE_FASTDEV_UNSAFE_FOR_PRODUCTION
 
 if ENABLE_FUZZ
 FASTDEV_CARGO_FEATURE_FUZZ_TARGETS=$(CARGO_FEATURE_FUZZ_TARGETS)
+# Since we're manually invoking cargo rustc here, not running `cargo-fuzz`, we
+# have to manually pass some sancov flags along to get fuzz instrumentation in
+# the rust code. We also have to inhibit the trace-pc-guard instrumentation if
+# the fuzz engine is libfuzzer, because it explicitly refuses to run with that
+# mode (it just exits with a message to turn it off). The other fuzz engines,
+# of course, require it.
+TRACE_PC_GUARD_FLAG := $(if $(findstring -fsanitize=fuzzer,$(LIB_FUZZING_ENGINE)),,-Cllvm-args=-sanitizer-coverage-trace-pc-guard)
+RUSTFLAGS_FUZZ := -C passes=sancov-module \
+				  -C llvm-args=-sanitizer-coverage-level=3 \
+				  -C llvm-args=-sanitizer-coverage-inline-8bit-counters \
+				  -C llvm-args=-sanitizer-coverage-pc-table \
+				  $(TRACE_PC_GUARD_FLAG)
 else
 FASTDEV_CARGO_FEATURE_FUZZ_TARGETS=
+RUSTFLAGS_FUZZ :=
 endif
 
 # In the fastdev build, we have to pass the --target flag. This actually breaks
@@ -357,17 +379,11 @@ endif
 RUST_TARGET=$(shell rustc -vV | sed -n 's/host: //p')
 LIBRUST_STELLAR_CORE=$(RUST_TARGET_DIR)/$(RUST_TARGET)/$(RUST_PROFILE_DIR)/librust_stellar_core.a
 
-RUSTFLAGS_ASAN := $(if $(findstring -fsanitize=address,$(CXXFLAGS)),-Zsanitizer=address,)
-RUSTFLAGS_TSAN := $(if $(findstring -fsanitize=thread,$(CXXFLAGS)),-Zsanitizer=thread,)
-RUSTFLAGS_SANI := $(RUSTFLAGS_ASAN) $(RUSTFLAGS_TSAN)
-CARGOFLAGS_BUILDSTD := $(if $(findstring sanitizer,$(RUSTFLAGS_SANI)),-Zbuild-std,)
-RUSTFLAGS_CFGS := $(if $(findstring sanitizer,$(RUSTFLAGS_SANI)),--cfg curve25519_dalek_backend=\"serial\",)
-
 $(LIBRUST_STELLAR_CORE): $(RUST_HOST_DEPFILES) $(SRC_RUST_FILES) Makefile $(RUST_TOOLCHAIN_FILE)
 	cd $(abspath $(top_srcdir))/src/rust && \
 	CC="$(CC)" CXX="$(CXX)" LD="$(LD)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" CXXSTDLIB="$(CXXSTDLIB)" LDFLAGS="$(LDFLAGS)" \
 	RUSTC_WRAPPER="$(RUSTC_WRAPPER)" \
-	RUSTFLAGS="$(RUSTFLAGS_SANI) $(RUSTFLAGS_CFGS)" \
+	RUSTFLAGS="$(RUSTFLAGS) $(RUSTFLAGS_SANI) $(RUSTFLAGS_CFGS) $(RUSTFLAGS_FUZZ)" \
 	CARGO_NET_GIT_FETCH_WITH_CLI=true \
 	$(CARGO) rustc \
 		$(CARGOFLAGS_BUILDSTD) \
@@ -444,7 +460,7 @@ $(SOROBAN_LIBS_STAMP): $(wildcard rust/soroban/p*/Cargo.lock) $(ALL_SOROBAN_GIT_
 		cd $(abspath $(top_srcdir))/src/rust/soroban/$$proto && \
 		CC="$(CC)" CXX="$(CXX)" LD="$(LD)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" CXXSTDLIB="$(CXXSTDLIB)" LDFLAGS="$(LDFLAGS)" \
 		RUSTC_WRAPPER="$(RUSTC_WRAPPER)" \
-		RUSTFLAGS="-Cmetadata=$$proto" \
+		RUSTFLAGS="$(RUSTFLAGS) -Cmetadata=$$proto" \
 		CARGO_TARGET_DIR=$(SOROBAN_BUILD_DIR)/$$proto/target \
 		CARGO_NET_GIT_FETCH_WITH_CLI=true \
 		$(CARGO) build \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -75,9 +75,11 @@ MAIN_FILES = $(GENERATED_VERSION_SOURCES) main/main.cpp
 
 if BUILD_TESTS
 stellar_core_SOURCES = $(MAIN_FILES) $(SRC_CXX_FILES) $(SRC_TEST_CXX_FILES)
+CARGO_FEATURE_FUZZ_TARGETS = --features fuzz_targets
 CARGO_FEATURE_TESTUTILS = --features testutils
 else # !BUILD_TESTS
 stellar_core_SOURCES = $(MAIN_FILES) $(SRC_CXX_FILES)
+CARGO_FEATURE_FUZZ_TARGETS =
 CARGO_FEATURE_TESTUTILS =
 endif # !BUILD_TESTS
 
@@ -310,17 +312,24 @@ $(SOROBAN_BUILD_DIR)/%/target/git-state.txt: $(top_srcdir)/.git/modules/src/rust
 	printf '%s\n' "$$state" > $@.tmp; \
 	if cmp -s $@.tmp $@; then rm -f $@.tmp; else mv -f $@.tmp $@; fi
 
-# The fastdev rust build is a special non-production mode that builds all of
-# the rust dependencies of librust_stellar_core.a through a single cargo
-# invocation, which is actually the "normal" way cargo operates, but which also
-# has the negative side effect of resolving (merging) different point releases
-# and pre-release minor versions across transitive dependencies, which means we
+# The fastdev rust build is a special non-production mode that builds all of the
+# rust dependencies of librust_stellar_core.a through a single cargo invocation,
+# which is actually the "normal" way cargo operates, but which also has the
+# negative side effect of resolving (merging) different point releases and
+# pre-release minor versions across transitive dependencies, which means we
 # can't control the _exact_ transitive dependencies as well as we'd like.
 #
-# So we only use the fastdev rust build for certain special cases such as
-# testing with asan/tsan (they seem to only work well when built this way) and
-# use the non-unified build (with separate .a files for each separate soroban
-# version) for production builds.
+# So we only use the fastdev rust build for fast iteration while doing
+# development, or for special cases like testing with asan/tsan (they seem to
+# only work well when built this way), and use the non-unified build (with
+# separate .a files for each separate soroban version) for production builds.
+#
+# One important caveat: the $(CARGO_FEATURE_FUZZ_TARGETS) feature should _not_
+# be passed to fastdev mode. It pulls in a separate copy of the soroban host
+# with `testutils` enabled, which winds up up causing `testutils` to be enabled
+# _on the production soroban host_ as well, which causes the build to diverge if
+# run against mainnet. Leave $(CARGO_FEATURE_FUZZ_TARGETS) for the non-fastdev
+# build.
 
 if ENABLE_FASTDEV_UNSAFE_FOR_PRODUCTION
 
@@ -461,7 +470,7 @@ $(LIBRUST_STELLAR_CORE): $(RUST_HOST_DEPFILES) $(SRC_RUST_FILES) $(ALL_SOROBAN_L
 		--locked \
 		--target-dir $(abspath $(RUST_TARGET_DIR)) \
 		$(CARGO_FEATURE_TRACY) $(CARGO_FEATURE_NEXT) $(CARGO_FEATURE_TESTUTILS) \
-		$(CARGO_FEATURE_TCMALLOC) \
+		$(CARGO_FEATURE_TCMALLOC) $(CARGO_FEATURE_FUZZ_TARGETS) \
 		-- \
 		$(ALL_SOROBAN_EXTERN_ARGS) \
 		$(ALL_SOROBAN_DEPEND_ARGS)

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -227,10 +227,20 @@ tcmalloc = []
 # staging work across intra-protocol releases.
 next = []
 
-
 # The testutils feature turns on stuff that should only be available in a core
 # BUILD_TESTS build, such as the code to support transaction re-execution on a
-# secondary host, AND enables the soroban-fuzz-targets dependency. This allows
-# fuzz smoke tests to run in normal test builds without requiring the full fuzz
-# _instrumentation_ infrastructure.
-testutils = ["dep:soroban-fuzz-targets"]
+# secondary host.
+
+testutils = []
+
+# Enables the soroban-fuzz-targets dependency. This may be enabled either in
+# full fuzz-instrumentation builds, or even just during normal test-enabled
+# builds in which the core unit tests will run soroban fuzz targets as smoke
+# tests.
+#
+# However, this should _not_ be enabled in a fastdev build, because the
+# soroban-fuzz-targets crate will pull in its own copy of the soroban host _with
+# testutils enabled_ (for recording), and since fastdev is a unified build, this
+# will turn on testutils in the accompanying _production soroban host_, which
+# will cause it to diverge if run on mainnet.
+fuzz_targets = ["dep:soroban-fuzz-targets"]

--- a/src/rust/src/soroban_fuzz.rs
+++ b/src/rust/src/soroban_fuzz.rs
@@ -20,13 +20,13 @@
 
 use crate::rust_bridge::FuzzResultCode;
 
-// Stub implementation when testutils feature is disabled
+// Stub implementation when fuzz_targets feature is disabled
 #[cfg(not(feature = "fuzz_targets"))]
 pub fn run_soroban_fuzz_target(_name: &str, _data: &[u8]) -> FuzzResultCode {
     FuzzResultCode::FUZZ_DISABLED
 }
 
-// When testutils feature is enabled, import and use the actual implementations
+// When fuzz_targets feature is enabled, import and use the actual targets
 #[cfg(feature = "fuzz_targets")]
 use soroban_fuzz_targets::{self as fuzz, FuzzResult};
 

--- a/src/rust/src/soroban_fuzz.rs
+++ b/src/rust/src/soroban_fuzz.rs
@@ -21,18 +21,18 @@
 use crate::rust_bridge::FuzzResultCode;
 
 // Stub implementation when testutils feature is disabled
-#[cfg(not(feature = "testutils"))]
+#[cfg(not(feature = "fuzz_targets"))]
 pub fn run_soroban_fuzz_target(_name: &str, _data: &[u8]) -> FuzzResultCode {
     FuzzResultCode::FUZZ_DISABLED
 }
 
 // When testutils feature is enabled, import and use the actual implementations
-#[cfg(feature = "testutils")]
+#[cfg(feature = "fuzz_targets")]
 use soroban_fuzz_targets::{self as fuzz, FuzzResult};
 
 /// Run a Soroban fuzz target with the given input bytes.
 /// Panics on internal errors (which is what the fuzzer wants to find!)
-#[cfg(feature = "testutils")]
+#[cfg(feature = "fuzz_targets")]
 pub fn run_soroban_fuzz_target(name: &str, data: &[u8]) -> FuzzResultCode {
     let result = match name {
         "soroban_expr" => fuzz::expr::run_fuzz_target(data),


### PR DESCRIPTION
Fastdev mode had unanticipated consequences:

1. The `soroban-fuzz-targets` dependency in `rust_stellar_core` actually pulls in its own specific copy of `soroban-env-host`, which is the one it fuzzes. We can debate whether this is ideal (it's probably not, since it can fall behind the production host in master, but .. it's what it does currently).
2. In order to fuzz that host, it enables `soroban-env-host/testutils`, specifically to use recording mode and set up transactions that have a chance of making it somewhat deep into the auth system. This is also probably not ideal -- it would be nice to fuzz with recording turned off -- but at the moment this is sort of hard to change.
3. We have `soroban-fuzz-targets` turned on basically "by default": currently (on master) when you do a tests-enabled build of core, it enables `rust_stellar_core/testutils` which turns on `soroban-fuzz-targets`. This is intentional and I want to keep doing that! It's to make sure we notice if we break the fuzz targets. The fuzz targets get smoke-tested as part of normal core unit testing.
4. Unfortunately `fastdev` mode makes a mess of this: since it's a _unified_ build driven by cargo (not just linking separately-compiled crates), whatever version of `soroban-env-host` the `soroban-fuzz-targets` dependency pulls in gets _feature unified_ with the corresponding version of `soroban-env-host` we're using for production transaction-processing. So like if the fuzz target is pulling in p27, the production p27 gets `soroban-env-host/testutils` turned on!
5. This, of course, causes recording to be enabled in the production host, which perturbs costs, which makes that host fairly likely to diverge from mainnet when attached to it. Which makes `fastdev` fairly useless for development! And also scary. Nobody likes seeing divergence while working on a change.

So the fix in this patch is a _slight_ degradation in the above arrangement: we split out `rust_stellar_core/fuzz_targets` as a separate feature from `rust_stellar_core/testutils`, and only turn it on when _not_ in `fastdev`. This way we still get smoketest coverage of the fuzz targets in the non-`fastdev` builds. We just get a warning that the fuzz target is disabled in a `fastdev` build.