### PR TITLE
Pass encoded Soroban changes to C++ in strict footprint order.

### DIFF
--- a/src/rust/src/soroban_proto_any.rs
+++ b/src/rust/src/soroban_proto_any.rs
@@ -235,16 +235,32 @@ fn encode_diagnostic_events(events: &Vec<DiagnosticEvent>) -> Vec<RustBuf> {
         .collect()
 }
 
+/// Extracts and encodes changed ledger entries from the provided Soroban host
+/// output.
+///
+/// If `aligned_with_footprint` is true, then the output will contain every RW
+/// footprint entry in the same order as the footprint and empty buffers
+/// standing for the deleted entries, followed by densely packed updated TTL
+/// entries (i.e. non-updated or deleted TTL entries are omitted). This flag
+/// both controls the output format and also relies on the input itself being
+/// in the footprint order (which is what Soroban host guarantees for the v2
+/// host function interface, starting from p28).
+///
+/// If `aligned_with_footprint` is false, then the output will only contain
+/// non-removed entries, and the output order can be considered arbitrary.
 fn extract_ledger_effects(
     entry_changes: Vec<LedgerEntryChange>,
+    aligned_with_footprint: bool,
 ) -> Result<Vec<RustBuf>, HostError> {
     let mut modified_entries = vec![];
+    let mut modified_ttl_entries = vec![];
 
     for change in entry_changes {
-        // Extract ContractCode and ContractData entry changes first
         if !change.read_only {
             if let Some(encoded_new_value) = change.encoded_new_value {
                 modified_entries.push(encoded_new_value.into());
+            } else if aligned_with_footprint {
+                modified_entries.push(RustBuf { data: vec![] });
             }
         }
 
@@ -270,10 +286,15 @@ fn extract_ledger_effects(
 
                 let encoded = non_metered_xdr_to_rust_buf(&le)
                     .map_err(|_| (ScErrorType::Value, ScErrorCode::InternalError))?;
-                modified_entries.push(encoded);
+                if aligned_with_footprint {
+                    modified_ttl_entries.push(encoded);
+                } else {
+                    modified_entries.push(encoded);
+                }
             }
         }
     }
+    modified_entries.append(&mut modified_ttl_entries);
 
     Ok(modified_entries)
 }
@@ -427,6 +448,7 @@ fn run_invoke_and_build_output<F>(
     instruction_limit: u32,
     ledger_info: &CxxLedgerInfo,
     rent_fee_configuration: &CxxRentFeeConfiguration,
+    effects_aligned_with_footprint: bool,
     invoke: F,
 ) -> Result<InvokeHostFunctionOutput, Box<dyn Error>>
 where
@@ -509,7 +531,8 @@ where
                     &rent_fee_configuration.into(),
                     ledger_seq_num,
                 );
