### PR TITLE
docs: overlay hashes vs payloads (pull by Hash)

### DIFF
--- a/docs/overlay.md
+++ b/docs/overlay.md
@@ -19,3 +19,36 @@ title: Overlay
         - peers request new data when they're ready to process it. This is done to prevent network congestion. Applying back-pressure on the receiver side also allows the sender to prioritize accumulated messages in the queue, and shed load that becomes obsolete.
 
     * Versioning: The overlay subsystem has a version number, which is the latest version of the protocol that the node supports. It also maintains a minimum supported overlay version. Any connection that doesn't support the minimum version is rejected.
+
+## Hashes versus payloads
+
+The overlay does not flood full objects by default. Peers first exchange
+**identifiers** (32-byte hashes). A node only **pulls** the matching payload if
+it does not already have it. Flooding is keyed by `Hash` in `FloodGate`
+(`src/overlay/Floodgate.h`).
+
+`StellarMessage` (see `Stellar-overlay.x`) splits into three kinds, documented
+in `src/overlay/OverlayManager.h`:
+
+- **Peer-directed:** `HELLO`, `PEERS`, `DONT_HAVE`, `ERROR_MSG`.
+- **Broadcast:** `TRANSACTION`, `SCP_MESSAGE`. Consensus votes are **pushed**
+  because they are small and latency-sensitive.
+- **Anycast by hash:** `GET_TX_SET` / `TX_SET`, `GET_SCP_QUORUMSET` /
+  `SCP_QUORUMSET`, `GET_SCP_STATE`. `ItemFetcher` asks connected peers, in
+  sequence, for the body of a hash. These messages are not flooded.
+
+Transaction dissemination in pull mode uses the same split:
+
+- `FLOOD_ADVERT` carries a `FloodAdvert` of `txHashes` (up to
+  `TX_ADVERT_VECTOR_MAX_SIZE`).
+- `FLOOD_DEMAND` carries a `FloodDemand` of hashes this node is missing.
+- The transaction body is sent only in response to a demand.
+
+So a peer that already holds a given hash never downloads the envelope again.
+That is the same rule as `broadcastMessage(..., std::optional<Hash>)`: when a
+transaction is flooded, its envelope hash is what overlay uses to decide
+whether the message is new.
+
+History catchup and long-term ledger archives stay **off** the overlay (see
+`docs/architecture.md` and `docs/history.md`). Overlay is for live consensus
+and mempool, not for shipping the full payload of the network's past.

--- a/src/overlay/README.md
+++ b/src/overlay/README.md
@@ -12,6 +12,7 @@ the network any transactions injected from public API servers.
 Good reading entry points are [`OverlayManager.h`](./OverlayManager.h), as well as the implementation of
 `OverlayManagerImpl::tick`, and `OverlayManagerImpl::broadcastMessage`.
 
-Flooding is hash-keyed (`FloodGate`). Transaction and quorum-set **payloads**
-are pulled by hash (`ItemFetcher`, `FLOOD_ADVERT` / `FLOOD_DEMAND`,
-`GET_TX_SET`). See [`docs/overlay.md`](../../docs/overlay.md).
+Flooding is hash-keyed (`Floodgate`). Transaction envelopes are advertised and
+requested with `FLOOD_ADVERT` / `FLOOD_DEMAND`; transaction sets and quorum
+sets are fetched by hash through `ItemFetcher` using `GET_TX_SET` and
+`GET_SCP_QUORUMSET`. See [`docs/overlay.md`](../../docs/overlay.md).

--- a/src/overlay/README.md
+++ b/src/overlay/README.md
@@ -11,3 +11,7 @@ the network any transactions injected from public API servers.
 
 Good reading entry points are [`OverlayManager.h`](./OverlayManager.h), as well as the implementation of
 `OverlayManagerImpl::tick`, and `OverlayManagerImpl::broadcastMessage`.
+
+Flooding is hash-keyed (`FloodGate`). Transaction and quorum-set **payloads**
+are pulled by hash (`ItemFetcher`, `FLOOD_ADVERT` / `FLOOD_DEMAND`,
+`GET_TX_SET`). See [`docs/overlay.md`](../../docs/overlay.md).


### PR DESCRIPTION
## Summary

`docs/overlay.md` already says block/tx flooding is pull-based and SCP is push-based. This PR names the actual machinery so a first-time reader of overlay does not have to reverse-engineer `OverlayManager.h` and `Stellar-overlay.x`.

No protocol or consensus change.

## What

Document that:

- `FloodGate` is keyed by `Hash`.
- Transaction and quorum-set **bodies** are anycast by hash (`GET_TX_SET` / `GET_SCP_QUORUMSET` via `ItemFetcher`).
- Pull-mode tx gossip advertises hashes (`FLOOD_ADVERT`) and demands missing ones (`FLOOD_DEMAND`); the envelope is sent only if the peer does not already have that hash.
- History / long-term ledger archives stay off the overlay (`docs/architecture.md`).

A short pointer is added in `src/overlay/README.md`.

## Why

Peers on this network already treat a 32-byte hash as the thing that is flooded, and the payload as something you pull iff you lack it. That is easy to miss from the current overlay glossary. Naming `FLOOD_ADVERT` / `FLOOD_DEMAND` and `ItemFetcher` matches the headers and XDR.

## Test plan

- [x] Docs only; no C++ change.
- [ ] Overlay maintainers: wording matches current pull-mode behavior.