### PR TITLE
Use loser-tree merge for ConservationOfLumens

### DIFF
--- a/src/bucket/BucketBase.cpp
+++ b/src/bucket/BucketBase.cpp
@@ -426,6 +426,13 @@ BucketBase<BucketT, IndexT>::merge(
     return out.getBucket(bucketManager, &mk);
 }
 
+template <typename BucketT, typename IndexT>
+std::optional<std::pair<std::streamoff, std::streamoff>>
+BucketBase<BucketT, IndexT>::getRangeForType(LedgerEntryType type) const
+{
+    return getIndex().getRangeForType(type);
+}
+
 template void BucketBase<LiveBucket, LiveBucket::IndexT>::mergeInternal<
     MemoryMergeInput<LiveBucket>, std::function<void(BucketEntry const&)>,
     std::vector<BucketInputIterator<LiveBucket>>&, bool&>(

--- a/src/bucket/BucketBase.h
+++ b/src/bucket/BucketBase.h
@@ -187,6 +187,12 @@ class BucketBase : public NonMovableOrCopyable
     static std::string randomBucketName(std::string const& tmpDir);
     static std::string randomBucketIndexName(std::string const& tmpDir);
 
+    // Returns [lowerBound, upperBound) of file offsets for all entries of the
+    // given type in the bucket, or std::nullopt if no entries of this type
+    // exist.
+    std::optional<std::pair<std::streamoff, std::streamoff>>
+    getRangeForType(LedgerEntryType type) const;
+
 #ifdef BUILD_TESTS
     IndexT const&
     getIndexForTesting() const

--- a/src/bucket/BucketListSnapshot.cpp
+++ b/src/bucket/BucketListSnapshot.cpp
@@ -709,9 +709,10 @@ namespace
 // to be positioned at the start of the type range. This is basically the same
 // as SearchableLiveBucketListSnapshot::scanForEntriesOfType's scanBucket except
 // with more control over when iteration happens.
-class BucketEntryIterator
+template <typename BucketT> class BucketEntryIterator
 {
-    BucketEntry mEntry;
+    BUCKET_TYPE_ASSERT(BucketT);
+    BucketT::EntryT mEntry;
     LedgerKey mKey;
     XDRInputFileStream mStream;
     LedgerEntryType const mType;
@@ -722,7 +723,7 @@ class BucketEntryIterator
     {
     }
 
-    BucketEntry const&
+    BucketT::EntryT const&
     getEntry() const
     {
         return mEntry;
@@ -738,7 +739,7 @@ class BucketEntryIterator
     {
         while (mStream.readOne(mEntry))
         {
-            if (isBucketMetaEntry<LiveBucket>(mEntry))
+            if (isBucketMetaEntry<BucketT>(mEntry))
             {
                 continue;
             }
@@ -758,10 +759,11 @@ class BucketEntryIterator
 };
 } // namespace
 
+template <class BucketT>
 void
-SearchableLiveBucketListSnapshot::scanForLiveEntriesOfType(
+SearchableBucketListSnapshot<BucketT>::scanForCurrentEntriesOfType(
     LedgerEntryType type,
-    std::function<void(LedgerEntry const&, LedgerKey const&)> callback) const
+    std::function<Loop(LedgerEntry const&, LedgerKey const&)> callback) const
 {
     ZoneScoped;
     // We implement this as a k-way merge over all buckets. We use a loser tree
@@ -777,9 +779,9 @@ SearchableLiveBucketListSnapshot::scanForLiveEntriesOfType(
     // intermediate nodes, we just store an index, since copying the XDR types
     // is probably more expensive than the extra indirection.
 
-    std::vector<BucketEntryIterator> iterators;
+    std::vector<BucketEntryIterator<BucketT>> iterators;
     loopAllBuckets(
-        [&iterators, type](std::shared_ptr<LiveBucket const> const& bucket) {
+        [&iterators, type](std::shared_ptr<BucketT const> const& bucket) {
             if (bucket->isEmpty())
             {
                 return Loop::INCOMPLETE;
@@ -878,9 +880,27 @@ SearchableLiveBucketListSnapshot::scanForLiveEntriesOfType(
         {
             last = key;
             auto& entry = iter.getEntry();
-            if (entry.type() == LIVEENTRY || entry.type() == INITENTRY)
+            if constexpr (std::is_same_v<BucketT, LiveBucket>)
             {
-                callback(entry.liveEntry(), key);
+                if (entry.type() == LIVEENTRY || entry.type() == INITENTRY)
+                {
+                    if (callback(entry.liveEntry(), key) == Loop::COMPLETE)
+                    {
+                        return;
+                    }
+                }
+            }
+            else
+            {
+                static_assert(std::is_same_v<BucketT, HotArchiveBucket>,
+                              "unexpected bucket type");
+                if (entry.type() == HOT_ARCHIVE_ARCHIVED)
+                {
+                    if (callback(entry.archivedEntry(), key) == Loop::COMPLETE)
+                    {
+                        return;
+                    }
+                }
             }
         }
         first = false;

--- a/src/bucket/BucketListSnapshot.h
+++ b/src/bucket/BucketListSnapshot.h
@@ -201,6 +201,19 @@ template <class BucketT> class SearchableBucketListSnapshot
     // Access to underlying data (for copying/refreshing)
     std::shared_ptr<BucketListSnapshotData<BucketT> const> const&
     getSnapshotData() const;
+
+    // Iterate over the visible, non-shadowed entries of a given type, i.e., the
+    // newest entry for each key if it isn't tombstoned. Calls callback for
+    // these entries, stopping early if callback returns Loop::COMPLETE. For the
+    // live bucket list, this will be the current values (LIVEENTRY or
+    // INITENTRY) for all keys of the given type that aren't dead (DEADENTRY).
+    // For the hot archive bucket list, this will be the latest version of all
+    // keys of the given type that are still archived (HOT_ARCHIVE_ARCHIVED) and
+    // haven't been restored (HOT_ARCHIVE_LIVE).
+    void scanForCurrentEntriesOfType(
+        LedgerEntryType type,
+        std::function<Loop(LedgerEntry const&, LedgerKey const&)> callback)
+        const;
 };
 
 // Live bucket list snapshot with additional query methods
@@ -240,13 +253,6 @@ class SearchableLiveBucketListSnapshot
     void scanForEntriesOfType(
         LedgerEntryType type,
         std::function<Loop(BucketEntry const&)> callback) const;
-
-    // Iterate over all live entries of a given type. Note that this handles
-    // shadowing and only returns the latest live entry for each key.
-    void scanForLiveEntriesOfType(
-        LedgerEntryType type,
-        std::function<void(LedgerEntry const&, LedgerKey const&)> callback)
-        const;
 
     friend class ImmutableLedgerData;
     friend class ImmutableLedgerView;

--- a/src/bucket/HotArchiveBucketIndex.cpp
+++ b/src/bucket/HotArchiveBucketIndex.cpp
@@ -28,6 +28,12 @@ HotArchiveBucketIndex::HotArchiveBucketIndex(
                mDiskIndex.getPageSize(), filename);
 }
 
+std::optional<std::pair<std::streamoff, std::streamoff>>
+HotArchiveBucketIndex::getRangeForType(LedgerEntryType type) const
+{
+    return mDiskIndex.getRangeForType(type);
+}
+
 std::streamoff
 HotArchiveBucketIndex::getPageSize(Config const& cfg, size_t bucketSize)
 {

--- a/src/bucket/HotArchiveBucketIndex.h
+++ b/src/bucket/HotArchiveBucketIndex.h
@@ -83,6 +83,9 @@ class HotArchiveBucketIndex : public NonMovableOrCopyable
     {
     }
 
+    std::optional<std::pair<std::streamoff, std::streamoff>>
+    getRangeForType(LedgerEntryType type) const;
+
     std::pair<IndexReturnT, IterT> scan(IterT start, LedgerKey const& k) const;
 
     BucketEntryCounters const&

--- a/src/bucket/LiveBucket.cpp
+++ b/src/bucket/LiveBucket.cpp
@@ -371,12 +371,6 @@ LiveBucket::getMaxCacheSize() const
 }
 #endif // BUILD_TESTS
 
-std::optional<std::pair<std::streamoff, std::streamoff>>
-LiveBucket::getRangeForType(LedgerEntryType type) const
-{
-    return getIndex().getRangeForType(type);
-}
-
 std::vector<BucketEntry>
 LiveBucket::convertToBucketEntry(bool useInit,
                                  std::vector<LedgerEntry> const& initEntries,

--- a/src/bucket/LiveBucket.h
+++ b/src/bucket/LiveBucket.h
@@ -105,14 +105,6 @@ class LiveBucket : public BucketBase<LiveBucket, LiveBucketIndex>,
     size_t getMaxCacheSize() const;
 #endif
 
-    // Returns [lowerBound, upperBound) of file offsets for all entries of the
-    // given type in the bucket, or std::nullopt if no entries of this type
-    // exist. Note that if the underlying index is a page based index, this is a
-    // rough bound such that entries of another type may also be present in the
-    // range.
-    std::optional<std::pair<std::streamoff, std::streamoff>>
-    getRangeForType(LedgerEntryType type) const;
-
     // Create a fresh bucket from given vectors of init (created) and live
     // (updated) LedgerEntries, and dead LedgerEntryKeys. The bucket will
     // be sorted, hashed, and adopted in the provided BucketManager.

--- a/src/bucket/test/BucketIndexTests.cpp
+++ b/src/bucket/test/BucketIndexTests.cpp
@@ -1607,9 +1607,9 @@ TEST_CASE("getRangeForType bounds verification", "[bucket][bucketindex]")
     testAllIndexTypes(f);
 }
 
-// Fixture for the scanForLiveEntriesOfType randomized test. Records the
-// live-entry set created by buildMultiVersionTest. Includes the genesis
-// root ACCOUNT but not genesis CONFIG_SETTINGs.
+// Fixture for the scanForCurrentEntriesOfType randomized test. Records the
+// live-entry set created by buildMultiVersionTest. Includes the genesis root
+// ACCOUNT but not genesis CONFIG_SETTINGs.
 class BucketIndexScanTest : public BucketIndexTest
 {
     UnorderedMap<LedgerKey, LedgerEntry> mAllEntries;
@@ -1654,7 +1654,7 @@ class BucketIndexScanTest : public BucketIndexTest
     }
 };
 
-TEST_CASE("scanForLiveEntriesOfType randomized testing",
+TEST_CASE("scanForCurrentEntriesOfType randomized testing",
           "[bucket][bucketindex]")
 {
     // Scan for each of the given types and check the result against the
@@ -1682,6 +1682,7 @@ TEST_CASE("scanForLiveEntriesOfType randomized testing",
 
                     // Each key should only be emitted once
                     REQUIRE(found.emplace(key, entry).second);
+                    return Loop::INCOMPLETE;
                 });
             REQUIRE(found == expected);
         }
@@ -1704,8 +1705,10 @@ TEST_CASE("scanForLiveEntriesOfType randomized testing",
             INFO(
                 "type = " << xdr::xdr_traits<LedgerEntryType>::enum_name(type));
             ledgerView.scanCurrentLiveEntriesOfType(
-                type,
-                [](LedgerEntry const&, LedgerKey const&) { REQUIRE(false); });
+                type, [](LedgerEntry const&, LedgerKey const&) {
+                    REQUIRE(false);
+                    return Loop::COMPLETE;
+                });
         }
     });
 
@@ -1721,7 +1724,7 @@ TEST_CASE("scanForLiveEntriesOfType randomized testing",
     });
 }
 
-TEST_CASE("scanForLiveEntriesOfType loser tree unit tests",
+TEST_CASE("scanForCurrentEntriesOfType loser tree unit tests",
           "[bucket][bucketindex]")
 {
     auto f = [&](Config& cfg) {
@@ -1794,6 +1797,7 @@ TEST_CASE("scanForLiveEntriesOfType loser tree unit tests",
 
                     // Each key must be emitted exactly once
                     REQUIRE(found.emplace(key, entry).second);
+                    return Loop::INCOMPLETE;
                 });
             return found;
         };
@@ -1801,8 +1805,10 @@ TEST_CASE("scanForLiveEntriesOfType loser tree unit tests",
         auto requireNoCallback = [](ImmutableLedgerView const& view,
                                     LedgerEntryType type) {
             view.scanCurrentLiveEntriesOfType(
-                type,
-                [](LedgerEntry const&, LedgerKey const&) { REQUIRE(false); });
+                type, [](LedgerEntry const&, LedgerKey const&) {
+                    REQUIRE(false);
+                    return Loop::COMPLETE;
+                });
         };
 
         SECTION("k disjoint buckets")

--- a/src/invariant/ConservationOfLumens.cpp
+++ b/src/invariant/ConservationOfLumens.cpp
@@ -177,7 +177,7 @@ ConservationOfLumens::checkOnOperationApply(
     return {};
 }
 
-// Helper function that processes an entry if it hasn't been seen before.
+// Helper function that processes an entry.
 // Returns true on success, false on error (with error set in errorMsg).
 static bool
 processEntry(LedgerEntry const& entry, LedgerKey const& key, Asset const& asset,

--- a/src/invariant/ConservationOfLumens.cpp
+++ b/src/invariant/ConservationOfLumens.cpp
@@ -180,17 +180,10 @@ ConservationOfLumens::checkOnOperationApply(
 // Helper function that processes an entry if it hasn't been seen before.
 // Returns true on success, false on error (with error set in errorMsg).
 static bool
-processEntryIfNew(LedgerEntry const& entry, LedgerKey const& key,
-                  std::unordered_set<LedgerKey>& countedKeys,
-                  Asset const& asset,
-                  AssetContractInfo const& assetContractInfo,
-                  int64_t& sumBalance, std::string& errorMsg)
+processEntry(LedgerEntry const& entry, LedgerKey const& key, Asset const& asset,
+             AssetContractInfo const& assetContractInfo, int64_t& sumBalance,
+             std::string& errorMsg)
 {
-    if (countedKeys.count(key) != 0)
-    {
-        return true;
-    }
-
     auto result = getAssetBalance(entry, asset, assetContractInfo);
 
     if (result.overflowed)
@@ -216,8 +209,6 @@ processEntryIfNew(LedgerEntry const& entry, LedgerKey const& key,
         return false;
     }
 
-    countedKeys.emplace(key);
-
     return true;
 }
 
@@ -236,28 +227,17 @@ scanLiveBuckets(ApplyLedgerView const& applyView, Asset const& asset,
             continue;
         }
 
-        std::unordered_set<LedgerKey> countedKeys;
-
-        applyView.scanLiveEntriesOfType(
-            type, [&](BucketEntry const& be) -> Loop {
+        applyView.scanCurrentLiveEntriesOfType(
+            type, [&](LedgerEntry const& le, LedgerKey const& key) -> Loop {
                 if (isStopping())
                 {
                     return Loop::COMPLETE;
                 }
 
-                if (be.type() == LIVEENTRY || be.type() == INITENTRY)
+                if (!processEntry(le, key, asset, assetContractInfo, sumBalance,
+                                  errorMsg))
                 {
-                    if (!processEntryIfNew(
-                            be.liveEntry(), LedgerEntryKey(be.liveEntry()),
-                            countedKeys, asset, assetContractInfo, sumBalance,
-                            errorMsg))
-                    {
-                        return Loop::COMPLETE;
-                    }
-                }
-                else if (be.type() == DEADENTRY)
-                {
-                    countedKeys.emplace(be.deadEntry());
+                    return Loop::COMPLETE;
                 }
                 return Loop::INCOMPLETE;
             });
@@ -275,36 +255,35 @@ scanHotArchiveBuckets(ApplyLedgerView const& applyView, Asset const& asset,
                       int64_t& sumBalance, std::string& errorMsg,
                       std::function<bool()> const& isStopping)
 {
-    std::unordered_set<LedgerKey> countedKeys;
-    applyView.scanAllArchiveEntries([&](HotArchiveBucketEntry const& be) {
-        if (isStopping())
+    // Scan all entry types that can hold the native asset
+    for (auto let : xdr::xdr_traits<LedgerEntryType>::enum_values())
+    {
+        LedgerEntryType type = static_cast<LedgerEntryType>(let);
+        if (!canHoldAsset(type, asset))
         {
-            return Loop::COMPLETE;
+            continue;
         }
 
-        if (be.type() == HOT_ARCHIVE_ARCHIVED)
-        {
-            if (!canHoldAsset(be.archivedEntry().data.type(), asset))
-            {
+        applyView.scanCurrentHotArchiveEntriesOfType(
+            type, [&](LedgerEntry const& le, LedgerKey const& key) -> Loop {
+                if (isStopping())
+                {
+                    return Loop::COMPLETE;
+                }
+
+                if (!processEntry(le, key, asset, assetContractInfo, sumBalance,
+                                  errorMsg))
+                {
+                    return Loop::COMPLETE;
+                }
                 return Loop::INCOMPLETE;
-            }
-            if (!processEntryIfNew(be.archivedEntry(),
-                                   LedgerEntryKey(be.archivedEntry()),
-                                   countedKeys, asset, assetContractInfo,
-                                   sumBalance, errorMsg))
-            {
-                return Loop::COMPLETE;
-            }
-        }
-        else if (be.type() == HOT_ARCHIVE_LIVE &&
-                 canHoldAsset(be.key().type(), asset))
+            });
+
+        if (!errorMsg.empty())
         {
-            // HOT_ARCHIVE_LIVE means entry was restored from archive,
-            // so mark it as seen (shadowing any archived versions)
-            countedKeys.emplace(be.key());
+            return;
         }
-        return Loop::INCOMPLETE;
-    });
+    }
 }
 
 std::string
@@ -340,8 +319,7 @@ ConservationOfLumens::checkSnapshot(
             sumBalance, header.feePool);
     }
 
-    // Scan the Live BucketList for native balances using loopAllBuckets
-
+    // Scan the Live BucketList for native balances
     scanLiveBuckets(applyView, nativeAsset, mLumenContractInfo, sumBalance,
                     errorMsg, isStopping);
 

--- a/src/ledger/ImmutableLedgerView.cpp
+++ b/src/ledger/ImmutableLedgerView.cpp
@@ -410,9 +410,17 @@ ImmutableLedgerView::scanLiveEntriesOfType(
 void
 ImmutableLedgerView::scanCurrentLiveEntriesOfType(
     LedgerEntryType type,
-    std::function<void(LedgerEntry const&, LedgerKey const&)> callback) const
+    std::function<Loop(LedgerEntry const&, LedgerKey const&)> callback) const
 {
-    mLiveSnapshot.scanForLiveEntriesOfType(type, std::move(callback));
+    mLiveSnapshot.scanForCurrentEntriesOfType(type, std::move(callback));
+}
+
+void
+ImmutableLedgerView::scanCurrentHotArchiveEntriesOfType(
+    LedgerEntryType type,
+    std::function<Loop(LedgerEntry const&, LedgerKey const&)> callback) const
+{
+    mHotArchiveSnapshot.scanForCurrentEntriesOfType(type, std::move(callback));
 }
 
 // === Hot Archive BucketList wrapper methods ===

--- a/src/ledger/ImmutableLedgerView.h
+++ b/src/ledger/ImmutableLedgerView.h
@@ -174,10 +174,17 @@ class ImmutableLedgerView : public virtual AbstractLedgerView
         std::function<Loop(BucketEntry const&)> callback) const;
 
     // Scan the live bucket list for entries of a given type. Calls callback
-    // with the latest live version for each entry.
+    // with the latest version for each non-dead entry.
     void scanCurrentLiveEntriesOfType(
         LedgerEntryType type,
-        std::function<void(LedgerEntry const&, LedgerKey const&)> callback)
+        std::function<Loop(LedgerEntry const&, LedgerKey const&)> callback)
+        const;
+
+    // Scan the hot archive bucket list for entries of a given type. Calls
+    // callback with the latest version for each non-restored entry.
+    void scanCurrentHotArchiveEntriesOfType(
+        LedgerEntryType type,
+        std::function<Loop(LedgerEntry const&, LedgerKey const&)> callback)
         const;
 
     // === Hot Archive BucketList methods ===
@@ -214,6 +221,7 @@ class ApplyLedgerView : private ImmutableLedgerView,
     using ImmutableLedgerView::loadLiveKeys;
     using ImmutableLedgerView::loadPoolShareTrustLinesByAccountAndAsset;
     using ImmutableLedgerView::scanAllArchiveEntries;
+    using ImmutableLedgerView::scanCurrentHotArchiveEntriesOfType;
     using ImmutableLedgerView::scanCurrentLiveEntriesOfType;
     using ImmutableLedgerView::scanForEviction;
     using ImmutableLedgerView::scanLiveEntriesOfType;

--- a/src/ledger/InMemorySorobanState.cpp
+++ b/src/ledger/InMemorySorobanState.cpp
@@ -459,16 +459,19 @@ InMemorySorobanState::initializeStateFromSnapshot(
         auto contractDataHandler = [this](LedgerEntry const& le,
                                           LedgerKey const&) {
             createContractDataEntry(le);
+            return Loop::INCOMPLETE;
         };
 
         auto ttlHandler = [this](LedgerEntry const& le, LedgerKey const&) {
             createTTL(le);
+            return Loop::INCOMPLETE;
         };
 
         auto contractCodeHandler = [this, &sorobanConfig,
                                     ledgerVersion](LedgerEntry const& le,
                                                    LedgerKey const&) {
             createContractCodeEntry(le, sorobanConfig, ledgerVersion);
+            return Loop::INCOMPLETE;
         };
 
         applyView.scanCurrentLiveEntriesOfType(CONTRACT_DATA,


### PR DESCRIPTION
Adapts the loser tree merge from #5252 to support the hot archive bucket list, as well. This lets us use the merge for the conservation of lumens invariant, which lowers the memory usage. On a noble dev watcher, the node no longer runs into memory problems; over the last week, memory usage (on commit 6c2ccfe06fd5090e82d8084d9a5164178408f2f7) settled to 11.8–12 GB (vs 12–14 on a different watcher running 27.0.0 jammy during the same timespan). 