### PR TITLE
Skip the Horizon and RPC integration tests on the private repo

### DIFF
--- a/.github/workflows/horizon.yml
+++ b/.github/workflows/horizon.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   horizon:
+    if: github.event.repository.visibility != 'private'
     uses: stellar/stellar-horizon/.github/workflows/integration-tests.yml@c9e78ebefea9721fcb0b386fc898e4c0e76cee33
     with:
       horizon_git_ref: protocol-next

--- a/.github/workflows/rpc.yml
+++ b/.github/workflows/rpc.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   rpc:
+    if: github.event.repository.visibility != 'private'
     uses: stellar/stellar-rpc/.github/workflows/integration-tests.yml@efd9eb95f1ed8a7d69d28f12e89762c3ecb64bcc
     with:
       rpc_git_ref: protocol-next


### PR DESCRIPTION
Gate the Horizon and RPC integration test workflows on repository visibility, matching what build.yml already does, so they only run on the public repo.

On stellar-core-internal these jobs pass `core_git_ref: ${{ github.sha }}` to reusable workflows that clone core from public stellar/stellar-core, so the PR merge commit isn't fetchable and the job dies before building.