-                let modified_ledger_entries = extract_ledger_effects(res.ledger_changes)?;
+                let modified_ledger_entries =
+                    extract_ledger_effects(res.ledger_changes, effects_aligned_with_footprint)?;
                 return Ok(InvokeHostFunctionOutput {
                     success: true,
                     is_internal_error: false,
@@ -601,6 +624,7 @@ fn invoke_host_function_or_maybe_panic(
         instruction_limit,
         ledger_info,
         rent_fee_configuration,
+        false,
         |budget, host_ledger_info, diagnostic_events, trace_hook| {
             super::invoke_host_function_with_trace_hook_and_module_cache(
                 budget,
@@ -641,6 +665,7 @@ fn invoke_host_function_v2_or_maybe_panic(
         instruction_limit,
         ledger_info,
         rent_fee_configuration,
+        true,
         |budget, host_ledger_info, diagnostic_events, trace_hook| {
             let ledger_entries = ledger_entries_and_ttls.iter().map(|e| {
                 let entry: Option<&CxxBuf> = if e.entry.data.is_empty() {

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -765,7 +765,69 @@ class InvokeHostFunctionApplyHelper : virtual LedgerAccessHelper
     }
 
     bool
-    recordStorageChanges(InvokeHostFunctionOutput const& out)
+    recordModifiedEntry(RustBuf const& entryBuf, bool allowClassicCreations,
+                        LedgerKey& lk, uint32_t& numCreatedSorobanEntries,
+                        uint32_t& numCreatedTTLEntries)
+    {
+        LedgerEntry le;
+        xdr::xdr_from_opaque(entryBuf.data, le);
+        lk = LedgerEntryKey(le);
+        auto entrySize = static_cast<uint32_t>(entryBuf.data.size());
+        if (!validateContractLedgerEntry(lk, entrySize, mSorobanConfig,
+                                         mAppConfig, mOpFrame.mParentTx,
+                                         mDiagnosticEvents))
+        {
+            mOpFrame.innerResult(mRes).code(
+                INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
+            return false;
+        }
+
+        // ttlEntry write fees come out of refundableFee, already
+        // accounted for by the host
+        if (lk.type() != TTL)
+        {
+            uint32_t keySize = static_cast<uint32_t>(xdr::xdr_size(lk));
+            mMetrics.noteWriteEntry(isContractCodeEntry(lk), keySize,
+                                    entrySize);
+            if (mResources.writeBytes < mMetrics.mLedgerWriteByte)
+            {
+                mDiagnosticEvents.pushError(
+                    SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
+                    "operation byte-write resources exceeds amount "
+                    "specified",
+                    {makeU64SCVal(mMetrics.mLedgerWriteByte),
+                     makeU64SCVal(mResources.writeBytes)});
+                mOpFrame.innerResult(mRes).code(
+                    INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
+                return false;
+            }
+        }
+
+        if (upsertLedgerEntry(lk, le))
+        {
+            if (isSorobanEntry(lk))
+            {
+                ++numCreatedSorobanEntries;
+            }
+            else if (lk.type() == TTL)
+            {
+                ++numCreatedTTLEntries;
+            }
+            else if (allowClassicCreations)
+            {
+                releaseAssertOrThrow(lk.type() == ACCOUNT ||
+                                     lk.type() == TRUSTLINE);
+            }
+            else
+            {
+                releaseAssertOrThrow(false);
+            }
+        }
+        return true;
+    }
+
+    bool
+    recordStorageChangesLegacy(InvokeHostFunctionOutput const& out)
     {
         ZoneScoped;
         // Every modified entry is either a newly created entry or an updated
@@ -779,63 +841,14 @@ class InvokeHostFunctionApplyHelper : virtual LedgerAccessHelper
             getLedgerVersion(), ProtocolVersion::V_26);
         for (auto const& buf : out.modified_ledger_entries)
         {
-            LedgerEntry le;
-            xdr::xdr_from_opaque(buf.data, le);
-            auto lk = LedgerEntryKey(le);
-            if (!validateContractLedgerEntry(
-                    lk, buf.data.size(), mSorobanConfig, mAppConfig,
-                    mOpFrame.mParentTx, mDiagnosticEvents))
+            LedgerKey lk;
+            if (!recordModifiedEntry(buf, allowClassicCreations, lk,
+                                     numCreatedSorobanEntries,
+                                     numCreatedTTLEntries))
             {
-                mOpFrame.innerResult(mRes).code(
-                    INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
                 return false;
             }
-
             createdAndModifiedKeys.insert(lk);
-
-            uint32_t entrySize = static_cast<uint32_t>(buf.data.size());
-
-            // ttlEntry write fees come out of refundableFee, already
-            // accounted for by the host
-            if (lk.type() != TTL)
-            {
-                uint32_t keySize = static_cast<uint32_t>(xdr::xdr_size(lk));
-                mMetrics.noteWriteEntry(isContractCodeEntry(lk), keySize,
-                                        entrySize);
-                if (mResources.writeBytes < mMetrics.mLedgerWriteByte)
-                {
-                    mDiagnosticEvents.pushError(
-                        SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
-                        "operation byte-write resources exceeds amount "
-                        "specified",
-                        {makeU64SCVal(mMetrics.mLedgerWriteByte),
-                         makeU64SCVal(mResources.writeBytes)});
-                    mOpFrame.innerResult(mRes).code(
-                        INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
-                    return false;
-                }
-            }
-
-            if (upsertLedgerEntry(lk, le))
-            {
-                if (isSorobanEntry(lk))
-                {
-                    ++numCreatedSorobanEntries;
-                }
-                else if (lk.type() == TTL)
-                {
-                    ++numCreatedTTLEntries;
-                }
-                else if (allowClassicCreations)
-                {
-                    releaseAssertOrThrow(lk.type() == ACCOUNT ||
-                                         lk.type() == TRUSTLINE);
-                }
-                else
-                {
-                    releaseAssertOrThrow(false);
-                }
-            }
         }
 
         // Verify that each newly created Soroban entry has a corresponding
@@ -860,6 +873,62 @@ class InvokeHostFunctionApplyHelper : virtual LedgerAccessHelper
                 }
             }
         }
+        return true;
+    }
+
+    bool
+    recordStorageChanges(InvokeHostFunctionOutput const& out)
+    {
+        ZoneScoped;
+        if (protocolVersionIsBefore(mProtocolVersion,
+                                    INVOKE_HOST_FUNCTION_V2_PROTOCOL_VERSION))
+        {
+            return recordStorageChangesLegacy(out);
+        }
+
+        auto const& rwKeys = mResources.footprint.readWrite;
+        releaseAssertOrThrow(out.modified_ledger_entries.size() >=
+                             rwKeys.size());
+        uint32_t numCreatedSorobanEntries = 0;
+        uint32_t numCreatedTTLEntries = 0;
+        for (size_t i = 0; i < out.modified_ledger_entries.size(); ++i)
+        {
+            auto const& buf = out.modified_ledger_entries[i];
+            // The output format is every RW entry in footprint order, followed
+            // by the updated TTL entries.
+            bool const isRwFootprintEntry = i < rwKeys.size();
+            // Deleted RW entries are represented by an empty buffer and have
+            // no corresponding TTL update.
+            if (isRwFootprintEntry && buf.data.size() == 0)
+            {
+                auto const& lk = rwKeys[i];
+                if (eraseLedgerEntryIfExists(lk))
+                {
+                    releaseAssertOrThrow(isSorobanEntry(lk));
+
+                    // Also delete associated ttlEntry as it won't appear
+                    // in modified_ledger_entries.
+                    auto ttlLK = getTTLKey(lk);
+                    releaseAssertOrThrow(eraseLedgerEntryIfExists(ttlLK));
+                }
+                continue;
+            }
+
+            LedgerKey lk;
+            if (!recordModifiedEntry(buf,
+                                     /* allowClassicCreations */ true, lk,
+                                     numCreatedSorobanEntries,
+                                     numCreatedTTLEntries))
+            {
+                return false;
+            }
+            releaseAssertOrThrow(isRwFootprintEntry ? lk == rwKeys[i]
+                                                    : lk.type() == TTL);
+        }
+
+        // Verify that each newly created Soroban entry has a corresponding
+        // newly created TTL entry (1:1 pairing guaranteed by the host).
+        releaseAssertOrThrow(numCreatedSorobanEntries == numCreatedTTLEntries);
         return true;
     }
 

--- a/src/transactions/ParallelApplyUtils.cpp
+++ b/src/transactions/ParallelApplyUtils.cpp
@@ -741,14 +741,14 @@ ThreadParallelApplyLedgerState::upsertEntry(
             releaseAssertOrThrow(le);
             le.value().lastModifiedLedgerSeq = ledgerSeq;
         });
-    mThreadEntryMap.insert_or_assign(key, parAppEntry);
+    mThreadEntryMap.insert_or_assign(key, std::move(parAppEntry));
 }
 void
 ThreadParallelApplyLedgerState::eraseEntry(LedgerKey const& key)
 {
     auto parAppEntry =
         ThreadParallelApplyEntry::dirty(scopeAdoptEntryOpt(std::nullopt));
-    mThreadEntryMap.insert_or_assign(key, parAppEntry);
+    mThreadEntryMap.insert_or_assign(key, std::move(parAppEntry));
 }
 
 void


### PR DESCRIPTION
# Description

This allows us to get rid of a hash map used for marking non-deleted RW keys, which saves us a few ms of apply time.

This change naturally comes from the refactoring done in p28 which caused host to operate on data in footprint order. Thus this is a non-breaking change that uses p28 host as is.

Also includes a passing-by copy->move optimization.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
